### PR TITLE
[nixpkgs version] generate nix files containing the nixpkgs version from config

### DIFF
--- a/boxcli/plan.go
+++ b/boxcli/plan.go
@@ -47,7 +47,11 @@ func runPlanCmd(_ *cobra.Command, args []string, flags planCmdFlags) error {
 	enc.SetIndent("", "  ")
 	enc.SetEscapeHTML(false)
 
-	shellPlan := box.ShellPlan()
+	shellPlan, err := box.ShellPlan()
+	if err != nil {
+		return err
+	}
+
 	err = enc.Encode(shellPlan)
 	if err != nil {
 		return errors.WithStack(err)

--- a/devbox_test.go
+++ b/devbox_test.go
@@ -51,7 +51,7 @@ func testShell(t *testing.T, testPath string) {
 		box.srcDir, err = filepath.Rel(currentDir, box.srcDir)
 		assert.NoErrorf(err, "expect to construct relative path from %s relative to base %s", box.srcDir, currentDir)
 
-		shellPlan := box.ShellPlan()
+		shellPlan, err := box.ShellPlan()
 		assert.NoError(err, "devbox shell plan should not fail")
 
 		err = box.generateShellFiles()

--- a/testdata/nodejs/nodejs-18/devbox.json
+++ b/testdata/nodejs/nodejs-18/devbox.json
@@ -1,5 +1,11 @@
 {
   "packages": [
     "nodejs-18_x"
-  ]
+  ],
+  "shell": {
+    "init_hook": null
+  },
+  "nixpkgs": {
+    "version": "22.05"
+  }
 }

--- a/testdata/nodejs/nodejs-18/devbox.json
+++ b/testdata/nodejs/nodejs-18/devbox.json
@@ -1,11 +1,5 @@
 {
   "packages": [
     "nodejs-18_x"
-  ],
-  "shell": {
-    "init_hook": null
-  },
-  "nixpkgs": {
-    "version": "22.05"
-  }
+  ]
 }

--- a/testdata/rust/rust-stable/devbox.json
+++ b/testdata/rust/rust-stable/devbox.json
@@ -7,5 +7,8 @@
     "init_hook": [
       "source init-shell.sh"
     ]
+  },
+  "nixpkgs": {
+    "version": "22.05"
   }
 }

--- a/tmpl/development.nix.tmpl
+++ b/tmpl/development.nix.tmpl
@@ -1,6 +1,6 @@
 let
   pkgs = import (fetchTarball {
-    url = "{{ .NixpkgsInfo.Url }}";
+    url = "{{ .NixpkgsInfo.URL }}";
     {{- if .NixpkgsInfo.Sha256 }}
     sha256 = "{{ .NixpkgsInfo.Sha256 }}";
     {{- end }}

--- a/tmpl/development.nix.tmpl
+++ b/tmpl/development.nix.tmpl
@@ -1,9 +1,9 @@
 let
   pkgs = import (fetchTarball {
-    # Commit hash as of 2022-08-16
-    # `git ls-remote https://github.com/nixos/nixpkgs nixos-unstable`
-    url = "https://github.com/nixos/nixpkgs/archive/af9e00071d0971eb292fd5abef334e66eda3cb69.tar.gz";
-    sha256 = "1mdwy0419m5i9ss6s5frbhgzgyccbwycxm5nal40c8486bai0hwy";
+    url = "{{ .NixpkgsInfo.Url }}";
+    {{- if .NixpkgsInfo.Sha256 }}
+    sha256 = "{{ .NixpkgsInfo.Sha256 }}";
+    {{- end }}
   }) {
     {{- if .NixOverlays }}
       overlays = [

--- a/tmpl/runtime.nix.tmpl
+++ b/tmpl/runtime.nix.tmpl
@@ -1,9 +1,9 @@
 let
   pkgs = import (fetchTarball {
-    # Commit hash as of 2022-08-16
-    # `git ls-remote https://github.com/nixos/nixpkgs nixos-unstable`
-    url = "https://github.com/nixos/nixpkgs/archive/af9e00071d0971eb292fd5abef334e66eda3cb69.tar.gz";
-    sha256 = "1mdwy0419m5i9ss6s5frbhgzgyccbwycxm5nal40c8486bai0hwy";
+    url = "{{ .NixpkgsInfo.URL }}";
+    {{- if .NixpkgsInfo.Sha256 }}
+    sha256 = "{{ .NixpkgsInfo.Sha256 }}";
+    {{- end }}
   }) {
     {{- if .NixOverlays }}
       overlays = [

--- a/tmpl/shell.nix.tmpl
+++ b/tmpl/shell.nix.tmpl
@@ -2,7 +2,7 @@ let
   pkgs = import (fetchTarball {
     # Commit hash as of 2022-08-16
     # `git ls-remote https://github.com/nixos/nixpkgs nixos-unstable`
-    url = "{{ .NixpkgsInfo.Url }}";
+    url = "{{ .NixpkgsInfo.URL }}";
     {{- if .NixpkgsInfo.Sha256 }}
     sha256 = "{{ .NixpkgsInfo.Sha256 }}";
     {{- end }}

--- a/tmpl/shell.nix.tmpl
+++ b/tmpl/shell.nix.tmpl
@@ -2,8 +2,10 @@ let
   pkgs = import (fetchTarball {
     # Commit hash as of 2022-08-16
     # `git ls-remote https://github.com/nixos/nixpkgs nixos-unstable`
-    url = "https://github.com/nixos/nixpkgs/archive/af9e00071d0971eb292fd5abef334e66eda3cb69.tar.gz";
-    sha256 = "1mdwy0419m5i9ss6s5frbhgzgyccbwycxm5nal40c8486bai0hwy";
+    url = "{{ .NixpkgsInfo.Url }}";
+    {{- if .NixpkgsInfo.Sha256 }}
+    sha256 = "{{ .NixpkgsInfo.Sha256 }}";
+    {{- end }}
   }) {
     {{- if .NixOverlays }}
       overlays = [


### PR DESCRIPTION
## Summary

This PR will parameterize the `shell.nix`, `development.nix` and `runtime.nix` files
to accept a `NixpkgsInfo` struct comprising of `url` and `sha256` fields.

To pass the `NixPkgsInfo` struct to these templates, we need to add them to the `ShellPlan`
and `BuildPlan` structs. I don't like this, but it seemed the most straightforward
approach. 

## How was it tested?

with the hardcoded commit hash
```
➜ DEVBOX_FEATURE_NIXPKG_VERSION=1 DEVBOX_DEBUG=0 devbox shell -- node --version
Installing nix packages. This may take a while...done.
Starting a devbox shell...
v18.7.0
```

From https://status.nixos.org, I got the most recent commit for the `nixos-22.05` channel:
`b3a8f7ed267e0a7ed100eb7d716c9137ff120fe3`. I set this in the devbox.json file.

```
> DEVBOX_FEATURE_NIXPKG_VERSION=1 DEVBOX_DEBUG=0 devbox shell -- node --version
Installing nix packages. This may take a while...done.
Starting a devbox shell...
v18.9.1
```
This matches the version seen in https://search.nixos.org

```
>  DEVBOX_FEATURE_NIXPKG_VERSION=1 devbox build && docker run devbox
.... // omitted
Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
the NODE_MAJOR_VERSION is 18
```