### PR TITLE
[plan] Plan.Definitions add omitempty

### DIFF
--- a/planner/plansdk/plansdk.go
+++ b/planner/plansdk/plansdk.go
@@ -51,7 +51,7 @@ type Plan struct {
 	// Ex: python main.py
 	StartStage *Stage `json:"start_stage,omitempty"`
 
-	Definitions []string `cue:"[...string]" json:"definitions"`
+	Definitions []string `cue:"[...string]" json:"definitions,omitempty"`
 	// Errors from plan generation. This usually means
 	// the user application may not be buildable.
 	Errors []PlanError `json:"errors,omitempty"`

--- a/testdata/zig/zig-hello-world/plan.json
+++ b/testdata/zig/zig-hello-world/plan.json
@@ -17,6 +17,5 @@
     "input_files": [
       "./zig-out/bin/"
     ]
-  },
-  "definitions": null
+  }
 }


### PR DESCRIPTION
## Summary

I'm adding omitempty to Plan.Definitions.

I'm not adding it to Plan.DevPackages and Plan.RuntimePackages. Because it explains to a reader that these are empty. These fields are so core and commonly used that I think we want to make an exception for them.

## How was it tested?

compiles
