### PR TITLE
[config] look for the devbox.json file in parent directories as well

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/boxcli/usererr"
 	"go.jetpack.io/devbox/cuecfg"
+	"go.jetpack.io/devbox/debug"
 	"go.jetpack.io/devbox/docker"
 	"go.jetpack.io/devbox/nix"
 	"go.jetpack.io/devbox/pkgslice"
@@ -39,11 +40,12 @@ type Devbox struct {
 
 // Open opens a devbox by reading the config file in dir.
 func Open(dir string) (*Devbox, error) {
-	cfgPath := filepath.Join(dir, configFilename)
 
-	if !plansdk.FileExists(cfgPath) {
-		return nil, missingDevboxJSONError(dir)
+	cfgDir, err := findConfigDir(dir)
+	if err != nil {
+		return nil, err
 	}
+	cfgPath := filepath.Join(cfgDir, configFilename)
 
 	cfg, err := ReadConfig(cfgPath)
 	if err != nil {
@@ -52,7 +54,7 @@ func Open(dir string) (*Devbox, error) {
 
 	box := &Devbox{
 		cfg:    cfg,
-		srcDir: dir,
+		srcDir: cfgDir,
 	}
 	return box, nil
 }
@@ -226,7 +228,7 @@ func (d *Devbox) generateBuildFiles() error {
 func missingDevboxJSONError(dir string) error {
 
 	// We try to prettify the `dir` before printing
-	if dir == "." {
+	if dir == "." || dir == "" {
 		dir = "this directory"
 	} else {
 		// Instead of a long absolute directory, print the relative directory
@@ -240,5 +242,29 @@ func missingDevboxJSONError(dir string) error {
 			}
 		}
 	}
-	return usererr.New("No devbox.json found in %s. Did you run `devbox init` yet?", dir)
+	return usererr.New("No devbox.json found in %s, or any parent directories. Did you run `devbox init` yet?", dir)
+}
+
+func findConfigDir(dir string) (string, error) {
+
+	cur := dir
+	if cur == "" || cur == "." {
+		var err error
+		cur, err = os.Getwd()
+		if err != nil {
+			return "", errors.WithStack(err)
+		}
+	}
+
+	for cur != "/" {
+		debug.Log("finding %s in dir: %s\n", configFilename, cur)
+		if plansdk.FileExists(filepath.Join(cur, configFilename)) {
+			return cur, nil
+		}
+		cur = filepath.Dir(cur)
+	}
+	if plansdk.FileExists(filepath.Join(cur, configFilename)) {
+		return cur, nil
+	}
+	return "", missingDevboxJSONError(dir)
 }

--- a/devbox.go
+++ b/devbox.go
@@ -247,13 +247,9 @@ func missingDevboxJSONError(dir string) error {
 
 func findConfigDir(dir string) (string, error) {
 
-	cur := dir
-	if cur == "" || cur == "." {
-		var err error
-		cur, err = os.Getwd()
-		if err != nil {
-			return "", errors.WithStack(err)
-		}
+	cur, err := filepath.Abs(dir)
+	if err != nil {
+		return "", errors.WithStack(err)
 	}
 
 	for cur != "/" {

--- a/devbox.go
+++ b/devbox.go
@@ -34,7 +34,8 @@ func InitConfig(dir string) (created bool, err error) {
 // Devbox provides an isolated development environment that contains a set of
 // Nix packages.
 type Devbox struct {
-	cfg    *Config
+	cfg *Config
+	// srcDir is the directory where the config file (devbox.json) resides
 	srcDir string
 }
 
@@ -247,6 +248,7 @@ func missingDevboxJSONError(dir string) error {
 
 func findConfigDir(dir string) (string, error) {
 
+	// Sanitize the directory and use the absolute path as canonical form
 	cur, err := filepath.Abs(dir)
 	if err != nil {
 		return "", errors.WithStack(err)

--- a/devbox_test.go
+++ b/devbox_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.jetpack.io/devbox/planner/plansdk"
 )
 
@@ -28,6 +29,10 @@ func TestDevbox(t *testing.T) {
 }
 
 func testExample(t *testing.T, testPath string) {
+
+	currentDir, err := os.Getwd()
+	require.New(t).NoError(err)
+
 	baseDir := filepath.Dir(testPath)
 	t.Run(baseDir, func(t *testing.T) {
 		assert := assert.New(t)
@@ -36,6 +41,13 @@ func testExample(t *testing.T, testPath string) {
 
 		box, err := Open(baseDir)
 		assert.NoErrorf(err, "%s should be a valid devbox project", baseDir)
+
+		// Just for tests, we make srcDir be a relative path so that the paths in plan.json
+		// of various test cases have relative paths. Absolute paths are a no-go because they'd
+		// be of the form `/Users/savil/...`, which are not generalized and cannot be checked in.
+		box.srcDir, err = filepath.Rel(currentDir, box.srcDir)
+		assert.NoErrorf(err, "expect to construct relative path from %s relative to base %s", box.srcDir, currentDir)
+
 		plan, err := box.ShellPlan()
 		assert.NoError(err, "devbox plan should not fail")
 


### PR DESCRIPTION
## Summary

**Motivation**
Previously, a user would need to specify the directory of the devbox.json when
invoking `devbox shell` or `devbox build` and similar commands. In the absence,
of an explicit directory argument, we would assume the user is saying that
the devbox.json file is in the current directory.

This PR changes this to look for the devbox.json file in the specified-directory, or current directory if none specified,
AND any parent directory. 

This is desirable for a few reasons:
1. Convenience: it is nice especially for mono-repos to be located in a sub-directory
   and be able to invoke `devbox shell` or `devbox build`, in a manner similar to
   how `git` works.
2. Enable `devbox add` and `devbox rm` to run from any sub-directory. These commands
   currently _require_ the user to be located in the "directory of the devbox.json".
   With this PR, this requirement is relaxed so that the commands can be run more naturally
   in any sub-directory as well.

Fixes #185

## How was it tested?

- `devbox shell` and `devbox build` inside a sub-directory
```
# this directory has a devbox.json
> cd testdata/rust/rust-stable
> mkdir fake-dir
> cd fake-dir

# verify shell is using the rustc from the nix store
> devbox shell
(devbox) > which rustc

> devbox build
> docker run devbox

> devbox add openssl
> git diff ../devbox.json
diff --git a/testdata/rust/rust-stable/devbox.json b/testdata/rust/rust-stable/devbox.json
index 288dade..66982f9 100644
--- a/testdata/rust/rust-stable/devbox.json
+++ b/testdata/rust/rust-stable/devbox.json
@@ -1,3 +1,9 @@
 {
-  "packages": ["rust-bin.stable.latest.default"]
-}
+  "packages": [
+    "rust-bin.stable.latest.default",
+    "openssl"
+  ],
+  "shell": {
+    "init_hook": null
+  }
+}
\ No newline at end of file

> devbox rm openssl
> git diff
# none! as expected (not quite, I'm lying, there's been some unrelated changes which still show up)
```

- `devbox shell` and `devbox build` in a directory containing a devbox.json
- did these commands in `testdata/rust/rust-stable`

- explicitly specify the folder of the devbox.json
```
> cd testdata/rust
> devbox shell rust-stable
```


- Error scenario
```
> cd testdata/rust/
> devbox shell
Error: No devbox.json found in this directory, or any parent directories. Did you run `devbox init` yet?

> devbox build
Error: No devbox.json found in this directory, or any parent directories. Did you run `devbox init` yet?

```

