### PR TITLE
[json] Make input files unexported

### DIFF
--- a/devbox_test.go
+++ b/devbox_test.go
@@ -67,9 +67,9 @@ func assertPlansMatch(t *testing.T, expected *plansdk.Plan, actual *plansdk.Plan
 	// Check that input files are the same for all stages.
 	// Depending on where the test command is invoked, the input file paths can be different.
 	// We will compare the file name only.
-	assert.ElementsMatch(expected.InstallStage.GetInputFiles(), getFileNames(actual.InstallStage.GetInputFiles()), "InstallStage.InputFiles should match")
-	assert.ElementsMatch(expected.BuildStage.GetInputFiles(), getFileNames(actual.BuildStage.GetInputFiles()), "BuildStage.InputFiles should match")
-	assert.ElementsMatch(expected.StartStage.GetInputFiles(), getFileNames(actual.StartStage.GetInputFiles()), "StartStage.InputFiles should match")
+	assert.ElementsMatch(expected.InstallStage.InputFiles(), getFileNames(actual.InstallStage.InputFiles()), "InstallStage.InputFiles should match")
+	assert.ElementsMatch(expected.BuildStage.InputFiles(), getFileNames(actual.BuildStage.InputFiles()), "BuildStage.InputFiles should match")
+	assert.ElementsMatch(expected.StartStage.InputFiles(), getFileNames(actual.StartStage.InputFiles()), "StartStage.InputFiles should match")
 }
 
 func fileExists(path string) bool {

--- a/planner/languages/javascript/nodejs_planner.go
+++ b/planner/languages/javascript/nodejs_planner.go
@@ -37,20 +37,9 @@ func (p *Planner) GetPlan(srcDir string) *plansdk.Plan {
 		RuntimePackages: packages,
 
 		SharedPlan: plansdk.SharedPlan{
-			InstallStage: &plansdk.Stage{
-				InputFiles: inputFiles,
-				Command:    fmt.Sprintf("%s install", pkgManager),
-			},
-
-			BuildStage: &plansdk.Stage{
-				// Copy the rest of the directory over, since at install stage we only copied package.json and its lock file.
-				InputFiles: []string{"."},
-				Command:    p.buildCommand(pkgManager, project),
-			},
-
-			StartStage: &plansdk.Stage{
-				Command: p.startCommand(pkgManager, project),
-			},
+			InstallStage: plansdk.NewStage(fmt.Sprintf("%s install", pkgManager), inputFiles...),
+			BuildStage:   plansdk.NewStage(p.buildCommand(pkgManager, project)),
+			StartStage:   plansdk.NewStage(p.startCommand(pkgManager, project)),
 		},
 	}
 }

--- a/planner/plansdk/plansdk.go
+++ b/planner/plansdk/plansdk.go
@@ -50,7 +50,14 @@ type SharedPlan struct {
 type Stage struct {
 	Command string `cue:"string" json:"command"`
 	// InputFiles is internal for planners only.
-	InputFiles []string `cue:"[...string]" json:"input_files,omitempty"`
+	inputFiles []string
+}
+
+func NewStage(command string, inputFiles ...string) *Stage {
+	return &Stage{
+		Command:    command,
+		inputFiles: inputFiles,
+	}
 }
 
 func (s *Stage) GetCommand() string {
@@ -60,11 +67,11 @@ func (s *Stage) GetCommand() string {
 	return s.Command
 }
 
-func (s *Stage) GetInputFiles() []string {
-	if s == nil {
-		return []string{}
+func (s *Stage) InputFiles() []string {
+	if s == nil || len(s.inputFiles) == 0 {
+		return []string{"."}
 	}
-	return s.InputFiles
+	return s.inputFiles
 }
 
 type Planner interface {
@@ -137,15 +144,6 @@ func MergePlans(plans ...*Plan) *Plan {
 
 	plan.DevPackages = pkgslice.Unique(plan.DevPackages)
 	plan.RuntimePackages = pkgslice.Unique(plan.RuntimePackages)
-
-	// Set default files for install stage to copy.
-	if plan.SharedPlan.InstallStage.InputFiles == nil {
-		plan.SharedPlan.InstallStage.InputFiles = []string{"."}
-	}
-	// Set default files for install stage to copy over from build step.
-	if plan.SharedPlan.StartStage.InputFiles == nil {
-		plan.SharedPlan.StartStage.InputFiles = []string{"."}
-	}
 
 	return plan
 }


### PR DESCRIPTION
## Summary

This makes input files not show up in json. One side effect is that they don't show up in `devbox plan` either.

Another minor side effect is that input files can never be empty, but we could fix that if needed. 

@LucilleH @loreto thoughts?

## How was it tested?
* Unit tests
* Tested go and node examples 
