### PR TITLE
Tweaks to release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,8 @@ on:
   # Build/Release on demand
   workflow_dispatch:
     inputs:
-      is_snapshot_release:
-        description: "Publish Release:"
+      is_prerelease:
+        description: "Pre-release?"
         required: false
         default: false
         type: boolean
@@ -26,11 +26,11 @@ jobs:
   tests:
     uses: ./.github/workflows/tests.yaml
 
-  release-snapshot:
+  prerelease:
     runs-on: ubuntu-latest
     environment: release
     needs: tests
-    if: ${{ inputs.is_snapshot_release || github.event.schedule }}
+    if: ${{ inputs.is_prerelease || github.event.schedule }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,35 +36,35 @@ announce:
   discord:
     # Whether its enabled or not.
     # Defaults to false.
-    enabled: true
+    enabled: false
 
     # Message template to use while publishing.
     # Defaults to `{{ .ProjectName }} {{ .Tag }} is out! Check it out at {{ .ReleaseURL }}`
     message_template: |
       **New Release: Devbox {{.Tag}}**
       We just released a version {{.Tag}} of `devbox`.
-      
+
       Description:
       {{.TagBody}}
-      
+
       Release: {{.ReleaseURL}}
-      
+
       Updating:
       If you installed devbox via our recommended installer
       (`curl -fsSL https://get.jetpack.io/devbox | bash`) you will get the new version
       _automatically_, the next time you run `devbox` 
-      
+
       Thanks,
       jetpack.io
 
     # Set author of the embed.
     # Defaults to `GoReleaser`
-    author: 'jetpack.io'
+    author: "jetpack.io"
 
     # Color code of the embed. You have to use decimal numeral system, not hexadecimal.
     # Defaults to `3888754` - the grey-ish from goreleaser
-    color: '2622553' #This is the Jetpack Space color
+    color: "2622553" #This is the Jetpack Space color
 
     # URL to an image to use as the icon for the embed.
     # Defaults to `https://goreleaser.com/static/avatar.png`
-    icon_url: ''
+    icon_url: ""


### PR DESCRIPTION
## Summary
+ Disable automatic Discord announcement. It's not working great right now, and I'd rather turn it off until we improve it.
+ Clean up "prerelease" terminology in Github Action.

## How was it tested?
Via this PR