### PR TITLE
[CLI] add --config flag

### DIFF
--- a/boxcli/add.go
+++ b/boxcli/add.go
@@ -11,21 +11,28 @@ import (
 	"go.jetpack.io/devbox"
 )
 
+type addCmdFlags struct {
+	config configFlags
+}
+
 func AddCmd() *cobra.Command {
+	flags := &addCmdFlags{}
+
 	command := &cobra.Command{
 		Use:               "add <pkg>...",
 		Short:             "Add a new package to your devbox",
 		Args:              cobra.MinimumNArgs(1),
 		PersistentPreRunE: nixShellPersistentPreRunE,
-		RunE:              addCmdFunc(),
+		RunE:              addCmdFunc(flags),
 	}
 
+	registerConfigFlags(command, &flags.config)
 	return command
 }
 
-func addCmdFunc() runFunc {
+func addCmdFunc(flags *addCmdFlags) runFunc {
 	return func(cmd *cobra.Command, args []string) error {
-		box, err := devbox.Open(".", os.Stdout)
+		box, err := devbox.Open(flags.config.path, os.Stdout)
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/boxcli/add.go
+++ b/boxcli/add.go
@@ -16,27 +16,27 @@ type addCmdFlags struct {
 }
 
 func AddCmd() *cobra.Command {
-	flags := &addCmdFlags{}
+	flags := addCmdFlags{}
 
 	command := &cobra.Command{
 		Use:               "add <pkg>...",
 		Short:             "Add a new package to your devbox",
 		Args:              cobra.MinimumNArgs(1),
 		PersistentPreRunE: nixShellPersistentPreRunE,
-		RunE:              addCmdFunc(flags),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return addCmdFunc(cmd, args, flags)
+		},
 	}
 
-	registerConfigFlags(command, &flags.config)
+	flags.config.register(command)
 	return command
 }
 
-func addCmdFunc(flags *addCmdFlags) runFunc {
-	return func(cmd *cobra.Command, args []string) error {
-		box, err := devbox.Open(flags.config.path, os.Stdout)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-
-		return box.Add(args...)
+func addCmdFunc(_ *cobra.Command, args []string, flags addCmdFlags) error {
+	box, err := devbox.Open(flags.config.path, os.Stdout)
+	if err != nil {
+		return errors.WithStack(err)
 	}
+
+	return box.Add(args...)
 }

--- a/boxcli/args.go
+++ b/boxcli/args.go
@@ -4,8 +4,10 @@
 package boxcli
 
 import (
+	"fmt"
 	"path/filepath"
 
+	"github.com/fatih/color"
 	"github.com/pkg/errors"
 )
 
@@ -13,8 +15,26 @@ import (
 
 // If args empty, defaults to the current directory
 // Otherwise grabs the path from the first argument
-func pathArg(args []string) string {
+func pathArg(args []string, flags *configFlags) string {
+
+	if flags.path != currentDir {
+		if len(args) > 0 {
+			// Choose the --config flag because config argument is being deprecated
+			fmt.Printf(
+				"%s You are specifying the config path as an argument and using the --config flag. "+
+					"Choosing to ignore the argument and use the flag.\n",
+				color.HiYellowString("Warning:"),
+			)
+		}
+		return flags.path
+	}
+
 	if len(args) > 0 {
+		fmt.Printf(
+			"%s please use the --config or -c flag to specify the path to the devbox.json config. "+
+				"We are deprecating the previous way of specifying this path as an argument to the command.\n",
+			color.HiYellowString("Warning:"),
+		)
 		p, err := filepath.Abs(args[0])
 		if err != nil {
 			panic(errors.WithStack(err)) // What even triggers this?

--- a/boxcli/build.go
+++ b/boxcli/build.go
@@ -21,7 +21,7 @@ func BuildCmd() *cobra.Command {
 	flags := newBuildFlags()
 
 	command := &cobra.Command{
-		Use:   "build [<dir>]",
+		Use:   "build",
 		Short: "Build an OCI image that can run as a container",
 		Long:  "Builds your current source directory and devbox configuration as a Docker container. Devbox will create a plan for your container based on your source code, and then apply the packages and stage overrides in your devbox.json. \n To learn more about how to configure your builds, see the [configuration reference](/docs/configuration_reference)",
 		Args:  cobra.MaximumNArgs(1),
@@ -49,7 +49,10 @@ func newBuildFlags() *buildCmdFlags {
 
 func buildCmdFunc(flags *buildCmdFlags) runFunc {
 	return func(cmd *cobra.Command, args []string) error {
-		path := pathArg(args, &flags.config)
+		path, err := configPathFromUser(args, &flags.config)
+		if err != nil {
+			return err
+		}
 
 		// Check the directory exists.
 		box, err := devbox.Open(path, os.Stdout)

--- a/boxcli/config.go
+++ b/boxcli/config.go
@@ -1,0 +1,18 @@
+package boxcli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+const currentDir = "."
+
+// to be composed into xyzCmdFlags structs
+type configFlags struct {
+	path string
+}
+
+func registerConfigFlags(cmd *cobra.Command, flags *configFlags) {
+	cmd.Flags().StringVarP(
+		&flags.path, "config", "c", currentDir, "path to directory containing a devbox.json config file",
+	)
+}

--- a/boxcli/config.go
+++ b/boxcli/config.go
@@ -4,8 +4,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const currentDir = "."
-
 // to be composed into xyzCmdFlags structs
 type configFlags struct {
 	path string
@@ -13,6 +11,6 @@ type configFlags struct {
 
 func registerConfigFlags(cmd *cobra.Command, flags *configFlags) {
 	cmd.Flags().StringVarP(
-		&flags.path, "config", "c", currentDir, "path to directory containing a devbox.json config file",
+		&flags.path, "config", "c", "", "path to directory containing a devbox.json config file",
 	)
 }

--- a/boxcli/config.go
+++ b/boxcli/config.go
@@ -9,7 +9,7 @@ type configFlags struct {
 	path string
 }
 
-func registerConfigFlags(cmd *cobra.Command, flags *configFlags) {
+func (flags *configFlags) register(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(
 		&flags.path, "config", "c", "", "path to directory containing a devbox.json config file",
 	)

--- a/boxcli/generate.go
+++ b/boxcli/generate.go
@@ -11,18 +11,29 @@ import (
 	"go.jetpack.io/devbox"
 )
 
+type generateCmdFlags struct {
+	config configFlags
+}
+
 func GenerateCmd() *cobra.Command {
+	flags := &generateCmdFlags{}
+
 	command := &cobra.Command{
 		Use:    "generate [<dir>]",
 		Args:   cobra.MaximumNArgs(1),
 		Hidden: true, // For debugging only
-		RunE:   runGenerateCmd,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGenerateCmd(cmd, args, flags)
+		},
 	}
+
+	registerConfigFlags(command, &flags.config)
+
 	return command
 }
 
-func runGenerateCmd(cmd *cobra.Command, args []string) error {
-	path := pathArg(args)
+func runGenerateCmd(cmd *cobra.Command, args []string, flags *generateCmdFlags) error {
+	path := pathArg(args, &flags.config)
 
 	// Check the directory exists.
 	box, err := devbox.Open(path, os.Stdout)

--- a/boxcli/generate.go
+++ b/boxcli/generate.go
@@ -19,7 +19,7 @@ func GenerateCmd() *cobra.Command {
 	flags := &generateCmdFlags{}
 
 	command := &cobra.Command{
-		Use:    "generate [<dir>]",
+		Use:    "generate",
 		Args:   cobra.MaximumNArgs(1),
 		Hidden: true, // For debugging only
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -32,8 +32,11 @@ func GenerateCmd() *cobra.Command {
 	return command
 }
 
-func runGenerateCmd(cmd *cobra.Command, args []string, flags *generateCmdFlags) error {
-	path := pathArg(args, &flags.config)
+func runGenerateCmd(_ *cobra.Command, args []string, flags *generateCmdFlags) error {
+	path, err := configPathFromUser(args, &flags.config)
+	if err != nil {
+		return err
+	}
 
 	// Check the directory exists.
 	box, err := devbox.Open(path, os.Stdout)

--- a/boxcli/generate.go
+++ b/boxcli/generate.go
@@ -27,7 +27,7 @@ func GenerateCmd() *cobra.Command {
 		},
 	}
 
-	registerConfigFlags(command, &flags.config)
+	flags.config.register(command)
 
 	return command
 }

--- a/boxcli/init.go
+++ b/boxcli/init.go
@@ -9,29 +9,22 @@ import (
 	"go.jetpack.io/devbox"
 )
 
-type initCmdFlags struct {
-	config configFlags
-}
-
 func InitCmd() *cobra.Command {
-	flags := &initCmdFlags{}
-
 	command := &cobra.Command{
 		Use:   "init [<dir>]",
 		Short: "Initialize a directory as a devbox project",
 		Long:  "Initialize a directory as a devbox project. This will create an empty devbox.json in the current directory. You can then add packages using `devbox add`",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runInitCmd(cmd, args, flags)
+			return runInitCmd(cmd, args)
 		},
 	}
 
-	registerConfigFlags(command, &flags.config)
 	return command
 }
 
-func runInitCmd(cmd *cobra.Command, args []string, flags *initCmdFlags) error {
-	path := pathArg(args, &flags.config)
+func runInitCmd(_ *cobra.Command, args []string) error {
+	path := pathArg(args)
 
 	_, err := devbox.InitConfig(path)
 	if err != nil {

--- a/boxcli/init.go
+++ b/boxcli/init.go
@@ -9,19 +9,29 @@ import (
 	"go.jetpack.io/devbox"
 )
 
+type initCmdFlags struct {
+	config configFlags
+}
+
 func InitCmd() *cobra.Command {
+	flags := &initCmdFlags{}
+
 	command := &cobra.Command{
 		Use:   "init [<dir>]",
 		Short: "Initialize a directory as a devbox project",
 		Long:  "Initialize a directory as a devbox project. This will create an empty devbox.json in the current directory. You can then add packages using `devbox add`",
 		Args:  cobra.MaximumNArgs(1),
-		RunE:  runInitCmd,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runInitCmd(cmd, args, flags)
+		},
 	}
+
+	registerConfigFlags(command, &flags.config)
 	return command
 }
 
-func runInitCmd(cmd *cobra.Command, args []string) error {
-	path := pathArg(args)
+func runInitCmd(cmd *cobra.Command, args []string, flags *initCmdFlags) error {
+	path := pathArg(args, &flags.config)
 
 	_, err := devbox.InitConfig(path)
 	if err != nil {

--- a/boxcli/plan.go
+++ b/boxcli/plan.go
@@ -17,7 +17,7 @@ type planCmdFlags struct {
 }
 
 func PlanCmd() *cobra.Command {
-	flags := &planCmdFlags{}
+	flags := planCmdFlags{}
 
 	command := &cobra.Command{
 		Use:   "plan",
@@ -28,11 +28,11 @@ func PlanCmd() *cobra.Command {
 		},
 	}
 
-	registerConfigFlags(command, &flags.config)
+	flags.config.register(command)
 	return command
 }
 
-func runPlanCmd(_ *cobra.Command, args []string, flags *planCmdFlags) error {
+func runPlanCmd(_ *cobra.Command, args []string, flags planCmdFlags) error {
 	path, err := configPathFromUser(args, &flags.config)
 	if err != nil {
 		return err

--- a/boxcli/plan.go
+++ b/boxcli/plan.go
@@ -12,18 +12,28 @@ import (
 	"go.jetpack.io/devbox"
 )
 
+type planCmdFlags struct {
+	config configFlags
+}
+
 func PlanCmd() *cobra.Command {
+	flags := &planCmdFlags{}
+
 	command := &cobra.Command{
 		Use:   "plan [<dir>]",
 		Short: "Preview the plan used to build your environment",
 		Args:  cobra.MaximumNArgs(1),
-		RunE:  runPlanCmd,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPlanCmd(cmd, args, flags)
+		},
 	}
+
+	registerConfigFlags(command, &flags.config)
 	return command
 }
 
-func runPlanCmd(cmd *cobra.Command, args []string) error {
-	path := pathArg(args)
+func runPlanCmd(cmd *cobra.Command, args []string, flags *planCmdFlags) error {
+	path := pathArg(args, &flags.config)
 
 	// Check the directory exists.
 	box, err := devbox.Open(path, os.Stdout)

--- a/boxcli/plan.go
+++ b/boxcli/plan.go
@@ -20,7 +20,7 @@ func PlanCmd() *cobra.Command {
 	flags := &planCmdFlags{}
 
 	command := &cobra.Command{
-		Use:   "plan [<dir>]",
+		Use:   "plan",
 		Short: "Preview the plan used to build your environment",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -32,8 +32,11 @@ func PlanCmd() *cobra.Command {
 	return command
 }
 
-func runPlanCmd(cmd *cobra.Command, args []string, flags *planCmdFlags) error {
-	path := pathArg(args, &flags.config)
+func runPlanCmd(_ *cobra.Command, args []string, flags *planCmdFlags) error {
+	path, err := configPathFromUser(args, &flags.config)
+	if err != nil {
+		return err
+	}
 
 	// Check the directory exists.
 	box, err := devbox.Open(path, os.Stdout)

--- a/boxcli/rm.go
+++ b/boxcli/rm.go
@@ -16,7 +16,7 @@ type removeCmdFlags struct {
 }
 
 func RemoveCmd() *cobra.Command {
-	flags := &removeCmdFlags{}
+	flags := removeCmdFlags{}
 	command := &cobra.Command{
 		Use:   "rm <pkg>...",
 		Short: "Remove a package from your devbox",
@@ -26,11 +26,11 @@ func RemoveCmd() *cobra.Command {
 		},
 	}
 
-	registerConfigFlags(command, &flags.config)
+	flags.config.register(command)
 	return command
 }
 
-func runRemoveCmd(_ *cobra.Command, args []string, flags *removeCmdFlags) error {
+func runRemoveCmd(_ *cobra.Command, args []string, flags removeCmdFlags) error {
 	box, err := devbox.Open(flags.config.path, os.Stdout)
 	if err != nil {
 		return errors.WithStack(err)

--- a/boxcli/rm.go
+++ b/boxcli/rm.go
@@ -30,7 +30,7 @@ func RemoveCmd() *cobra.Command {
 	return command
 }
 
-func runRemoveCmd(cmd *cobra.Command, args []string, flags *removeCmdFlags) error {
+func runRemoveCmd(_ *cobra.Command, args []string, flags *removeCmdFlags) error {
 	box, err := devbox.Open(flags.config.path, os.Stdout)
 	if err != nil {
 		return errors.WithStack(err)

--- a/boxcli/rm.go
+++ b/boxcli/rm.go
@@ -11,18 +11,27 @@ import (
 	"go.jetpack.io/devbox"
 )
 
+type removeCmdFlags struct {
+	config configFlags
+}
+
 func RemoveCmd() *cobra.Command {
+	flags := &removeCmdFlags{}
 	command := &cobra.Command{
 		Use:   "rm <pkg>...",
 		Short: "Remove a package from your devbox",
 		Args:  cobra.MinimumNArgs(1),
-		RunE:  runRemoveCmd,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRemoveCmd(cmd, args, flags)
+		},
 	}
+
+	registerConfigFlags(command, &flags.config)
 	return command
 }
 
-func runRemoveCmd(cmd *cobra.Command, args []string) error {
-	box, err := devbox.Open(".", os.Stdout)
+func runRemoveCmd(cmd *cobra.Command, args []string, flags *removeCmdFlags) error {
+	box, err := devbox.Open(flags.config.path, os.Stdout)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/boxcli/root.go
+++ b/boxcli/root.go
@@ -56,5 +56,3 @@ func Main() {
 	code := Execute(context.Background(), os.Args[1:])
 	os.Exit(code)
 }
-
-type runFunc func(cmd *cobra.Command, args []string) error

--- a/boxcli/shell.go
+++ b/boxcli/shell.go
@@ -19,15 +19,15 @@ type shellCmdFlags struct {
 }
 
 func ShellCmd() *cobra.Command {
-	flags := &shellCmdFlags{}
+	flags := shellCmdFlags{}
 	command := &cobra.Command{
 		Use:   "shell -- [<cmd>]",
 		Short: "Start a new shell or run a command with access to your packages",
 		Long: "Start a new shell or run a command with access to your packages. \n" +
-			"If invoked without `cmd`, this will start an interactive shell.\n" +
-			"If invoked with a `cmd`, this will start a shell, run the command, and then exit.\n" +
-			"In both cases, the shell will be started using the devbox.json from the --config flag, " +
-			"or searching for a devbox.json in a parent directory.",
+			"If invoked without `cmd`, devbox will start an interactive shell.\n" +
+			"If invoked with a `cmd`, devbox will run the command in a shell and then exit.\n" +
+			"In both cases, the shell will be started using the devbox.json found in the --config flag directory. " +
+			"If --config isn't set, then devbox recursively searches the current directory and its parents.",
 		Args:              validateShellArgs,
 		PersistentPreRunE: nixShellPersistentPreRunE,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -37,11 +37,11 @@ func ShellCmd() *cobra.Command {
 
 	command.Flags().BoolVar(
 		&flags.PrintEnv, "print-env", false, "Print script to setup shell environment")
-	registerConfigFlags(command, &flags.config)
+	flags.config.register(command)
 	return command
 }
 
-func runShellCmd(cmd *cobra.Command, args []string, flags *shellCmdFlags) error {
+func runShellCmd(cmd *cobra.Command, args []string, flags shellCmdFlags) error {
 	path, cmds, err := parseShellArgs(cmd, args, flags)
 	if err != nil {
 		return err
@@ -91,7 +91,7 @@ func validateShellArgs(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func parseShellArgs(cmd *cobra.Command, args []string, flags *shellCmdFlags) (string, []string, error) {
+func parseShellArgs(cmd *cobra.Command, args []string, flags shellCmdFlags) (string, []string, error) {
 	index := cmd.ArgsLenAtDash()
 	if index < 0 {
 		configPath, err := configPathFromUser(args, &flags.config)

--- a/boxcli/version.go
+++ b/boxcli/version.go
@@ -11,13 +11,19 @@ import (
 	"go.jetpack.io/devbox/build"
 )
 
+type versionFlags struct {
+	verbose bool
+}
+
 func VersionCmd() *cobra.Command {
-	flags := &versionFlags{}
+	flags := versionFlags{}
 	command := &cobra.Command{
 		Use:   "version",
 		Short: "Print version information",
 		Args:  cobra.NoArgs,
-		RunE:  versionCmdFunc(flags),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return versionCmdFunc(cmd, args, flags)
+		},
 	}
 
 	command.Flags().BoolVarP(&flags.verbose, "verbose", "v", false, // value
@@ -26,24 +32,18 @@ func VersionCmd() *cobra.Command {
 	return command
 }
 
-type versionFlags struct {
-	verbose bool
-}
-
-func versionCmdFunc(flags *versionFlags) runFunc {
-	return func(cmd *cobra.Command, args []string) error {
-		v := getVersionInfo()
-		if flags.verbose {
-			fmt.Printf("Version:     %v\n", v.Version)
-			fmt.Printf("Platform:    %v\n", v.Platform)
-			fmt.Printf("Commit:      %v\n", v.Commit)
-			fmt.Printf("Commit Time: %v\n", v.CommitDate)
-			fmt.Printf("Go Version:  %v\n", v.GoVersion)
-		} else {
-			fmt.Printf("%v\n", v.Version)
-		}
-		return nil
+func versionCmdFunc(_ *cobra.Command, _ []string, flags versionFlags) error {
+	v := getVersionInfo()
+	if flags.verbose {
+		fmt.Printf("Version:     %v\n", v.Version)
+		fmt.Printf("Platform:    %v\n", v.Platform)
+		fmt.Printf("Commit:      %v\n", v.Commit)
+		fmt.Printf("Commit Time: %v\n", v.CommitDate)
+		fmt.Printf("Go Version:  %v\n", v.GoVersion)
+	} else {
+		fmt.Printf("%v\n", v.Version)
 	}
+	return nil
 }
 
 type versionInfo struct {

--- a/config_test.go
+++ b/config_test.go
@@ -3,9 +3,12 @@ package devbox
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConfigShellCmdsUnmarshalString(t *testing.T) {
@@ -245,6 +248,135 @@ func TestAppendScript(t *testing.T) {
 			gotCmds := shCmds.Cmds
 			if diff := cmp.Diff(test.wantCmds, gotCmds); diff != "" {
 				t.Errorf("Got incorrect commands slice (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFindConfigDirFromParentDirSearch(t *testing.T) {
+	testCases := []struct {
+		name        string
+		allDirs     string
+		configDir   string
+		searchPath  string
+		expectError bool
+	}{
+		{
+			name:        "search_dir_same_as_config_dir",
+			allDirs:     "a/b/c",
+			configDir:   "a/b",
+			searchPath:  "a/b",
+			expectError: false,
+		},
+		{
+			name:        "search_dir_in_nested_folder",
+			allDirs:     "a/b/c",
+			configDir:   "a/b",
+			searchPath:  "a/b/c",
+			expectError: false,
+		},
+		{
+			name:        "search_dir_in_parent_folder",
+			allDirs:     "a/b/c",
+			configDir:   "a/b",
+			searchPath:  "a",
+			expectError: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			root, err := filepath.Abs(t.TempDir())
+			assert.NoError(err)
+
+			err = os.MkdirAll(filepath.Join(root, testCase.allDirs), 0777)
+			assert.NoError(err)
+
+			absConfigPath, err := filepath.Abs(filepath.Join(root, testCase.configDir, configFilename))
+			assert.NoError(err)
+			err = os.WriteFile(absConfigPath, []byte("{}"), 0666)
+			assert.NoError(err)
+
+			absSearchPath := filepath.Join(root, testCase.searchPath)
+			result, err := findConfigDirFromParentDirSearch(root, absSearchPath)
+
+			if testCase.expectError {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+				assert.Equal(filepath.Dir(filepath.Join(absConfigPath)), result)
+			}
+		})
+	}
+}
+
+func TestFindConfigDirAtPath(t *testing.T) {
+
+	testCases := []struct {
+		name        string
+		allDirs     string
+		configDir   string
+		flagPath    string
+		expectError bool
+	}{
+		{
+			name:        "flag_path_is_dir_has_config",
+			allDirs:     "a/b/c",
+			configDir:   "a/b",
+			flagPath:    "a/b",
+			expectError: false,
+		},
+		{
+			name:        "flag_path_is_dir_missing_config",
+			allDirs:     "a/b/c",
+			configDir:   "", // missing config
+			flagPath:    "a/b",
+			expectError: true,
+		},
+		{
+			name:        "flag_path_is_file_has_config",
+			allDirs:     "a/b/c",
+			configDir:   "a/b",
+			flagPath:    "a/b/" + configFilename,
+			expectError: false,
+		},
+		{
+			name:        "flag_path_is_file_missing_config",
+			allDirs:     "a/b/c",
+			configDir:   "", // missing config
+			flagPath:    "a/b/" + configFilename,
+			expectError: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			root, err := filepath.Abs(t.TempDir())
+			assert.NoError(err)
+
+			err = os.MkdirAll(filepath.Join(root, testCase.allDirs), 0777)
+			assert.NoError(err)
+
+			var absConfigPath string
+			if testCase.configDir != "" {
+				absConfigPath, err = filepath.Abs(filepath.Join(root, testCase.configDir, configFilename))
+				assert.NoError(err)
+				err = os.WriteFile(absConfigPath, []byte("{}"), 0666)
+				assert.NoError(err)
+			}
+
+			absFlagPath := filepath.Join(root, testCase.flagPath)
+			result, err := findConfigDirAtPath(absFlagPath)
+
+			if testCase.expectError {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+				assert.Equal(filepath.Dir(filepath.Join(absConfigPath)), result)
 			}
 		})
 	}

--- a/devbox.go
+++ b/devbox.go
@@ -16,7 +16,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
-	"go.jetpack.io/devbox/boxcli/usererr"
 	"go.jetpack.io/devbox/cuecfg"
 	"go.jetpack.io/devbox/debug"
 	"go.jetpack.io/devbox/docker"
@@ -56,6 +55,7 @@ type Devbox struct {
 }
 
 // Open opens a devbox by reading the config file in dir.
+// TODO savil. dir is technically path since it could be a dir or file
 func Open(dir string, writer io.Writer) (*Devbox, error) {
 
 	cfgDir, err := findConfigDir(dir)
@@ -309,77 +309,6 @@ func (d *Devbox) profileBinDir() (string, error) {
 		return "", err
 	}
 	return filepath.Join(profileDir, "bin"), nil
-}
-
-func missingDevboxJSONError(dir string, didCheckParents bool) error {
-
-	// We try to prettify the `dir` before printing
-	if dir == "." || dir == "" {
-		dir = "this directory"
-	} else {
-		// Instead of a long absolute directory, print the relative directory
-
-		wd, err := os.Getwd()
-		// if an error occurs, then just use `dir`
-		if err == nil {
-			relDir, err := filepath.Rel(wd, dir)
-			if err == nil {
-				dir = relDir
-			}
-		}
-	}
-
-	parentDirCheckAddendum := ""
-	if didCheckParents {
-		parentDirCheckAddendum = ", or any parent directories"
-	}
-
-	return usererr.New("No devbox.json found in %s%s. Did you run `devbox init` yet?", dir, parentDirCheckAddendum)
-}
-
-func findConfigDir(dir string) (string, error) {
-
-	// Sanitize the directory and use the absolute path as canonical form
-	absDir, err := filepath.Abs(dir)
-	if err != nil {
-		return "", errors.WithStack(err)
-	}
-
-	// If the directory (`dir`) is specified, then we check just that directory.
-	// Otherwise, we search the parent directories.
-	if dir != "" {
-		fi, err := os.Stat(dir)
-		if err != nil {
-			return "", err
-		}
-		switch mode := fi.Mode(); {
-		case mode.IsDir():
-			if !plansdk.FileExists(filepath.Join(absDir, configFilename)) {
-				return "", missingDevboxJSONError(dir, false /*didCheckParents*/)
-			}
-			return absDir, nil
-		default: // assumes 'file' i.e. mode.IsRegular()
-			if !plansdk.FileExists(filepath.Clean(absDir)) {
-				return "", missingDevboxJSONError(dir, false /*didCheckParents*/)
-			}
-			// we return a directory from this function
-			return filepath.Dir(absDir), nil
-		}
-	}
-
-	cur := absDir
-	// Search parent directories for a devbox.json
-	for cur != "/" {
-		debug.Log("finding %s in dir: %s\n", configFilename, cur)
-		if plansdk.FileExists(filepath.Join(cur, configFilename)) {
-			return cur, nil
-		}
-		cur = filepath.Dir(cur)
-	}
-	if plansdk.FileExists(filepath.Join(cur, configFilename)) {
-		return cur, nil
-	}
-	return "", missingDevboxJSONError(dir, true /*didCheckParents*/)
 }
 
 // installMode is an enum for helping with ensurePackagesAreInstalled implementation

--- a/devbox.go
+++ b/devbox.go
@@ -337,7 +337,6 @@ func missingDevboxJSONError(dir string, didCheckParents bool) error {
 	return usererr.New("No devbox.json found in %s%s. Did you run `devbox init` yet?", dir, parentDirCheckAddendum)
 }
 
-// findConfigDir
 func findConfigDir(dir string) (string, error) {
 
 	// Sanitize the directory and use the absolute path as canonical form
@@ -359,14 +358,12 @@ func findConfigDir(dir string) (string, error) {
 				return "", missingDevboxJSONError(dir, false /*didCheckParents*/)
 			}
 			return absDir, nil
-		case mode.IsRegular(): // regular means 'file'
+		default: // assumes 'file' i.e. mode.IsRegular()
 			if !plansdk.FileExists(filepath.Clean(absDir)) {
 				return "", missingDevboxJSONError(dir, false /*didCheckParents*/)
 			}
 			// we return a directory from this function
 			return filepath.Dir(absDir), nil
-		default:
-			return "", errors.Errorf("unhandled mode %v", mode)
 		}
 	}
 

--- a/devbox.go
+++ b/devbox.go
@@ -311,7 +311,7 @@ func (d *Devbox) profileBinDir() (string, error) {
 	return filepath.Join(profileDir, "bin"), nil
 }
 
-func missingDevboxJSONError(dir string) error {
+func missingDevboxJSONError(dir string, didCheckParents bool) error {
 
 	// We try to prettify the `dir` before printing
 	if dir == "." || dir == "" {
@@ -328,17 +328,50 @@ func missingDevboxJSONError(dir string) error {
 			}
 		}
 	}
-	return usererr.New("No devbox.json found in %s, or any parent directories. Did you run `devbox init` yet?", dir)
+
+	parentDirCheckAddendum := ""
+	if didCheckParents {
+		parentDirCheckAddendum = ", or any parent directories"
+	}
+
+	return usererr.New("No devbox.json found in %s%s. Did you run `devbox init` yet?", dir, parentDirCheckAddendum)
 }
 
+// findConfigDir
 func findConfigDir(dir string) (string, error) {
 
 	// Sanitize the directory and use the absolute path as canonical form
-	cur, err := filepath.Abs(dir)
+	absDir, err := filepath.Abs(dir)
 	if err != nil {
 		return "", errors.WithStack(err)
 	}
 
+	// If the directory (`dir`) is specified, then we check just that directory.
+	// Otherwise, we search the parent directories.
+	if dir != "" {
+		fi, err := os.Stat(dir)
+		if err != nil {
+			return "", err
+		}
+		switch mode := fi.Mode(); {
+		case mode.IsDir():
+			if !plansdk.FileExists(filepath.Join(absDir, configFilename)) {
+				return "", missingDevboxJSONError(dir, false /*didCheckParents*/)
+			}
+			return absDir, nil
+		case mode.IsRegular(): // regular means 'file'
+			if !plansdk.FileExists(filepath.Clean(absDir)) {
+				return "", missingDevboxJSONError(dir, false /*didCheckParents*/)
+			}
+			// we return a directory from this function
+			return filepath.Dir(absDir), nil
+		default:
+			return "", errors.Errorf("unhandled mode %v", mode)
+		}
+	}
+
+	cur := absDir
+	// Search parent directories for a devbox.json
 	for cur != "/" {
 		debug.Log("finding %s in dir: %s\n", configFilename, cur)
 		if plansdk.FileExists(filepath.Join(cur, configFilename)) {
@@ -349,7 +382,7 @@ func findConfigDir(dir string) (string, error) {
 	if plansdk.FileExists(filepath.Join(cur, configFilename)) {
 		return cur, nil
 	}
-	return "", missingDevboxJSONError(dir)
+	return "", missingDevboxJSONError(dir, true /*didCheckParents*/)
 }
 
 // installMode is an enum for helping with ensurePackagesAreInstalled implementation

--- a/testdata/nodejs/nodejs-18/devbox.json
+++ b/testdata/nodejs/nodejs-18/devbox.json
@@ -1,3 +1,5 @@
 {
-  "packages": []
+  "packages": [
+    "nodejs-18_x"
+  ]
 }


### PR DESCRIPTION
## Summary

**Motivation**
We want to introduce a `--config` flag and deprecate the use of config as an argument.

1. **ephemeral shells**. By enabling a way to (eventually) do `devbox shell --config path/to/devbox/json  nodejs-18_x`, or even more simply `devbox shell nodejs-18_x`.
2. **using devbox add/rm from shells started in parent directories**: today, if I have `my_sub_directory/devbox.json` and start `devbox shell my_sub_directory/devbox.json` from the root of the repository, then doing `devbox add` or `devbox rm` inside this shell will fail. 
    - A first attempt at fixing this was in #206. This PR (#225) is a generalization of that idea. I'll be stacking #206 on top of this PR, and enabling the `--config` flag to override the env-var.

<insert motivation>

## How was it tested?

**preliminary steps**
- i added `nodejs-18_x` to `testdata/nodejs/nodejs-18`
- I (temporarily) deleted the `devbox.json` at the root of this repo. This is to ensure I verify that the CLI still complains if no devbox.json is found.

```
# giving a path
> cd testdata/nodejs
> devbox shell nodejs-18
Warning: devbox shell <path> is deprecated, use devbox shell --config <path> instead
Installing nix packages. This may take a while...done.
Starting a devbox shell...
> which node
# get nix store path
> exit

# using --config
> devbox shell -c nodejs-18
> which node
# get nix store path
> exit

# using neither path nor --config
> cd testdata/nodejs/node-18
> devbox shell
> which node
# get nix path
> exit

# using neither path nor --config, where devbox.json resides in a parent directory
> cd testdata/nodejs/nodejs-18/fake-dir
> devbox shell
which node
# get nix path
> exit

# using both path and --config
> cd testdata/nodejs
> devbox shell -c nodejs-18 nodejs-18

Error: Cannot specify devbox.json's path via both --config and the command arguments. Please use --config only.

# No devbox.json in parent dirs
> cd testdata/nodejs
> devbox shell

Error: No devbox.json found in this directory, or any parent directories. Did you run `devbox init` yet?

# giving a path where no devbox.json exists
> devbox shell nodejs-18/fake-dir
Warning: devbox shell <path> is deprecated, use devbox shell --config <path> instead

Error: No devbox.json found in nodejs-18/fake-dir. Did you run `devbox init` yet?
```