### PR TITLE
[polish] improve error message for missing devbox-json

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/boxcli/usererr"
 	"go.jetpack.io/devbox/cuecfg"
 	"go.jetpack.io/devbox/docker"
 	"go.jetpack.io/devbox/nix"
@@ -20,26 +21,6 @@ import (
 
 // configFilename is name of the JSON file that defines a devbox environment.
 const configFilename = "devbox.json"
-
-var errNoDevboxJSON = func(dir string) error {
-
-	// We try to prettify the `dir` before printing
-	if dir == "." {
-		dir = "this directory"
-	} else {
-		// Instead of a long absolute directory, print the relative directory
-
-		wd, err := os.Getwd()
-		// if an error occurs, then just use `dir`
-		if err == nil {
-			relDir, err := filepath.Rel(wd, dir)
-			if err == nil {
-				dir = relDir
-			}
-		}
-	}
-	return errors.Errorf("No devbox.json found in %s. Did you run `devbox init` yet?", dir)
-}
 
 // InitConfig creates a default devbox config file if one doesn't already
 // exist.
@@ -60,7 +41,7 @@ func Open(dir string) (*Devbox, error) {
 	cfgPath := filepath.Join(dir, configFilename)
 
 	if !plansdk.FileExists(cfgPath) {
-		return nil, errNoDevboxJSON(dir)
+		return nil, missingDevboxJsonError(dir)
 	}
 
 	cfg, err := ReadConfig(cfgPath)
@@ -236,4 +217,24 @@ func (d *Devbox) generateBuildFiles() error {
 		return buildPlan.Error()
 	}
 	return generate(d.srcDir, buildPlan, buildFiles)
+}
+
+func missingDevboxJsonError(dir string) error {
+
+	// We try to prettify the `dir` before printing
+	if dir == "." {
+		dir = "this directory"
+	} else {
+		// Instead of a long absolute directory, print the relative directory
+
+		wd, err := os.Getwd()
+		// if an error occurs, then just use `dir`
+		if err == nil {
+			relDir, err := filepath.Rel(wd, dir)
+			if err == nil {
+				dir = relDir
+			}
+		}
+	}
+	return usererr.New("No devbox.json found in %s. Did you run `devbox init` yet?", dir)
 }

--- a/devbox.go
+++ b/devbox.go
@@ -41,7 +41,7 @@ func Open(dir string) (*Devbox, error) {
 	cfgPath := filepath.Join(dir, configFilename)
 
 	if !plansdk.FileExists(cfgPath) {
-		return nil, missingDevboxJsonError(dir)
+		return nil, missingDevboxJSONError(dir)
 	}
 
 	cfg, err := ReadConfig(cfgPath)
@@ -219,7 +219,7 @@ func (d *Devbox) generateBuildFiles() error {
 	return generate(d.srcDir, buildPlan, buildFiles)
 }
 
-func missingDevboxJsonError(dir string) error {
+func missingDevboxJSONError(dir string) error {
 
 	// We try to prettify the `dir` before printing
 	if dir == "." {


### PR DESCRIPTION
## Summary

The old message was not very nice.


```
> devbox shell empty-projects/no-devbox-json
Error: open /Users/savil/code/jetpack/devbox/testdata/empty-projects/no-devbox-json/devbox.json: no such file or directory
```
or

```
> devbox shell
Error: open devbox.json: no such file or directory
````
## How was it tested?

inside the project directory:
```
➜ devbox shell
Error: No devbox.json found in this directory. Did you run `devbox init` yet?
```

when using a path, print the relative dir:
```
➜ devbox shell empty-projects/no-devbox-json
Error: No devbox.json found in empty-projects/no-devbox-json. Did you run `devbox init` yet?
```
