### PR TITLE
nix: fix shellrc PATH word splitting in bash

### DIFF
--- a/nix/shellrc.tmpl
+++ b/nix/shellrc.tmpl
@@ -51,7 +51,7 @@ content readable.
 # 	  different shells.
 PATH="$(
 	IFS=:
-	for path_dir in $(echo $PATH); do
+	for path_dir in $(echo "$PATH"); do
 		case "$path_dir" in
 			$NIX_STORE/*) nix_path="${nix_path:+$nix_path:}${path_dir}" ;;
 			*) non_nix_path="${non_nix_path:+$non_nix_path:}${path_dir}" ;;

--- a/nix/testdata/shellrc/basic/shellrc.golden
+++ b/nix/testdata/shellrc/basic/shellrc.golden
@@ -65,7 +65,7 @@ zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
 # 	  different shells.
 PATH="$(
 	IFS=:
-	for path_dir in $(echo $PATH); do
+	for path_dir in $(echo "$PATH"); do
 		case "$path_dir" in
 			$NIX_STORE/*) nix_path="${nix_path:+$nix_path:}${path_dir}" ;;
 			*) non_nix_path="${non_nix_path:+$non_nix_path:}${path_dir}" ;;

--- a/nix/testdata/shellrc/nohook/shellrc.golden
+++ b/nix/testdata/shellrc/nohook/shellrc.golden
@@ -65,7 +65,7 @@ zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
 # 	  different shells.
 PATH="$(
 	IFS=:
-	for path_dir in $(echo $PATH); do
+	for path_dir in $(echo "$PATH"); do
 		case "$path_dir" in
 			$NIX_STORE/*) nix_path="${nix_path:+$nix_path:}${path_dir}" ;;
 			*) non_nix_path="${non_nix_path:+$non_nix_path:}${path_dir}" ;;

--- a/nix/testdata/shellrc/noshellrc/shellrc.golden
+++ b/nix/testdata/shellrc/noshellrc/shellrc.golden
@@ -23,7 +23,7 @@
 # 	  different shells.
 PATH="$(
 	IFS=:
-	for path_dir in $(echo $PATH); do
+	for path_dir in $(echo "$PATH"); do
 		case "$path_dir" in
 			$NIX_STORE/*) nix_path="${nix_path:+$nix_path:}${path_dir}" ;;
 			*) non_nix_path="${non_nix_path:+$non_nix_path:}${path_dir}" ;;


### PR DESCRIPTION
## Summary

Fix the loop in `shellrc.tmpl` so that `devbox shell` doesn't end up with a broken `PATH` delimited by spaces instead of colons. This was due to a subtle bug related to how bash and zsh do word splitting differently. Read on for an in-depth explanation.

We fix up the `PATH` in `shellrc.tmpl` by looping over each `PATH` directory. To get each dir, we set `IFS=:` and rely on the shell's word splitting to loop over `PATH`. A caveat to this approach is that zsh doesn't follow the POSIX behavior for word splitting. Here's an example showing the difference:

bash:

	bash$ export x=a:b:c
	bash$ export IFS=:
	bash$ echo $x
	a b c

zsh:

	zsh$ export x=a:b:c
	zsh$ export IFS=:
	zsh$ echo $x
	a:b:c

To workaround this, we use command substitution to force zsh to word split:

	zsh$ export x=a:b:c
	zsh$ export IFS=:
	zsh$ echo $(echo $x)
	a b c

There's a subtle bug here that causes the splitting to break in bash because the splitting happens too soon (note the single quotes around the first echo output):

	bash$ export x=a:b:c
	bash$ export IFS=:
	bash$ set -x; echo $(echo $x)
	++ echo a b c
	+ echo 'a b c' a b c

The subshell splits `$x`, resulting in 'a b c'. The parent shell doesn't split 'a b c' because it has already been split and doesn't have any colons. This doesn't happen in zsh, because zsh doesn't split unquoted variables. Quoting `$x` stops bash from splitting in the subshell, fixing this for both shells:

	bash$ export x=a:b:c
	bash$ export IFS=:
	bash$ set -x; echo $(echo "$x")
	++ echo a:b:c
	+ echo a b c a b c

Fixes #175.

## How was it tested?

Launched a `devbox shell` in bash and zsh and made sure both `PATH`s were correct.