### PR TITLE
[pkg-config] Add bin sym links and add to path

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -214,7 +214,11 @@ func (d *Devbox) Shell() error {
 		if err != nil {
 			return err
 		}
-		opts = append(opts, nix.WithEnvVariables(env))
+		opts = append(
+			opts,
+			nix.WithEnvVariables(env),
+			nix.WithPath(filepath.Join(d.srcDir, ".devbox/conf/bin")),
+		)
 	}
 
 	shell, err := nix.DetectShell(opts...)

--- a/devbox.go
+++ b/devbox.go
@@ -217,7 +217,7 @@ func (d *Devbox) Shell() error {
 		opts = append(
 			opts,
 			nix.WithEnvVariables(env),
-			nix.WithPath(filepath.Join(d.srcDir, ".devbox/conf/bin")),
+			nix.WithPKGCOnfigDir(filepath.Join(d.srcDir, ".devbox/conf/bin")),
 		)
 	}
 

--- a/nix/shell.go
+++ b/nix/shell.go
@@ -44,6 +44,7 @@ type Shell struct {
 	// UserInitHook contains commands that will run at shell startup.
 	UserInitHook string
 
+	path string // This gets prepended PARENT_PATH if it is set.
 	// profileDir is the absolute path to the directory storing the nix-profile
 	profileDir  string
 	historyFile string
@@ -123,6 +124,12 @@ func WithEnvVariables(envVariables map[string]string) ShellOption {
 	}
 }
 
+func WithPath(path string) ShellOption {
+	return func(s *Shell) {
+		s.path = path
+	}
+}
+
 // rcfilePath returns the absolute path for an rcfile, which is usually in the
 // user's home directory. It doesn't guarantee that the file exists.
 func rcfilePath(basename string) string {
@@ -142,6 +149,9 @@ func (s *Shell) Run(nixShellFilePath string) error {
 	// Copy the current PATH into nix-shell, but clean and remove some
 	// directories that are incompatible.
 	parentPath := cleanEnvPath(os.Getenv("PATH"), nixProfileDirs)
+	if s.path != "" {
+		parentPath = s.path + ":" + parentPath
+	}
 
 	env := append(s.env, os.Environ()...)
 	env = append(

--- a/nix/shellrc.tmpl
+++ b/nix/shellrc.tmpl
@@ -28,7 +28,7 @@ content readable.
 
 # Begin Devbox Post-init Hook
 
-PATH="{{ .ProfileBinDir }}:$PATH"
+PATH="{{ .PathPrepend }}:$PATH"
 
 {{- if .HistoryFile }}
 HISTFILE={{.HistoryFile}}

--- a/pkgcfg/package-configuration/dummy-config/echo.sh
+++ b/pkgcfg/package-configuration/dummy-config/echo.sh
@@ -1,0 +1,1 @@
+echo "I get installed if go_1_19 is installed"

--- a/pkgcfg/package-configuration/dummy-config/go_1_19.json
+++ b/pkgcfg/package-configuration/dummy-config/go_1_19.json
@@ -1,0 +1,11 @@
+{
+  "name": "dummy config for go_1_19",
+  "version": "1.0.0",
+  "env": {
+    "FOO": "bar",
+    "DEVBOX_HELP": "true that"
+  },
+  "create_files": {
+    ".devbox/conf/go_1_19/bin/test-echo": "echo.sh"
+  }
+}

--- a/pkgcfg/pkgcfg.go
+++ b/pkgcfg/pkgcfg.go
@@ -12,36 +12,11 @@ import (
 const localPkgConfigPath = "DEVBOX_LOCAL_PKG_CONFIG"
 
 type config struct {
-	Name        string            `json:"name"`
-	Version     string            `json:"version"`
-	CreateFiles map[string]string `json:"create_files"`
-	Env         map[string]string `json:"env"`
-}
-
-func get(pkg string) (*config, error) {
-	if configPath := os.Getenv(localPkgConfigPath); configPath != "" {
-		debug.Log("Using local package config at %q", configPath)
-		return getLocalConfig(configPath, pkg)
-	}
-	return &config{}, nil
-}
-
-func getLocalConfig(configPath, pkg string) (*config, error) {
-	configPath = filepath.Join(configPath, pkg+".json")
-	if _, err := os.Stat(configPath); errors.Is(err, os.ErrNotExist) {
-		// We don't need config for all packages and that's fine
-		return &config{}, nil
-	}
-	debug.Log("Reading local package config at %q", configPath)
-	content, err := os.ReadFile(configPath)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	cfg := &config{}
-	if err = json.Unmarshal(content, cfg); err != nil {
-		return nil, errors.WithStack(err)
-	}
-	return cfg, nil
+	Name            string            `json:"name"`
+	Version         string            `json:"version"`
+	CreateFiles     map[string]string `json:"create_files"`
+	Env             map[string]string `json:"env"`
+	localConfigPath string            `json:"-"`
 }
 
 func CreateFiles(pkg, basePath string) error {
@@ -51,15 +26,21 @@ func CreateFiles(pkg, basePath string) error {
 	}
 	for name, contentPath := range cfg.CreateFiles {
 		filePath := filepath.Join(basePath, name)
-		if _, err := os.Stat(filePath); err == nil {
-			continue
-		}
-		content, err := os.ReadFile(filepath.Join(basePath, contentPath))
+		// if _, err := os.Stat(filePath); err == nil {
+		// 	continue
+		// }
+		content, err := os.ReadFile(filepath.Join(cfg.localConfigPath, contentPath))
 		if err != nil {
 			return errors.WithStack(err)
 		}
+		if err = createDir(filepath.Dir(filePath)); err != nil {
+			return err
+		}
 		if err := os.WriteFile(filePath, content, 0744); err != nil {
 			return errors.WithStack(err)
+		}
+		if err := createSymlink(basePath, filePath); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -77,4 +58,60 @@ func Env(pkgs []string) (map[string]string, error) {
 		}
 	}
 	return env, nil
+}
+
+func get(pkg string) (*config, error) {
+	if configPath := os.Getenv(localPkgConfigPath); configPath != "" {
+		debug.Log("Using local package config at %q", configPath)
+		return getLocalConfig(configPath, pkg)
+	}
+	return &config{}, nil
+}
+
+func getLocalConfig(configPath, pkg string) (*config, error) {
+	pkgConfigPath := filepath.Join(configPath, pkg+".json")
+	if _, err := os.Stat(pkgConfigPath); errors.Is(err, os.ErrNotExist) {
+		// We don't need config for all packages and that's fine
+		return &config{}, nil
+	}
+	debug.Log("Reading local package config at %q", pkgConfigPath)
+	content, err := os.ReadFile(pkgConfigPath)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	cfg := &config{localConfigPath: configPath}
+	if err = json.Unmarshal(content, cfg); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return cfg, nil
+}
+func createDir(path string) error {
+	if path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(path, 0755); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+func createSymlink(root, filePath string) error {
+	name := filepath.Base(filePath)
+	newname := filepath.Join(root, ".devbox/conf/bin", name)
+
+	// Create bin path just in case it doesn't exist
+	if err := os.MkdirAll(filepath.Join(root, ".devbox/conf/bin"), 0755); err != nil {
+		return errors.WithStack(err)
+	}
+
+	if _, err := os.Stat(newname); err == nil {
+		if err = os.Remove(newname); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	if err := os.Symlink(filePath, newname); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
 }

--- a/pkgcfg/pkgcfg.go
+++ b/pkgcfg/pkgcfg.go
@@ -26,9 +26,6 @@ func CreateFiles(pkg, basePath string) error {
 	}
 	for name, contentPath := range cfg.CreateFiles {
 		filePath := filepath.Join(basePath, name)
-		// if _, err := os.Stat(filePath); err == nil {
-		// 	continue
-		// }
 		content, err := os.ReadFile(filepath.Join(cfg.localConfigPath, contentPath))
 		if err != nil {
 			return errors.WithStack(err)


### PR DESCRIPTION
## Summary

This PR does two things:

* Adds `.devbox/conf/bin` to path
* Creates sym links for any files in `.devbox/conf/[pkg]/bin`

## How was it tested?

Using dummy package config
