### PR TITLE
[RFC] move gitignore file to .devbox directory and ignore gen/profile/shell_history

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -20,8 +20,8 @@ import (
 //go:embed tmpl/* tmpl/.*
 var tmplFS embed.FS
 
-var shellFiles = []string{".gitignore", "development.nix", "shell.nix"}
-var buildFiles = []string{".gitignore", "development.nix", "runtime.nix", "Dockerfile", "Dockerfile.dockerignore"}
+var shellFiles = []string{"development.nix", "shell.nix"}
+var buildFiles = []string{"development.nix", "runtime.nix", "Dockerfile", "Dockerfile.dockerignore"}
 
 func generate(rootPath string, plan *plansdk.Plan, files []string) error {
 	outPath := filepath.Join(rootPath, ".devbox/gen")
@@ -31,6 +31,14 @@ func generate(rootPath string, plan *plansdk.Plan, files []string) error {
 		if err != nil {
 			return errors.WithStack(err)
 		}
+	}
+
+	// Gitignore file is added to the .devbox directory
+	// TODO savil. Remove this hardcode from here, so this function can be generically defined again
+	//    by accepting the files list parameter.
+	err := writeFromTemplate(filepath.Join(rootPath, ".devbox"), plan, ".gitignore")
+	if err != nil {
+		return errors.WithStack(err)
 	}
 
 	for name, content := range plan.GeneratedFiles {

--- a/tmpl/.gitignore.tmpl
+++ b/tmpl/.gitignore.tmpl
@@ -1,2 +1,4 @@
-*
-.*
+gen/
+profile*
+nix-profile/
+shell_history

--- a/tmpl/.gitignore.tmpl
+++ b/tmpl/.gitignore.tmpl
@@ -1,4 +1,2 @@
-gen/
-profile*
-nix-profile/
-shell_history
+*
+.*


### PR DESCRIPTION
## Summary

With the recent use of nix-profile, the `profile` symlinks are showing up in git history.
This is regrettable.

This PR adds a `.gitignore` file to `.devbox` directory and ignoring the `gen/`, `profile*`
, `nix-profile` and `shell-history` symlinks.

Going forward, we should avoid editing this file. Each edit will need to be checked
in by our users. So, this PR is a breaking change, in a sense.

New features we add that generate files in `.devbox` should be added inside `gen/` 
if they want to be gitignored.

New features that we do want users to check in (like a lock file) can be placed
in `.devbox/` (and not `.devbox/gen`).

## How was it tested?

in a new devbox project, with `git init` and initial files already committed:
- did `devbox shell` to generate the gitignore and other files 
- did `git status` to inspect changes and found no new file changes were reported.
- did `ls -al .devbox` and saw the other files (like gen/ and profile* were generated) as well as `.devbox/.gitignore`.
