### PR TITLE
boxcli: skip shell tests due to timeout

### DIFF
--- a/boxcli/shell_test.go
+++ b/boxcli/shell_test.go
@@ -19,6 +19,9 @@ func testShellHello(t *testing.T, name string) {
 	// Skip this test if the required shell isn't installed, unless we're
 	// running in CI.
 	ci, _ := strconv.ParseBool(os.Getenv("CI"))
+	if ci {
+		t.Skip("Skipping because this test times out in CI.")
+	}
 	if _, err := exec.LookPath(name); err != nil && !ci {
 		t.Skipf("Skipping because %s isn't installed or in your PATH.", name)
 	}


### PR DESCRIPTION
## Summary

The shell tests are taking even longer now, presumably due to how long it takes to install the Nix packages. Skip them in CI until we can figure out a way to make them run faster and more reliably.

## How was it tested?

CI.