### PR TITLE
[plan] do not html-escape json encoding

### DIFF
--- a/boxcli/plan.go
+++ b/boxcli/plan.go
@@ -4,7 +4,8 @@
 package boxcli
 
 import (
-	"fmt"
+	"encoding/json"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -37,6 +38,9 @@ func runPlanCmd(cmd *cobra.Command, args []string) error {
 	if plan.Invalid() {
 		return plan.Error()
 	}
-	fmt.Println(plan)
-	return nil
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	return errors.WithStack(enc.Encode(plan))
 }

--- a/testdata/python/poetry-with-custom-dir-structure/plan.json
+++ b/testdata/python/poetry-with-custom-dir-structure/plan.json
@@ -1,6 +1,13 @@
 {
+  "dev_packages": [
+    "python310",
+    "poetry"
+  ],
+  "runtime_packages": [
+    "python310"
+  ],
   "install_stage": {
-    "command": "poetry add pex -n --no-ansi \u0026\u0026 poetry install --no-dev -n --no-ansi",
+    "command": "poetry add pex -n --no-ansi && poetry install --no-dev -n --no-ansi",
     "input_files": [
       "."
     ]
@@ -14,11 +21,5 @@
       "."
     ]
   },
-  "dev_packages": [
-    "python310",
-    "poetry"
-  ],
-  "runtime_packages": [
-    "python310"
-  ]
+  "definitions": null
 }

--- a/testdata/python/poetry-with-main/plan.json
+++ b/testdata/python/poetry-with-main/plan.json
@@ -1,6 +1,13 @@
 {
+  "dev_packages": [
+    "python310",
+    "poetry"
+  ],
+  "runtime_packages": [
+    "python310"
+  ],
   "install_stage": {
-    "command": "poetry add pex -n --no-ansi \u0026\u0026 poetry install --no-dev -n --no-ansi",
+    "command": "poetry add pex -n --no-ansi && poetry install --no-dev -n --no-ansi",
     "input_files": [
       "."
     ]
@@ -14,11 +21,5 @@
       "."
     ]
   },
-  "dev_packages": [
-    "python310",
-    "poetry"
-  ],
-  "runtime_packages": [
-    "python310"
-  ]
+  "definitions": null
 }

--- a/testdata/python/poetry-with-scripts/plan.json
+++ b/testdata/python/poetry-with-scripts/plan.json
@@ -1,12 +1,19 @@
 {
+  "dev_packages": [
+    "python310",
+    "poetry"
+  ],
+  "runtime_packages": [
+    "python310"
+  ],
   "install_stage": {
-    "command": "poetry add pex -n --no-ansi \u0026\u0026 poetry install --no-dev -n --no-ansi",
+    "command": "poetry add pex -n --no-ansi && poetry install --no-dev -n --no-ansi",
     "input_files": [
       "."
     ]
   },
   "build_stage": {
-    "command": "poetry run pex . -o app.pex $(poetry run python -c \"import pkgutil;import poetry_with_scripts;modules = [name for _, name, _ in pkgutil.iter_modules(poetry_with_scripts.__path__)];print('-m poetry_with_scripts' if '__main__' in modules else '--script script');\") --validate-entry-point \u0026\u003e/dev/null || (echo 'Build failed. Could not find entrypoint' \u0026\u0026 exit 1)"
+    "command": "poetry run pex . -o app.pex $(poetry run python -c \"import pkgutil;import poetry_with_scripts;modules = [name for _, name, _ in pkgutil.iter_modules(poetry_with_scripts.__path__)];print('-m poetry_with_scripts' if '__main__' in modules else '--script script');\") --validate-entry-point &>/dev/null || (echo 'Build failed. Could not find entrypoint' && exit 1)"
   },
   "start_stage": {
     "command": "python ./app.pex",
@@ -14,11 +21,5 @@
       "."
     ]
   },
-  "dev_packages": [
-    "python310",
-    "poetry"
-  ],
-  "runtime_packages": [
-    "python310"
-  ]
+  "definitions": null
 }


### PR DESCRIPTION
## Summary

In our `plan.json` that we generate the ampersand gets escaped. This happens
because golang does html escaping by default in its json/encoding. Hard for it to
escape its  web roots, I guess.

Anyway, there's no reason ampersands cannot exist in jsons, so we can turn off this escaping.

## How was it tested?

tests pass, so current testdata plan.json all work.

made this edit to a zig testdatum:
```➜ git diff
diff --git a/testdata/zig/zig-hello-world/devbox.json b/testdata/zig/zig-hello-world/devbox.json
index 3352a1b..498559e 100644
--- a/testdata/zig/zig-hello-world/devbox.json
+++ b/testdata/zig/zig-hello-world/devbox.json
@@ -2,5 +2,8 @@
   "packages": [],
   "shell": {
     "init_hook": null
-  }
-}
\ No newline at end of file
+  },
+  "start_stage": {
+     "command": "./zig-hello-world && echo \"used ampersand\""
+   }
+}
```
and got this output
```
{
  "dev_packages": [
    "zig"
  ],
  "runtime_packages": [],
  "install_stage": {
    "command": ""
  },
  "build_stage": {
    "command": "zig build install",
    "input_files": [
      "."
    ]
  },
  "start_stage": {
    "command": "./zig-hello-world && echo \"used ampersand\"",
    "input_files": [
      "./zig-out/bin/"
    ]
  },
  "definitions": null
}
```
