### PR TITLE
devbox shell -- cmd

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -146,6 +146,22 @@ func (d *Devbox) Shell() error {
 	return sh.Run(nixDir)
 }
 
+func (d *Devbox) Exec(cmds ...string) error {
+	plan, err := d.Plan()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if plan.Invalid() {
+		return plan.Error()
+	}
+	err = generate(d.srcDir, plan, shellFiles)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	nixDir := filepath.Join(d.srcDir, ".devbox/gen/shell.nix")
+	return nix.Exec(nixDir, cmds)
+}
+
 // saveCfg writes the config file to the devbox directory.
 func (d *Devbox) saveCfg() error {
 	cfgPath := filepath.Join(d.srcDir, configFilename)

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -7,7 +7,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
+	"strings"
+
+	"github.com/pkg/errors"
 )
 
 func PkgExists(pkg string) bool {
@@ -20,6 +24,15 @@ type Info struct {
 	Name    string
 	Version string
 	System  string
+}
+
+func Exec(path string, command []string) error {
+	runCmd := strings.Join(command, " ")
+	cmd := exec.Command("nix-shell", path, "--run", runCmd)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return errors.WithStack(cmd.Run())
 }
 
 func PkgInfo(pkg string) (*Info, bool) {


### PR DESCRIPTION
## Summary
Simple implementation of `devbox shell -- <cmd>`. I struggled integrating this with all the other stuff that is happening with `devbox shell`. Would like thoughts on whether this is a good enough for an MVP of the feature, and later we improve it, or whether we think integrating with the other `devbox shell` logic is a must have.

## How was it tested?
Ran a few commands with `devbox shell --`