### PR TITLE
[Rust Shell] change to use rustup nix package to avoid overlay

### DIFF
--- a/testdata/rust/rust-1.62.0/.gitignore
+++ b/testdata/rust/rust-1.62.0/.gitignore
@@ -1,1 +1,2 @@
 target/
+.rustup/

--- a/testdata/rust/rust-1.62.0/build_plan.json
+++ b/testdata/rust/rust-1.62.0/build_plan.json
@@ -1,31 +1,28 @@
 {
-  "nix_overlays": [
-    "https://github.com/oxalica/rust-overlay/archive/stable.tar.gz"
-  ],
   "dev_packages": [
-    "rust-bin.stable.\"1.62.0\".default",
+    "rustup",
     "gcc"
   ],
   "runtime_packages": [
-    "glibc"
+    "rustup",
+    "gcc"
   ],
   "install_stage": {
-    "command": "cargo fetch",
+    "command": "mkdir -p ./.devbox/rust/cargo && export CARGO_HOME=./.devbox/rust/cargo && export PATH=$PATH:$CARGO_HOME && mkdir -p ./.devbox/rust/rustup/ && export RUSTUP_HOME=./.devbox/rust/rustup/ && rustup default \"1.62.0\" && cargo fetch",
     "input_files": [
       "."
     ]
   },
   "build_stage": {
-    "command": "cargo build --release --offline",
+    "command": "mkdir -p ./.devbox/rust/cargo && export CARGO_HOME=./.devbox/rust/cargo && export PATH=$PATH:$CARGO_HOME && mkdir -p ./.devbox/rust/rustup/ && export RUSTUP_HOME=./.devbox/rust/rustup/ && rustup default \"1.62.0\" && cargo build --release --offline",
     "input_files": [
       "."
     ]
   },
   "start_stage": {
-    "command": "./hello-rust",
+    "command": "mkdir -p ./.devbox/rust/cargo && export CARGO_HOME=./.devbox/rust/cargo && export PATH=$PATH:$CARGO_HOME && mkdir -p ./.devbox/rust/rustup/ && export RUSTUP_HOME=./.devbox/rust/rustup/ && rustup default \"1.62.0\" && cargo run --release --offline",
     "input_files": [
-      "target/release/hello-rust"
+      "."
     ]
-  },
-  "definitions": null
+  }
 }

--- a/testdata/rust/rust-1.62.0/devbox.json
+++ b/testdata/rust/rust-1.62.0/devbox.json
@@ -1,6 +1,11 @@
 {
   "packages": [
-    "rust-bin.stable.\"1.62.0\".default",
+    "rustup",
     "gcc"
-  ]
+  ],
+  "shell": {
+    "init_hook": [
+      "source init-shell.sh"
+    ]
+  }
 }

--- a/testdata/rust/rust-1.62.0/init-shell.sh
+++ b/testdata/rust/rust-1.62.0/init-shell.sh
@@ -1,0 +1,13 @@
+
+# TODO this only works when devbox shell is started in this directory. Using
+# the --config flag to start the shell will break this.
+# We could inject $JETPACK_CONFIG env-var into the shell environment to replace this.
+projectDir=$(dirname $(readlink -f "$0"))
+echo "project dir is $projectDir"
+
+rustupHomeDir="$projectDir"/.rustup
+mkdir -p $rustupHomeDir
+export RUSTUP_HOME=$rustupHomeDir
+export LIBRARY_PATH=$LIBRARY_PATH:"$projectDir/nix/profile/default/lib"
+
+rustup default 1.62.0

--- a/testdata/rust/rust-1.62.0/shell_plan.json
+++ b/testdata/rust/rust-1.62.0/shell_plan.json
@@ -1,10 +1,6 @@
 {
   "dev_packages": [
-    "rust-bin.stable.\"1.62.0\".default",
+    "rustup",
     "gcc"
-  ],
-  "nix_overlays": [
-    "https://github.com/oxalica/rust-overlay/archive/stable.tar.gz"
   ]
 }
-

--- a/testdata/rust/rust-stable-hello-world/.gitignore
+++ b/testdata/rust/rust-stable-hello-world/.gitignore
@@ -1,1 +1,3 @@
 target/
+.devbox/
+.rustup/

--- a/testdata/rust/rust-stable-hello-world/build_plan.json
+++ b/testdata/rust/rust-stable-hello-world/build_plan.json
@@ -1,31 +1,29 @@
 {
-  "nix_overlays": [
-    "https://github.com/oxalica/rust-overlay/archive/stable.tar.gz"
-  ],
   "dev_packages": [
-    "rust-bin.stable.latest.default",
+    "rustup",
+    "libiconv",
     "gcc"
   ],
   "runtime_packages": [
-    "glibc"
+    "rustup",
+    "gcc"
   ],
   "install_stage": {
-    "command": "cargo fetch",
+    "command": "mkdir -p ./.devbox/rust/cargo && export CARGO_HOME=./.devbox/rust/cargo && export PATH=$PATH:$CARGO_HOME && mkdir -p ./.devbox/rust/rustup/ && export RUSTUP_HOME=./.devbox/rust/rustup/ && rustup default stable && cargo fetch",
     "input_files": [
       "."
     ]
   },
   "build_stage": {
-    "command": "cargo build --release --offline",
+    "command": "mkdir -p ./.devbox/rust/cargo && export CARGO_HOME=./.devbox/rust/cargo && export PATH=$PATH:$CARGO_HOME && mkdir -p ./.devbox/rust/rustup/ && export RUSTUP_HOME=./.devbox/rust/rustup/ && rustup default stable && cargo build --release --offline",
     "input_files": [
       "."
     ]
   },
   "start_stage": {
-    "command": "./rust-stable-hello-world",
+    "command": "mkdir -p ./.devbox/rust/cargo && export CARGO_HOME=./.devbox/rust/cargo && export PATH=$PATH:$CARGO_HOME && mkdir -p ./.devbox/rust/rustup/ && export RUSTUP_HOME=./.devbox/rust/rustup/ && rustup default stable && cargo run --release --offline",
     "input_files": [
-      "target/release/rust-stable-hello-world"
+      "."
     ]
-  },
-  "definitions": null
+  }
 }

--- a/testdata/rust/rust-stable-hello-world/devbox.json
+++ b/testdata/rust/rust-stable-hello-world/devbox.json
@@ -1,7 +1,11 @@
 {
   "packages": [
-    "rust-bin.stable.latest.default",
-    "gcc"
+    "rustup",
+    "libiconv"
   ],
-  "shell": {}
+  "shell": {
+    "init_hook": [
+      "source init-shell.sh"
+    ]
+  }
 }

--- a/testdata/rust/rust-stable-hello-world/shell_plan.json
+++ b/testdata/rust/rust-stable-hello-world/shell_plan.json
@@ -1,10 +1,7 @@
 {
   "dev_packages": [
-    "rust-bin.stable.latest.default",
-    "gcc"
-  ],
-  "nix_overlays": [
-    "https://github.com/oxalica/rust-overlay/archive/stable.tar.gz"
+    "rustup",
+    "libiconv"
   ]
 }
 

--- a/testdata/rust/rust-stable/.gitignore
+++ b/testdata/rust/rust-stable/.gitignore
@@ -1,2 +1,3 @@
 target/
 .devbox/
+.rustup/

--- a/testdata/rust/rust-stable/build_plan.json
+++ b/testdata/rust/rust-stable/build_plan.json
@@ -1,31 +1,29 @@
 {
-  "nix_overlays": [
-    "https://github.com/oxalica/rust-overlay/archive/stable.tar.gz"
-  ],
   "dev_packages": [
-    "rust-bin.stable.latest.default",
+    "rustup",
+    "libiconv",
     "gcc"
   ],
   "runtime_packages": [
-    "glibc"
+    "rustup",
+    "gcc"
   ],
   "install_stage": {
-    "command": "cargo fetch",
+    "command": "mkdir -p ./.devbox/rust/cargo && export CARGO_HOME=./.devbox/rust/cargo && export PATH=$PATH:$CARGO_HOME && mkdir -p ./.devbox/rust/rustup/ && export RUSTUP_HOME=./.devbox/rust/rustup/ && rustup default stable && cargo fetch",
     "input_files": [
       "."
     ]
   },
   "build_stage": {
-    "command": "cargo build --release --offline",
+    "command": "mkdir -p ./.devbox/rust/cargo && export CARGO_HOME=./.devbox/rust/cargo && export PATH=$PATH:$CARGO_HOME && mkdir -p ./.devbox/rust/rustup/ && export RUSTUP_HOME=./.devbox/rust/rustup/ && rustup default stable && cargo build --release --offline",
     "input_files": [
       "."
     ]
   },
   "start_stage": {
-    "command": "./hello-rust",
+    "command": "mkdir -p ./.devbox/rust/cargo && export CARGO_HOME=./.devbox/rust/cargo && export PATH=$PATH:$CARGO_HOME && mkdir -p ./.devbox/rust/rustup/ && export RUSTUP_HOME=./.devbox/rust/rustup/ && rustup default stable && cargo run --release --offline",
     "input_files": [
-      "target/release/hello-rust"
+      "."
     ]
-  },
-  "definitions": null
+  }
 }

--- a/testdata/rust/rust-stable/devbox.json
+++ b/testdata/rust/rust-stable/devbox.json
@@ -1,9 +1,11 @@
 {
   "packages": [
-    "rust-bin.stable.latest.default",
-    "gcc"
+    "rustup",
+    "libiconv"
   ],
   "shell": {
-    "init_hook": null
+    "init_hook": [
+      "source init-shell.sh"
+    ]
   }
 }

--- a/testdata/rust/rust-stable/init-shell.sh
+++ b/testdata/rust/rust-stable/init-shell.sh
@@ -1,0 +1,13 @@
+
+# TODO this only works when devbox shell is started in this directory. Using
+# the --config flag to start the shell will break this.
+# We could inject $JETPACK_CONFIG env-var into the shell environment to replace this.
+projectDir=$(dirname $(readlink -f "$0"))
+echo "project dir is $projectDir"
+
+rustupHomeDir="$projectDir"/.rustup
+mkdir -p $rustupHomeDir
+export RUSTUP_HOME=$rustupHomeDir
+export LIBRARY_PATH=$LIBRARY_PATH:"$projectDir/nix/profile/default/lib"
+
+rustup default stable

--- a/testdata/rust/rust-stable/shell_plan.json
+++ b/testdata/rust/rust-stable/shell_plan.json
@@ -1,10 +1,7 @@
 {
   "dev_packages": [
-    "rust-bin.stable.latest.default",
-    "gcc"
-  ],
-  "nix_overlays": [
-    "https://github.com/oxalica/rust-overlay/archive/stable.tar.gz"
+    "rustup",
+    "libiconv"
   ]
 }
 


### PR DESCRIPTION
## Summary

In furtherance of our efforts to remove "magic" and simplify the plans, this PR
removes the NixOverlay from the Rust Planner.

We replace it with the `rustup` toolchain. This should work, although the
performance for `devbox build` is bad, and the image is bloated now.

The `devbox shell` experience is good. I'll add an example in `devbox-example`
repo for others to reference to add the shell init hooks.

- [ ] send followup PR to remove NixOverlay from the core plansdk.

## How was it tested?

did `devbox shell` and `devbox build && docker run devbox` in the rust folders
