### PR TITLE
[CICD] Run tests in parallel, ensure we run all tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-12]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,10 +16,7 @@ permissions:
 
 jobs:
   golangci-lint:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-12]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -33,7 +30,6 @@ jobs:
 
   test-linux:
     runs-on: ubuntu-latest
-    needs: golangci-lint
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -55,7 +51,6 @@ jobs:
 
   test-darwin:
     runs-on: macos-12
-    needs: golangci-lint
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,6 +16,9 @@ permissions:
 
 jobs:
   golangci-lint:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-12]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -47,7 +50,7 @@ jobs:
       - name: Run tests
         run: |
           . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-          go test ./boxcli
+          go test -v ./...
 
   test-darwin:
     runs-on: macos-12
@@ -74,4 +77,4 @@ jobs:
       - name: Run tests
         run: |
           . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-          go test ./boxcli
+          go test -v ./...


### PR DESCRIPTION
## Summary

I think this got removed by accident? We were only running boxcli tests instead of all tests.

btw, linting darwin is probably overkill (the tests themselves will confirm everything compiles, I guess we could do `go build -v ./...` but since it's pretty fast, it's not a big deal)


## How was it tested?

GHA
