### PR TITLE
Simple change to support shell hooks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,6 @@ on:
         default: false
         type: boolean
   # Nightly releases
-  schedule:
-    - cron: "45 8 * * 1-5"
   push:
     tags:
       - "*" # Tags that trigger a new release version

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: none
 
 jobs:
   golangci-lint:

--- a/config.go
+++ b/config.go
@@ -12,7 +12,8 @@ import (
 type Config struct {
 	// Packages is the slice of Nix packages that devbox makes available in
 	// its environment.
-	Packages []string `cue:"[...string]" json:"packages,omitempty"`
+	Packages  []string `cue:"[...string]" json:"packages,omitempty"`
+	ShellHook string   `cue:"string" json:"shell-hook"`
 }
 
 // ReadConfig reads a devbox config file.

--- a/devbox.go
+++ b/devbox.go
@@ -91,7 +91,8 @@ func (d *Devbox) Build(opts ...docker.BuildOptions) error {
 // environment.
 func (d *Devbox) Plan() *planner.BuildPlan {
 	basePlan := &planner.BuildPlan{
-		Packages: d.cfg.Packages,
+		Packages:  d.cfg.Packages,
+		ShellHook: d.cfg.ShellHook,
 	}
 	return planner.MergePlans(basePlan, planner.Plan(d.srcDir))
 }

--- a/planner/plan.go
+++ b/planner/plan.go
@@ -13,6 +13,7 @@ import (
 // or whether it should be the same structure as devbox.Config.
 type BuildPlan struct {
 	Packages       []string `cue:"[...string]" json:"packages"`
+	ShellHook      string   `cue:"string" json:"shell-hook,omitempty"`
 	InstallCommand string   `cue:"string" json:"install_command,omitempty"`
 	BuildCommand   string   `cue:"string" json:"build_command,omitempty"`
 	StartCommand   string   `cue:"string" json:"start_command,omitempty"`

--- a/tmpl/shell.nix.tmpl
+++ b/tmpl/shell.nix.tmpl
@@ -13,6 +13,7 @@ mkShell {
       export name="devbox"
       export IN_NIX_SHELL=0
       export DEVBOX_SHELL_ENABLED=1
+      {{.ShellHook}}
     '';
   packages = [
   {{- range .Packages}}


### PR DESCRIPTION
## Summary

A simple change to support custom shell hooks. This is something I often need and currently use [direnv](https://github.com/direnv/direnv) for, but I find it convenient to have the configuration within `devbox.json`.

Fully understand if you decide not to pull this in. :)  This is just a very quick hack, and in general, JSON is not that great a fit for storing multi-line strings. But I find devbox very useful, and this feature makes it a bit more useful for me.

## How was it tested?

go build
go test
devbox init
devbox shell
