### PR TITLE
Generate runtime.nix

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -23,7 +23,7 @@ var tmplFS embed.FS
 var shellFiles = []string{".gitignore", "shell.nix"}
 
 // TODO: we should also generate a .dockerignore file
-var buildFiles = []string{".gitignore", "development.nix", "Dockerfile"}
+var buildFiles = []string{".gitignore", "development.nix", "runtime.nix", "Dockerfile"}
 
 func generate(rootPath string, plan *planner.Plan, files []string) error {
 	outPath := filepath.Join(rootPath, ".devbox/gen")


### PR DESCRIPTION
## Summary
Generate runtime.nix. After a bad merge, this file was no longer being generated, but it's required by my runtime dependencies change.

## How was it tested?
Built locally and ran devbox build against a clean example.