### PR TITLE
Add support for podman

### DIFF
--- a/boxcli/build.go
+++ b/boxcli/build.go
@@ -22,6 +22,8 @@ func BuildCmd() *cobra.Command {
 
 	command.Flags().BoolVar(
 		&flags.NoCache, "no-cache", false, "Do not use a cache")
+	command.Flags().StringVar(
+		&flags.Engine, "engine", "docker", "Engine used to build the container: 'docker', 'podman'")
 
 	return command
 }


### PR DESCRIPTION
## Summary
As requested in https://github.com/jetpack-io/devbox/issues/18 this PR adds support for podman via a new `--engine` flag.
