### PR TITLE
[nipkgs version] add feature flag and write to devbox.json if missing

### DIFF
--- a/boxcli/featureflag/nixpkgversion.go
+++ b/boxcli/featureflag/nixpkgversion.go
@@ -1,0 +1,7 @@
+package featureflag
+
+const NixpkgVersion = "NIXPKG_VERSION"
+
+func init() {
+	disabled(NixpkgVersion)
+}

--- a/devbox.go
+++ b/devbox.go
@@ -69,6 +69,10 @@ func Open(dir string, writer io.Writer) (*Devbox, error) {
 		return nil, errors.WithStack(err)
 	}
 
+	if err = upgradeConfig(cfg, cfgPath); err != nil {
+		return nil, err
+	}
+
 	box := &Devbox{
 		cfg:    cfg,
 		srcDir: cfgDir,


### PR DESCRIPTION
## Summary

We add `nixpkgs.version` to `devbox.json` if it is missing.

## How was it tested?

```
> cd testdata/rust/rust-stable

# control
> DEVBOX_DEBUG=1 devbox shell
> git diff devbox.json
# no change as expected


> DEVBOX_FEATURE_NIXPKG_VERSION=1 DEVBOX_DEBUG=1 devbox shell
> git diff devbox.json
diff --git a/testdata/rust/rust-stable/devbox.json b/testdata/rust/rust-stable/devbox.json
index 89b7c0d..028385d 100644
--- a/testdata/rust/rust-stable/devbox.json
+++ b/testdata/rust/rust-stable/devbox.json
@@ -7,5 +7,8 @@
     "init_hook": [
       "source init-shell.sh"
     ]
+  },
+  "nixpkgs": {
+    "version": "af9e00071d0971eb292fd5abef334e66eda3cb69"
   }
-}
+}
\ No newline at end of file

```
