### PR TITLE
[easy] make yaml, json, toml specific functions be private in cuecfg

### DIFF
--- a/cuecfg/cuecfg.go
+++ b/cuecfg/cuecfg.go
@@ -21,11 +21,11 @@ func Marshal(valuePtr any, extension string) ([]byte, error) {
 
 	switch extension {
 	case ".json":
-		return MarshalJSON(valuePtr)
+		return marshalJSON(valuePtr)
 	case ".yml", ".yaml":
-		return MarshalYaml(valuePtr)
+		return marshalYaml(valuePtr)
 	case ".toml":
-		return MarshalToml(valuePtr)
+		return marshalToml(valuePtr)
 	}
 	return nil, errors.Errorf("Unsupported file format '%s' for config file", extension)
 }
@@ -33,19 +33,19 @@ func Marshal(valuePtr any, extension string) ([]byte, error) {
 func Unmarshal(data []byte, extension string, valuePtr any) error {
 	switch extension {
 	case ".json":
-		err := UnmarshalJSON(data, valuePtr)
+		err := unmarshalJSON(data, valuePtr)
 		if err != nil {
 			return errors.WithStack(err)
 		}
 		return nil
 	case ".yml", ".yaml":
-		err := UnmarshalYaml(data, valuePtr)
+		err := unmarshalYaml(data, valuePtr)
 		if err != nil {
 			return errors.WithStack(err)
 		}
 		return nil
 	case ".toml":
-		err := UnmarshalToml(data, valuePtr)
+		err := unmarshalToml(data, valuePtr)
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/cuecfg/json.go
+++ b/cuecfg/json.go
@@ -8,10 +8,10 @@ import "encoding/json"
 // TODO: consider using cue's JSON marshaller instead of
 // "encoding/json" ... it might have extra functionality related
 // to the cue language.
-func MarshalJSON(v interface{}) ([]byte, error) {
+func marshalJSON(v interface{}) ([]byte, error) {
 	return json.MarshalIndent(v, "", "  ")
 }
 
-func UnmarshalJSON(data []byte, v interface{}) error {
+func unmarshalJSON(data []byte, v interface{}) error {
 	return json.Unmarshal(data, v)
 }

--- a/cuecfg/toml.go
+++ b/cuecfg/toml.go
@@ -7,10 +7,10 @@ import (
 	"github.com/pelletier/go-toml/v2"
 )
 
-func MarshalToml(v interface{}) ([]byte, error) {
+func marshalToml(v interface{}) ([]byte, error) {
 	return toml.Marshal(v)
 }
 
-func UnmarshalToml(data []byte, v interface{}) error {
+func unmarshalToml(data []byte, v interface{}) error {
 	return toml.Unmarshal(data, v)
 }

--- a/cuecfg/yaml.go
+++ b/cuecfg/yaml.go
@@ -8,10 +8,10 @@ import "gopkg.in/yaml.v3"
 // TODO: consider using cue's YAML marshaller.
 // It might have extra functionality related
 // to the cue language.
-func MarshalYaml(v interface{}) ([]byte, error) {
+func marshalYaml(v interface{}) ([]byte, error) {
 	return yaml.Marshal(v)
 }
 
-func UnmarshalYaml(data []byte, v interface{}) error {
+func unmarshalYaml(data []byte, v interface{}) error {
 	return yaml.Unmarshal(data, v)
 }


### PR DESCRIPTION
## Summary

These should be private for this package. External callers should invoke
`cuecfg.Marshal` and `cuecfg.Unmarshal`

## How was it tested?

compiles
