### PR TITLE
bump the dockerfile base image to nixos/nix:2.11.0

### DIFF
--- a/tmpl/Dockerfile.tmpl
+++ b/tmpl/Dockerfile.tmpl
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # BASE IMAGE
-FROM nixos/nix:2.10.3 as base
+FROM nixos/nix:2.11.0 as base
 WORKDIR /scratch
 # Setup shell so that we catch any errors early
 SHELL [ "/bin/sh", "-eux", "-o", "pipefail", "-c"]


### PR DESCRIPTION
## Summary

The recommended base image in https://nixos.org/download.html#nix-install-docker
is `nixos/nix:2.11.0`. Can we bump to this? Are there any (hidden) dependencies
with some other pieces (like pinned nix packages version?)?

## How was it tested?

sanity test:
```
> cd testdata/go/go-1.19
> devbox build
> docker run devbox
```
