### PR TITLE
Added search command with sorted results

### DIFF
--- a/boxcli/root.go
+++ b/boxcli/root.go
@@ -31,6 +31,7 @@ func RootCmd() *cobra.Command {
 	command.AddCommand(InitCmd())
 	command.AddCommand(PlanCmd())
 	command.AddCommand(RemoveCmd())
+	command.AddCommand(SearchCmd())
 	command.AddCommand(ShellCmd())
 	command.AddCommand(VersionCmd())
 	command.AddCommand(genDocsCmd())

--- a/boxcli/search.go
+++ b/boxcli/search.go
@@ -1,0 +1,35 @@
+// Copyright 2022 Jetpack Technologies Inc and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package boxcli
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"go.jetpack.io/devbox"
+)
+
+func SearchCmd() *cobra.Command {
+	command := &cobra.Command{
+		Use:               "search <pkg>...",
+		Short:             "Search packages in nix store.",
+		Args:              cobra.MinimumNArgs(1),
+		PersistentPreRunE: nixShellPersistentPreRunE,
+		RunE:              searchCmdFunc(),
+	}
+
+	return command
+}
+
+func searchCmdFunc() runFunc {
+	return func(cmd *cobra.Command, args []string) error {
+		box, err := devbox.Open(".", os.Stdout)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		return box.Search(args[0])
+	}
+}


### PR DESCRIPTION
## Summary
Added `devbox search <package name>` command that searches nix store for packages that contain the `<package name>` in their name or description.

## How was it tested?
1. compile devbox
2. run `./devbox search openjdk` or any other package
3. see results
