### PR TITLE
[nixpkgs version] change field from version to commit; add validation

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -381,3 +381,32 @@ func TestFindConfigDirAtPath(t *testing.T) {
 		})
 	}
 }
+
+func TestNixpkgsValidation(t *testing.T) {
+	testCases := map[string]struct {
+		commit   string
+		isErrant bool
+	}{
+		"invalid_nixpkg_commit": {"1234545", true},
+		"valid_nixpkg_commit":   {"af9e00071d0971eb292fd5abef334e66eda3cb69", false},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			err := validateNixpkg(&Config{
+				Nixpkgs: struct {
+					Commit string `json:"commit,omitempty"`
+				}{
+					Commit: testCase.commit,
+				},
+			})
+			if testCase.isErrant {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Changing the field name inside `Config.Nixpkgs` from `version` to `commit`.
The motivation stems from the realization that even `YY.MM` stable channels of
nixpkgs have periodic updates (mostly for security), which means the commit-hash
tracked by the `nixos-stable` branch changes.

To simplify the product design for now, and to avoid introducing a lockfile, 
we change `version` to be the unambiguous `commit`. For users who would like
to track the nixpkgs commit from `search.nixos.org` webpage, they can refer
to `status.nixos.org` and use the commit for the nixpkgs channel they want.

## How was it tested?

`go test ./...` b/c added a testcase for the validation function.

```
> cd testdata/nodejs/nodejs-18
> DEVBOX_FEATURE_NIXPKG_VERSION=1 DEVBOX_DEBUG=0 devbox shell -- node --version
Installing nix packages. This may take a while...done.
Starting a devbox shell...
v18.7.0
```
