### PR TITLE
[config] add shellExitHooks

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,6 +37,9 @@ type Config struct {
 	Shell struct {
 		// InitHook contains commands that will run at shell startup.
 		InitHook ConfigShellCmds `json:"init_hook,omitempty"`
+
+		// ExitHook contains commands that will run at shell exit.
+		ExitHook ConfigShellCmds `json:"exit_hook,omitempty"`
 	} `json:"shell,omitempty"`
 }
 

--- a/devbox.go
+++ b/devbox.go
@@ -202,17 +202,19 @@ func (d *Devbox) Shell() error {
 	}
 
 	nixShellFilePath := filepath.Join(d.srcDir, ".devbox/gen/shell.nix")
-	sh, err := nix.DetectShell(
+	shellInstance, err := nix.DetectShell(
 		nix.WithPlanInitHook(plan.ShellInitHook),
+		nix.WithPlanInitHook(plan.ShellExitHook),
 		nix.WithProfile(profileDir),
 		nix.WithHistoryFile(filepath.Join(d.srcDir, shellHistoryFile)),
 	)
 	if err != nil {
 		// Fall back to using a plain Nix shell.
-		sh = &nix.Shell{}
+		shellInstance = &nix.Shell{}
 	}
-	sh.UserInitHook = d.cfg.Shell.InitHook.String()
-	return sh.Run(nixShellFilePath)
+	shellInstance.UserInitHook = d.cfg.Shell.InitHook.String()
+	shellInstance.UserExitHook = d.cfg.Shell.ExitHook.String()
+	return shellInstance.Run(nixShellFilePath)
 }
 
 func (d *Devbox) Exec(cmds ...string) error {

--- a/nix/shell.go
+++ b/nix/shell.go
@@ -38,9 +38,11 @@ type Shell struct {
 	binPath         string
 	userShellrcPath string
 	planInitHook    string
+	planExitHook    string
 
 	// UserInitHook contains commands that will run at shell startup.
 	UserInitHook string
+	UserExitHook string
 
 	// profileDir is the absolute path to the directory storing the nix-profile
 	profileDir  string
@@ -266,15 +268,19 @@ func (s *Shell) writeDevboxShellrc() (path string, err error) {
 	err = shellrcTmpl.Execute(shellrcf, struct {
 		OriginalInit     string
 		OriginalInitPath string
-		UserHook         string
+		UserInitHook     string
+		UserExitHook     string
 		PlanInitHook     string
+		PlanExitHook     string
 		ProfileBinDir    string
 		HistoryFile      string
 	}{
 		OriginalInit:     string(bytes.TrimSpace(userShellrc)),
 		OriginalInitPath: filepath.Clean(s.userShellrcPath),
-		UserHook:         strings.TrimSpace(s.UserInitHook),
+		UserInitHook:     strings.TrimSpace(s.UserInitHook),
+		UserExitHook:     strings.TrimSpace(s.UserExitHook),
 		PlanInitHook:     strings.TrimSpace(s.planInitHook),
+		PlanExitHook:     strings.TrimSpace(s.planExitHook),
 		ProfileBinDir:    s.profileDir + "/bin",
 		HistoryFile:      strings.TrimSpace(s.historyFile),
 	})

--- a/nix/shellrc.tmpl
+++ b/nix/shellrc.tmpl
@@ -39,11 +39,11 @@ export PS1="(devbox) $PS1"
 
 # End Devbox Post-init Hook
 
-{{- if .UserHook }}
+{{- if .UserInitHook }}
 
 # Begin Devbox User Hook
 
-{{ .UserHook }}
+{{ .UserInitHook }}
 
 # End Devbox User Hook
 
@@ -58,3 +58,27 @@ export PS1="(devbox) $PS1"
 {{- end }}
 
 # End Plan Init Hook
+
+# Begin Plan Exit Hook
+
+{{- if .PlanExitHook }}
+
+# TODO savil. Implement PlanExitHook
+
+{{- end }}
+
+# End Plan Exit Hook
+
+# Begin User Exit Hook
+
+{{- if .UserExitHook }}
+
+runUserExitHook() {
+  {{ .UserExitHook }}
+}
+trap runUserExitHook EXIT
+
+{{- end }}
+
+
+# End User Exit Hook

--- a/planner/plansdk/plansdk.go
+++ b/planner/plansdk/plansdk.go
@@ -28,6 +28,7 @@ type PlanError struct {
 // Plan tells devbox how to start shells and build projects.
 type Plan struct {
 	ShellInitHook string `json:"shell_init_hook,omitempty"`
+	ShellExitHook string `json:"shell_exit_hook,omitempty"`
 
 	NixOverlays []string `cur:"[...string]" json:"nix_overlays,omitempty"`
 

--- a/testdata/rust/rust-stable/devbox.json
+++ b/testdata/rust/rust-stable/devbox.json
@@ -3,6 +3,7 @@
     "rust-bin.stable.latest.default"
   ],
   "shell": {
-    "init_hook": null
+    "init_hook": "export FOO=bar",
+    "exit_hook": "echo \"exiting rust shell hook: $FOO\""
   }
 }


### PR DESCRIPTION
## Summary

**Motivation**
A proof of concept for shell exit hooks.

In a `init-hook` for shell, users may choose to create resources (like a mysql database). Providing a structured way to cleanup upon shell exit is currently lacking. Users could choose to write a cleanup function and trap it themselves, but it feels cleaner to provide a corresponding exit hook, which this PR does.

ref. https://github.com/jetpack-io/devbox-examples/blob/main/databases/mariadb/conf/set-exit.sh


- [ ] Hook up Plan Shell Exit Hooks

## How was it tested?


```
devbox/testdata/rust/rust-stable on  savil/exit-hook [$!] is 📦 vhello-rust@0.1.0 via 𝗥 v1.63.0 at ☸️  jetpack-cloud (savil-srivastava-jetpack-io) took 24s
➜ devbox shell
Installing nix packages. This may take a while...done.
Starting a devbox shell...
(devbox)
devbox/testdata/rust/rust-stable on  savil/exit-hook [$+] is 📦 vhello-rust@0.1.0 via 𝗥 v1.64.0 at ☸️  jetpack-cloud (savil-srivastava-jetpack-io)
➜ which rustc
/Users/savil/code/jetpack/devbox/testdata/rust/rust-stable/.devbox/nix/profile/default/bin/rustc
(devbox)
devbox/testdata/rust/rust-stable on  savil/exit-hook [$] is 📦 vhello-rust@0.1.0 via 𝗥 v1.64.0 at ☸️  jetpack-cloud (savil-srivastava-jetpack-io)
➜ exit
exiting rust shell hook

```

