### PR TITLE
nix: fix PkgExists panic for some missing packages

### DIFF
--- a/nix/nix.go
+++ b/nix/nix.go
@@ -59,9 +59,6 @@ func parseInfo(pkg string, data []byte) *Info {
 	if err != nil {
 		panic(err)
 	}
-	if len(results) != 1 {
-		panic(fmt.Sprintf("unexpected number of results: %d", len(results)))
-	}
 	for _, result := range results {
 		pkgInfo := &Info{
 			NixName: pkg,

--- a/nix/nix_test.go
+++ b/nix/nix_test.go
@@ -1,0 +1,14 @@
+package nix
+
+import "testing"
+
+func TestPkgExists(t *testing.T) {
+	// nix-env returns an empty JSON object instead of an error for some
+	// missing packages, which was leading to a panic. "rust" happens to be
+	// one of those packages.
+	pkg := "rust"
+	exists := PkgExists(pkg)
+	if exists {
+		t.Errorf("got PkgExists(%q) = true, want false.", pkg)
+	}
+}


### PR DESCRIPTION
## Summary

nix-env returns an empty JSON object instead of an error for some missing packages. This leads to a panic because we check that unmarshalled nix-env JSON output only has 1 entry. Remove that check since it seems unnecessary.

## How was it tested?

Added a test that looks for the "rust" package, which triggers this panic for some reason.