### PR TITLE
[shell] enable devbox add/rm to work for shells started in child directories

### DIFF
--- a/boxcli/add.go
+++ b/boxcli/add.go
@@ -32,7 +32,13 @@ func AddCmd() *cobra.Command {
 
 func addCmdFunc(flags *addCmdFlags) runFunc {
 	return func(cmd *cobra.Command, args []string) error {
-		box, err := devbox.Open(flags.config.path, os.Stdout)
+		dir := ""
+		if devbox.IsDevboxShellEnabled() {
+			if envdir := os.Getenv("DEVBOX_CONFIG_DIR"); envdir != "" {
+				dir = envdir
+			}
+		}
+		box, err := devbox.Open(dir, os.Stdout)
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/boxcli/add.go
+++ b/boxcli/add.go
@@ -32,9 +32,9 @@ func AddCmd() *cobra.Command {
 
 func addCmdFunc(flags *addCmdFlags) runFunc {
 	return func(cmd *cobra.Command, args []string) error {
-		dir := ""
-		if devbox.IsDevboxShellEnabled() {
-			if envdir := os.Getenv("DEVBOX_CONFIG_DIR"); envdir != "" {
+		dir := flags.config.path
+		if dir == "" && devbox.IsDevboxShellEnabled() {
+			if envdir := os.Getenv(shellConfigEnvVar); envdir != "" {
 				dir = envdir
 			}
 		}

--- a/boxcli/config.go
+++ b/boxcli/config.go
@@ -4,6 +4,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Keep this env-var name same as its usage in shell.nix.tmpl
+const shellConfigEnvVar = "DEVBOX_SHELL_CONFIG"
+
 // to be composed into xyzCmdFlags structs
 type configFlags struct {
 	path string

--- a/boxcli/rm.go
+++ b/boxcli/rm.go
@@ -31,7 +31,15 @@ func RemoveCmd() *cobra.Command {
 }
 
 func runRemoveCmd(_ *cobra.Command, args []string, flags *removeCmdFlags) error {
-	box, err := devbox.Open(flags.config.path, os.Stdout)
+
+	dir := ""
+	if devbox.IsDevboxShellEnabled() {
+		if envdir := os.Getenv("DEVBOX_CONFIG_DIR"); envdir != "" {
+			dir = envdir
+		}
+	}
+
+	box, err := devbox.Open(dir, os.Stdout)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/boxcli/rm.go
+++ b/boxcli/rm.go
@@ -32,9 +32,9 @@ func RemoveCmd() *cobra.Command {
 
 func runRemoveCmd(_ *cobra.Command, args []string, flags *removeCmdFlags) error {
 
-	dir := ""
-	if devbox.IsDevboxShellEnabled() {
-		if envdir := os.Getenv("DEVBOX_CONFIG_DIR"); envdir != "" {
+	dir := flags.config.path
+	if dir == "" && devbox.IsDevboxShellEnabled() {
+		if envdir := os.Getenv(shellConfigEnvVar); envdir != "" {
 			dir = envdir
 		}
 	}

--- a/tmpl/shell.nix.tmpl
+++ b/tmpl/shell.nix.tmpl
@@ -26,7 +26,8 @@ mkShell {
       # exec a devbox shell.
       export IN_NIX_SHELL=0
       export DEVBOX_SHELL_ENABLED=1
-      export DEVBOX_CONFIG_DIR={{ configDir }}
+      # Keep this env-var name same as boxcli.shellConfigEnvVar
+      export DEVBOX_SHELL_CONFIG={{ configDir }}
 
       # Undo the effects of `nix-shell --pure` on SSL certs.
       # See https://github.com/NixOS/nixpkgs/blob/dae204faa0243b4d0c0234a5f5f83a2549ecb5b7/pkgs/stdenv/generic/setup.sh#L677-L685

--- a/tmpl/shell.nix.tmpl
+++ b/tmpl/shell.nix.tmpl
@@ -26,6 +26,7 @@ mkShell {
       # exec a devbox shell.
       export IN_NIX_SHELL=0
       export DEVBOX_SHELL_ENABLED=1
+      export DEVBOX_CONFIG_DIR={{ configDir }}
 
       # Undo the effects of `nix-shell --pure` on SSL certs.
       # See https://github.com/NixOS/nixpkgs/blob/dae204faa0243b4d0c0234a5f5f83a2549ecb5b7/pkgs/stdenv/generic/setup.sh#L677-L685


### PR DESCRIPTION
## Summary

When doing `devbox shell <dir>`, we want `devbox add` and `rm` to continue working.

This PR enables this by setting an environment variable when within devbox shell that
contains the directory of devbox.json (config).

In `devbox add` and `devbox rm` we check if this environment-variable is set and  use that as the starting point for the config-directory search.

## How was it tested?

```
> cd testdata/rust
> devbox shell rust-stable
(devbox)> go version
1.19

(devbox)> devbox add go_1_18
(devbox)> hash -r
(devbox)> go version
1.18

(devbox)> devbox rm go_1_18
(devbox)> go version
1.19

(devbox)> git status
# no changes in devbox.json


```
