### PR TITLE
Change the merging logic of devbox.json and planners

### DIFF
--- a/boxcli/plan.go
+++ b/boxcli/plan.go
@@ -30,7 +30,10 @@ func runPlanCmd(cmd *cobra.Command, args []string) error {
 		return errors.WithStack(err)
 	}
 
-	plan := box.Plan()
+	plan, err := box.Plan()
+	if err != nil {
+		return errors.WithStack(err)
+	}
 	if plan.Invalid() {
 		return plan.Error()
 	}

--- a/devbox.go
+++ b/devbox.go
@@ -106,7 +106,12 @@ func (d *Devbox) Plan() *plansdk.Plan {
 		RuntimePackages: d.cfg.Packages,
 		SharedPlan:      d.cfg.SharedPlan,
 	}
-	return plansdk.MergePlans(basePlan, planner.GetPlan(d.srcDir))
+	plannerPlan := planner.GetPlan(d.srcDir)
+
+	plan := plansdk.MergePlans(basePlan, plannerPlan)
+	plan.SharedPlan = plansdk.OverrideSharedPlan(basePlan, plannerPlan)
+
+	return plan
 }
 
 // Generate creates the directory of Nix files and the Dockerfile that define

--- a/devbox.go
+++ b/devbox.go
@@ -101,17 +101,13 @@ func (d *Devbox) Build(opts ...docker.BuildOptions) error {
 // Plan creates a plan of the actions that devbox will take to generate its
 // environment.
 func (d *Devbox) Plan() *plansdk.Plan {
-	basePlan := &plansdk.Plan{
+	userPlan := &plansdk.Plan{
 		DevPackages:     d.cfg.Packages,
 		RuntimePackages: d.cfg.Packages,
 		SharedPlan:      d.cfg.SharedPlan,
 	}
-	plannerPlan := planner.GetPlan(d.srcDir)
 
-	plan := plansdk.MergePlans(basePlan, plannerPlan)
-	plan.SharedPlan = plansdk.OverrideSharedPlan(basePlan, plannerPlan)
-
-	return plan
+	return plansdk.MergeUserPlan(userPlan, planner.GetPlan(d.srcDir))
 }
 
 // Generate creates the directory of Nix files and the Dockerfile that define

--- a/devbox.go
+++ b/devbox.go
@@ -100,7 +100,7 @@ func (d *Devbox) Build(opts ...docker.BuildOptions) error {
 
 // Plan creates a plan of the actions that devbox will take to generate its
 // environment.
-func (d *Devbox) Plan() *plansdk.Plan {
+func (d *Devbox) Plan() (*plansdk.Plan, error) {
 	userPlan := &plansdk.Plan{
 		DevPackages:     d.cfg.Packages,
 		RuntimePackages: d.cfg.Packages,
@@ -113,7 +113,10 @@ func (d *Devbox) Plan() *plansdk.Plan {
 // Generate creates the directory of Nix files and the Dockerfile that define
 // the devbox environment.
 func (d *Devbox) Generate() error {
-	plan := d.Plan()
+	plan, err := d.Plan()
+	if err != nil {
+		return errors.WithStack(err)
+	}
 	if plan.Invalid() {
 		return plan.Error()
 	}
@@ -123,11 +126,14 @@ func (d *Devbox) Generate() error {
 // Shell generates the devbox environment and launches nix-shell as a child
 // process.
 func (d *Devbox) Shell() error {
-	plan := d.Plan()
+	plan, err := d.Plan()
+	if err != nil {
+		return errors.WithStack(err)
+	}
 	if plan.Invalid() {
 		return plan.Error()
 	}
-	err := generate(d.srcDir, plan, shellFiles)
+	err = generate(d.srcDir, plan, shellFiles)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/devbox_test.go
+++ b/devbox_test.go
@@ -35,7 +35,8 @@ func testExample(t *testing.T, testPath string) {
 
 		box, err := Open(baseDir)
 		assert.NoErrorf(err, "%s should be a valid devbox project", baseDir)
-		plan := box.Plan()
+		plan, err := box.Plan()
+		assert.NoError(err, "devbox plan should not fail")
 
 		err = box.Generate()
 		assert.NoError(err, "devbox generate should not fail")

--- a/planner/languages/golang/golang_planner.go
+++ b/planner/languages/golang/golang_planner.go
@@ -42,13 +42,15 @@ func (p *Planner) GetPlan(srcDir string) *plansdk.Plan {
 		},
 		SharedPlan: plansdk.SharedPlan{
 			InstallStage: &plansdk.Stage{
-				Command: "go get",
+				InputFiles: []string{"."},
+				Command:    "go get",
 			},
 			BuildStage: &plansdk.Stage{
 				Command: "CGO_ENABLED=0 go build -o app",
 			},
 			StartStage: &plansdk.Stage{
-				Command: "./app",
+				InputFiles: []string{"."},
+				Command:    "./app",
 			},
 		},
 	}

--- a/planner/languages/javascript/nodejs_planner.go
+++ b/planner/languages/javascript/nodejs_planner.go
@@ -49,7 +49,8 @@ func (p *Planner) GetPlan(srcDir string) *plansdk.Plan {
 			},
 
 			StartStage: &plansdk.Stage{
-				Command: p.startCommand(pkgManager, project),
+				InputFiles: []string{"."},
+				Command:    p.startCommand(pkgManager, project),
 			},
 		},
 	}

--- a/planner/languages/php/php_planner.go
+++ b/planner/languages/php/php_planner.go
@@ -56,10 +56,12 @@ func (p *Planner) GetPlan(srcDir string) *plansdk.Plan {
 	}
 
 	plan.InstallStage = &plansdk.Stage{
-		Command: "composer install --no-dev --no-ansi",
+		InputFiles: []string{"."},
+		Command:    "composer install --no-dev --no-ansi",
 	}
 	plan.StartStage = &plansdk.Stage{
-		Command: "php -S 0.0.0.0:8080 -t public",
+		InputFiles: []string{"."},
+		Command:    "php -S 0.0.0.0:8080 -t public",
 	}
 	return plan
 }

--- a/planner/languages/python/python_poetry_planner.go
+++ b/planner/languages/python/python_poetry_planner.go
@@ -45,6 +45,7 @@ func (p *Planner) GetPlan(srcDir string) *plansdk.Plan {
 	}
 
 	plan.InstallStage = &plansdk.Stage{
+		InputFiles: []string{"."},
 		// pex is is incompatible with certain less common python versions,
 		// but because versions are sometimes expressed open-ended (e.g. ^3.10)
 		// It will cause `poetry add pex` to fail. One solution is to use: --version
@@ -53,7 +54,10 @@ func (p *Planner) GetPlan(srcDir string) *plansdk.Plan {
 			"poetry install --no-dev -n --no-ansi",
 	}
 	plan.BuildStage = &plansdk.Stage{Command: p.buildCommand(srcDir)}
-	plan.StartStage = &plansdk.Stage{Command: "python ./app.pex"}
+	plan.StartStage = &plansdk.Stage{
+		InputFiles: []string{"."},
+		Command:    "python ./app.pex",
+	}
 	return plan
 }
 

--- a/planner/plansdk/plansdk.go
+++ b/planner/plansdk/plansdk.go
@@ -155,7 +155,7 @@ func findBuildablePlan(plans ...*Plan) *Plan {
 	return &Plan{}
 }
 
-func MergeUserPlan(userPlan *Plan, automatedPlan *Plan) *Plan {
+func MergeUserPlan(userPlan *Plan, automatedPlan *Plan) (*Plan, error) {
 	plan := MergePlans(userPlan, automatedPlan)
 	sharedPlan := &Plan{
 		SharedPlan: userPlan.SharedPlan,
@@ -164,12 +164,12 @@ func MergeUserPlan(userPlan *Plan, automatedPlan *Plan) *Plan {
 	//   if empty, will inherit the corresponding fields in the automatedPlan
 	//   if set, will override corresponding automatedPlan fields
 	if err := mergo.Merge(sharedPlan, automatedPlan); err != nil {
-		panic(err) // TODO: propagate error.
+		return nil, err
 	}
 
 	plan.SharedPlan = sharedPlan.SharedPlan
 
-	return plan
+	return plan, nil
 }
 
 func (p PlanError) MarshalJSON() ([]byte, error) {

--- a/planner/plansdk/plansdk_test.go
+++ b/planner/plansdk/plansdk_test.go
@@ -22,19 +22,7 @@ func TestMergePlans(t *testing.T) {
 	expected := &Plan{
 		DevPackages:     []string{"foo", "bar", "baz"},
 		RuntimePackages: []string{"a", "b", "c"},
-		SharedPlan: SharedPlan{
-			InstallStage: &Stage{
-				Command:    "",
-				InputFiles: []string{"."},
-			},
-			BuildStage: &Stage{
-				Command: "",
-			},
-			StartStage: &Stage{
-				Command:    "",
-				InputFiles: []string{"."},
-			},
-		},
+		SharedPlan:      SharedPlan{},
 	}
 	actual := MergePlans(plan1, plan2)
 	assert.Equal(t, expected, actual)
@@ -58,16 +46,8 @@ func TestMergePlans(t *testing.T) {
 		DevPackages:     []string{},
 		RuntimePackages: []string{},
 		SharedPlan: SharedPlan{
-			InstallStage: &Stage{
-				Command:    "",
-				InputFiles: []string{"."},
-			},
 			BuildStage: &Stage{
 				Command: "plan1",
-			},
-			StartStage: &Stage{
-				Command:    "",
-				InputFiles: []string{"."},
 			},
 		},
 	}
@@ -93,18 +73,131 @@ func TestMergePlans(t *testing.T) {
 		RuntimePackages: []string{},
 		SharedPlan: SharedPlan{
 			InstallStage: &Stage{
-				Command:    "",
 				InputFiles: []string{"package.json"},
 			},
-			BuildStage: &Stage{
-				Command: "",
-			},
 			StartStage: &Stage{
-				Command:    "",
 				InputFiles: []string{"input"},
 			},
 		},
 	}
 	actual = MergePlans(plan1, plan2)
 	assert.Equal(t, expected, actual)
+}
+
+func TestOverrideSharedPlans(t *testing.T) {
+	plannerPlan := &Plan{
+		SharedPlan: SharedPlan{
+			InstallStage: &Stage{
+				InputFiles: []string{"package.json"},
+				Command:    "npm install",
+			},
+			BuildStage: &Stage{
+				InputFiles: []string{"."},
+			},
+			StartStage: &Stage{
+				InputFiles: []string{"."},
+				Command:    "npm start",
+			},
+		},
+	}
+	cases := []struct {
+		name string
+		in   *Plan
+		out  *Plan
+	}{
+		{
+			name: "empty base plan",
+			in: &Plan{
+				SharedPlan: SharedPlan{},
+			},
+			out: &Plan{
+				SharedPlan: SharedPlan{
+					InstallStage: &Stage{
+						InputFiles: []string{"package.json"},
+						Command:    "npm install",
+					},
+					BuildStage: &Stage{
+						InputFiles: []string{"."},
+					},
+					StartStage: &Stage{
+						InputFiles: []string{"."},
+						Command:    "npm start",
+					},
+				},
+			},
+		},
+		{
+			name: "different input files",
+			in: &Plan{
+				SharedPlan: SharedPlan{
+					InstallStage: &Stage{
+						InputFiles: []string{"package.json", "yarn.lock"},
+						Command:    "",
+					},
+					BuildStage: &Stage{
+						InputFiles: []string{"."},
+						Command:    "",
+					},
+					StartStage: &Stage{
+						InputFiles: []string{"."},
+						Command:    "npm start",
+					},
+				},
+			},
+			out: &Plan{
+				SharedPlan: SharedPlan{
+					InstallStage: &Stage{
+						InputFiles: []string{"package.json", "yarn.lock"},
+						Command:    "npm install",
+					},
+					BuildStage: &Stage{
+						InputFiles: []string{"."},
+						Command:    "",
+					},
+					StartStage: &Stage{
+						InputFiles: []string{"."},
+						Command:    "npm start",
+					},
+				},
+			},
+		},
+		{
+			name: "custom build command",
+			in: &Plan{
+				SharedPlan: SharedPlan{
+					InstallStage: &Stage{
+						InputFiles: []string{"app"},
+					},
+					BuildStage: &Stage{
+						Command: "npm run build",
+					},
+				},
+			},
+			out: &Plan{
+				SharedPlan: SharedPlan{
+					InstallStage: &Stage{
+						InputFiles: []string{"app"},
+						Command:    "npm install",
+					},
+					BuildStage: &Stage{
+						InputFiles: []string{"."},
+						Command:    "npm run build",
+					},
+					StartStage: &Stage{
+						InputFiles: []string{"."},
+						Command:    "npm start",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			got := OverrideSharedPlan(tc.in, plannerPlan)
+
+			assert.Equal(tc.out.SharedPlan, got, "SharedPlan should match")
+		})
+	}
 }

--- a/planner/plansdk/plansdk_test.go
+++ b/planner/plansdk/plansdk_test.go
@@ -84,8 +84,10 @@ func TestMergePlans(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
-func TestOverrideSharedPlans(t *testing.T) {
+func TestMergeUserPlans(t *testing.T) {
 	plannerPlan := &Plan{
+		DevPackages:     []string{"nodejs"},
+		RuntimePackages: []string{"nodejs"},
 		SharedPlan: SharedPlan{
 			InstallStage: &Stage{
 				InputFiles: []string{"package.json"},
@@ -111,6 +113,8 @@ func TestOverrideSharedPlans(t *testing.T) {
 				SharedPlan: SharedPlan{},
 			},
 			out: &Plan{
+				DevPackages:     []string{"nodejs"},
+				RuntimePackages: []string{"nodejs"},
 				SharedPlan: SharedPlan{
 					InstallStage: &Stage{
 						InputFiles: []string{"package.json"},
@@ -129,6 +133,8 @@ func TestOverrideSharedPlans(t *testing.T) {
 		{
 			name: "different input files",
 			in: &Plan{
+				DevPackages:     []string{"nodejs", "yarn"},
+				RuntimePackages: []string{"nodejs", "yarn"},
 				SharedPlan: SharedPlan{
 					InstallStage: &Stage{
 						InputFiles: []string{"package.json", "yarn.lock"},
@@ -145,6 +151,8 @@ func TestOverrideSharedPlans(t *testing.T) {
 				},
 			},
 			out: &Plan{
+				DevPackages:     []string{"nodejs", "yarn"},
+				RuntimePackages: []string{"nodejs", "yarn"},
 				SharedPlan: SharedPlan{
 					InstallStage: &Stage{
 						InputFiles: []string{"package.json", "yarn.lock"},
@@ -174,6 +182,8 @@ func TestOverrideSharedPlans(t *testing.T) {
 				},
 			},
 			out: &Plan{
+				DevPackages:     []string{"nodejs"},
+				RuntimePackages: []string{"nodejs"},
 				SharedPlan: SharedPlan{
 					InstallStage: &Stage{
 						InputFiles: []string{"app"},
@@ -195,9 +205,9 @@ func TestOverrideSharedPlans(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			assert := assert.New(t)
-			got := OverrideSharedPlan(tc.in, plannerPlan)
+			got := MergeUserPlan(tc.in, plannerPlan)
 
-			assert.Equal(tc.out.SharedPlan, got, "SharedPlan should match")
+			assert.Equal(tc.out, got, "plans should match")
 		})
 	}
 }

--- a/planner/plansdk/plansdk_test.go
+++ b/planner/plansdk/plansdk_test.go
@@ -134,7 +134,7 @@ func TestMergeUserPlans(t *testing.T) {
 			name: "different input files",
 			in: &Plan{
 				DevPackages:     []string{"nodejs", "yarn"},
-				RuntimePackages: []string{"nodejs", "yarn"},
+				RuntimePackages: []string{"nodejs"},
 				SharedPlan: SharedPlan{
 					InstallStage: &Stage{
 						InputFiles: []string{"package.json", "yarn.lock"},
@@ -152,7 +152,7 @@ func TestMergeUserPlans(t *testing.T) {
 			},
 			out: &Plan{
 				DevPackages:     []string{"nodejs", "yarn"},
-				RuntimePackages: []string{"nodejs", "yarn"},
+				RuntimePackages: []string{"nodejs"},
 				SharedPlan: SharedPlan{
 					InstallStage: &Stage{
 						InputFiles: []string{"package.json", "yarn.lock"},
@@ -205,8 +205,9 @@ func TestMergeUserPlans(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			assert := assert.New(t)
-			got := MergeUserPlan(tc.in, plannerPlan)
+			got, err := MergeUserPlan(tc.in, plannerPlan)
 
+			assert.NoError(err)
 			assert.Equal(tc.out, got, "plans should match")
 		})
 	}

--- a/testdata/python/poetry-no-entrypoint/plan.json
+++ b/testdata/python/poetry-no-entrypoint/plan.json
@@ -1,18 +1,12 @@
 {
   "install_stage": {
-    "command": "",
-    "input_files": [
-      "."
-    ]
+    "command": ""
   },
   "build_stage": {
     "command": ""
   },
   "start_stage": {
-    "command": "",
-    "input_files": [
-      "."
-    ]
+    "command": ""
   },
   "dev_packages": [
     "python310",

--- a/testdata/python/poetry-no-lock-file/plan.json
+++ b/testdata/python/poetry-no-lock-file/plan.json
@@ -1,18 +1,12 @@
 {
   "install_stage": {
-    "command": "",
-    "input_files": [
-      "."
-    ]
+    "command": ""
   },
   "build_stage": {
     "command": ""
   },
   "start_stage": {
-    "command": "",
-    "input_files": [
-      "."
-    ]
+    "command": ""
   },
   "dev_packages": [
     "python310",


### PR DESCRIPTION
## Summary
We have decided on the following merging logic between `devbox.json` and `planners`:

- devbox.json `packages` field will merge with planners `devPackages` and `runtimePackages`. Merge will be `appendWithSlice`.
- devbox.json `start_stage`, `build_stage` and `install_stage` subfields (shared plan):
  - if empty, will inherit the corresponding planners fields
  - if set, will override corresponding planners fields

TODO (Will follow up with separate PRs)
- devbox.json schema would be a separate one from the planner

## How was it tested?
go build -o devbox cmd/devbox/main.go
devbox plan