### PR TITLE
[shell] add /share and /lib to development.nix

### DIFF
--- a/tmpl/development.nix.tmpl
+++ b/tmpl/development.nix.tmpl
@@ -25,5 +25,5 @@ buildEnv {
     {{.}}
   {{end -}}
   ];
-  pathsToLink = [ "/bin" ];
+  pathsToLink = [ "/bin" "/share" "/lib"];
 }


### PR DESCRIPTION
## Summary

Certain packages like mariaDB require access to the lib and share directories, so
we include those in `development.nix`. 

Recall that `development.nix` is used during `devbox shell` for:
`nix-env --profile .devbox/nix/profile/default --install -f path/to/development.nix`

## How was it tested?

```
> cd testdata/nodejs/nodejs-18
> rm -rf .devbox
> readlink -f .devbox/nix/profile/default/*
/nix/store/pnwba30msbx2dwld1ji3ak25f96pd9im-devbox-development/bin
/nix/store/pnwba30msbx2dwld1ji3ak25f96pd9im-devbox-development/lib
/nix/store/d1785s25kbb67l717srvnmf44a41dqk3-env-manifest.nix
/nix/store/pnwba30msbx2dwld1ji3ak25f96pd9im-devbox-development/share
```
