### PR TITLE
[Fix] Ensure python sys path contains nix installed modules 

### DIFF
--- a/testdata/python/pipenv/devbox.json
+++ b/testdata/python/pipenv/devbox.json
@@ -1,0 +1,9 @@
+{
+  "packages": [
+    "python310",
+    "pipenv"
+  ],
+  "shell": {
+    "init_hook": null
+  }
+}

--- a/tmpl/shell.nix.tmpl
+++ b/tmpl/shell.nix.tmpl
@@ -44,4 +44,9 @@ mkShell {
       echo "PATH=$PATH"
       {{- end }}
     '';
+     packages = [
+      {{- range .DevPackages}}
+        {{.}}
+      {{end -}}
+    ];
 }


### PR DESCRIPTION
## Summary

Fixes #216

Fixes issue where python can't find modules installed as nix packages. 

## How was it tested?

testdata/python/pipenv

`devbox shell`
`python -m pipenv`