### PR TITLE
Change nix-shell requirements to only add and shell command

### DIFF
--- a/boxcli/add.go
+++ b/boxcli/add.go
@@ -11,10 +11,11 @@ import (
 
 func AddCmd() *cobra.Command {
 	command := &cobra.Command{
-		Use:   "add <pkg>...",
-		Short: "Add a new package to your devbox",
-		Args:  cobra.MinimumNArgs(1),
-		RunE:  addCmdFunc(),
+		Use:               "add <pkg>...",
+		Short:             "Add a new package to your devbox",
+		Args:              cobra.MinimumNArgs(1),
+		PersistentPreRunE: nixShellPersistentPreRunE,
+		RunE:              addCmdFunc(),
 	}
 
 	return command

--- a/boxcli/root.go
+++ b/boxcli/root.go
@@ -5,9 +5,7 @@ package boxcli
 
 import (
 	"context"
-	"errors"
 	"os"
-	"os/exec"
 
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox/boxcli/midcobra"
@@ -21,13 +19,6 @@ func RootCmd() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "devbox",
 		Short: "Instant, easy, predictable shells and containers",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			_, err := exec.LookPath("nix-shell")
-			if err != nil {
-				return errors.New("could not find nix in your PATH\nInstall nix by following the instructions at https://nixos.org/download.html and make sure you've set up your PATH correctly")
-			}
-			return nil
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},

--- a/boxcli/shell.go
+++ b/boxcli/shell.go
@@ -15,10 +15,11 @@ import (
 
 func ShellCmd() *cobra.Command {
 	command := &cobra.Command{
-		Use:   "shell [<dir>]",
-		Short: "Start a new shell with access to your packages",
-		Args:  cobra.MaximumNArgs(1),
-		RunE:  runShellCmd,
+		Use:               "shell [<dir>]",
+		Short:             "Start a new shell with access to your packages",
+		Args:              cobra.MaximumNArgs(1),
+		PersistentPreRunE: nixShellPersistentPreRunE,
+		RunE:              runShellCmd,
 	}
 	return command
 }
@@ -46,4 +47,12 @@ func runShellCmd(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 	}
 	return err
+}
+
+func nixShellPersistentPreRunE(cmd *cobra.Command, args []string) error {
+	_, err := exec.LookPath("nix-shell")
+	if err != nil {
+		return errors.New("could not find nix in your PATH\nInstall nix by following the instructions at https://nixos.org/download.html and make sure you've set up your PATH correctly")
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
Change nix-shell requirements to only add and shell command. `devbox build` on CICD should not require Nix dependency

## How was it tested?
`devbox shell`
`devbox add`
`devbox build`