### PR TITLE
[WIP] Add platform flag to devbox build

### DIFF
--- a/boxcli/build.go
+++ b/boxcli/build.go
@@ -25,6 +25,9 @@ func BuildCmd() *cobra.Command {
 	command.Flags().StringVar(
 		&flags.Engine, "engine", "docker", "Engine used to build the container: 'docker', 'podman'")
 
+	command.Flags().StringSliceVar(
+		&flags.Platforms, "platform", []string{}, "Platform to build the container")
+
 	return command
 }
 


### PR DESCRIPTION
## Summary

Add platform flag to devbox build

Example: `devbox build --platform linux/amd64`

Had to move this issue https://github.com/jetpack-io/devbox/issues/73 up to this cycle since we need it internally.

Currently running into the following error:
```
error: unable to load seccomp BPF program: Invalid argument
```

## How was it tested?
`devbox build --platform linux/amd64`