### PR TITLE
[shell] move nix-profile into a specific directory inside .devbox directory

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -30,7 +30,8 @@ const (
 	configFilename = "devbox.json"
 
 	// profileDir contains the contents of the profile generated via `nix-env --profile profileDir <command>`
-	profileDir = ".devbox/profile"
+	// Instead of using directory, prefer using the devbox.profileDir() function that ensures the directory exists.
+	profileDir = ".devbox/nix-profile/profile"
 
 	// shellHistoryFile keeps the history of commands invoked inside devbox shell
 	shellHistoryFile = ".devbox/shell_history"
@@ -179,10 +180,16 @@ func (d *Devbox) Shell() error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
+
+	profileDir, err := d.profileDir()
+	if err != nil {
+		return err
+	}
+
 	nixShellFilePath := filepath.Join(d.srcDir, ".devbox/gen/shell.nix")
 	sh, err := nix.DetectShell(
 		nix.WithPlanInitHook(plan.ShellInitHook),
-		nix.WithProfile(d.profileDir()),
+		nix.WithProfile(profileDir),
 		nix.WithHistoryFile(filepath.Join(d.srcDir, shellHistoryFile)),
 	)
 	if err != nil {
@@ -198,7 +205,12 @@ func (d *Devbox) Exec(cmds ...string) error {
 		return err
 	}
 
-	pathWithProfileBin := fmt.Sprintf("PATH=%s:$PATH", d.profileBinDir())
+	profileBinDir, err := d.profileBinDir()
+	if err != nil {
+		return err
+	}
+
+	pathWithProfileBin := fmt.Sprintf("PATH=%s:$PATH", profileBinDir)
 	cmds = append([]string{pathWithProfileBin}, cmds...)
 
 	nixDir := filepath.Join(d.srcDir, ".devbox/gen/shell.nix")
@@ -256,12 +268,21 @@ func (d *Devbox) generateBuildFiles() error {
 	return generate(d.srcDir, buildPlan, buildFiles)
 }
 
-func (d *Devbox) profileDir() string {
-	return filepath.Join(d.srcDir, profileDir)
+func (d *Devbox) profileDir() (string, error) {
+	absPath := filepath.Join(d.srcDir, profileDir)
+	if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	return absPath, nil
 }
 
-func (d *Devbox) profileBinDir() string {
-	return filepath.Join(d.profileDir(), "bin")
+func (d *Devbox) profileBinDir() (string, error) {
+	profileDir, err := d.profileDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(profileDir, "bin"), nil
 }
 
 func missingDevboxJSONError(dir string) error {
@@ -358,17 +379,21 @@ func (d *Devbox) printPackageUpdateMessage(mode installMode, pkgs []string) erro
 //
 // Will move to a store interface/package
 func (d *Devbox) ApplyDevNixDerivation() error {
+	profileDir, err := d.profileDir()
+	if err != nil {
+		return err
+	}
 
 	cmdStr := fmt.Sprintf(
 		"--profile %s --install -f %s/.devbox/gen/development.nix",
-		filepath.Join(d.srcDir, profileDir),
+		profileDir,
 		d.srcDir,
 	)
 	cmdParts := strings.Split(cmdStr, " ")
 	execCmd := exec.Command("nix-env", cmdParts...)
 
 	debug.Log("running command: %s\n", execCmd.Args)
-	err := execCmd.Run()
+	err = execCmd.Run()
 	return errors.WithStack(err)
 }
 

--- a/devbox.go
+++ b/devbox.go
@@ -31,7 +31,8 @@ const (
 
 	// profileDir contains the contents of the profile generated via `nix-env --profile profileDir <command>`
 	// Instead of using directory, prefer using the devbox.profileDir() function that ensures the directory exists.
-	profileDir = ".devbox/nix-profile/profile"
+	// TODO savil. Rename to profilePath. This is the symlink of the profile, and not a directory.
+	profileDir = ".devbox/nix/profile/default"
 
 	// shellHistoryFile keeps the history of commands invoked inside devbox shell
 	shellHistoryFile = ".devbox/shell_history"


### PR DESCRIPTION
## Summary

To avoid the nix-profile symlinks crowding the `.devbox/` directory, I push them
inside a `.devbox/nix/profile/` sub-directory. The symlink is renamed to `default` inside `.devbox/nix/profile` to be consistent with [nix naming](https://nixos.org/manual/nix/stable/package-management/profiles.html).

I also want to rename `profileDir` to `profilePath`. That is more accurate since 
it is not a directory but a symlink. However, will do in a separate PR since
it has some conflicts with concurrent work like #207.

## How was it tested?

```
> cd testdata/rust/rust-stable
> devbox shell
> which rustc
# see path in nix store

> devbox add openssl
> hash -r
> which openssl
# see path in nix store

# inspect directory and symlinks:
> ls -al /Users/savil/code/jetpack/devbox/testdata/rust/rust-stable/.devbox/nix/profile/
total 0
drwxr-xr-x 5 savil staff 160 Oct  6 11:55 .
drwxr-xr-x 3 savil staff  96 Oct  6 11:55 ..
lrwxr-xr-x 1 savil staff  14 Oct  6 11:55 default -> default-2-link
lrwxr-xr-x 1 savil staff  60 Oct  6 11:55 default-1-link -> /nix/store/qn9px7zzx500d0l78nhz0b39v8nm1siq-user-environment
lrwxr-xr-x 1 savil staff  60 Oct  6 11:55 default-2-link -> /nix/store/6q654ka2lcdvamxxvnsa9vp9dcj9b6yg-user-environment
```
