### PR TITLE
[pkgcfg] Create new pkgckg that can load local config

### DIFF
--- a/boxcli/featureflag/feature.go
+++ b/boxcli/featureflag/feature.go
@@ -3,6 +3,8 @@ package featureflag
 import (
 	"os"
 	"strconv"
+
+	"go.jetpack.io/devbox/debug"
 )
 
 type feature struct {
@@ -29,6 +31,7 @@ func (f *feature) Enabled() bool {
 		return false
 	}
 	if on, _ := strconv.ParseBool(os.Getenv("DEVBOX_FEATURE_" + f.name)); on {
+		debug.Log("Feature %q enabled via environment variable.", f.name)
 		return true
 	}
 	return f.enabled

--- a/generate.go
+++ b/generate.go
@@ -13,7 +13,9 @@ import (
 	"text/template"
 
 	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/boxcli/featureflag"
 	"go.jetpack.io/devbox/debug"
+	"go.jetpack.io/devbox/pkgcfg"
 	"go.jetpack.io/devbox/planner/plansdk"
 )
 
@@ -45,6 +47,14 @@ func generateForShell(rootPath string, plan *plansdk.ShellPlan) error {
 		filePath := filepath.Join(outPath, name)
 		if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
 			return errors.WithStack(err)
+		}
+	}
+
+	if featureflag.Get(featureflag.PKGConfig).Enabled() {
+		for _, pkg := range plan.DevPackages {
+			if err := pkgcfg.CreateFiles(pkg, rootPath); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkgcfg/pkgcfg.go
+++ b/pkgcfg/pkgcfg.go
@@ -34,6 +34,9 @@ func getLocalConfig(configPath, pkg string) (*config, error) {
 	}
 	debug.Log("Reading local package config at %q", configPath)
 	content, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
 	cfg := &config{}
 	if err = json.Unmarshal(content, cfg); err != nil {
 		return nil, errors.WithStack(err)

--- a/pkgcfg/pkgcfg.go
+++ b/pkgcfg/pkgcfg.go
@@ -1,0 +1,75 @@
+package pkgcfg
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/debug"
+)
+
+const localPkgConfigPath = "DEVBOX_LOCAL_PKG_CONFIG"
+
+type config struct {
+	Name        string            `json:"name"`
+	Version     string            `json:"version"`
+	CreateFiles map[string]string `json:"create_files"`
+	Env         map[string]string `json:"env"`
+}
+
+func get(pkg string) (*config, error) {
+	if configPath := os.Getenv(localPkgConfigPath); configPath != "" {
+		debug.Log("Using local package config at %q", configPath)
+		return getLocalConfig(configPath, pkg)
+	}
+	return &config{}, nil
+}
+
+func getLocalConfig(configPath, pkg string) (*config, error) {
+	configPath = filepath.Join(configPath, pkg+".json")
+	debug.Log("Reading local package config at %q", configPath)
+	content, err := os.ReadFile(configPath)
+	cfg := &config{}
+	if err == nil {
+		if err = json.Unmarshal(content, cfg); err != nil {
+			return nil, errors.WithStack(err)
+		}
+	}
+	return cfg, nil
+}
+
+func CreateFiles(pkg, basePath string) error {
+	cfg, err := get(pkg)
+	if err != nil {
+		return err
+	}
+	for name, contentPath := range cfg.CreateFiles {
+		filePath := filepath.Join(basePath, name)
+		if _, err := os.Stat(filePath); err == nil {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(basePath, contentPath))
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if err := os.WriteFile(filePath, content, 0744); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+	return nil
+}
+
+func Env(pkgs []string) (map[string]string, error) {
+	env := map[string]string{}
+	for _, pkg := range pkgs {
+		cfg, err := get(pkg)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range cfg.Env {
+			env[k] = v
+		}
+	}
+	return env, nil
+}

--- a/pkgcfg/pkgcfg.go
+++ b/pkgcfg/pkgcfg.go
@@ -28,13 +28,15 @@ func get(pkg string) (*config, error) {
 
 func getLocalConfig(configPath, pkg string) (*config, error) {
 	configPath = filepath.Join(configPath, pkg+".json")
+	if _, err := os.Stat(configPath); errors.Is(err, os.ErrNotExist) {
+		// We don't need config for all packages and that's fine
+		return &config{}, nil
+	}
 	debug.Log("Reading local package config at %q", configPath)
 	content, err := os.ReadFile(configPath)
 	cfg := &config{}
-	if err == nil {
-		if err = json.Unmarshal(content, cfg); err != nil {
-			return nil, errors.WithStack(err)
-		}
+	if err = json.Unmarshal(content, cfg); err != nil {
+		return nil, errors.WithStack(err)
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
## Summary

Creates a new package that allows loading of local configs. This will allow for rapid testing and iteration of package configuration before we read them remotely. 

## How was it tested?

Created dummy go config and ran:

```
DEVBOX_FEATURE_PKG_CONFIG=1 DEVBOX_LOCAL_PKG_CONFIG=~/dev/devbox ./dist/devbox shell
echo $FOO
./.devbox/test-file.sh
```

