### PR TITLE
[Docs] Haskell and Zig Planners

### DIFF
--- a/docs/app/docs/language_support/csharp.md
+++ b/docs/app/docs/language_support/csharp.md
@@ -30,7 +30,7 @@ If no version is set, Devbox will use .NET 6 as the default version. Devbox will
 
 ### Default Stages
 
-These stages can be customized by adding them to your `devbox.json`. See the [Configuration Guide](../configuration.md) for more details
+These stages can be customized by adding them to your `devbox.json`. See the [Configuration Guide](../configuration.md) for more details.
 
 ### Install Stage
 

--- a/docs/app/docs/language_support/go.md
+++ b/docs/app/docs/language_support/go.md
@@ -24,7 +24,7 @@ If no Go version can be detected, Devbox will default to 1.19.
   * `go_1_19`
 
 ### Default Stages
-These stages can be customized by adding them to your `devbox.json`. See the [Configuration Guide](../configuration.md) for more details
+These stages can be customized by adding them to your `devbox.json`. See the [Configuration Guide](../configuration.md) for more details.
 #### Install Stage 
 
 ```bash

--- a/docs/app/docs/language_support/haskell.md
+++ b/docs/app/docs/language_support/haskell.md
@@ -1,0 +1,42 @@
+---
+title: Haskell
+---
+
+### Detection
+
+Devbox will automatically create a Haskell project plan whenever a `stack.yaml` file is detected in the project's root directory.
+
+For now, the Haskell planner only works for the [Stack framework](https://docs.haskellstack.org/en/stable/).
+
+### Supported Versions
+
+Devbox currently installs the latest Glasgow Haskell Compiler version 9.
+
+### Included Nix Packages
+
+* `ghc`
+* `stack`
+* `libiconv`
+* `libffi`
+* `binutils`
+
+### Default Stages
+These stages can be customized by adding them to your `devbox.json`. See the [Configuration Guide](../configuration.md) for more details.
+#### Install Stage
+
+```bash
+stack build --system-ghc --dependencies-only
+```
+
+#### Build Stage
+
+```bash
+stack build --system-ghc
+```
+
+#### Start Stage
+
+```bash
+stack exec --system-ghc <project name>-exe
+```
+where `<project name>` is from the `Name` field in `stack.yaml`

--- a/docs/app/docs/language_support/java.md
+++ b/docs/app/docs/language_support/java.md
@@ -30,7 +30,7 @@ If no version is set, Devbox will use Java 17 as the default version.
 
 ### Default Stages
 
-These stages can be customized by adding them to your `devbox.json`. See the [Configuration Guide](../configuration.md) for more details
+These stages can be customized by adding them to your `devbox.json`. See the [Configuration Guide](../configuration.md) for more details.
 
 ### Install Stage
 

--- a/docs/app/docs/language_support/nginx.md
+++ b/docs/app/docs/language_support/nginx.md
@@ -25,7 +25,7 @@ Devbox will use the nginx provided by the Nix Package manager. It is currently n
 
 ### Default Stages
 
-These stages can be customized by adding them to your `devbox.json`. See the [Configuration Guide](../configuration.md) for more details
+These stages can be customized by adding them to your `devbox.json`. See the [Configuration Guide](../configuration.md) for more details.
 
 ### Install Stage
 

--- a/docs/app/docs/language_support/nodejs.md
+++ b/docs/app/docs/language_support/nodejs.md
@@ -32,7 +32,7 @@ If no version is set, Devbox will use 16 as the default version
 
 ### Default Stages
 
-These stages can be customized by adding them to your `devbox.json`. See the [Configuration Guide](../configuration.md) for more details
+These stages can be customized by adding them to your `devbox.json`. See the [Configuration Guide](../configuration.md) for more details.
 
 ### Install Stage
 

--- a/docs/app/docs/language_support/php.md
+++ b/docs/app/docs/language_support/php.md
@@ -28,7 +28,7 @@ If no version is set, Devbox will use 8.1 as the default version
 
 ### Default Stages
 
-These stages can be customized by adding them to your `devbox.json`. See the [Configuration Guide](../configuration.md) for more details
+These stages can be customized by adding them to your `devbox.json`. See the [Configuration Guide](../configuration.md) for more details.
 
 #### Install Stage
 

--- a/docs/app/docs/language_support/python.md
+++ b/docs/app/docs/language_support/python.md
@@ -31,7 +31,7 @@ If no version is specified, Devbox will default to Python 3.10
 
 ## Default Stages
 
-These stages can be customized by adding them to your `devbox.json`. See the [Configuration Guide](../configuration.md) for more details
+These stages can be customized by adding them to your `devbox.json`. See the [Configuration Guide](../configuration.md) for more details.
 
 ### Install Stage
 ```bash

--- a/docs/app/docs/language_support/rust.md
+++ b/docs/app/docs/language_support/rust.md
@@ -20,7 +20,7 @@ Devbox uses the [nix-overlay from oxalica](https://github.com/oxalica/rust-overl
 
 ### Default Stages
 
-These stages can be customized by adding them to your `devbox.json`. See the [Configuration Guide](../configuration.md) for more details
+These stages can be customized by adding them to your `devbox.json`. See the [Configuration Guide](../configuration.md) for more details.
 
 ### Install Stage
 

--- a/docs/app/docs/language_support/zig.md
+++ b/docs/app/docs/language_support/zig.md
@@ -1,0 +1,44 @@
+---
+title: Zig
+---
+
+### Detection
+
+Devbox will automatically create a Zig project plan whenever a `build.zig` file is detected in the project's root directory.
+
+### Supported Versions
+
+Devbox currently installs the latest Zig version.
+
+### Included Nix Packages
+
+Install and Build Stage Image:
+* `zig`
+
+Start Stage Image:
+* None, if we can parse the executable name from `build.zig`.
+* `zig`, otherwise.
+
+### Default Stages
+These stages can be customized by adding them to your `devbox.json`. See the [Configuration Guide](../configuration.md) for more details.
+#### Install Stage
+
+Skipped: _No install stage for zig planner_
+
+#### Build Stage
+
+```bash
+zig build install
+```
+
+#### Start Stage
+
+If `<exe-name>` is found from parsing `build.zig` to find the `addExecutable` statement, then:
+```bash
+./<exe-name>
+```
+
+Else if no `<exe-name>` is found, then:
+```bash
+zig build run
+```

--- a/docs/app/sidebars.js
+++ b/docs/app/sidebars.js
@@ -45,6 +45,9 @@ const sidebars = {
             id: 'language_support/go'
         }, {
             type: 'doc',
+            id: 'language_support/haskell'
+        }, {
+            type: 'doc',
             id: 'language_support/java'
         }, {
             type: 'doc',
@@ -61,8 +64,11 @@ const sidebars = {
         }, {
             type: 'doc',
             id: 'language_support/rust'
+        }, {
+        type: 'doc',
+        id: 'language_support/zig'
         }]
-    }],
+}],
 
 };
 


### PR DESCRIPTION
## Summary

- Added Haskell and Zig planners.
- Added a period after "See the Configuration Guide for more details" in all the planner docs.

## How was it tested?

in `docs/app`:
```
yarn install
yarn start
```

inspected changes in `localhost:3000/devbox`
