### PR TITLE
nix: allow user's shellrc to update PATH; add tests for shellrc template

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	cuelang.org/go v0.4.3
 	github.com/bmatcuk/doublestar/v4 v4.2.0
 	github.com/denisbrodbeck/machineid v1.0.1
+	github.com/fatih/color v1.13.0
+	github.com/google/go-cmp v0.4.0
 	github.com/imdario/mergo v0.3.13
 	github.com/pelletier/go-toml/v2 v2.0.5
 	github.com/pkg/errors v0.9.1
@@ -24,7 +26,6 @@ require (
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/cockroachdb/apd/v2 v2.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/fatih/color v1.13.0 // indirect
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/kr/text v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,7 @@ github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
+github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
@@ -81,6 +82,7 @@ golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/nix/shell_test.go
+++ b/nix/shell_test.go
@@ -1,0 +1,89 @@
+package nix
+
+import (
+	"errors"
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// update overwrites golden files with the new test results.
+var update = flag.Bool("update", false, "update the golden files with the test results")
+
+func TestWriteDevboxShellrc(t *testing.T) {
+	testdirs, err := filepath.Glob("testdata/shellrc/*")
+	if err != nil {
+		t.Fatal("Error globbing testdata:", err)
+	}
+
+	// Load up all the necessary data from each testdata/shellrc directory
+	// into a slice of tests cases.
+	tests := make([]struct {
+		name            string
+		env             []string
+		hook            string
+		shellrcPath     string
+		goldShellrcPath string
+		goldShellrc     []byte
+	}, len(testdirs))
+	for i, path := range testdirs {
+		test := &tests[i]
+		test.name = filepath.Base(path)
+		if b, err := os.ReadFile(filepath.Join(path, "env")); err == nil {
+			test.env = strings.Split(string(b), "\n")
+		}
+		if b, err := os.ReadFile(filepath.Join(path, "hook")); err == nil {
+			test.hook = string(b)
+		}
+		test.shellrcPath = filepath.Join(path, "shellrc")
+		if _, err := os.Stat(test.shellrcPath); errors.Is(err, os.ErrNotExist) {
+			test.shellrcPath = "noshellrc"
+		}
+		test.goldShellrcPath = filepath.Join(path, "shellrc.golden")
+		test.goldShellrc, err = os.ReadFile(test.goldShellrcPath)
+		if err != nil {
+			t.Fatal("Got error reading golden file:", err)
+		}
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gotPath, err := writeDevboxShellrc(test.shellrcPath, test.hook, test.env)
+			if err != nil {
+				t.Fatal("Got writeDevboxShellrc error:", err)
+			}
+			gotShellrc, err := os.ReadFile(gotPath)
+			if err != nil {
+				t.Fatalf("Got error reading generated shellrc at %s: %v", gotPath, err)
+			}
+
+			// Overwrite the golden file if the -update flag was
+			// set, and then proceed normally. The test should
+			// always pass in this case.
+			if *update {
+				err = os.WriteFile(test.goldShellrcPath, gotShellrc, 0666)
+				if err != nil {
+					t.Error("Error updating golden files:", err)
+				}
+			}
+			goldShellrc, err := os.ReadFile(test.goldShellrcPath)
+			if err != nil {
+				t.Fatal("Got error reading golden file:", err)
+			}
+			diff := cmp.Diff(goldShellrc, gotShellrc)
+			if diff != "" {
+				t.Errorf(strings.TrimSpace(`
+Generated shellrc != shellrc.golden (-shellrc.golden +shellrc):
+
+	%s
+If the new shellrc is correct, you can update the golden file with:
+
+	go test -run "^%s$" -update`), diff, t.Name())
+			}
+		})
+	}
+}

--- a/nix/shellrc.tmpl
+++ b/nix/shellrc.tmpl
@@ -12,21 +12,34 @@
 // before and after the user's shellrc. These commands are in the
 // "Devbox Pre/Post-init Hook" sections.
 //
-// The devbox pre/post-init hooks assume two environment variables are already
-// set:
+// The devbox pre/post-init hooks assume a PURE_NIX_PATH environment variable is
+// already set by the shell hook in shell.nix.tmpl. It preserves the PATH set by
+// Nix's "pure" shell mode.
 //
-// - ORIGINAL_PATH - embedded into the command built by Shell.execCommand. It
-//                   preserves the PATH at the time `devbox shell` is invoked.
-// - PURE_NIX_PATH - set by the shell hook in shell.nix.tmpl. It preserves the
-//                   PATH set by Nix's "pure" shell mode.
+// This file is useful for debugging shell errors, so try to keep the generated
+// content readable.
 
  */ -}}
 
 # Begin Devbox Pre-init Hook
 
-# Update the $PATH so that the user's init script has access to all of their
-# non-devbox programs.
-export PATH="$PURE_NIX_PATH:$ORIGINAL_PATH"
+# Don't allow the user's shellrc to re-source Nix since we're already in Nix.
+export __ETC_PROFILE_NIX_SOURCED=1
+
+# Put the Nix packages at the beginning of the PATH to give them priority over
+# programs outside of devbox.
+export PATH="$PURE_NIX_PATH"
+
+{{- if .Paths }}
+
+# Append any paths that were in the environment at the time the user launched
+# devbox. This gives the shell access to non-devbox programs, while still
+# preferring the ones that Nix installed.
+{{- range .Paths }}
+PATH="$PATH:{{ . }}"
+{{- end }}
+
+{{- end }}
 
 # End Devbox Pre-init Hook
 
@@ -44,7 +57,7 @@ export PATH="$PURE_NIX_PATH:$ORIGINAL_PATH"
 
 # Update the $PATH again so that the Nix packages take priority over the
 # programs outside of devbox.
-export PATH="$PURE_NIX_PATH:$ORIGINAL_PATH"
+export PATH="$PURE_NIX_PATH:$PATH"
 
 # Prepend to the prompt to make it clear we're in a devbox shell.
 export PS1="(devbox) $PS1"

--- a/nix/testdata/shellrc/basic/env
+++ b/nix/testdata/shellrc/basic/env
@@ -1,0 +1,1 @@
+PATH=/a/test/path

--- a/nix/testdata/shellrc/basic/hook
+++ b/nix/testdata/shellrc/basic/hook
@@ -1,0 +1,1 @@
+echo "Hello from a devbox shell hook!"

--- a/nix/testdata/shellrc/basic/shellrc
+++ b/nix/testdata/shellrc/basic/shellrc
@@ -1,0 +1,37 @@
+# Set up the prompt
+
+autoload -Uz promptinit
+promptinit
+#prompt adam1
+
+setopt histignorealldups sharehistory
+
+# Use emacs keybindings even if our EDITOR is set to vi
+bindkey -e
+
+# Keep 1000 lines of history within the shell and save it to ~/.zsh_history:
+HISTSIZE=1000
+SAVEHIST=1000
+HISTFILE=~/.zsh_history
+
+# Use modern completion system
+autoload -Uz compinit
+compinit
+
+zstyle ':completion:*' auto-description 'specify: %d'
+zstyle ':completion:*' completer _expand _complete _correct _approximate
+zstyle ':completion:*' format 'Completing %d'
+zstyle ':completion:*' group-name ''
+zstyle ':completion:*' menu select=2
+eval "$(dircolors -b)"
+zstyle ':completion:*:default' list-colors ${(s.:.)LS_COLORS}
+zstyle ':completion:*' list-colors ''
+zstyle ':completion:*' list-prompt %SAt %p: Hit TAB for more, or the character to insert%s
+zstyle ':completion:*' matcher-list '' 'm:{a-z}={A-Z}' 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=* l:|=*'
+zstyle ':completion:*' menu select=long
+zstyle ':completion:*' select-prompt %SScrolling active: current selection at %p%s
+zstyle ':completion:*' use-compctl false
+zstyle ':completion:*' verbose true
+
+zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#)*=0=01;31'
+zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'

--- a/nix/testdata/shellrc/basic/shellrc.golden
+++ b/nix/testdata/shellrc/basic/shellrc.golden
@@ -1,0 +1,74 @@
+# Begin Devbox Pre-init Hook
+
+# Don't allow the user's shellrc to re-source Nix since we're already in Nix.
+export __ETC_PROFILE_NIX_SOURCED=1
+
+# Put the Nix packages at the beginning of the PATH to give them priority over
+# programs outside of devbox.
+export PATH="$PURE_NIX_PATH"
+
+# Append any paths that were in the environment at the time the user launched
+# devbox. This gives the shell access to non-devbox programs, while still
+# preferring the ones that Nix installed.
+PATH="$PATH:/a/test/path"
+
+# End Devbox Pre-init Hook
+
+# Begin testdata/shellrc/basic/shellrc
+
+# Set up the prompt
+
+autoload -Uz promptinit
+promptinit
+#prompt adam1
+
+setopt histignorealldups sharehistory
+
+# Use emacs keybindings even if our EDITOR is set to vi
+bindkey -e
+
+# Keep 1000 lines of history within the shell and save it to ~/.zsh_history:
+HISTSIZE=1000
+SAVEHIST=1000
+HISTFILE=~/.zsh_history
+
+# Use modern completion system
+autoload -Uz compinit
+compinit
+
+zstyle ':completion:*' auto-description 'specify: %d'
+zstyle ':completion:*' completer _expand _complete _correct _approximate
+zstyle ':completion:*' format 'Completing %d'
+zstyle ':completion:*' group-name ''
+zstyle ':completion:*' menu select=2
+eval "$(dircolors -b)"
+zstyle ':completion:*:default' list-colors ${(s.:.)LS_COLORS}
+zstyle ':completion:*' list-colors ''
+zstyle ':completion:*' list-prompt %SAt %p: Hit TAB for more, or the character to insert%s
+zstyle ':completion:*' matcher-list '' 'm:{a-z}={A-Z}' 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=* l:|=*'
+zstyle ':completion:*' menu select=long
+zstyle ':completion:*' select-prompt %SScrolling active: current selection at %p%s
+zstyle ':completion:*' use-compctl false
+zstyle ':completion:*' verbose true
+
+zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#)*=0=01;31'
+zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
+
+# End testdata/shellrc/basic/shellrc
+
+# Begin Devbox Post-init Hook
+
+# Update the $PATH again so that the Nix packages take priority over the
+# programs outside of devbox.
+export PATH="$PURE_NIX_PATH:$PATH"
+
+# Prepend to the prompt to make it clear we're in a devbox shell.
+export PS1="(devbox) $PS1"
+
+# End Devbox Post-init Hook
+
+# Begin Devbox User Hook
+
+echo "Hello from a devbox shell hook!"
+
+# End Devbox User Hook

--- a/nix/testdata/shellrc/nohook/env
+++ b/nix/testdata/shellrc/nohook/env
@@ -1,0 +1,1 @@
+PATH=/a/test/path

--- a/nix/testdata/shellrc/nohook/shellrc
+++ b/nix/testdata/shellrc/nohook/shellrc
@@ -1,0 +1,37 @@
+# Set up the prompt
+
+autoload -Uz promptinit
+promptinit
+#prompt adam1
+
+setopt histignorealldups sharehistory
+
+# Use emacs keybindings even if our EDITOR is set to vi
+bindkey -e
+
+# Keep 1000 lines of history within the shell and save it to ~/.zsh_history:
+HISTSIZE=1000
+SAVEHIST=1000
+HISTFILE=~/.zsh_history
+
+# Use modern completion system
+autoload -Uz compinit
+compinit
+
+zstyle ':completion:*' auto-description 'specify: %d'
+zstyle ':completion:*' completer _expand _complete _correct _approximate
+zstyle ':completion:*' format 'Completing %d'
+zstyle ':completion:*' group-name ''
+zstyle ':completion:*' menu select=2
+eval "$(dircolors -b)"
+zstyle ':completion:*:default' list-colors ${(s.:.)LS_COLORS}
+zstyle ':completion:*' list-colors ''
+zstyle ':completion:*' list-prompt %SAt %p: Hit TAB for more, or the character to insert%s
+zstyle ':completion:*' matcher-list '' 'm:{a-z}={A-Z}' 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=* l:|=*'
+zstyle ':completion:*' menu select=long
+zstyle ':completion:*' select-prompt %SScrolling active: current selection at %p%s
+zstyle ':completion:*' use-compctl false
+zstyle ':completion:*' verbose true
+
+zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#)*=0=01;31'
+zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'

--- a/nix/testdata/shellrc/nohook/shellrc.golden
+++ b/nix/testdata/shellrc/nohook/shellrc.golden
@@ -1,0 +1,68 @@
+# Begin Devbox Pre-init Hook
+
+# Don't allow the user's shellrc to re-source Nix since we're already in Nix.
+export __ETC_PROFILE_NIX_SOURCED=1
+
+# Put the Nix packages at the beginning of the PATH to give them priority over
+# programs outside of devbox.
+export PATH="$PURE_NIX_PATH"
+
+# Append any paths that were in the environment at the time the user launched
+# devbox. This gives the shell access to non-devbox programs, while still
+# preferring the ones that Nix installed.
+PATH="$PATH:/a/test/path"
+
+# End Devbox Pre-init Hook
+
+# Begin testdata/shellrc/nohook/shellrc
+
+# Set up the prompt
+
+autoload -Uz promptinit
+promptinit
+#prompt adam1
+
+setopt histignorealldups sharehistory
+
+# Use emacs keybindings even if our EDITOR is set to vi
+bindkey -e
+
+# Keep 1000 lines of history within the shell and save it to ~/.zsh_history:
+HISTSIZE=1000
+SAVEHIST=1000
+HISTFILE=~/.zsh_history
+
+# Use modern completion system
+autoload -Uz compinit
+compinit
+
+zstyle ':completion:*' auto-description 'specify: %d'
+zstyle ':completion:*' completer _expand _complete _correct _approximate
+zstyle ':completion:*' format 'Completing %d'
+zstyle ':completion:*' group-name ''
+zstyle ':completion:*' menu select=2
+eval "$(dircolors -b)"
+zstyle ':completion:*:default' list-colors ${(s.:.)LS_COLORS}
+zstyle ':completion:*' list-colors ''
+zstyle ':completion:*' list-prompt %SAt %p: Hit TAB for more, or the character to insert%s
+zstyle ':completion:*' matcher-list '' 'm:{a-z}={A-Z}' 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=* l:|=*'
+zstyle ':completion:*' menu select=long
+zstyle ':completion:*' select-prompt %SScrolling active: current selection at %p%s
+zstyle ':completion:*' use-compctl false
+zstyle ':completion:*' verbose true
+
+zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#)*=0=01;31'
+zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
+
+# End testdata/shellrc/nohook/shellrc
+
+# Begin Devbox Post-init Hook
+
+# Update the $PATH again so that the Nix packages take priority over the
+# programs outside of devbox.
+export PATH="$PURE_NIX_PATH:$PATH"
+
+# Prepend to the prompt to make it clear we're in a devbox shell.
+export PS1="(devbox) $PS1"
+
+# End Devbox Post-init Hook

--- a/nix/testdata/shellrc/noshellrc/env
+++ b/nix/testdata/shellrc/noshellrc/env
@@ -1,0 +1,1 @@
+PATH=/a/test/path

--- a/nix/testdata/shellrc/noshellrc/hook
+++ b/nix/testdata/shellrc/noshellrc/hook
@@ -1,0 +1,1 @@
+echo "Hello from a devbox shell hook!"

--- a/nix/testdata/shellrc/noshellrc/shellrc.golden
+++ b/nix/testdata/shellrc/noshellrc/shellrc.golden
@@ -1,0 +1,32 @@
+# Begin Devbox Pre-init Hook
+
+# Don't allow the user's shellrc to re-source Nix since we're already in Nix.
+export __ETC_PROFILE_NIX_SOURCED=1
+
+# Put the Nix packages at the beginning of the PATH to give them priority over
+# programs outside of devbox.
+export PATH="$PURE_NIX_PATH"
+
+# Append any paths that were in the environment at the time the user launched
+# devbox. This gives the shell access to non-devbox programs, while still
+# preferring the ones that Nix installed.
+PATH="$PATH:/a/test/path"
+
+# End Devbox Pre-init Hook
+
+# Begin Devbox Post-init Hook
+
+# Update the $PATH again so that the Nix packages take priority over the
+# programs outside of devbox.
+export PATH="$PURE_NIX_PATH:$PATH"
+
+# Prepend to the prompt to make it clear we're in a devbox shell.
+export PS1="(devbox) $PS1"
+
+# End Devbox Post-init Hook
+
+# Begin Devbox User Hook
+
+echo "Hello from a devbox shell hook!"
+
+# End Devbox User Hook


### PR DESCRIPTION
## Summary

At the end of the devbox shellrc file, we're setting:

	export PATH="$PURE_NIX_PATH:$ORIGINAL_PATH"

This will overwrite anything that the user's shellrc might've added to PATH. Change ORIGINAL_PATH to PATH to preserve those changes. There's also no need for ORIGINAL_PATH to be an environment variable, so set it directly in the template instead.

To prevent regressions, some tests that generate a devbox shellrc file and compare it to an expected golden file. This ensures we don't unknowingly change the way the shellrc is generated.

If we do intentionally change the devbox shellrc, the tests can automatically update the golden files with -update:

	go test ./nix -update

It's up to the author of the change to verify that any new shellrc files still work in a real shell.

## How was it tested?

`go test` and `devbox shell`