### PR TITLE
[Bug] Unblock shell when build fails

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -314,7 +314,7 @@ const (
 )
 
 func (d *Devbox) ensurePackagesAreInstalled(mode installMode) error {
-	if err := d.Generate(); err != nil {
+	if err := d.generateShellFiles(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary
Unblock shell when build fails. We are seeing
```
Error: Multiple buildable plans found: [{...}]
```
on `devbox shell`

## How was it tested?
devbox shell