### PR TITLE
Separate devbox config struct from planner struct

### DIFF
--- a/config.go
+++ b/config.go
@@ -6,22 +6,33 @@ package devbox
 import (
 	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/cuecfg"
-	"go.jetpack.io/devbox/planner/plansdk"
 )
 
 // Config defines a devbox environment as JSON.
 type Config struct {
-	plansdk.SharedPlan
-
 	// Packages is the slice of Nix packages that devbox makes available in
 	// its environment.
 	Packages []string `cue:"[...string]" json:"packages"`
+	// InstallStage defines the actions that should be taken when
+	// installing language-specific libraries.
+	InstallStage *Stage `json:"install_stage,omitempty"`
+	// BuildStage defines the actions that should be taken when
+	// compiling the application binary.
+	BuildStage *Stage `json:"build_stage,omitempty"`
+	// StartStage defines the actions that should be taken when
+	// starting (running) the application.
+	StartStage *Stage `json:"start_stage,omitempty"`
 
 	// Shell configures the devbox shell environment.
 	Shell struct {
 		// InitHook contains commands that will run at shell startup.
 		InitHook string `json:"init_hook,omitempty"`
 	} `json:"shell,omitempty"`
+}
+
+// This contains a subset of fields from plansdk.Stage
+type Stage struct {
+	Command string `cue:"string" json:"command"`
 }
 
 // ReadConfig reads a devbox config file.

--- a/devbox.go
+++ b/devbox.go
@@ -5,7 +5,6 @@
 package devbox
 
 import (
-	"encoding/json"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -102,11 +101,7 @@ func (d *Devbox) Build(opts ...docker.BuildOptions) error {
 // Plan creates a plan of the actions that devbox will take to generate its
 // environment.
 func (d *Devbox) Plan() (*plansdk.Plan, error) {
-	userPlan, err := d.convertToPlan()
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
+	userPlan := d.convertToPlan()
 	automatedPlan, err := planner.GetPlan(d.srcDir)
 	if err != nil {
 		return nil, err
@@ -157,26 +152,22 @@ func (d *Devbox) saveCfg() error {
 	return cuecfg.WriteFile(cfgPath, d.cfg)
 }
 
-func (d *Devbox) convertToPlan() (*plansdk.Plan, error) {
+func (d *Devbox) convertToPlan() *plansdk.Plan {
 	configStages := []*Stage{d.cfg.InstallStage, d.cfg.BuildStage, d.cfg.StartStage}
 	planStages := []*plansdk.Stage{{}, {}, {}}
 
 	for i, stage := range configStages {
-		b, err := json.Marshal(stage)
-		if err != nil {
-			return nil, errors.WithStack(err)
-		}
-		err = json.Unmarshal(b, planStages[i])
-		if err != nil {
-			return nil, errors.WithStack(err)
+		if stage != nil {
+			planStages[i] = &plansdk.Stage{
+				Command: stage.Command,
+			}
 		}
 	}
-
 	return &plansdk.Plan{
 		DevPackages:     d.cfg.Packages,
 		RuntimePackages: d.cfg.Packages,
 		InstallStage:    planStages[0],
 		BuildStage:      planStages[1],
 		StartStage:      planStages[2],
-	}, nil
+	}
 }

--- a/planner/languages/golang/golang_planner.go
+++ b/planner/languages/golang/golang_planner.go
@@ -40,18 +40,16 @@ func (p *Planner) GetPlan(srcDir string) *plansdk.Plan {
 		DevPackages: []string{
 			goPkg,
 		},
-		SharedPlan: plansdk.SharedPlan{
-			InstallStage: &plansdk.Stage{
-				InputFiles: []string{"."},
-				Command:    "go get",
-			},
-			BuildStage: &plansdk.Stage{
-				Command: "CGO_ENABLED=0 go build -o app",
-			},
-			StartStage: &plansdk.Stage{
-				InputFiles: []string{"."},
-				Command:    "./app",
-			},
+		InstallStage: &plansdk.Stage{
+			InputFiles: []string{"."},
+			Command:    "go get",
+		},
+		BuildStage: &plansdk.Stage{
+			Command: "CGO_ENABLED=0 go build -o app",
+		},
+		StartStage: &plansdk.Stage{
+			InputFiles: []string{"."},
+			Command:    "./app",
 		},
 	}
 }

--- a/planner/languages/javascript/nodejs_planner.go
+++ b/planner/languages/javascript/nodejs_planner.go
@@ -36,22 +36,20 @@ func (p *Planner) GetPlan(srcDir string) *plansdk.Plan {
 		// TODO: Optimize runtime packages to remove npm or yarn if startStage command use Node directly.
 		RuntimePackages: packages,
 
-		SharedPlan: plansdk.SharedPlan{
-			InstallStage: &plansdk.Stage{
-				InputFiles: inputFiles,
-				Command:    fmt.Sprintf("%s install", pkgManager),
-			},
+		InstallStage: &plansdk.Stage{
+			InputFiles: inputFiles,
+			Command:    fmt.Sprintf("%s install", pkgManager),
+		},
 
-			BuildStage: &plansdk.Stage{
-				// Copy the rest of the directory over, since at install stage we only copied package.json and its lock file.
-				InputFiles: []string{"."},
-				Command:    p.buildCommand(pkgManager, project),
-			},
+		BuildStage: &plansdk.Stage{
+			// Copy the rest of the directory over, since at install stage we only copied package.json and its lock file.
+			InputFiles: []string{"."},
+			Command:    p.buildCommand(pkgManager, project),
+		},
 
-			StartStage: &plansdk.Stage{
-				InputFiles: []string{"."},
-				Command:    p.startCommand(pkgManager, project),
-			},
+		StartStage: &plansdk.Stage{
+			InputFiles: []string{"."},
+			Command:    p.startCommand(pkgManager, project),
 		},
 	}
 }

--- a/planner/plansdk/plansdk_test.go
+++ b/planner/plansdk/plansdk_test.go
@@ -22,7 +22,6 @@ func TestMergePlans(t *testing.T) {
 	expected := &Plan{
 		DevPackages:     []string{"foo", "bar", "baz"},
 		RuntimePackages: []string{"a", "b", "c"},
-		SharedPlan:      SharedPlan{},
 	}
 	actual, err := MergePlans(plan1, plan2)
 	assert.NoError(t, err)
@@ -30,26 +29,20 @@ func TestMergePlans(t *testing.T) {
 
 	// Base plan (the first one) takes precedence:
 	plan1 = &Plan{
-		SharedPlan: SharedPlan{
-			BuildStage: &Stage{
-				Command: "plan1",
-			},
+		BuildStage: &Stage{
+			Command: "plan1",
 		},
 	}
 	plan2 = &Plan{
-		SharedPlan: SharedPlan{
-			BuildStage: &Stage{
-				Command: "plan2",
-			},
+		BuildStage: &Stage{
+			Command: "plan2",
 		},
 	}
 	expected = &Plan{
 		DevPackages:     []string{},
 		RuntimePackages: []string{},
-		SharedPlan: SharedPlan{
-			BuildStage: &Stage{
-				Command: "plan1",
-			},
+		BuildStage: &Stage{
+			Command: "plan1",
 		},
 	}
 	actual, err = MergePlans(plan1, plan2)
@@ -58,28 +51,22 @@ func TestMergePlans(t *testing.T) {
 
 	// InputFiles can be overwritten:
 	plan1 = &Plan{
-		SharedPlan: SharedPlan{
-			InstallStage: &Stage{
-				InputFiles: []string{"package.json"},
-			},
-			StartStage: &Stage{
-				InputFiles: []string{"input"},
-			},
+		InstallStage: &Stage{
+			InputFiles: []string{"package.json"},
+		},
+		StartStage: &Stage{
+			InputFiles: []string{"input"},
 		},
 	}
-	plan2 = &Plan{
-		SharedPlan: SharedPlan{},
-	}
+	plan2 = &Plan{}
 	expected = &Plan{
 		DevPackages:     []string{},
 		RuntimePackages: []string{},
-		SharedPlan: SharedPlan{
-			InstallStage: &Stage{
-				InputFiles: []string{"package.json"},
-			},
-			StartStage: &Stage{
-				InputFiles: []string{"input"},
-			},
+		InstallStage: &Stage{
+			InputFiles: []string{"package.json"},
+		},
+		StartStage: &Stage{
+			InputFiles: []string{"input"},
 		},
 	}
 	actual, err = MergePlans(plan1, plan2)
@@ -91,18 +78,16 @@ func TestMergeUserPlans(t *testing.T) {
 	plannerPlan := &Plan{
 		DevPackages:     []string{"nodejs"},
 		RuntimePackages: []string{"nodejs"},
-		SharedPlan: SharedPlan{
-			InstallStage: &Stage{
-				InputFiles: []string{"package.json"},
-				Command:    "npm install",
-			},
-			BuildStage: &Stage{
-				InputFiles: []string{"."},
-			},
-			StartStage: &Stage{
-				InputFiles: []string{"."},
-				Command:    "npm start",
-			},
+		InstallStage: &Stage{
+			InputFiles: []string{"package.json"},
+			Command:    "npm install",
+		},
+		BuildStage: &Stage{
+			InputFiles: []string{"."},
+		},
+		StartStage: &Stage{
+			InputFiles: []string{"."},
+			Command:    "npm start",
 		},
 	}
 	cases := []struct {
@@ -112,24 +97,20 @@ func TestMergeUserPlans(t *testing.T) {
 	}{
 		{
 			name: "empty base plan",
-			in: &Plan{
-				SharedPlan: SharedPlan{},
-			},
+			in:   &Plan{},
 			out: &Plan{
 				DevPackages:     []string{"nodejs"},
 				RuntimePackages: []string{"nodejs"},
-				SharedPlan: SharedPlan{
-					InstallStage: &Stage{
-						InputFiles: []string{"package.json"},
-						Command:    "npm install",
-					},
-					BuildStage: &Stage{
-						InputFiles: []string{"."},
-					},
-					StartStage: &Stage{
-						InputFiles: []string{"."},
-						Command:    "npm start",
-					},
+				InstallStage: &Stage{
+					InputFiles: []string{"package.json"},
+					Command:    "npm install",
+				},
+				BuildStage: &Stage{
+					InputFiles: []string{"."},
+				},
+				StartStage: &Stage{
+					InputFiles: []string{"."},
+					Command:    "npm start",
 				},
 			},
 		},
@@ -138,68 +119,60 @@ func TestMergeUserPlans(t *testing.T) {
 			in: &Plan{
 				DevPackages:     []string{"nodejs", "yarn"},
 				RuntimePackages: []string{"nodejs"},
-				SharedPlan: SharedPlan{
-					InstallStage: &Stage{
-						InputFiles: []string{"package.json", "yarn.lock"},
-						Command:    "",
-					},
-					BuildStage: &Stage{
-						InputFiles: []string{"."},
-						Command:    "",
-					},
-					StartStage: &Stage{
-						InputFiles: []string{"."},
-						Command:    "npm start",
-					},
+				InstallStage: &Stage{
+					InputFiles: []string{"package.json", "yarn.lock"},
+					Command:    "",
+				},
+				BuildStage: &Stage{
+					InputFiles: []string{"."},
+					Command:    "",
+				},
+				StartStage: &Stage{
+					InputFiles: []string{"."},
+					Command:    "npm start",
 				},
 			},
 			out: &Plan{
 				DevPackages:     []string{"nodejs", "yarn"},
 				RuntimePackages: []string{"nodejs"},
-				SharedPlan: SharedPlan{
-					InstallStage: &Stage{
-						InputFiles: []string{"package.json", "yarn.lock"},
-						Command:    "npm install",
-					},
-					BuildStage: &Stage{
-						InputFiles: []string{"."},
-						Command:    "",
-					},
-					StartStage: &Stage{
-						InputFiles: []string{"."},
-						Command:    "npm start",
-					},
+				InstallStage: &Stage{
+					InputFiles: []string{"package.json", "yarn.lock"},
+					Command:    "npm install",
+				},
+				BuildStage: &Stage{
+					InputFiles: []string{"."},
+					Command:    "",
+				},
+				StartStage: &Stage{
+					InputFiles: []string{"."},
+					Command:    "npm start",
 				},
 			},
 		},
 		{
 			name: "custom build command",
 			in: &Plan{
-				SharedPlan: SharedPlan{
-					InstallStage: &Stage{
-						InputFiles: []string{"app"},
-					},
-					BuildStage: &Stage{
-						Command: "npm run build",
-					},
+				InstallStage: &Stage{
+					InputFiles: []string{"app"},
+				},
+				BuildStage: &Stage{
+					Command: "npm run build",
 				},
 			},
 			out: &Plan{
 				DevPackages:     []string{"nodejs"},
 				RuntimePackages: []string{"nodejs"},
-				SharedPlan: SharedPlan{
-					InstallStage: &Stage{
-						InputFiles: []string{"app"},
-						Command:    "npm install",
-					},
-					BuildStage: &Stage{
-						InputFiles: []string{"."},
-						Command:    "npm run build",
-					},
-					StartStage: &Stage{
-						InputFiles: []string{"."},
-						Command:    "npm start",
-					},
+				InstallStage: &Stage{
+					InputFiles: []string{"app"},
+					Command:    "npm install",
+				},
+				BuildStage: &Stage{
+					InputFiles: []string{"."},
+					Command:    "npm run build",
+				},
+				StartStage: &Stage{
+					InputFiles: []string{"."},
+					Command:    "npm start",
 				},
 			},
 		},


### PR DESCRIPTION
## Summary
This is a continuation of https://github.com/jetpack-io/devbox/pull/103. It hides the `inputFiles` fields in each stage and only expose the `command` field.

This PR 
- Get rid of `SharedPlan`
- Separate stage struct for devbox.json config
- Only expose `command` field in each stage

It does not include:
- Getters and setters
- immutability

## How was it tested?
go test ./...
