### PR TITLE
[devbox shell] fix parsing of cmd and path

### DIFF
--- a/boxcli/shell.go
+++ b/boxcli/shell.go
@@ -68,10 +68,11 @@ func validateShellArgs(cmd *cobra.Command, args []string) error {
 func parseShellArgs(cmd *cobra.Command, args []string) (string, []string) {
 	index := cmd.ArgsLenAtDash()
 	if index < 0 {
-		index = 0
+		return pathArg(args), []string{}
 	}
 
 	path := pathArg(args[:index])
 	cmds := args[index:]
+
 	return path, cmds
 }


### PR DESCRIPTION
## Summary

fixes parsing of the path/to/devbox/json and the command to be invoked

## How was it tested?

```
> cd testdata/zig/
> devbox shell zig-hello-world 
> devbox shell zig-hello-world -- zig help
> devbox shell -- zig help
```
