### PR TITLE
[nixpkgs version] devbox init should add default nixpkgs commit

### DIFF
--- a/config.go
+++ b/config.go
@@ -41,9 +41,11 @@ type Config struct {
 	} `json:"shell,omitempty"`
 
 	// Nixpkgs specifies the repository to pull packages from
-	Nixpkgs struct {
-		Commit string `json:"commit,omitempty"`
-	} `json:"nixpkgs,omitempty"`
+	Nixpkgs NixpkgsConfig `json:"nixpkgs,omitempty"`
+}
+
+type NixpkgsConfig struct {
+	Commit string `json:"commit,omitempty"`
 }
 
 // This contains a subset of fields from plansdk.Stage

--- a/config_test.go
+++ b/config_test.go
@@ -396,9 +396,7 @@ func TestNixpkgsValidation(t *testing.T) {
 			assert := assert.New(t)
 
 			err := validateNixpkg(&Config{
-				Nixpkgs: struct {
-					Commit string `json:"commit,omitempty"`
-				}{
+				Nixpkgs: NixpkgsConfig{
 					Commit: testCase.commit,
 				},
 			})

--- a/devbox.go
+++ b/devbox.go
@@ -44,7 +44,14 @@ const (
 // exist.
 func InitConfig(dir string) (created bool, err error) {
 	cfgPath := filepath.Join(dir, configFilename)
-	return cuecfg.InitFile(cfgPath, &Config{})
+
+	config := &Config{}
+	if featureflag.Get(featureflag.NixpkgVersion).Enabled() {
+		config.Nixpkgs = NixpkgsConfig{
+			Commit: plansdk.DefaultNixpkgsCommit,
+		}
+	}
+	return cuecfg.InitFile(cfgPath, config)
 }
 
 // Devbox provides an isolated development environment that contains a set of

--- a/planner/plansdk/plansdk.go
+++ b/planner/plansdk/plansdk.go
@@ -213,18 +213,19 @@ type NixpkgsInfo struct {
 	Sha256 string
 }
 
+// Commit hash as of 2022-08-16
+// `git ls-remote https://github.com/nixos/nixpkgs nixos-unstable`
+const DefaultNixpkgsCommit = "af9e00071d0971eb292fd5abef334e66eda3cb69"
+
 func GetNixpkgsInfo(commitHash string) (*NixpkgsInfo, error) {
 
 	// If the featureflag is OFF, then we fallback to the hardcoded commit
 	// and ignore any value set in the devbox.json
 	if !featureflag.Get(featureflag.NixpkgVersion).Enabled() {
-		// Commit hash as of 2022-08-16
-		// `git ls-remote https://github.com/nixos/nixpkgs nixos-unstable`
-		//
 		// sha256 from:
 		// nix-prefetch-url --unpack  https://github.com/nixos/nixpkgs/archive/<commit-hash>.tar.gz
 		return &NixpkgsInfo{
-			URL:    "https://github.com/nixos/nixpkgs/archive/af9e00071d0971eb292fd5abef334e66eda3cb69.tar.gz",
+			URL:    fmt.Sprintf("https://github.com/nixos/nixpkgs/archive/%s.tar.gz", DefaultNixpkgsCommit),
 			Sha256: "1mdwy0419m5i9ss6s5frbhgzgyccbwycxm5nal40c8486bai0hwy",
 		}, nil
 	}


### PR DESCRIPTION
## Summary

This PR updates `devbox init` to insert the default nixpkgs commit.

## How was it tested?

feature flag OFF:
```
devbox/testdata/nodejs/nodejs-18/fake-dir on  savil/nixpkgs-version-init [!] at ☸️  jetpack-cloud (savil-srivastava-jetpack-io)
➜ devbox init

devbox/testdata/nodejs/nodejs-18/fake-dir on  savil/nixpkgs-version-init [!?] at ☸️  jetpack-cloud (savil-srivastava-jetpack-io)
➜ cat devbox.json
{
  "packages": [],
  "shell": {
    "init_hook": null
  },
  "nixpkgs": {}
}%
```

feature flag ON
```
devbox/testdata/nodejs/nodejs-18/fake-dir on  savil/nixpkgs-version-init [!] at ☸️  jetpack-cloud (savil-srivastava-jetpack-io)
➜ DEVBOX_FEATURE_NIXPKG_VERSION=1 devbox init

devbox/testdata/nodejs/nodejs-18/fake-dir on  savil/nixpkgs-version-init [!?] at ☸️  jetpack-cloud (savil-srivastava-jetpack-io)
➜ cat devbox.json
{
  "packages": [],
  "shell": {
    "init_hook": null
  },
  "nixpkgs": {
    "commit": "af9e00071d0971eb292fd5abef334e66eda3cb69"
  }
}%
```
