### PR TITLE
[RFC] add config packages to BuildPlan's runtimePackages

### DIFF
--- a/planner/plansdk/plansdk.go
+++ b/planner/plansdk/plansdk.go
@@ -159,7 +159,8 @@ func MergeUserBuildPlan(userPlan *BuildPlan, automatedPlan *BuildPlan) (*BuildPl
 	}
 	// Merging devPackages and runtimePackages fields.
 	packagesPlan := &BuildPlan{
-		DevPackages: append([]string{}, userPlan.DevPackages...),
+		DevPackages:     append([]string{}, userPlan.DevPackages...),
+		RuntimePackages: append([]string{}, userPlan.DevPackages...),
 	}
 	err := mergo.Merge(packagesPlan, automatedPlan, mergo.WithAppendSlice)
 	if err != nil {


### PR DESCRIPTION
## Summary

Previously, the `devbox.json` config's packages were being added to the Runtime packages
of `devbox build`. #227 changed that. Was it intentional (RFC)?

This PR fixes that to make the rust build work again

## How was it tested?

```
> cd testdata/rust/rust-stable
> devbox build && docker run devbox
Installed version is 1.64.0
```
