### PR TITLE
[bug] Change BUILDKIT to DOCKER_BUILDKIT

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -76,7 +76,7 @@ func Build(path string, opts ...BuildOptions) error {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Env = append(os.Environ(), "BUILDKIT=1")
+	cmd.Env = append(os.Environ(), "DOCKER_BUILDKIT=1")
 	cmd.Dir = dir
 	return errors.WithStack(cmd.Run())
 }


### PR DESCRIPTION
## Summary
Not 100% why `BUILDKIT=1` worked locally, but not in CICD. 

Looking at all the documentations, it seems everywhere it uses `DOCKER_BUILDKIT`, hence the change.

Reference: https://docs.docker.com/develop/develop-images/build_enhancements/

## How was it tested?
devbox build