### PR TITLE
boxcli: don't print help w/ shell non-zero exit code

### DIFF
--- a/boxcli/shell.go
+++ b/boxcli/shell.go
@@ -6,6 +6,7 @@ package boxcli
 import (
 	"fmt"
 	"os"
+	"os/exec"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -37,5 +38,11 @@ func runShellCmd(cmd *cobra.Command, args []string) error {
 
 	fmt.Println("Installing nix packages. This may take a while...")
 
-	return box.Shell()
+	err = box.Shell()
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+	}
+	return err
 }


### PR DESCRIPTION
## Summary

Don't print an error message or the usage help when `devbox shell` exits with a non-zero code. We still want to propagate the shell's exit code in order to support scripts.

Before:

	$ devbox shell
	Installing nix packages. This may take a while...
	Starting a devbox shell...
	$ exit 1
	Usage:
	  devbox shell [<dir>] [flags]

	Flags:
	  -h, --help   help for shell

After:

	$ devbox shell
	Installing nix packages. This may take a while...
	Starting a devbox shell...
	$ exit 1
	$ echo $?
	1

## How was it tested?

- Running `devbox shell` and exiting 1 to check there's no error output.
- Removing nix from my PATH and running `devbox shell` to check I still see an error.