### PR TITLE
Expose nix package path as environment variables

### DIFF
--- a/tmpl/shell.nix.tmpl
+++ b/tmpl/shell.nix.tmpl
@@ -31,6 +31,10 @@ mkShell {
       # non-Nix programs, while still preferring the Nix ones.
       export "PATH=$PATH:$PARENT_PATH"
 
+      {{- range $i, $value := .DevPackages}}
+      export DEVBOX_$(echo {{$value}} | sed "s/\./_/g")=${pkgs.{{.}}}
+      {{end -}}
+
       {{ if debug }}
       echo "PATH=$PATH"
       {{- end }}


### PR DESCRIPTION
## Summary
Expose nix package path as environment variables
This is valuable if a shell hook wants to set default values that points to a nix package path.

The environment variable will have the pattern of `DEVBOX_<pkg_name>`
eg. 
```
MYSQL_BASEDIR=${DEVBOX_mariadb}
```

Example variables:
<img width="857" alt="Screen Shot 2022-09-20 at 6 02 36 PM" src="https://user-images.githubusercontent.com/2292093/191391476-1bb6d764-e273-48a4-8198-c024517cd839.png">

Example values
<img width="865" alt="Screen Shot 2022-09-20 at 6 02 45 PM" src="https://user-images.githubusercontent.com/2292093/191391498-564b00f2-6b5b-4082-a152-f155c5fb759d.png">

## How was it tested?
`devbox shell`