### PR TITLE
tmpl: fix nil pointer error in Dockerfile.tmpl

### DIFF
--- a/tmpl/Dockerfile.tmpl
+++ b/tmpl/Dockerfile.tmpl
@@ -26,12 +26,16 @@ RUN --mount=type=cache,target=/nix/store,from=base,source=/nix/store \
 # -----------------------------------------------
 
 COPY --link . ./
+{{ if .InstallStage }}
 RUN --mount=type=cache,target=/nix/store,from=base,source=/nix/store {{.InstallStage.Command}}
+{{- end }}
 
 # 3. BUILD STAGE
 #    Compile the source code into an executable.
 # ----------------------------------------------
+{{ if .BuildStage }}
 RUN --mount=type=cache,target=/nix/store,from=base,source=/nix/store {{.BuildStage.Command}}
+{{- end }}
 
 # 4. PACKAGING STAGE
 #    Create a minimal image that contains the executable.
@@ -52,4 +56,6 @@ WORKDIR /app
 
 # We default to ENTRYPOINT instead of CMD as we consider it best practice
 # when the container is wrapping an application or service.
+{{ if .StartStage }}
 ENTRYPOINT {{.StartStage.Command}}
+{{- end }}


### PR DESCRIPTION
## Summary

Check that each stage is set in the plan before attempting to use its command. This fixes a nil pointer error that occurs when using an empty devbox.json in an unsupported language.

## How was it tested?

Ran `devbox plan` in a Go project with an empty `devbox.json`.