### PR TITLE
Add discord env variables to release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,5 +86,7 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
+          DISCORD_WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
+          DISCORD_WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TELEMETRY_KEY: ${{ secrets.TELEMETRY_KEY }}


### PR DESCRIPTION
## Summary
We updated the release process to automatically announce on Discord, but we forgot to pass those secrets as environment variables. As a result, the release process fails and I'm unable to release version `0.0.4`. This PR fixes that.

## How was it tested?
I'll test by trying to release again.