### PR TITLE
ci: debug workflow, rate limit fixes, cleanup

### DIFF
--- a/.github/workflows/debug.yaml
+++ b/.github/workflows/debug.yaml
@@ -1,4 +1,5 @@
 name: debug
+
 on:
   workflow_dispatch:
     inputs:
@@ -10,23 +11,47 @@ on:
         options:
           - macos-12
           - ubuntu-latest
+
 permissions:
   contents: read
+
+env:
+  HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}"
+  HOMEBREW_NO_ANALYTICS: 1
+  HOMEBREW_NO_AUTO_UPDATE: 1
+  HOMEBREW_NO_EMOJI: 1
+  HOMEBREW_NO_ENV_HINTS: 1
+  HOMEBREW_NO_INSTALL_CLEANUP: 1
+
 jobs:
-  golangci-lint:
+  debug:
     runs-on: ${{ inputs.runner }}
+    timeout-minutes: 10
     steps:
       - name: Get rate limits
         run: |
-          curl \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: ${{ github.token }}" \
-            https://api.github.com/rate_limit | jq .
+          curl https://api.github.com/rate_limit \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              --show-error \
+              --silent \
+            | jq .
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version-file: ./go.mod
+      - run: |
+          echo "Starting a tmate session for 10 minutes."
+          echo
+          echo "You can connect using the SSH command printed below to get an interactive shell"
+          echo "on this GitHub Actions runner. Access is limited to the public SSH keys"
+          echo "associated with your GitHub account."
+
+          curl https://api.github.com/users/${{ github.actor }}/keys \
+              -H "Accept: application/vnd.github+json" \
+              --show-error \
+              --silent \
+            | jq .
       - uses: mxschmitt/action-tmate@v3
         with:
-          args: --timeout=10m
           limit-access-to-actor: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,12 +14,21 @@ permissions:
   contents: read
   pull-requests: read
 
+env:
+  HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}"
+  HOMEBREW_NO_ANALYTICS: 1
+  HOMEBREW_NO_AUTO_UPDATE: 1
+  HOMEBREW_NO_EMOJI: 1
+  HOMEBREW_NO_ENV_HINTS: 1
+  HOMEBREW_NO_INSTALL_CLEANUP: 1
+
 jobs:
   golangci-lint:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-12]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -28,11 +37,13 @@ jobs:
           cache: false # use golangci cache instead
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.2.0
-        with:
-          args: --timeout=10m
 
-  test-linux:
-    runs-on: ubuntu-latest
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-12]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -41,42 +52,23 @@ jobs:
           cache: true
       - name: Build devbox
         run: go install ./cmd/devbox
-      - name: Install additional shells
+      - name: Install additional shells (dash, zsh)
         run: |
-          sudo apt-get update
-          sudo apt-get install dash zsh
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            sudo apt-get update
+            sudo apt-get install dash zsh
+          elif [ "$RUNNER_OS" == "macOS" ]; then
+            brew update
+            brew install dash zsh
+          fi
       - name: Install Nix
-        run: sh <(curl -L https://nixos.org/nix/install) --daemon
-      - name: Run tests
         run: |
+          sh <(curl -L https://nixos.org/nix/install) --no-modify-profile --daemon --daemon-user-count 1
           . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-          go test ./...
-
-  test-darwin:
-    if: ${{ false }} # disable until we figure out Homebrew rate limiting
-    runs-on: macos-12
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version-file: ./go.mod
-          cache: true
-      - name: Build devbox
-        run: go install ./cmd/devbox
-      - name: Install additional shells
-        env:
-          HOMEBREW_NO_ANALYTICS: 1
-          HOMEBREW_NO_AUTO_UPDATE: 1
-          HOMEBREW_NO_EMOJI: 1
-          HOMEBREW_NO_ENV_HINTS: 1
-          HOMEBREW_NO_INSTALL_CLEANUP: 1
-          HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
-        run: |
-          brew update
-          brew install dash zsh
-      - name: Install Nix
-        run: sh <(curl -L https://nixos.org/nix/install) --daemon
+          nix-build '<nixpkgs>' -A stdenv -A bash -A hello
+          echo "__ETC_PROFILE_NIX_SOURCED=1" >> $GITHUB_ENV
+          echo "NIX_PROFILES=$NIX_PROFILES" >> $GITHUB_ENV
+          echo "NIX_SSL_CERT_FILE=$NIX_SSL_CERT_FILE" >> $GITHUB_ENV
+          echo "PATH=$PATH" >> $GITHUB_ENV
       - name: Run tests
-        run: |
-          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-          go test ./...
+        run: go test -race -cover ./...

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	cuelang.org/go v0.4.3
 	github.com/bmatcuk/doublestar/v4 v4.2.0
+	github.com/creekorful/mvnparser v1.5.0
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/fatih/color v1.13.0
 	github.com/google/go-cmp v0.4.0
@@ -25,7 +26,6 @@ require golang.org/x/net v0.0.0-20200226121028-0de0cce0169b // indirect
 require (
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/cockroachdb/apd/v2 v2.0.1 // indirect
-	github.com/creekorful/mvnparser v1.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect


### PR DESCRIPTION
## Summary

Update the debug workflow to echo a message with some basic info on how to use tmate. Also rename the job to `debug`, put the timeout at the job level, and set a Homebrew GitHub token to help with rate limiting (as described below).

The changes in the second commit fix some of the rate limit issues in testa and clean up the job:

- Set HOMEBREW_GITHUB_API_TOKEN to tell Homebrew to use our CI token to authenticate with the GitHub API. This drastically increases the rate limit.
- Combine the two test jobs into a single matrix job. When installing additional shells, just look at the RUNNER_OS env var to decide whether to use apt or brew.
- Install Nix with a single build user to speed up the install time.
- Source Nix and set the relevant env vars in the install step so we don't forget to do it in other steps that need Nix.
- Run go tests with the race detector and code coverage.

## How was it tested?

N/A