### PR TITLE
[php planner] sort extensions for test stability

### DIFF
--- a/planner/languages/php/php_planner.go
+++ b/planner/languages/php/php_planner.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -148,6 +149,8 @@ func (p *Planner) extensions(srcDir string) ([]string, error) {
 			}
 		}
 	}
+
+	sort.Strings(extensions)
 
 	return extensions, nil
 }

--- a/testdata/php/php8.1/plan.json
+++ b/testdata/php/php8.1/plan.json
@@ -1,4 +1,12 @@
 {
+  "dev_packages": [
+    "php81",
+    "php81Packages.composer"
+  ],
+  "runtime_packages": [
+    "php81",
+    "php81Packages.composer"
+  ],
   "install_stage": {
     "command": "composer install --no-dev --no-ansi",
     "input_files": [
@@ -14,15 +22,7 @@
       "."
     ]
   },
-  "dev_packages": [
-    "php81",
-    "php81Packages.composer"
-  ],
-  "runtime_packages": [
-    "php81",
-    "php81Packages.composer"
-  ],
   "definitions": [
-    "php81 = pkgs.php81.withExtensions ({ enabled, all }: enabled ++ (with all; [ mbstring imagick ]));"
+    "php81 = pkgs.php81.withExtensions ({ enabled, all }: enabled ++ (with all; [ imagick mbstring ]));"
   ]
 }


### PR DESCRIPTION
## Summary

The extensions array was not stably sorted so the testcase would be flaky when comparing the `devbox plan` output with `plan.json` 

## How was it tested?

`go test -v`
