### PR TITLE
nix: carry over (NIX_)SSL_CERT_FILE to devbox shells

### DIFF
--- a/nix/shell.go
+++ b/nix/shell.go
@@ -312,6 +312,8 @@ var envToKeep = map[string]bool{
 	// Variables specific to running in a Nix shell and devbox shell.
 	"PARENT_PATH":               true, // The PATH of the parent shell (where `devbox shell` was invoked).
 	"__ETC_PROFILE_NIX_SOURCED": true, // Prevents Nix from being sourced again inside a devbox shell.
+	"NIX_SSL_CERT_FILE":         true, // The path to Nix-installed SSL certificates (used by some Nix programs).
+	"SSL_CERT_FILE":             true, // The path to non-Nix SSL certificates (used by some Nix and non-Nix programs).
 }
 
 // toKeepArgs takes a slice of environment variables in key=value format and

--- a/tmpl/shell.nix.tmpl
+++ b/tmpl/shell.nix.tmpl
@@ -27,6 +27,15 @@ mkShell {
       export IN_NIX_SHELL=0
       export DEVBOX_SHELL_ENABLED=1
 
+      # Undo the effects of `nix-shell --pure` on SSL certs.
+      # See https://github.com/NixOS/nixpkgs/blob/dae204faa0243b4d0c0234a5f5f83a2549ecb5b7/pkgs/stdenv/generic/setup.sh#L677-L685
+      if [ "$NIX_SSL_CERT_FILE" == "/no-cert-file.crt" ]; then
+      	unset NIX_SSL_CERT_FILE
+      fi
+      if [ "$SSL_CERT_FILE" == "/no-cert-file.crt" ]; then
+      	unset SSL_CERT_FILE
+      fi
+
       # Append the parent shell's PATH so that we retain access to
       # non-Nix programs, while still preferring the Nix ones.
       export "PATH=$PATH:$PARENT_PATH"


### PR DESCRIPTION
## Summary

When `NIX_SSL_CERT_FILE` and `SSL_CERT_FILE` aren't explicitly set, `nix-shell --pure` sets them to invalid paths
(specifically "/no-cert-file.crt") to ensure that openssl doesn't use certificates that live outside of the current Nix environment. This causes HTTPS requests in most programs to fail. For example:

	(devbox) $ curl https://google.com
	curl: (77) error setting certificate verify locations:  CAfile: /no-cert-file.crt CApath: none

This is pretty inconvenient for development, so we want to undo those changes when launching a devbox shell. To do that, we:

1. Keep any `NIX_SSL_CERT_FILE` and `SSL_CERT_FILE` values that are set in the parent shell.
2. Unset `NIX_SSL_CERT_FILE` or `SSL_CERT_FILE` when they're set to the "/no-cert-file.crt" value set by `nix-shell`. This causes openssl to go back to using the default paths.

NIX_SSL_CERT_FILE is used by some programs installed by Nix. SSL_CERT_FILE is used by non-Nix programs and some Nix programs.

Fixes #177.

## How was it tested?

Running `curl https://google.com` in a devbox shell to check that it works again.