### PR TITLE
[planner] Golang planner return error when main.go is not found

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -5,6 +5,7 @@
 package devbox
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -215,6 +216,9 @@ func (d *Devbox) generateBuildFiles() error {
 	}
 	if buildPlan.Invalid() {
 		return buildPlan.Error()
+	}
+	if buildPlan.Warning() != nil {
+		fmt.Printf("[WARNING]: %s\n", buildPlan.Warning().Error())
 	}
 	return generate(d.srcDir, buildPlan, buildFiles)
 }

--- a/planner/plansdk/plansdk_test.go
+++ b/planner/plansdk/plansdk_test.go
@@ -115,68 +115,40 @@ func TestMergeUserPlans(t *testing.T) {
 					InputFiles: []string{"."},
 					Command:    "npm start",
 				},
+				NixOverlays: []string{},
 			},
 		},
 		{
-			name: "different input files",
+			name: "custom commands",
 			in: &Plan{
-				DevPackages:     []string{"nodejs", "yarn"},
-				RuntimePackages: []string{"nodejs"},
+				DevPackages:     []string{"yarn"},
+				RuntimePackages: []string{"yarn"},
 				InstallStage: &Stage{
-					InputFiles: []string{"package.json", "yarn.lock"},
-					Command:    "",
+					Command: "yarn install",
 				},
 				BuildStage: &Stage{
-					InputFiles: []string{"."},
-					Command:    "",
+					Command: "yarn build",
 				},
 				StartStage: &Stage{
-					InputFiles: []string{"."},
-					Command:    "npm start",
+					Command: "yarn start",
 				},
 			},
 			out: &Plan{
-				DevPackages:     []string{"nodejs", "yarn"},
-				RuntimePackages: []string{"nodejs"},
+				DevPackages:     []string{"yarn", "nodejs"},
+				RuntimePackages: []string{"yarn", "nodejs"},
 				InstallStage: &Stage{
-					InputFiles: []string{"package.json", "yarn.lock"},
-					Command:    "npm install",
+					InputFiles: []string{"package.json"},
+					Command:    "yarn install",
 				},
 				BuildStage: &Stage{
 					InputFiles: []string{"."},
-					Command:    "",
+					Command:    "yarn build",
 				},
 				StartStage: &Stage{
 					InputFiles: []string{"."},
-					Command:    "npm start",
+					Command:    "yarn start",
 				},
-			},
-		},
-		{
-			name: "custom build command",
-			in: &Plan{
-				InstallStage: &Stage{
-					InputFiles: []string{"app"},
-				},
-				BuildStage: &Stage{
-					Command: "npm run build",
-				},
-			},
-			out: &Plan{
-				DevPackages:     []string{"nodejs"},
-				RuntimePackages: []string{"nodejs"},
-				InstallStage: &Stage{
-					InputFiles: []string{"app"},
-					Command:    "npm install",
-				},
-				BuildStage: &Stage{
-					InputFiles: []string{"."},
-					Command:    "npm run build",
-				},
-				StartStage: &Stage{
-					InputFiles: []string{"."},
-					Command:    "npm start",
-				},
+				NixOverlays: []string{},
 			},
 		},
 	}

--- a/planner/plansdk/stage.go
+++ b/planner/plansdk/stage.go
@@ -4,6 +4,10 @@ type Stage struct {
 	Command string `cue:"string" json:"command"`
 	// InputFiles is internal for planners only.
 	InputFiles []string `cue:"[...string]" json:"input_files,omitempty"`
+	// Warning is internal for planners only.
+	// If a stage has Warning, we will print it if
+	// a command override is not present in devbox.json
+	Warning error `json:"warning,omitempty"`
 }
 
 func (s *Stage) GetCommand() string {


### PR DESCRIPTION
## Summary
Golang planner return error when main is not found. It looks for `main()` and if not found, print the following error as warnings:

```
Error: Cannot find main() file in the directory. If you wish to specify a different import path, add `build_stage` in your devbox.json
```

Warnings will only get printed out if the stage is not overridden by devbox.json.

related to https://github.com/jetpack-io/devbox/issues/137

## How was it tested?
devbox build