### PR TITLE
[shell] add packages within shell, leveraging nix-profile

### DIFF
--- a/boxcli/add.go
+++ b/boxcli/add.go
@@ -4,6 +4,9 @@
 package boxcli
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
@@ -27,6 +30,31 @@ func addCmdFunc() runFunc {
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		return box.Add(args...)
+
+		if err = box.Add(args...); err != nil {
+			return err
+		}
+
+		if err := box.Generate(); err != nil {
+			return err
+		}
+
+		fmt.Print("Installing nix packages. This may take a while...")
+		if err = installDevPackages(box.SourceDir()); err != nil {
+			fmt.Println()
+			return err
+		}
+		fmt.Println("done.")
+
+		if isDevboxShellEnabled() {
+			successMsg := fmt.Sprintf("%s is now installed.", args[0])
+			if len(args) > 1 {
+				successMsg = fmt.Sprintf("%s are now installed.", strings.Join(args, ", "))
+			}
+			fmt.Print(successMsg)
+			fmt.Println(" Run `hash -r` to ensure your shell is updated.")
+		}
+
+		return nil
 	}
 }

--- a/boxcli/add.go
+++ b/boxcli/add.go
@@ -4,8 +4,7 @@
 package boxcli
 
 import (
-	"fmt"
-	"strings"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -26,35 +25,11 @@ func AddCmd() *cobra.Command {
 
 func addCmdFunc() runFunc {
 	return func(cmd *cobra.Command, args []string) error {
-		box, err := devbox.Open(".")
+		box, err := devbox.Open(".", os.Stdout)
 		if err != nil {
 			return errors.WithStack(err)
 		}
 
-		if err = box.Add(args...); err != nil {
-			return err
-		}
-
-		if err := box.Generate(); err != nil {
-			return err
-		}
-
-		fmt.Print("Installing nix packages. This may take a while...")
-		if err = installDevPackages(box.SourceDir()); err != nil {
-			fmt.Println()
-			return err
-		}
-		fmt.Println("done.")
-
-		if isDevboxShellEnabled() {
-			successMsg := fmt.Sprintf("%s is now installed.", args[0])
-			if len(args) > 1 {
-				successMsg = fmt.Sprintf("%s are now installed.", strings.Join(args, ", "))
-			}
-			fmt.Print(successMsg)
-			fmt.Println(" Run `hash -r` to ensure your shell is updated.")
-		}
-
-		return nil
+		return box.Add(args...)
 	}
 }

--- a/boxcli/build.go
+++ b/boxcli/build.go
@@ -4,6 +4,8 @@
 package boxcli
 
 import (
+	"os"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
@@ -38,7 +40,7 @@ func buildCmdFunc(flags *docker.BuildFlags) runFunc {
 		path := pathArg(args)
 
 		// Check the directory exists.
-		box, err := devbox.Open(path)
+		box, err := devbox.Open(path, os.Stdout)
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/boxcli/generate.go
+++ b/boxcli/generate.go
@@ -4,6 +4,8 @@
 package boxcli
 
 import (
+	"os"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
@@ -23,7 +25,7 @@ func runGenerateCmd(cmd *cobra.Command, args []string) error {
 	path := pathArg(args)
 
 	// Check the directory exists.
-	box, err := devbox.Open(path)
+	box, err := devbox.Open(path, os.Stdout)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/boxcli/plan.go
+++ b/boxcli/plan.go
@@ -26,7 +26,7 @@ func runPlanCmd(cmd *cobra.Command, args []string) error {
 	path := pathArg(args)
 
 	// Check the directory exists.
-	box, err := devbox.Open(path)
+	box, err := devbox.Open(path, os.Stdout)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/boxcli/rm.go
+++ b/boxcli/rm.go
@@ -4,8 +4,7 @@
 package boxcli
 
 import (
-	"fmt"
-	"strings"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -23,35 +22,10 @@ func RemoveCmd() *cobra.Command {
 }
 
 func runRemoveCmd(cmd *cobra.Command, args []string) error {
-	box, err := devbox.Open(".")
+	box, err := devbox.Open(".", os.Stdout)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	if err = box.Remove(args...); err != nil {
-		return err
-	}
-
-	if err := box.Generate(); err != nil {
-		return err
-	}
-
-	fmt.Print("Uninstalling nix packages. This may take a while...")
-	// We need to reinstall the packages
-	if err = installDevPackages(box.SourceDir()); err != nil {
-		fmt.Println()
-		return err
-	}
-	fmt.Println("done.")
-
-	if isDevboxShellEnabled() {
-		successMsg := fmt.Sprintf("%s is now removed.", args[0])
-		if len(args) > 1 {
-			successMsg = fmt.Sprintf("%s are now removed.", strings.Join(args, ", "))
-		}
-		fmt.Print(successMsg)
-		fmt.Println(" Run `hash -r` to ensure your shell is updated.")
-	}
-
-	return nil
+	return box.Remove(args...)
 }

--- a/boxcli/rm.go
+++ b/boxcli/rm.go
@@ -37,7 +37,8 @@ func runRemoveCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Print("Uninstalling nix packages. This may take a while...")
-	if err = uninstallDevPackages(args...); err != nil {
+	// We need to reinstall the packages
+	if err = installDevPackages(box.SourceDir()); err != nil {
 		fmt.Println()
 		return err
 	}
@@ -49,9 +50,7 @@ func runRemoveCmd(cmd *cobra.Command, args []string) error {
 			successMsg = fmt.Sprintf("%s are now removed.", strings.Join(args, ", "))
 		}
 		fmt.Print(successMsg)
-
-		// Sadface. This doesn't seem to work within devbox shell for now.
-		fmt.Println(" You may need to restart `devbox shell` for this to take effect.")
+		fmt.Println(" Run `hash -r` to ensure your shell is updated.")
 	}
 
 	return nil

--- a/boxcli/shell.go
+++ b/boxcli/shell.go
@@ -113,15 +113,3 @@ func installDevPackages(srcDir string) error {
 	err := execCmd.Run()
 	return errors.WithStack(err)
 }
-
-// will move to store package
-func uninstallDevPackages(pkgs ...string) error {
-
-	cmdStr := fmt.Sprintf("--profile %s --uninstall %s", nix.ProfileDir, strings.Join(pkgs, ","))
-	cmdParts := strings.Split(cmdStr, " ")
-	execCmd := exec.Command("nix-env", cmdParts...)
-
-	debug.Log("running command: %s\n", execCmd.Args)
-	err := execCmd.Run()
-	return errors.WithStack(err)
-}

--- a/devbox.go
+++ b/devbox.go
@@ -6,8 +6,12 @@ package devbox
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/boxcli/usererr"
@@ -20,6 +24,9 @@ import (
 	"go.jetpack.io/devbox/planner/plansdk"
 	"golang.org/x/exp/slices"
 )
+
+// profileDir contains the contents of the profile generated via `nix-env --profile profileDir <command>`
+const profileDir = ".devbox/profile"
 
 // configFilename is name of the JSON file that defines a devbox environment.
 const configFilename = "devbox.json"
@@ -37,10 +44,11 @@ type Devbox struct {
 	cfg *Config
 	// srcDir is the directory where the config file (devbox.json) resides
 	srcDir string
+	writer io.Writer
 }
 
 // Open opens a devbox by reading the config file in dir.
-func Open(dir string) (*Devbox, error) {
+func Open(dir string, writer io.Writer) (*Devbox, error) {
 
 	cfgDir, err := findConfigDir(dir)
 	if err != nil {
@@ -53,24 +61,12 @@ func Open(dir string) (*Devbox, error) {
 		return nil, errors.WithStack(err)
 	}
 
-	// if dir is current directory, then get the full path
-	if dir == "." {
-		var err error
-		dir, err = os.Getwd()
-		if err != nil {
-			return nil, errors.WithStack(err)
-		}
-	}
-
 	box := &Devbox{
 		cfg:    cfg,
 		srcDir: cfgDir,
+		writer: writer,
 	}
 	return box, nil
-}
-
-func (d *Devbox) SourceDir() string {
-	return d.srcDir
 }
 
 // Add adds a Nix package to the config so that it's available in the devbox
@@ -85,14 +81,21 @@ func (d *Devbox) Add(pkgs ...string) error {
 		}
 	}
 
-	// Add to Packages only if it's not already there
+	// Add to Packages to config only if it's not already there
 	for _, pkg := range pkgs {
 		if slices.Contains(d.cfg.Packages, pkg) {
 			continue
 		}
 		d.cfg.Packages = append(d.cfg.Packages, pkg)
 	}
-	return d.saveCfg()
+	if err := d.saveCfg(); err != nil {
+		return err
+	}
+
+	if err := d.ensurePackagesAreInstalled(install); err != nil {
+		return err
+	}
+	return d.printPackageUpdateMessage(install, pkgs)
 }
 
 // Remove removes Nix packages from the config so that it no longer exists in
@@ -100,7 +103,14 @@ func (d *Devbox) Add(pkgs ...string) error {
 func (d *Devbox) Remove(pkgs ...string) error {
 	// Remove packages from config.
 	d.cfg.Packages = pkgslice.Exclude(d.cfg.Packages, pkgs)
-	return d.saveCfg()
+	if err := d.saveCfg(); err != nil {
+		return err
+	}
+
+	if err := d.ensurePackagesAreInstalled(uninstall); err != nil {
+		return err
+	}
+	return d.printPackageUpdateMessage(uninstall, pkgs)
 }
 
 // Build creates a Docker image containing a shell with the devbox environment.
@@ -155,35 +165,33 @@ func (d *Devbox) Generate() error {
 // Shell generates the devbox environment and launches nix-shell as a child
 // process.
 func (d *Devbox) Shell() error {
-	if err := d.generateShellFiles(); err != nil {
-		return errors.WithStack(err)
+
+	if err := d.ensurePackagesAreInstalled(install); err != nil {
+		return err
 	}
+
 	plan, err := d.ShellPlan()
 	if err != nil {
 		return errors.WithStack(err)
 	}
 	nixShellFilePath := filepath.Join(d.srcDir, ".devbox/gen/shell.nix")
-	sh, err := nix.DetectShell(nix.WithPlanInitHook(plan.ShellInitHook))
+	sh, err := nix.DetectShell(nix.WithPlanInitHook(plan.ShellInitHook), nix.WithProfile(d.profileDir()))
 	if err != nil {
 		// Fall back to using a plain Nix shell.
 		sh = &nix.Shell{}
 	}
 	sh.UserInitHook = d.cfg.Shell.InitHook.String()
-	return sh.Run(nixShellFilePath, d.srcDir)
+	return sh.Run(nixShellFilePath)
 }
 
 func (d *Devbox) Exec(cmds ...string) error {
-	plan, err := d.ShellPlan()
-	if err != nil {
-		return errors.WithStack(err)
+	if err := d.ensurePackagesAreInstalled(install); err != nil {
+		return err
 	}
-	if plan.Invalid() {
-		return plan.Error()
-	}
-	err = generate(d.srcDir, plan, shellFiles)
-	if err != nil {
-		return errors.WithStack(err)
-	}
+
+	pathWithProfileBin := fmt.Sprintf("PATH=%s:$PATH", d.profileBinDir())
+	cmds = append([]string{pathWithProfileBin}, cmds...)
+
 	nixDir := filepath.Join(d.srcDir, ".devbox/gen/shell.nix")
 	return nix.Exec(nixDir, cmds)
 }
@@ -239,6 +247,14 @@ func (d *Devbox) generateBuildFiles() error {
 	return generate(d.srcDir, buildPlan, buildFiles)
 }
 
+func (d *Devbox) profileDir() string {
+	return d.srcDir + "/" + profileDir
+}
+
+func (d *Devbox) profileBinDir() string {
+	return d.profileDir() + "/bin"
+}
+
 func missingDevboxJSONError(dir string) error {
 
 	// We try to prettify the `dir` before printing
@@ -278,4 +294,80 @@ func findConfigDir(dir string) (string, error) {
 		return cur, nil
 	}
 	return "", missingDevboxJSONError(dir)
+}
+
+// installMode is an enum for helping with ensurePackagesAreInstalled implementation
+type installMode string
+
+const (
+	install   installMode = "install"
+	uninstall installMode = "uninstall"
+)
+
+func (d *Devbox) ensurePackagesAreInstalled(mode installMode) error {
+	if err := d.Generate(); err != nil {
+		return err
+	}
+
+	installingVerb := "Installing"
+	if mode == uninstall {
+		installingVerb = "Uninstalling"
+	}
+	fmt.Fprintf(d.writer, "%s nix packages. This may take a while...", installingVerb)
+
+	// We need to re-install the packages
+	if err := d.ApplyDevNixDerivation(); err != nil {
+		fmt.Println()
+		return err
+	}
+	fmt.Println("done.")
+
+	return nil
+}
+
+func (d *Devbox) printPackageUpdateMessage(mode installMode, pkgs []string) error {
+	// (Only when in devbox shell) Prompt the user to run `hash -r` to ensure their
+	// shell can access the most recently installed binaries, or ensure their
+	// recently uninstalled binaries are not accidentally still available.
+	if len(pkgs) > 0 && IsDevboxShellEnabled() {
+		installedVerb := "installed"
+		if mode == uninstall {
+			installedVerb = "removed"
+		}
+
+		successMsg := fmt.Sprintf("%s is now %s.", pkgs[0], installedVerb)
+		if len(pkgs) > 1 {
+			successMsg = fmt.Sprintf("%s are now %s.", strings.Join(pkgs, ", "), installedVerb)
+		}
+		fmt.Fprint(d.writer, successMsg)
+		fmt.Fprintln(d.writer, " Run `hash -r` to ensure your shell is updated.")
+	}
+	return nil
+}
+
+// ApplyDevNixDerivation ensures the local profile has exactly the packages in the development.nix file
+//
+// Will move to a store interface/package
+func (d *Devbox) ApplyDevNixDerivation() error {
+
+	cmdStr := fmt.Sprintf(
+		"--profile %s --install -f %s/.devbox/gen/development.nix",
+		d.srcDir+"/"+profileDir,
+		d.srcDir,
+	)
+	cmdParts := strings.Split(cmdStr, " ")
+	execCmd := exec.Command("nix-env", cmdParts...)
+
+	debug.Log("running command: %s\n", execCmd.Args)
+	err := execCmd.Run()
+	return errors.WithStack(err)
+}
+
+// Move to a utility package?
+func IsDevboxShellEnabled() bool {
+	inDevboxShell, err := strconv.ParseBool(os.Getenv("DEVBOX_SHELL_ENABLED"))
+	if err != nil {
+		return false
+	}
+	return inDevboxShell
 }

--- a/devbox.go
+++ b/devbox.go
@@ -248,11 +248,11 @@ func (d *Devbox) generateBuildFiles() error {
 }
 
 func (d *Devbox) profileDir() string {
-	return d.srcDir + "/" + profileDir
+	return filepath.Join(d.srcDir, profileDir)
 }
 
 func (d *Devbox) profileBinDir() string {
-	return d.profileDir() + "/bin"
+	return filepath.Join(d.profileDir(), "bin")
 }
 
 func missingDevboxJSONError(dir string) error {
@@ -352,7 +352,7 @@ func (d *Devbox) ApplyDevNixDerivation() error {
 
 	cmdStr := fmt.Sprintf(
 		"--profile %s --install -f %s/.devbox/gen/development.nix",
-		d.srcDir+"/"+profileDir,
+		filepath.Join(d.srcDir, profileDir),
 		d.srcDir,
 	)
 	cmdParts := strings.Split(cmdStr, " ")

--- a/devbox_test.go
+++ b/devbox_test.go
@@ -39,7 +39,7 @@ func testExample(t *testing.T, testPath string) {
 		goldenFile := filepath.Join(baseDir, "plan.json")
 		hasGoldenFile := fileExists(goldenFile)
 
-		box, err := Open(baseDir)
+		box, err := Open(baseDir, os.Stdout)
 		assert.NoErrorf(err, "%s should be a valid devbox project", baseDir)
 
 		// Just for tests, we make srcDir be a relative path so that the paths in plan.json

--- a/generate.go
+++ b/generate.go
@@ -20,7 +20,7 @@ import (
 //go:embed tmpl/* tmpl/.*
 var tmplFS embed.FS
 
-var shellFiles = []string{".gitignore", "shell.nix"}
+var shellFiles = []string{".gitignore", "development.nix", "shell.nix"}
 var buildFiles = []string{".gitignore", "development.nix", "runtime.nix", "Dockerfile", "Dockerfile.dockerignore"}
 
 func generate(rootPath string, plan *plansdk.Plan, files []string) error {

--- a/nix/shell.go
+++ b/nix/shell.go
@@ -126,9 +126,6 @@ func (s *Shell) Run(nixShellFilePath string) error {
 	// directories that are incompatible.
 	parentPath := cleanEnvPath(os.Getenv("PATH"), nixProfileDirs)
 
-	// Add the profile's binaries directory
-	// parentPath = parentPath + string(filepath.ListSeparator) + ProfileDir + "/bin"
-
 	env := append(
 		os.Environ(),
 		"PARENT_PATH="+parentPath,

--- a/nix/shell_test.go
+++ b/nix/shell_test.go
@@ -53,7 +53,7 @@ func TestWriteDevboxShellrc(t *testing.T) {
 				UserInitHook:    test.hook,
 				planInitHook:    `echo "Welcome to the devbox!"`,
 			}
-			gotPath, err := s.writeDevboxShellrc()
+			gotPath, err := s.writeDevboxShellrc("" /*srcDir*/)
 			if err != nil {
 				t.Fatal("Got writeDevboxShellrc error:", err)
 			}

--- a/nix/shell_test.go
+++ b/nix/shell_test.go
@@ -52,8 +52,9 @@ func TestWriteDevboxShellrc(t *testing.T) {
 				userShellrcPath: test.shellrcPath,
 				UserInitHook:    test.hook,
 				planInitHook:    `echo "Welcome to the devbox!"`,
+				profileDir:      "./devbox/profile",
 			}
-			gotPath, err := s.writeDevboxShellrc("" /*srcDir*/)
+			gotPath, err := s.writeDevboxShellrc()
 			if err != nil {
 				t.Fatal("Got writeDevboxShellrc error:", err)
 			}

--- a/nix/shellrc.tmpl
+++ b/nix/shellrc.tmpl
@@ -28,6 +28,10 @@ content readable.
 
 # Begin Devbox Post-init Hook
 
+# TODO: this can likely be simplified, because we no longer expect any NIX_STORE paths.
+# These are replaced by having the NixProfilePath. However, refactoring
+# this is a bit risky due to the diff behavior of various shells, so not doing just yet.
+#
 # We need to do some processing on the PATH to ensure that any NIX_STORE paths
 # stay at the front.
 #
@@ -57,7 +61,7 @@ PATH="$(
 			*) non_nix_path="${non_nix_path:+$non_nix_path:}${path_dir}" ;;
 		esac
 	done
-	echo "${nix_path:+$nix_path:}${non_nix_path}"
+	echo "{{ .NixProfileDir }}:${non_nix_path}"
 )"
 
 # Prepend to the prompt to make it clear we're in a devbox shell.

--- a/nix/shellrc.tmpl
+++ b/nix/shellrc.tmpl
@@ -61,7 +61,7 @@ PATH="$(
 			*) non_nix_path="${non_nix_path:+$non_nix_path:}${path_dir}" ;;
 		esac
 	done
-	echo "{{ .NixProfileDir }}:${non_nix_path}"
+	echo "{{ .ProfileBinDir }}:${non_nix_path}"
 )"
 
 # Prepend to the prompt to make it clear we're in a devbox shell.

--- a/nix/testdata/shellrc/basic/shellrc.golden
+++ b/nix/testdata/shellrc/basic/shellrc.golden
@@ -75,7 +75,7 @@ PATH="$(
 			*) non_nix_path="${non_nix_path:+$non_nix_path:}${path_dir}" ;;
 		esac
 	done
-	echo "${nix_path:+$nix_path:}${non_nix_path}"
+	echo "./devbox/profile/bin:${non_nix_path}"
 )"
 
 # Prepend to the prompt to make it clear we're in a devbox shell.

--- a/nix/testdata/shellrc/basic/shellrc.golden
+++ b/nix/testdata/shellrc/basic/shellrc.golden
@@ -42,6 +42,10 @@ zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
 
 # Begin Devbox Post-init Hook
 
+# TODO: this can likely be simplified, because we no longer expect any NIX_STORE paths.
+# These are replaced by having the NixProfilePath. However, refactoring
+# this is a bit risky due to the diff behavior of various shells, so not doing just yet.
+#
 # We need to do some processing on the PATH to ensure that any NIX_STORE paths
 # stay at the front.
 #

--- a/nix/testdata/shellrc/nohook/shellrc.golden
+++ b/nix/testdata/shellrc/nohook/shellrc.golden
@@ -75,7 +75,7 @@ PATH="$(
 			*) non_nix_path="${non_nix_path:+$non_nix_path:}${path_dir}" ;;
 		esac
 	done
-	echo "${nix_path:+$nix_path:}${non_nix_path}"
+	echo "./devbox/profile/bin:${non_nix_path}"
 )"
 
 # Prepend to the prompt to make it clear we're in a devbox shell.

--- a/nix/testdata/shellrc/nohook/shellrc.golden
+++ b/nix/testdata/shellrc/nohook/shellrc.golden
@@ -42,6 +42,10 @@ zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
 
 # Begin Devbox Post-init Hook
 
+# TODO: this can likely be simplified, because we no longer expect any NIX_STORE paths.
+# These are replaced by having the NixProfilePath. However, refactoring
+# this is a bit risky due to the diff behavior of various shells, so not doing just yet.
+#
 # We need to do some processing on the PATH to ensure that any NIX_STORE paths
 # stay at the front.
 #

--- a/nix/testdata/shellrc/noshellrc/shellrc.golden
+++ b/nix/testdata/shellrc/noshellrc/shellrc.golden
@@ -1,5 +1,9 @@
 # Begin Devbox Post-init Hook
 
+# TODO: this can likely be simplified, because we no longer expect any NIX_STORE paths.
+# These are replaced by having the NixProfilePath. However, refactoring
+# this is a bit risky due to the diff behavior of various shells, so not doing just yet.
+#
 # We need to do some processing on the PATH to ensure that any NIX_STORE paths
 # stay at the front.
 #

--- a/nix/testdata/shellrc/noshellrc/shellrc.golden
+++ b/nix/testdata/shellrc/noshellrc/shellrc.golden
@@ -33,7 +33,7 @@ PATH="$(
 			*) non_nix_path="${non_nix_path:+$non_nix_path:}${path_dir}" ;;
 		esac
 	done
-	echo "${nix_path:+$nix_path:}${non_nix_path}"
+	echo "./devbox/profile/bin:${non_nix_path}"
 )"
 
 # Prepend to the prompt to make it clear we're in a devbox shell.

--- a/testdata/rust/rust-stable/.gitignore
+++ b/testdata/rust/rust-stable/.gitignore
@@ -1,1 +1,2 @@
 target/
+.devbox/

--- a/testdata/rust/rust-stable/devbox.json
+++ b/testdata/rust/rust-stable/devbox.json
@@ -1,3 +1,8 @@
 {
-  "packages": ["rust-bin.stable.latest.default"]
+  "packages": [
+    "rust-bin.stable.latest.default"
+  ],
+  "shell": {
+    "init_hook": null
+  }
 }

--- a/tmpl/development.nix.tmpl
+++ b/tmpl/development.nix.tmpl
@@ -18,6 +18,7 @@ let
   {{end -}}
 in with pkgs;
 buildEnv {
+  ignoreCollisions = true;
   name = "devbox-development";
   paths = [
   {{- range .DevPackages}}

--- a/tmpl/shell.nix.tmpl
+++ b/tmpl/shell.nix.tmpl
@@ -44,9 +44,4 @@ mkShell {
       echo "PATH=$PATH"
       {{- end }}
     '';
-  packages = [
-  {{- range .DevPackages}}
-    {{.}}
-  {{end -}}
-  ];
 }


### PR DESCRIPTION
## Summary

**Motivation:**
We can define a custom nix-profile, and install packages scoped to this profile.

The goal is to make it easier to add packages when within devbox shell. Currently,
users need to exit the shell and restart it for the nix package to be installed - clearly
not ideal. With a nix-profile, if we install the package using that profile, then the
package's binary should be downloaded and visible within the shell.

Within `devbox shell`:
- previously, we would manually add the path to each package to `PATH`.
- now, we can add the path to the nix-profile to `PATH` and skip manually adding each package.

**Limitations:**
1. For `devbox add` within a `devbox shell`, the user needs to manually execute `hash -r` to ensure the latest binaries are visible. 
2. ~For `devbox rm` within a `devbox shell`, the user still needs to restart the shell. I'm not quite sure why the `nix-env --profile <profile dir> --uninstall <pkg>` isn't working as intended.~ Fixed via reapplying `nix-env --profile <profile> -if development.nix`
3. `devbox add` and `rm` when in a shell started from a parent directory will not work. 
    - A possible fix is to set `DEVBOX_CONFIG_DIR` env-var when inside a shell, and use that value in `devbox add` and `rm`.
    - Example:
```
> cd testdata/rust/
> devbox shell rust-stable
(devbox)> devbox add go_1_18
Error: No devbox.json found in this directory, or any parent directories. Did you run `devbox init` yet?
```
  



## How was it tested?

- [x] in `testdata/rust/rust-stable`:
  - open `devbox shell`
  - verify openssl not installed via `which openssl` and getting `/usr/bin/openssl`
  - do `devbox add openssl`
     - note that `which openssl` still reflects the non nix-store location. It has NOT yet been updated.
  - do `hash -r` and then `which openssl` and see it point to a nix-store location
  - do `devbox rm openssl`  
    - note that `which openssl` still reflects the nix-store location. It has NOT yet been updated.   
  - restart `devbox shell` and do `which openssl` to verify it has been removed