### PR TITLE
[RFC][Rust Planner] Reduce image size by using glibc, and copying built binary

### DIFF
--- a/devbox_test.go
+++ b/devbox_test.go
@@ -68,9 +68,21 @@ func assertPlansMatch(t *testing.T, expected *plansdk.Plan, actual *plansdk.Plan
 	// Check that input files are the same for all stages.
 	// Depending on where the test command is invoked, the input file paths can be different.
 	// We will compare the file name only.
-	assert.ElementsMatch(expected.InstallStage.GetInputFiles(), getFileNames(actual.InstallStage.GetInputFiles()), "InstallStage.InputFiles should match")
-	assert.ElementsMatch(expected.BuildStage.GetInputFiles(), getFileNames(actual.BuildStage.GetInputFiles()), "BuildStage.InputFiles should match")
-	assert.ElementsMatch(expected.StartStage.GetInputFiles(), getFileNames(actual.StartStage.GetInputFiles()), "StartStage.InputFiles should match")
+	assert.ElementsMatch(
+		expected.InstallStage.GetInputFiles(),
+		getFileNames(actual.InstallStage.GetInputFiles()),
+		"InstallStage.InputFiles should match",
+	)
+	assert.ElementsMatch(
+		expected.BuildStage.GetInputFiles(),
+		getFileNames(actual.BuildStage.GetInputFiles()),
+		"BuildStage.InputFiles should match",
+	)
+	assert.ElementsMatch(
+		expected.StartStage.GetInputFiles(),
+		actual.StartStage.GetInputFiles(),
+		"StartStage.InputFiles should match",
+	)
 
 	assert.ElementsMatch(expected.Definitions, actual.Definitions, "Definitions should match")
 }

--- a/planner/languages/rust/rust_planner.go
+++ b/planner/languages/rust/rust_planner.go
@@ -61,16 +61,15 @@ func (p *Planner) getPlan(srcDir string) (*plansdk.Plan, error) {
 		// 'gcc' added as a linker for libc (C toolchain)
 		// 1. https://softwareengineering.stackexchange.com/a/332254
 		// 2. https://stackoverflow.com/a/56166959
-		DevPackages: []string{rustPkgDev, "gcc"},
-		// 'gcc' needs to be present to execute the binary
-		RuntimePackages: []string{"gcc"},
+		DevPackages:     []string{rustPkgDev, "gcc"},
+		RuntimePackages: []string{"binutils"},
 		BuildStage: &plansdk.Stage{
 			InputFiles: []string{"."},
 			Command:    "cargo build --release",
 		},
 		StartStage: &plansdk.Stage{
-			InputFiles: []string{"."},
-			Command:    fmt.Sprintf("./target/release/%s", manifest.PackageField.Name),
+			InputFiles: []string{fmt.Sprintf("target/release/%s", manifest.PackageField.Name)},
+			Command:    fmt.Sprintf("./%s", manifest.PackageField.Name),
 		},
 	}, nil
 }

--- a/planner/languages/rust/rust_planner.go
+++ b/planner/languages/rust/rust_planner.go
@@ -62,7 +62,7 @@ func (p *Planner) getPlan(srcDir string) (*plansdk.Plan, error) {
 		// 1. https://softwareengineering.stackexchange.com/a/332254
 		// 2. https://stackoverflow.com/a/56166959
 		DevPackages:     []string{rustPkgDev, "gcc"},
-		RuntimePackages: []string{"binutils"},
+		RuntimePackages: []string{"glibc"},
 		BuildStage: &plansdk.Stage{
 			InputFiles: []string{"."},
 			Command:    "cargo build --release",

--- a/testdata/rust/rust-1.62.0/devbox.json
+++ b/testdata/rust/rust-1.62.0/devbox.json
@@ -1,3 +1,3 @@
 {
-  "packages": ["rust-bin.stable.\"1.62.0\".minimal"]
+  "packages": ["rust-bin.stable.\"1.62.0\".default"]
 }

--- a/testdata/rust/rust-1.62.0/plan.json
+++ b/testdata/rust/rust-1.62.0/plan.json
@@ -4,7 +4,6 @@
   ],
   "dev_packages": [
     "rust-bin.stable.\"1.62.0\".default",
-    "binutils",
     "gcc"
   ],
   "runtime_packages": [

--- a/testdata/rust/rust-1.62.0/plan.json
+++ b/testdata/rust/rust-1.62.0/plan.json
@@ -3,13 +3,13 @@
     "https://github.com/oxalica/rust-overlay/archive/stable.tar.gz"
   ],
   "dev_packages": [
-    "rust-bin.stable.\"1.62.0\".minimal",
     "rust-bin.stable.\"1.62.0\".default",
+    "binutils",
     "gcc"
   ],
   "runtime_packages": [
-    "rust-bin.stable.\"1.62.0\".minimal",
-    "gcc"
+    "rust-bin.stable.\"1.62.0\".default",
+    "binutils"
   ],
   "install_stage": {
     "command": ""
@@ -21,9 +21,9 @@
     ]
   },
   "start_stage": {
-    "command": "./target/release/hello-rust",
+    "command": "./hello-rust",
     "input_files": [
-      "."
+      "target/release/hello-rust"
     ]
   },
   "definitions": null

--- a/testdata/rust/rust-1.62.0/plan.json
+++ b/testdata/rust/rust-1.62.0/plan.json
@@ -8,7 +8,7 @@
   ],
   "runtime_packages": [
     "rust-bin.stable.\"1.62.0\".default",
-    "binutils"
+    "glibc"
   ],
   "install_stage": {
     "command": ""

--- a/testdata/rust/rust-stable-hello-world/plan.json
+++ b/testdata/rust/rust-stable-hello-world/plan.json
@@ -7,7 +7,7 @@
     "gcc"
   ],
   "runtime_packages": [
-    "binutils"
+    "glibc"
   ],
   "install_stage": {
     "command": ""

--- a/testdata/rust/rust-stable-hello-world/plan.json
+++ b/testdata/rust/rust-stable-hello-world/plan.json
@@ -4,10 +4,11 @@
   ],
   "dev_packages": [
     "rust-bin.stable.latest.default",
+    "binutils",
     "gcc"
   ],
   "runtime_packages": [
-    "gcc"
+    "binutils"
   ],
   "install_stage": {
     "command": ""
@@ -19,9 +20,9 @@
     ]
   },
   "start_stage": {
-    "command": "./target/release/rust-stable-hello-world",
+    "command": "./rust-stable-hello-world",
     "input_files": [
-      "."
+      "target/release/rust-stable-hello-world"
     ]
   },
   "definitions": null

--- a/testdata/rust/rust-stable-hello-world/plan.json
+++ b/testdata/rust/rust-stable-hello-world/plan.json
@@ -4,7 +4,6 @@
   ],
   "dev_packages": [
     "rust-bin.stable.latest.default",
-    "binutils",
     "gcc"
   ],
   "runtime_packages": [

--- a/testdata/rust/rust-stable/devbox.json
+++ b/testdata/rust/rust-stable/devbox.json
@@ -1,3 +1,3 @@
 {
-  "packages": ["rust-bin.stable.latest.minimal"]
+  "packages": ["rust-bin.stable.latest.default"]
 }

--- a/testdata/rust/rust-stable/plan.json
+++ b/testdata/rust/rust-stable/plan.json
@@ -8,7 +8,7 @@
   ],
   "runtime_packages": [
     "rust-bin.stable.latest.default",
-    "binutils"
+    "glibc"
   ],
   "install_stage": {
     "command": ""

--- a/testdata/rust/rust-stable/plan.json
+++ b/testdata/rust/rust-stable/plan.json
@@ -3,13 +3,13 @@
     "https://github.com/oxalica/rust-overlay/archive/stable.tar.gz"
   ],
   "dev_packages": [
-    "rust-bin.stable.latest.minimal",
     "rust-bin.stable.latest.default",
+    "binutils",
     "gcc"
   ],
   "runtime_packages": [
-    "rust-bin.stable.latest.minimal",
-    "gcc"
+    "rust-bin.stable.latest.default",
+    "binutils"
   ],
   "install_stage": {
     "command": ""
@@ -21,9 +21,9 @@
     ]
   },
   "start_stage": {
-    "command": "./target/release/hello-rust",
+    "command": "./hello-rust",
     "input_files": [
-      "."
+      "target/release/hello-rust"
     ]
   },
   "definitions": null

--- a/testdata/rust/rust-stable/plan.json
+++ b/testdata/rust/rust-stable/plan.json
@@ -4,7 +4,6 @@
   ],
   "dev_packages": [
     "rust-bin.stable.latest.default",
-    "binutils",
     "gcc"
   ],
   "runtime_packages": [


### PR DESCRIPTION
## Summary

Reduce image size by

1. Replace `gcc` with `glibc` in the Runtime image. 
   - `gcc` is needed in the DevPackages for the Build Stage. Replacing it with `glibc` doesn't work because `glibc` nix pkg is not available on mac OS (linux only). We want universal packages (defined as linux and mac, lol) since we share DevPackages with `devbox shell`.

2. Copy just the specific built binary to the Runtime image.

## How was it tested?

Using the basic `testdata/rust/rust-stable-hello-world` project:
- before, size of image = 320MB
- after, size of image = 64MB


