### PR TITLE
Do not generate dockerfile on shell command

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -98,13 +98,14 @@ func (d *Devbox) Plan() *planner.Plan {
 // the devbox environment.
 func (d *Devbox) Generate() error {
 	plan := d.Plan()
-	return generate(d.srcDir, plan)
+	return generate(d.srcDir, plan, true)
 }
 
 // Shell generates the devbox environment and launches nix-shell as a child
 // process.
 func (d *Devbox) Shell() error {
-	err := d.Generate()
+	plan := d.Plan()
+	err := generate(d.srcDir, plan, false)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/devbox.go
+++ b/devbox.go
@@ -98,7 +98,7 @@ func (d *Devbox) Plan() *planner.Plan {
 // the devbox environment.
 func (d *Devbox) Generate() error {
 	plan := d.Plan()
-	return generate(d.srcDir, plan, buildFiles)
+	return generate(d.srcDir, plan, append(shellFiles, buildFiles...))
 }
 
 // Shell generates the devbox environment and launches nix-shell as a child

--- a/devbox.go
+++ b/devbox.go
@@ -98,14 +98,14 @@ func (d *Devbox) Plan() *planner.Plan {
 // the devbox environment.
 func (d *Devbox) Generate() error {
 	plan := d.Plan()
-	return generate(d.srcDir, plan, true)
+	return generate(d.srcDir, plan, buildFiles)
 }
 
 // Shell generates the devbox environment and launches nix-shell as a child
 // process.
 func (d *Devbox) Shell() error {
 	plan := d.Plan()
-	err := generate(d.srcDir, plan, false)
+	err := generate(d.srcDir, plan, shellFiles)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/generate.go
+++ b/generate.go
@@ -18,13 +18,12 @@ import (
 //go:embed tmpl/* tmpl/.*
 var tmplFS embed.FS
 
-func generate(rootPath string, plan *planner.Plan, includeBuildFiles bool) error {
-	// TODO: we should also generate a .dockerignore file
-	files := []string{".gitignore", "shell.nix", "default.nix"}
-	if includeBuildFiles {
-		files = append(files, "Dockerfile")
-	}
+var shellFiles = []string{".gitignore", "shell.nix"}
 
+// TODO: we should also generate a .dockerignore file
+var buildFiles = []string{".gitignore", "default.nix", "Dockerfile"}
+
+func generate(rootPath string, plan *planner.Plan, files []string) error {
 	outPath := filepath.Join(rootPath, ".devbox/gen")
 
 	for _, file := range files {

--- a/generate.go
+++ b/generate.go
@@ -18,9 +18,12 @@ import (
 //go:embed tmpl/* tmpl/.*
 var tmplFS embed.FS
 
-func generate(rootPath string, plan *planner.Plan) error {
+func generate(rootPath string, plan *planner.Plan, includeBuildFiles bool) error {
 	// TODO: we should also generate a .dockerignore file
-	files := []string{".gitignore", "Dockerfile", "shell.nix", "default.nix"}
+	files := []string{".gitignore", "shell.nix", "default.nix"}
+	if includeBuildFiles {
+		files = append(files, "Dockerfile")
+	}
 
 	outPath := filepath.Join(rootPath, ".devbox/gen")
 


### PR DESCRIPTION
## Summary
Do not generate dockerfile on shell command, as someone who is using the shell command may not need to use language detector, or need to fill in `install`, `build` and `start` command if the language planner is absent.

## How was it tested?
devbox shell
devbox generate
devbox build