### PR TITLE
[cuecfg] add toml support

### DIFF
--- a/cuecfg/cuecfg.go
+++ b/cuecfg/cuecfg.go
@@ -13,39 +13,39 @@ import (
 
 // TODO: add support for .cue
 
-func Marshal(v any, extension string) ([]byte, error) {
-	err := cuego.Complete(v)
+func Marshal(value any, extension string) ([]byte, error) {
+	err := cuego.Complete(value)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 
 	switch extension {
 	case ".json":
-		return MarshalJSON(v)
+		return MarshalJSON(value)
 	case ".yml", ".yaml":
-		return MarshalYaml(v)
+		return MarshalYaml(value)
 	case ".toml":
-		return MarshalToml(v)
+		return MarshalToml(value)
 	}
 	return nil, errors.Errorf("Unsupported file format '%s' for config file", extension)
 }
 
-func Unmarshal(data []byte, extension string, v any) error {
+func Unmarshal(data []byte, extension string, value any) error {
 	switch extension {
 	case ".json":
-		err := UnmarshalJSON(data, v)
+		err := UnmarshalJSON(data, value)
 		if err != nil {
 			return errors.WithStack(err)
 		}
 		return nil
 	case ".yml", ".yaml":
-		err := UnmarshalYaml(data, v)
+		err := UnmarshalYaml(data, value)
 		if err != nil {
 			return errors.WithStack(err)
 		}
 		return nil
 	case ".toml":
-		err := UnmarshalToml(data, v)
+		err := UnmarshalToml(data, value)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -54,14 +54,14 @@ func Unmarshal(data []byte, extension string, v any) error {
 	return errors.Errorf("Unsupported file format '%s' for config file", extension)
 }
 
-func InitFile(path string, v any) (bool, error) {
+func InitFile(path string, value any) (bool, error) {
 	if _, err := os.Stat(path); err == nil {
 		// File already exists, don't create a new one.
 		// TODO: should we read and write again, in case the schema needs updating?
 		return false, nil
 	} else if errors.Is(err, os.ErrNotExist) {
 		// File does not exist, create a new one:
-		return true, WriteFile(path, v)
+		return true, WriteFile(path, value)
 	} else {
 		// Error case:
 		return false, errors.WithStack(err)
@@ -69,17 +69,17 @@ func InitFile(path string, v any) (bool, error) {
 
 }
 
-func ReadFile(path string, v any) error {
+func ReadFile(path string, value any) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	return Unmarshal(data, filepath.Ext(path), v)
+	return Unmarshal(data, filepath.Ext(path), value)
 }
 
-func WriteFile(path string, v any) error {
-	data, err := Marshal(v, filepath.Ext(path))
+func WriteFile(path string, value any) error {
+	data, err := Marshal(value, filepath.Ext(path))
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/cuecfg/cuecfg.go
+++ b/cuecfg/cuecfg.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// TODO: add support for .cue and possible .toml
+// TODO: add support for .cue
 
 func Marshal(v any, extension string) ([]byte, error) {
 	err := cuego.Complete(v)
@@ -24,6 +24,8 @@ func Marshal(v any, extension string) ([]byte, error) {
 		return MarshalJSON(v)
 	case ".yml", ".yaml":
 		return MarshalYaml(v)
+	case ".toml":
+		return MarshalToml(v)
 	}
 	return nil, errors.Errorf("Unsupported file format '%s' for config file", extension)
 }
@@ -38,6 +40,12 @@ func Unmarshal(data []byte, extension string, v any) error {
 		return nil
 	case ".yml", ".yaml":
 		err := UnmarshalYaml(data, v)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		return nil
+	case ".toml":
+		err := UnmarshalToml(data, v)
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/cuecfg/cuecfg_test.go
+++ b/cuecfg/cuecfg_test.go
@@ -1,0 +1,44 @@
+package cuecfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type MyConfig struct {
+	Version int
+	Name    string
+	Tags    []string
+}
+
+var testTomlCfg = &MyConfig{
+	Version: 2,
+	Name:    "go-toml",
+	Tags:    []string{"go", "toml"},
+}
+
+func TestMarshalToml(t *testing.T) {
+	req := require.New(t)
+
+	bytes, err := Marshal(testTomlCfg, ".toml")
+	req.NoError(err)
+
+	expected := `Version = 2
+Name = 'go-toml'
+Tags = ['go', 'toml']
+`
+	req.Equal(expected, string(bytes))
+}
+
+func TestUnmarshalToml(t *testing.T) {
+	req := require.New(t)
+	tomlStr := `Version = 2
+Name = 'go-toml'
+Tags = ['go', 'toml']
+`
+	cfg := &MyConfig{}
+	err := Unmarshal([]byte(tomlStr), ".toml", cfg)
+	req.NoError(err)
+	req.Equal(testTomlCfg, cfg)
+}

--- a/cuecfg/cuecfg_test.go
+++ b/cuecfg/cuecfg_test.go
@@ -6,17 +6,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type Metadata struct {
+	Tags []string
+}
+
 type MyConfig struct {
 	Version int
 	Name    string
-	Tags    []string
+	Meta    *Metadata
 }
 
 var testTomlCfg = &MyConfig{
 	Version: 2,
 	Name:    "go-toml",
-	Tags:    []string{"go", "toml"},
+	Meta: &Metadata{
+		Tags: []string{"go", "toml"},
+	},
 }
+
+var testTomlStr = `Version = 2
+Name = 'go-toml'
+
+[Meta]
+Tags = ['go', 'toml']
+`
 
 func TestMarshalToml(t *testing.T) {
 	req := require.New(t)
@@ -24,21 +37,13 @@ func TestMarshalToml(t *testing.T) {
 	bytes, err := Marshal(testTomlCfg, ".toml")
 	req.NoError(err)
 
-	expected := `Version = 2
-Name = 'go-toml'
-Tags = ['go', 'toml']
-`
-	req.Equal(expected, string(bytes))
+	req.Equal(testTomlStr, string(bytes))
 }
 
 func TestUnmarshalToml(t *testing.T) {
 	req := require.New(t)
-	tomlStr := `Version = 2
-Name = 'go-toml'
-Tags = ['go', 'toml']
-`
 	cfg := &MyConfig{}
-	err := Unmarshal([]byte(tomlStr), ".toml", cfg)
+	err := Unmarshal([]byte(testTomlStr), ".toml", cfg)
 	req.NoError(err)
 	req.Equal(testTomlCfg, cfg)
 }

--- a/cuecfg/toml.go
+++ b/cuecfg/toml.go
@@ -1,0 +1,19 @@
+// Copyright 2022 Jetpack Technologies Inc and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package cuecfg
+
+import (
+	"github.com/pelletier/go-toml/v2"
+)
+
+// TODO: consider using cue's JSON marshaller instead of
+// "encoding/json" ... it might have extra functionality related
+// to the cue language.
+func MarshalToml(v interface{}) ([]byte, error) {
+	return toml.Marshal(v)
+}
+
+func UnmarshalToml(data []byte, v interface{}) error {
+	return toml.Unmarshal(data, v)
+}

--- a/cuecfg/toml.go
+++ b/cuecfg/toml.go
@@ -7,9 +7,6 @@ import (
 	"github.com/pelletier/go-toml/v2"
 )
 
-// TODO: consider using cue's JSON marshaller instead of
-// "encoding/json" ... it might have extra functionality related
-// to the cue language.
 func MarshalToml(v interface{}) ([]byte, error) {
 	return toml.Marshal(v)
 }


### PR DESCRIPTION
## Summary

We need this to parse Cargo.toml files.

I chose this  library: [github.com/pelletier/go-toml](https://github.com/pelletier/go-toml). 
 - The alternative is https://github.com/BurntSushi/toml. This one has more github stars than `go-toml`.
 - `go-toml`'s interface is more similar to `encoding/json`, and is also used by `viper`.

Also, changed `v` to `value` in `cuecfg.go` to address linter complaint.

## How was it tested?

`go test ./cuecfg/...`
