### PR TITLE
[Java planner] part3 reducing docker image size

### DIFF
--- a/planner/languages/java/java_planner.go
+++ b/planner/languages/java/java_planner.go
@@ -37,7 +37,6 @@ func (p *Planner) IsRelevant(srcDir string) bool {
 	// Checking for pom.xml (maven) only for now
 	// TODO: add build.gradle file detection
 	pomXMLPath := filepath.Join(srcDir, "pom.xml")
-	fmt.Printf("plansdk.FileExists(pomXMLPath): %v\n", plansdk.FileExists(pomXMLPath))
 	return plansdk.FileExists(pomXMLPath)
 }
 
@@ -49,7 +48,6 @@ func (p *Planner) GetPlan(srcDir string) *plansdk.Plan {
 		},
 	}
 	javaPkg, err := getJavaPackage(srcDir)
-	fmt.Printf("javaPkg: %v\n", javaPkg)
 	if err != nil {
 		return plan.WithError(err)
 	}

--- a/planner/languages/java/java_planner.go
+++ b/planner/languages/java/java_planner.go
@@ -37,6 +37,7 @@ func (p *Planner) IsRelevant(srcDir string) bool {
 	// Checking for pom.xml (maven) only for now
 	// TODO: add build.gradle file detection
 	pomXMLPath := filepath.Join(srcDir, "pom.xml")
+	fmt.Printf("plansdk.FileExists(pomXMLPath): %v\n", plansdk.FileExists(pomXMLPath))
 	return plansdk.FileExists(pomXMLPath)
 }
 
@@ -48,6 +49,7 @@ func (p *Planner) GetPlan(srcDir string) *plansdk.Plan {
 		},
 	}
 	javaPkg, err := getJavaPackage(srcDir)
+	fmt.Printf("javaPkg: %v\n", javaPkg)
 	if err != nil {
 		return plan.WithError(err)
 	}

--- a/planner/plansdk/plansdk.go
+++ b/planner/plansdk/plansdk.go
@@ -6,9 +6,7 @@ package plansdk
 import (
 	"encoding/json"
 	"fmt"
-	"io/fs"
 	"os"
-	"path/filepath"
 
 	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
@@ -194,25 +192,4 @@ func (p PlanError) MarshalJSON() ([]byte, error) {
 func FileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
-}
-
-// Walks through all the files in the provided 'path' and returns the file that matches
-// with 'fileExtention'. If multiple matches exist, it returns an error.
-func GetFileWithExtention(path string, fileExtention string) (string, error) {
-	var a []string
-	filepath.WalkDir(path, func(s string, d fs.DirEntry, e error) error {
-		if e != nil {
-			return e
-		}
-		if filepath.Ext(d.Name()) == fileExtention {
-			a = append(a, s)
-		}
-		return nil
-	})
-	if len(a) == 0 {
-		return "", errors.Errorf("Did not find any file with extention %s \n", fileExtention)
-	} else if len(a) > 1 {
-		return "", errors.Errorf("Found multiple files with extention %s \n", fileExtention)
-	}
-	return a[0], nil
 }

--- a/planner/plansdk/plansdk.go
+++ b/planner/plansdk/plansdk.go
@@ -5,7 +5,6 @@ package plansdk
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 
 	"github.com/imdario/mergo"
@@ -114,7 +113,6 @@ func (p *Plan) Error() error {
 
 func (p *Plan) WithError(err error) *Plan {
 	p.Errors = append(p.Errors, PlanError{err})
-	fmt.Printf("p.Errors: %v\n", p.Errors)
 	return p
 }
 

--- a/testdata/java/openjdk-11/plan.json
+++ b/testdata/java/openjdk-11/plan.json
@@ -1,11 +1,11 @@
 {
     "dev_packages": [
         "maven",
-        "jdk11"
+        "jdk11",
+        "binutils"
     ],
     "runtime_packages": [
-        "maven",
-        "jdk11"
+        "binutils"
     ],
     "install_stage": {
         "command": "mvn clean install",
@@ -14,10 +14,13 @@
         ]
     },
     "build_stage": {
-        "command": ""
+        "command": "jlink --verbose --add-modules ALL-MODULE-PATH --strip-debug --no-man-pages  --no-header-files  --compress=2 --output ./customjre",
+        "input_files": [
+            "."
+        ]
     },
     "start_stage": {
-        "command": "java -jar target/devbox-maven-app-1.0-SNAPSHOT.jar",
+        "command": "./customjre/bin/java -jar target/devbox-maven-app-1.0-SNAPSHOT.jar",
         "input_files": [
             "."
         ]

--- a/testdata/java/openjdk-17/plan.json
+++ b/testdata/java/openjdk-17/plan.json
@@ -1,11 +1,11 @@
 {
     "dev_packages": [
         "maven",
-        "jdk17_headless"
+        "jdk17_headless",
+        "binutils"
     ],
     "runtime_packages": [
-        "maven",
-        "jdk17_headless"
+        "binutils"
     ],
     "install_stage": {
         "command": "mvn clean install",
@@ -14,10 +14,13 @@
         ]
     },
     "build_stage": {
-        "command": ""
+        "command": "jlink --verbose --add-modules ALL-MODULE-PATH --strip-debug --no-man-pages  --no-header-files  --compress=2 --output ./customjre",
+        "input_files": [
+            "."
+        ]
     },
     "start_stage": {
-        "command": "java -jar target/devbox-maven-app-1.0-SNAPSHOT.jar",
+        "command": "./customjre/bin/java -jar target/devbox-maven-app-1.0-SNAPSHOT.jar",
         "input_files": [
             "."
         ]

--- a/testdata/java/openjdk-8/plan.json
+++ b/testdata/java/openjdk-8/plan.json
@@ -1,11 +1,11 @@
 {
     "dev_packages": [
         "maven",
-        "jdk8"
+        "jdk8",
+        "binutils"
     ],
     "runtime_packages": [
-        "maven",
-        "jdk8"
+        "binutils"
     ],
     "install_stage": {
         "command": "mvn clean install",
@@ -14,10 +14,13 @@
         ]
     },
     "build_stage": {
-        "command": ""
+        "command": "jlink --verbose --add-modules ALL-MODULE-PATH --strip-debug --no-man-pages  --no-header-files  --compress=2 --output ./customjre",
+        "input_files": [
+            "."
+        ]
     },
     "start_stage": {
-        "command": "java -jar target/devbox-maven-app-1.0-SNAPSHOT.jar",
+        "command": "./customjre/bin/java -jar target/devbox-maven-app-1.0-SNAPSHOT.jar",
         "input_files": [
             "."
         ]

--- a/testdata/java/openjdk-default/plan.json
+++ b/testdata/java/openjdk-default/plan.json
@@ -1,11 +1,11 @@
 {
     "dev_packages": [
         "maven",
-        "jdk"
+        "jdk",
+        "binutils"
     ],
     "runtime_packages": [
-        "maven",
-        "jdk"
+        "binutils"
     ],
     "install_stage": {
         "command": "mvn clean install",
@@ -14,10 +14,13 @@
         ]
     },
     "build_stage": {
-        "command": ""
+        "command": "jlink --verbose --add-modules ALL-MODULE-PATH --strip-debug --no-man-pages  --no-header-files  --compress=2 --output ./customjre",
+        "input_files": [
+            "."
+        ]
     },
     "start_stage": {
-        "command": "java -jar target/devbox-maven-app-1.0-SNAPSHOT.jar",
+        "command": "./customjre/bin/java -jar target/devbox-maven-app-1.0-SNAPSHOT.jar",
         "input_files": [
             "."
         ]


### PR DESCRIPTION
## Summary
- Added custom JRE for runtime instead of installing JDK + maven
- Updated testdata plan
- Added build command to java planner

## How was it tested?
- devbox plan
- devbox build
- docker run devbox
- run `docker images | grep devbox` to check image size

see screenshot:

<img width="562" alt="Screen Shot 2022-09-19 at 5 14 24 PM" src="https://user-images.githubusercontent.com/22227661/191117804-0231762c-00dd-4140-b824-534988e39d63.png">
