### PR TITLE
devbox: allow shell.init_hook to be a JSON array

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,6 +4,10 @@
 package devbox
 
 import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
 	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/cuecfg"
 )
@@ -26,7 +30,7 @@ type Config struct {
 	// Shell configures the devbox shell environment.
 	Shell struct {
 		// InitHook contains commands that will run at shell startup.
-		InitHook string `json:"init_hook,omitempty"`
+		InitHook ConfigShellCmds `json:"init_hook,omitempty"`
 	} `json:"shell,omitempty"`
 }
 
@@ -48,4 +52,85 @@ func ReadConfig(path string) (*Config, error) {
 // WriteConfig saves a devbox config file.
 func WriteConfig(path string, cfg *Config) error {
 	return cuecfg.WriteFile(path, cfg)
+}
+
+// Formats for marshalling and unmarshalling a series of shell commands in a
+// devbox config.
+const (
+	// CmdArray formats shell commands as an array of of strings.
+	CmdArray CmdFormat = iota
+
+	// CmdString formats shell commands as a single string.
+	CmdString
+)
+
+// CmdFormat defines a way of formatting shell commands in a devbox config.
+type CmdFormat int
+
+func (c CmdFormat) String() string {
+	switch c {
+	case CmdArray:
+		return "array"
+	case CmdString:
+		return "string"
+	default:
+		return fmt.Sprintf("invalid (%d)", c)
+	}
+}
+
+// ConfigShellCmds marshals and unmarshals shell commands from a devbox config
+// as either a single string or an array of strings. It preserves the original
+// value such that:
+//
+//	data == marshal(unmarshal(data)))
+type ConfigShellCmds struct {
+	// MarshalAs determines how MarshalJSON encodes the shell commands.
+	// UnmarshalJSON will set MarshalAs automatically so that commands
+	// marshal back to their original format. The default zero-value
+	// formats them as an array.
+	//
+	MarshalAs CmdFormat
+	Cmds      []string
+}
+
+// MarshalJSON marshals shell commands according to s.MarshalAs. It marshals
+// commands to a string by joining s.Cmds with newlines.
+func (s ConfigShellCmds) MarshalJSON() ([]byte, error) {
+	switch s.MarshalAs {
+	case CmdArray:
+		return json.Marshal(s.Cmds)
+	case CmdString:
+		return json.Marshal(s.String())
+	default:
+		panic(fmt.Sprintf("invalid command format: %s", s.MarshalAs))
+	}
+}
+
+// UnmarshalJSON unmarshals shell commands from a string, an array of strings,
+// or null. When the JSON value is a string, it unmarshals into the first index
+// of s.Cmds.
+func (s *ConfigShellCmds) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || string(data) == "null" {
+		s.MarshalAs = CmdArray
+		s.Cmds = nil
+		return nil
+	}
+
+	switch data[0] {
+	case '"':
+		s.MarshalAs = CmdString
+		s.Cmds = []string{""}
+		return json.Unmarshal(data, &s.Cmds[0])
+
+	case '[':
+		s.MarshalAs = CmdArray
+		return json.Unmarshal(data, &s.Cmds)
+	default:
+		return nil
+	}
+}
+
+// String formats the commands as a single string by joining them with newlines.
+func (s *ConfigShellCmds) String() string {
+	return strings.Join(s.Cmds, "\n")
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,147 @@
+package devbox
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestConfigShellCmdsUnmarshalString(t *testing.T) {
+	tests := []struct {
+		jsonIn string
+		want   ConfigShellCmds
+	}{
+		{
+			jsonIn: `null`,
+			want: ConfigShellCmds{
+				MarshalAs: CmdArray,
+				Cmds:      nil,
+			},
+		},
+		{
+			jsonIn: `""`,
+			want: ConfigShellCmds{
+				MarshalAs: CmdString,
+				Cmds:      []string{""},
+			},
+		},
+		{
+			jsonIn: `"\n"`,
+			want: ConfigShellCmds{
+				MarshalAs: CmdString,
+				Cmds:      []string{"\n"},
+			},
+		},
+		{
+			jsonIn: `"echo 'line1'\necho 'line2'"`,
+			want: ConfigShellCmds{
+				MarshalAs: CmdString,
+				Cmds:      []string{"echo 'line1'\necho 'line2'"},
+			},
+		},
+		{
+			jsonIn: `"echo '\nline1'\necho 'line2'\n"`,
+			want: ConfigShellCmds{
+				MarshalAs: CmdString,
+				Cmds:      []string{"echo '\nline1'\necho 'line2'\n"},
+			},
+		},
+		{
+			jsonIn: `"echo 'line1'\n\necho 'line2'"`,
+			want: ConfigShellCmds{
+				MarshalAs: CmdString,
+				Cmds:      []string{"echo 'line1'\n\necho 'line2'"},
+			},
+		},
+		{
+			jsonIn: `"echo 'line1'\necho '\tline2'"`,
+			want: ConfigShellCmds{
+				MarshalAs: CmdString,
+				Cmds:      []string{"echo 'line1'\necho '\tline2'"},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.jsonIn, func(t *testing.T) {
+			got := ConfigShellCmds{}
+			if err := json.Unmarshal([]byte(test.jsonIn), &got); err != nil {
+				t.Fatal("Got error unmarshalling test input:", err)
+			}
+			if got.MarshalAs != test.want.MarshalAs {
+				t.Errorf("Got MarshalAs == %s after unmarshalling, want "+
+					"MarshalAs == %s.", got.MarshalAs, test.want.MarshalAs)
+			}
+			if len(got.Cmds) != len(test.want.Cmds) {
+				t.Fatalf("len(got.Cmds) != len(want.Cmds)\ngot:  %q (len %d)\nwant: %q (len %d)",
+					got.Cmds, len(got.Cmds), test.want.Cmds, len(test.want.Cmds))
+			}
+			for i := range got.Cmds {
+				got, want := got.Cmds[i], test.want.Cmds[i]
+				if got != want {
+					t.Fatalf("got.Cmds[%[1]d] != want.Cmds[%[1]d]\ngot:  %q\nwant: %q",
+						i, got, want)
+				}
+			}
+			b, err := json.Marshal(got)
+			if err != nil {
+				t.Fatal("Got error marshalling back to JSON:", err)
+			}
+			if diff := cmp.Diff(test.jsonIn, string(b)); diff != "" {
+				t.Errorf("Got different JSON after unmarshalling and re-marshalling (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestConfigShellCmdsString(t *testing.T) {
+	tests := []struct {
+		jsonIn string
+		want   string
+	}{
+		{
+			jsonIn: `null`,
+			want:   "",
+		},
+		{
+			jsonIn: `[]`,
+			want:   "",
+		},
+		{
+			jsonIn: `[""]`,
+			want:   "",
+		},
+		{
+			jsonIn: `["\n"]`,
+			want:   "\n",
+		},
+		{
+			jsonIn: `["echo 'line1'\necho 'line2'"]`,
+			want:   "echo 'line1'\necho 'line2'",
+		},
+		{
+			jsonIn: `["echo 'line1'", "echo 'line2'"]`,
+			want:   "echo 'line1'\necho 'line2'",
+		},
+		{
+			jsonIn: `["echo 'line1'\n\necho 'line2'"]`,
+			want:   "echo 'line1'\n\necho 'line2'",
+		},
+		{
+			jsonIn: `["echo 'line1'", "", "echo 'line2'"]`,
+			want:   "echo 'line1'\n\necho 'line2'",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.jsonIn, func(t *testing.T) {
+			got := ConfigShellCmds{}
+			if err := json.Unmarshal([]byte(test.jsonIn), &got); err != nil {
+				t.Fatal("Got error unmarshalling test input:", err)
+			}
+			if got.String() != test.want {
+				t.Errorf("got.String() != want\ngot:  %q\nwant: %q",
+					got.String(), test.want)
+			}
+		})
+	}
+}

--- a/devbox.go
+++ b/devbox.go
@@ -142,7 +142,7 @@ func (d *Devbox) Shell() error {
 		// Fall back to using a plain Nix shell.
 		sh = &nix.Shell{}
 	}
-	sh.UserInitHook = d.cfg.Shell.InitHook
+	sh.UserInitHook = d.cfg.Shell.InitHook.String()
 	return sh.Run(nixDir)
 }
 


### PR DESCRIPTION
## Summary

Add a `ConfigShellCmds` type that supports marshalling/unmarshalling shell commands from devbox.json as either a string or an array of strings. This makes writing multi-line shell hooks a bit easier.

Example:

	{
	  "packages": [
	    "go"
	  ],
	  "shell": {
	    "init_hook": [
	      "echo 'line 1'",
	      "echo 'line 2'"
	    ]
	  }
	}

The original format is preserved so that if the hook is a string, it will marshal back to a string. Converting from a string to an array results in an array where the only element is the original string.

## How was it tested?

Unit tests and manually creating shell hooks in both formats.