### PR TITLE
boxcli,devbox: move default prompt into devbox.json

### DIFF
--- a/boxcli/init.go
+++ b/boxcli/init.go
@@ -7,24 +7,44 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
+	"go.jetpack.io/devbox/boxcli/usererr"
 )
 
 func InitCmd() *cobra.Command {
+	fixes := &[]string{}
+
 	command := &cobra.Command{
 		Use:   "init [<dir>]",
 		Short: "Initialize a directory as a devbox project",
 		Args:  cobra.MaximumNArgs(1),
-		RunE:  runInitCmd,
+		RunE:  initCmdFunc(fixes),
 	}
+	command.Flags().StringSliceVar(fixes, "fix", nil, "Run a comma-separated list of fixes on a devbox config: 'prompt'")
 	return command
 }
 
-func runInitCmd(cmd *cobra.Command, args []string) error {
-	path := pathArg(args)
+func initCmdFunc(fixes *[]string) runFunc {
+	return func(cmd *cobra.Command, args []string) error {
+		path := pathArg(args)
 
-	_, err := devbox.InitConfig(path)
-	if err != nil {
-		return errors.WithStack(err)
+		created, err := devbox.InitConfig(path)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// New configs come with the latest and greatest fixes already,
+		// so no need to apply any.
+		if created || len(*fixes) == 0 {
+			return nil
+		}
+
+		if len(*fixes) > 1 || (*fixes)[0] != "prompt" {
+			return usererr.New("The only currently available fix is 'prompt'.")
+		}
+		box, err := devbox.Open(path)
+		if err != nil {
+			return err
+		}
+		return box.Fix()
 	}
-	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	cuelang.org/go v0.4.3
 	github.com/bmatcuk/doublestar/v4 v4.2.0
+	github.com/creekorful/mvnparser v1.5.0
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/fatih/color v1.13.0
 	github.com/google/go-cmp v0.4.0
@@ -25,7 +26,6 @@ require golang.org/x/net v0.0.0-20200226121028-0de0cce0169b // indirect
 require (
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/cockroachdb/apd/v2 v2.0.1 // indirect
-	github.com/creekorful/mvnparser v1.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/nix/shellrc.tmpl
+++ b/nix/shellrc.tmpl
@@ -60,9 +60,6 @@ PATH="$(
 	echo "${nix_path:+$nix_path:}${non_nix_path}"
 )"
 
-# Prepend to the prompt to make it clear we're in a devbox shell.
-export PS1="(devbox) $PS1"
-
 # End Devbox Post-init Hook
 
 {{- if .UserHook }}

--- a/nix/testdata/shellrc/basic/shellrc.golden
+++ b/nix/testdata/shellrc/basic/shellrc.golden
@@ -74,9 +74,6 @@ PATH="$(
 	echo "${nix_path:+$nix_path:}${non_nix_path}"
 )"
 
-# Prepend to the prompt to make it clear we're in a devbox shell.
-export PS1="(devbox) $PS1"
-
 # End Devbox Post-init Hook
 
 # Begin Devbox User Hook

--- a/nix/testdata/shellrc/nohook/shellrc.golden
+++ b/nix/testdata/shellrc/nohook/shellrc.golden
@@ -74,7 +74,4 @@ PATH="$(
 	echo "${nix_path:+$nix_path:}${non_nix_path}"
 )"
 
-# Prepend to the prompt to make it clear we're in a devbox shell.
-export PS1="(devbox) $PS1"
-
 # End Devbox Post-init Hook

--- a/nix/testdata/shellrc/noshellrc/shellrc.golden
+++ b/nix/testdata/shellrc/noshellrc/shellrc.golden
@@ -32,9 +32,6 @@ PATH="$(
 	echo "${nix_path:+$nix_path:}${non_nix_path}"
 )"
 
-# Prepend to the prompt to make it clear we're in a devbox shell.
-export PS1="(devbox) $PS1"
-
 # End Devbox Post-init Hook
 
 # Begin Devbox User Hook


### PR DESCRIPTION
## Summary

We currently set the devbox shell prompt in the shellrc template with:

	export PS1="(devbox) $PS1"

This breaks the prompt for users that have a theme or use a shell that sets the prompt in some other way. To allow user's to opt out of the prompt, move it into devbox.json where they can modify or delete it. Running `devbox init` will now generate a config that looks like:

	{
	  "packages": [],
	  "shell": {
	    "init_hook": [
	      "# Here you can remove or customize the prompt for your project's devbox shell.",
	      "# By convention, individual users can set DEVBOX_NO_PROMPT=1 in their shell's",
	      "# rc file to opt out of prompt customization.",
	      "if [ -z \"$DEVBOX_NO_PROMPT\" ]; then",
	      "\tPS1=\"(devbox:tmp.wGAYMHRO) $PS1\"",
	      "fi"
	    ]
	  }
	}

This also means that users with an existing devbox config will no longer get a prompt. If they want to get the default prompt back, they can run:

	devbox init -fix prompt

This fix will automatically append the default devbox prompt to the shell init hook unless there's already a command that contains `PS1=`. A future change will print a hint when launching a shell to tell the user about this change.

Note that the `-fix` flag accepts a comma-separated list of fixes in case we need to add more as the config evolves. For simplicity, the current implementation only allows "prompt", but can be redone later to support more.

## How was it tested?

Manually running `devbox shell` after:

1. Initializing a new config.
2. Fixing an existing config.
3. Fixing an already fixed config.

This one is trickier to add tests for because the prompt only applies for interactive shells, and the tests are obviously not interactive.