### PR TITLE
[shell] preserve history

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -25,11 +25,16 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-// profileDir contains the contents of the profile generated via `nix-env --profile profileDir <command>`
-const profileDir = ".devbox/profile"
+const (
+	// configFilename is name of the JSON file that defines a devbox environment.
+	configFilename = "devbox.json"
 
-// configFilename is name of the JSON file that defines a devbox environment.
-const configFilename = "devbox.json"
+	// profileDir contains the contents of the profile generated via `nix-env --profile profileDir <command>`
+	profileDir = ".devbox/profile"
+
+	// shellHistoryFile keeps the history of commands invoked inside devbox shell
+	shellHistoryFile = ".devbox/shell_history"
+)
 
 // InitConfig creates a default devbox config file if one doesn't already
 // exist.
@@ -175,7 +180,11 @@ func (d *Devbox) Shell() error {
 		return errors.WithStack(err)
 	}
 	nixShellFilePath := filepath.Join(d.srcDir, ".devbox/gen/shell.nix")
-	sh, err := nix.DetectShell(nix.WithPlanInitHook(plan.ShellInitHook), nix.WithProfile(d.profileDir()))
+	sh, err := nix.DetectShell(
+		nix.WithPlanInitHook(plan.ShellInitHook),
+		nix.WithProfile(d.profileDir()),
+		nix.WithHistoryFile(filepath.Join(d.srcDir, shellHistoryFile)),
+	)
 	if err != nil {
 		// Fall back to using a plain Nix shell.
 		sh = &nix.Shell{}

--- a/nix/shell.go
+++ b/nix/shell.go
@@ -43,7 +43,8 @@ type Shell struct {
 	UserInitHook string
 
 	// profileDir is the absolute path to the directory storing the nix-profile
-	profileDir string
+	profileDir  string
+	historyFile string
 }
 
 type ShellOption func(*Shell)
@@ -103,6 +104,12 @@ func WithPlanInitHook(hook string) ShellOption {
 func WithProfile(profileDir string) ShellOption {
 	return func(s *Shell) {
 		s.profileDir = profileDir
+	}
+}
+
+func WithHistoryFile(historyFile string) ShellOption {
+	return func(s *Shell) {
+		s.historyFile = historyFile
 	}
 }
 
@@ -262,12 +269,14 @@ func (s *Shell) writeDevboxShellrc() (path string, err error) {
 		UserHook         string
 		PlanInitHook     string
 		ProfileBinDir    string
+		HistoryFile      string
 	}{
 		OriginalInit:     string(bytes.TrimSpace(userShellrc)),
 		OriginalInitPath: filepath.Clean(s.userShellrcPath),
 		UserHook:         strings.TrimSpace(s.UserInitHook),
 		PlanInitHook:     strings.TrimSpace(s.planInitHook),
 		ProfileBinDir:    s.profileDir + "/bin",
+		HistoryFile:      strings.TrimSpace(s.historyFile),
 	})
 	if err != nil {
 		return "", fmt.Errorf("execute shellrc template: %v", err)

--- a/nix/shellrc.tmpl
+++ b/nix/shellrc.tmpl
@@ -64,6 +64,10 @@ PATH="$(
 	echo "{{ .ProfileBinDir }}:${non_nix_path}"
 )"
 
+{{- if .HistoryFile }}
+HISTFILE={{.HistoryFile}}
+{{- end }}
+
 # Prepend to the prompt to make it clear we're in a devbox shell.
 export PS1="(devbox) $PS1"
 


### PR DESCRIPTION
## Summary

This PR aims to preserve shell command history across sessions, where sessions is defined as starting and exiting a `devbox shell`.

## How was it tested?

- started a `devbox shell`
- invoked `go version` and `which go` and `exit`
- restarted the `devbox shell`
- used up arrow key to get the previous commands used.
