### PR TITLE
[devbox] Add version detection to the go planner

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/spf13/cobra v1.5.0
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17
+	golang.org/x/mod v0.6.0-dev.0.20211013180041-c96bc1413d57
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -30,5 +31,6 @@ require (
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b // indirect
 	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
 	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c/go.mod h1:UrdRz5enIKZ63M
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 h1:3MTrJm4PyNL9NBqvYDSj3DHl46qQakyfqfWo4jgfaEM=
 golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
+golang.org/x/mod v0.6.0-dev.0.20211013180041-c96bc1413d57 h1:LQmS1nU0twXLA96Kt7U9qtHJEbBk3z6Q0V4UXjZkpr4=
+golang.org/x/mod v0.6.0-dev.0.20211013180041-c96bc1413d57/go.mod h1:3p9vT2HGsQu2K1YbXdKPJLVgG5VJdoTa1poYQBtP1AY=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b h1:0mm1VjtFUOIlE1SbDlwjYaDxZVDP2S5ou6y0gSgXHu8=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -66,6 +68,7 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/planner/go_planner.go
+++ b/planner/go_planner.go
@@ -19,7 +19,7 @@ var versionMap = map[string]string{
 	"1.17": "go_1_17",
 }
 
-const defaultPkg = "go_1_19" // Default for cases where we can't determine a version.
+const defaultPkg = "go_1_19" // Default to "latest" for cases where we can't determine a version.
 
 // GoPlanner implements interface Planner (compile-time check)
 var _ Planner = (*GoPlanner)(nil)
@@ -53,7 +53,7 @@ func (g *GoPlanner) GetPlan(srcDir string) *Plan {
 
 func getGoPackage(srcDir string) string {
 	goModPath := filepath.Join(srcDir, "go.mod")
-	goVersion := getVersion(goModPath)
+	goVersion := parseGoVersion(goModPath)
 	v, ok := versionMap[goVersion]
 	if ok {
 		return v
@@ -64,7 +64,7 @@ func getGoPackage(srcDir string) string {
 	}
 }
 
-func getVersion(gomodPath string) string {
+func parseGoVersion(gomodPath string) string {
 	content, err := os.ReadFile(gomodPath)
 	if err != nil {
 		return ""

--- a/planner/go_planner.go
+++ b/planner/go_planner.go
@@ -4,11 +4,23 @@
 package planner
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"golang.org/x/mod/modfile"
 )
 
 type GoPlanner struct{}
+
+var versionMap = map[string]string{
+	// Map go versions to the corresponding nixpkgs:
+	"1.19": "go_1_19",
+	"1.18": "go",
+	"1.17": "go_1_17",
+}
+
+const defaultPkg = "go_1_19" // Default for cases where we can't determine a version.
 
 // GoPlanner implements interface Planner (compile-time check)
 var _ Planner = (*GoPlanner)(nil)
@@ -23,9 +35,10 @@ func (g *GoPlanner) IsRelevant(srcDir string) bool {
 }
 
 func (g *GoPlanner) GetPlan(srcDir string) *Plan {
+	goPkg := getGoPackage(srcDir)
 	return &Plan{
 		Packages: []string{
-			"go",
+			goPkg,
 		},
 		InstallStage: &Stage{
 			Command: "go get",
@@ -37,6 +50,31 @@ func (g *GoPlanner) GetPlan(srcDir string) *Plan {
 			Command: "./app",
 		},
 	}
+}
+
+func getGoPackage(srcDir string) string {
+	goModPath := filepath.Join(srcDir, "go.mod")
+	goVersion := getVersion(goModPath)
+	v, ok := versionMap[goVersion]
+	if ok {
+		return v
+	} else {
+		// Should we be throwing an error instead, if we don't have a nix package
+		// for the specified version of go?
+		return defaultPkg
+	}
+}
+
+func getVersion(gomodPath string) string {
+	content, err := ioutil.ReadFile(gomodPath)
+	if err != nil {
+		return ""
+	}
+	parsed, err := modfile.ParseLax(gomodPath, content, nil)
+	if err != nil {
+		return ""
+	}
+	return parsed.Go.Version
 }
 
 func fileExists(path string) bool {

--- a/planner/go_planner.go
+++ b/planner/go_planner.go
@@ -4,7 +4,6 @@
 package planner
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -66,7 +65,7 @@ func getGoPackage(srcDir string) string {
 }
 
 func getVersion(gomodPath string) string {
-	content, err := ioutil.ReadFile(gomodPath)
+	content, err := os.ReadFile(gomodPath)
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
## Summary
Add version detection to the go planner based on the contents of `go.mod`. When we don't have a corresponding package in `nixpkgs` we default to `1.19`

## How was it tested?
Compiled and ran against local project.