### PR TITLE
[WIP] nix-flakes etude

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -41,6 +41,11 @@ func generateForShell(rootPath string, plan *plansdk.ShellPlan) error {
 		return errors.WithStack(err)
 	}
 
+	err = writeFromTemplate(rootPath, plan, "flake.nix")
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
 	for name, content := range plan.GeneratedFiles {
 		filePath := filepath.Join(outPath, name)
 		if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {

--- a/testdata/rust/rust-stable/flake.lock
+++ b/testdata/rust/rust-stable/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1666753130,
+        "narHash": "sha256-Wff1dGPFSneXJLI2c0kkdWTgxnQ416KE6X4KnFkgPYQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f540aeda6f677354f1e7144ab04352f61aaa0118",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/testdata/rust/rust-stable/flake.nix
+++ b/testdata/rust/rust-stable/flake.nix
@@ -1,0 +1,40 @@
+{
+    description = "A devbox shell";
+    outputs = { self, nixpkgs }:
+        # TODO generalize system using flake-util
+        let pkgs = nixpkgs.legacyPackages.x86_64-darwin;
+
+        in {
+            devShell.x86_64-darwin = pkgs.mkShell {
+              shellHook =
+                ''
+                  echo "Starting a devbox shell..."
+
+                  # We're technically no longer in a Nix shell after this hook because we
+                  # exec a devbox shell.
+                  export IN_NIX_SHELL=0
+                  export DEVBOX_SHELL_ENABLED=1
+
+                  # Undo the effects of `nix-shell --pure` on SSL certs.
+                  # See https://github.com/NixOS/nixpkgs/blob/dae204faa0243b4d0c0234a5f5f83a2549ecb5b7/pkgs/stdenv/generic/setup.sh#L677-L685
+                  if [ "$NIX_SSL_CERT_FILE" == "/no-cert-file.crt" ]; then
+                     unset NIX_SSL_CERT_FILE
+                  fi
+                  if [ "$SSL_CERT_FILE" == "/no-cert-file.crt" ]; then
+                     unset SSL_CERT_FILE
+                  fi
+
+                  # Append the parent shell's PATH so that we retain access to
+                  # non-Nix programs, while still preferring the Nix ones.
+                  export "PATH=$PATH:$PARENT_PATH"
+
+                  
+                '';
+              buildInputs = with pkgs; [
+                    rustup
+                  
+                    libiconv
+                  ];
+            };
+        };
+}

--- a/tmpl/flake.nix.tmpl
+++ b/tmpl/flake.nix.tmpl
@@ -1,0 +1,42 @@
+{
+    description = "A devbox shell";
+    outputs = { self, nixpkgs }:
+        # TODO generalize system using flake-util
+        let pkgs = nixpkgs.legacyPackages.x86_64-darwin;
+
+        in {
+            devShell.x86_64-darwin = pkgs.mkShell {
+              shellHook =
+                ''
+                  echo "Starting a devbox shell..."
+
+                  # We're technically no longer in a Nix shell after this hook because we
+                  # exec a devbox shell.
+                  export IN_NIX_SHELL=0
+                  export DEVBOX_SHELL_ENABLED=1
+
+                  # Undo the effects of `nix-shell --pure` on SSL certs.
+                  # See https://github.com/NixOS/nixpkgs/blob/dae204faa0243b4d0c0234a5f5f83a2549ecb5b7/pkgs/stdenv/generic/setup.sh#L677-L685
+                  if [ "$NIX_SSL_CERT_FILE" == "/no-cert-file.crt" ]; then
+                     unset NIX_SSL_CERT_FILE
+                  fi
+                  if [ "$SSL_CERT_FILE" == "/no-cert-file.crt" ]; then
+                     unset SSL_CERT_FILE
+                  fi
+
+                  # Append the parent shell's PATH so that we retain access to
+                  # non-Nix programs, while still preferring the Nix ones.
+                  export "PATH=$PATH:$PARENT_PATH"
+
+                  {{ if debug }}
+                  echo "PATH=$PATH"
+                  {{- end }}
+                '';
+              buildInputs = with pkgs; [
+                  {{- range .DevPackages}}
+                    {{.}}
+                  {{end -}}
+              ];
+            };
+        };
+}


### PR DESCRIPTION
## Summary

Generates a basic `flake.nix` file that can be used with `nix develop`.

- [ ] understand how flakes and nix-profile work together
- [ ] figure out story for adding to git (or not)
- [ ] shell environment and prompt doesn't seem to be getting set

## How was it tested?

```
> cd testdata/rust/rust-stable

# See TODO around managing this git add
> git add flake.nix

> nix develop

> ➜ nix develop
Starting a devbox shell...
Savil-Srivastavas-MacBook-Pro:rust-stable savil$ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/hello-rust`
Installed version is 1.61.0
thread 'main' panicked at 'Version 1.61.0 is less than expected version of 1.63.0', src/main.rs:11:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
This failure is somewhat expected. It arises because we are (likely) getting the stable
nix channel. That likely has the older version of `rustup`.
