### PR TITLE
[Bug] Do not propagate error on explicit shell exit

### DIFF
--- a/boxcli/shell.go
+++ b/boxcli/shell.go
@@ -47,6 +47,10 @@ func runShellCmd(cmd *cobra.Command, args []string) error {
 		err = box.Shell()
 	}
 
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return nil
+	}
 	return err
 }
 


### PR DESCRIPTION
## Summary
Silence error on shell exit. This addresses https://github.com/jetpack-io/devbox/issues/159

## How was it tested?
devbox shell