### PR TITLE
Telemetry should send the failure message

### DIFF
--- a/boxcli/midcobra/telemetry.go
+++ b/boxcli/midcobra/telemetry.go
@@ -59,7 +59,11 @@ func (m *telemetryMiddleware) postRun(cmd *cobra.Command, args []string, runErr 
 		return
 	}
 
-	segmentClient, _ := segment.NewWithConfig(m.opts.TelemetryKey, segment.Config{Verbose: false})
+	segmentClient, _ := segment.NewWithConfig(m.opts.TelemetryKey,
+		segment.Config{
+			Verbose:   false,
+			BatchSize: 1, // We're in a short lived program, so batching doesn't make sense
+		})
 
 	defer func() {
 		_ = segmentClient.Close()


### PR DESCRIPTION
## Summary
Telemetry should send the failure message whenever there's an error. That will allow us to understand what the errors are and how to fix them.

## How was it tested?
Development version of segment.