### PR TITLE
vscode extension settings + devcontainer setup + devbox commands

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -25,6 +25,18 @@
       {
         "command": "devbox.add",
         "title": "Devbox: Add - add packages to your devbox project"
+      },
+      {
+        "command": "devbox.shell",
+        "title": "Devbox: Shell - Go to devbox shell in the terminal"
+      },
+      {
+        "command": "devbox.install",
+        "title": "Devbox: Install - Install packages specified in devbox.json"
+      },
+      {
+        "command": "devbox.init",
+        "title": "Devbox: Init - Initiate a devbox project"
       }
     ],
     "menus": {
@@ -36,6 +48,18 @@
         {
           "command": "devbox.add",
           "when": "devbox.configFileExists == true"
+        },
+        {
+          "command": "devbox.shell",
+          "when": "devbox.configFileExists == true"
+        },
+        {
+          "command": "devbox.install",
+          "when": "devbox.configFileExists == true"
+        },
+        {
+          "command": "devbox.init",
+          "when": "devbox.configFileExists == false"
         }
       ]
     },

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -39,10 +39,6 @@
         "title": "Devbox: Shell - Go to devbox shell in the terminal"
       },
       {
-        "command": "devbox.install",
-        "title": "Devbox: Install - Install packages specified in devbox.json"
-      },
-      {
         "command": "devbox.init",
         "title": "Devbox: Init - Initiate a devbox project"
       }
@@ -67,10 +63,6 @@
         },
         {
           "command": "devbox.shell",
-          "when": "devbox.configFileExists == true"
-        },
-        {
-          "command": "devbox.install",
           "when": "devbox.configFileExists == true"
         },
         {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -21,8 +21,24 @@
       {
         "command": "devbox.setupDevContainer",
         "title": "Devbox: Generate Dev Containers config files"
+      },
+      {
+        "command": "devbox.add",
+        "title": "Devbox: Add - add packages to your devbox project"
       }
     ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "devbox.setupDevContainer",
+          "when": "devbox.configFileExists == true"
+        },
+        {
+          "command": "devbox.add",
+          "when": "devbox.configFileExists == true"
+        }
+      ]
+    },
     "configuration": {
       "title": "devbox",
       "properties": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -27,6 +27,14 @@
         "title": "Devbox: Add - add packages to your devbox project"
       },
       {
+        "command": "devbox.remove",
+        "title": "Devbox: Remove - remove packages from your devbox project"
+      },
+      {
+        "command": "devbox.run",
+        "title": "Devbox: Run - execute scripts specified in devbox.json"
+      },
+      {
         "command": "devbox.shell",
         "title": "Devbox: Shell - Go to devbox shell in the terminal"
       },
@@ -50,6 +58,14 @@
           "when": "devbox.configFileExists == true"
         },
         {
+          "command": "devbox.remove",
+          "when": "devbox.configFileExists == true"
+        },
+        {
+          "command": "devbox.run",
+          "when": "devbox.configFileExists == true"
+        },
+        {
           "command": "devbox.shell",
           "when": "devbox.configFileExists == true"
         },
@@ -66,11 +82,6 @@
     "configuration": {
       "title": "devbox",
       "properties": {
-        "devbox.promptUpdateSettings": {
-          "type": "boolean",
-          "default": true,
-          "description": "Prompt to update workspace language settings to match devbox shell."
-        },
         "devbox.autoShellOnTerminal": {
           "type": "boolean",
           "default": true,

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -13,17 +13,31 @@
     "Other"
   ],
   "activationEvents": [
-    "workspaceContains:./devbox.json",
-    "onCommand:devbox.setupDevContainer"
+    "onStartupFinished"
   ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
       {
         "command": "devbox.setupDevContainer",
-        "title": "Devbox: Setup DevContainer config files"
+        "title": "Devbox: Generate Dev Containers config files"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "devbox",
+      "properties": {
+        "devbox.promptUpdateSettings": {
+          "type": "boolean",
+          "default": true,
+          "description": "Prompt to update workspace language settings to match devbox shell."
+        },
+        "devbox.autoShellOnTerminal": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically run devbox shell when terminal is opened."
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "yarn run compile",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -21,7 +21,7 @@
     "commands": [
       {
         "command": "devbox.setupDevContainer",
-        "title": "Setup DevContainer config files based on devbox.json"
+        "title": "Devbox: Setup DevContainer config files"
       }
     ]
   },

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -13,10 +13,18 @@
     "Other"
   ],
   "activationEvents": [
-    "workspaceContains:./devbox.json"
+    "workspaceContains:./devbox.json",
+    "onCommand:devbox.setupDevContainer"
   ],
   "main": "./out/extension.js",
-  "contributes": {},
+  "contributes": {
+    "commands": [
+      {
+        "command": "devbox.setupDevContainer",
+        "title": "Setup DevContainer config files based on devbox.json"
+      }
+    ]
+  },
   "scripts": {
     "vscode:prepublish": "yarn run compile",
     "compile": "tsc -p ./",

--- a/vscode-extension/src/devcontainer.ts
+++ b/vscode-extension/src/devcontainer.ts
@@ -1,0 +1,115 @@
+import { workspace, window, Uri } from 'vscode';
+import { posix } from 'path';
+
+export async function setupDevContainerFiles(cpuArch: String) {
+    try {
+        if (!workspace.workspaceFolders) {
+            return window.showInformationMessage('No folder or workspace opened');
+        }
+        const workspaceUri = workspace.workspaceFolders[0].uri;
+        const devcontainerUri = Uri.joinPath(workspaceUri, '.devcontainer/');
+        // Parsing devbox.json data
+        const devboxJson = await readDevboxJson(workspaceUri);
+        // creating .devcontainer directory and its files
+        await workspace.fs.createDirectory(devcontainerUri);
+        const dockerfileContent = getDockerfileContent();
+        await workspace.fs.writeFile(
+            Uri.joinPath(devcontainerUri, 'Dockerfile'),
+            Buffer.from(dockerfileContent, 'utf8')
+        );
+
+        const devContainerJSON = getDevcontainerJSON(devboxJson, cpuArch);
+        await workspace.fs.writeFile(
+            Uri.joinPath(devcontainerUri, 'devcontainer.json'),
+            Buffer.from(devContainerJSON, 'utf8')
+        );
+    } catch (error) {
+        console.error('Error processing devbox.json - ', error);
+        window.showErrorMessage('Error processing devbox.json');
+    }
+}
+
+export async function readDevboxJson(workspaceUri: Uri) {
+    const fileUri = workspaceUri.with({ path: posix.join(workspaceUri.path, 'devbox.json') });
+    const readData = await workspace.fs.readFile(fileUri);
+    const readStr = Buffer.from(readData).toString('utf8');
+    const devboxJsonData = JSON.parse(readStr);
+    return devboxJsonData;
+
+}
+
+
+
+function getDockerfileContent(): String {
+    return `
+	# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/debian/.devcontainer/base.Dockerfile
+
+	# [Choice] Debian version (use bullseye on local arm64/Apple Silicon): bullseye, buster
+	ARG VARIANT="buster"
+	FROM mcr.microsoft.com/vscode/devcontainers/base:0-\${VARIANT}
+
+	# These dependencies are required by Nix.
+	RUN apt update -y
+	RUN apt -y install --no-install-recommends curl xz-utils
+
+	USER vscode
+
+	# Install nix
+	ARG NIX_INSTALL_SCRIPT=https://nixos.org/nix/install
+	RUN curl -fsSL \${NIX_INSTALL_SCRIPT} | sh -s -- --no-daemon
+	ENV PATH /home/vscode/.nix-profile/bin:\${PATH}
+
+	# Install devbox
+	RUN sudo mkdir /devbox && sudo chown vscode /devbox
+	RUN curl -fsSL https://get.jetpack.io/devbox | bash -s -- -f
+
+	# Setup devbox environment
+	COPY --chown=vscode ./devbox.json /devbox/devbox.json
+	RUN devbox shell --config /devbox/devbox.json -- echo "Nix Store Populated"
+	ENV PATH /devbox/.devbox/nix/profile/default/bin:\${PATH}
+	ENTRYPOINT devbox shell
+	`;
+}
+
+function getDevcontainerJSON(devboxJson: any, cpuArch: String): String {
+
+    let devcontainerObject: any = {};
+    devcontainerObject = {
+        // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+        // https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/debian
+        "name": "Devbox Remote Container",
+        "build": {
+            "dockerfile": "./Dockerfile",
+            // Update 'VARIANT' to pick a Debian version: bullseye, buster
+            // Use bullseye on local arm64/Apple Silicon.
+            "args": {
+                "VARIANT": cpuArch.trim() === "arm64" ? "bullseye" : "buster"
+            }
+        },
+        "customizations": {
+            "vscode": {
+                "settings": {
+                    // Add custom vscode settings for remote environment here
+                },
+                "extensions": [
+                    // Add custom vscode extensions for remote environment here
+                ]
+            }
+        },
+        // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+        "remoteUser": "vscode"
+    };
+
+    devboxJson["packages"].forEach((pkg: String) => {
+        if (pkg.includes("python3")) {
+            devcontainerObject.customizations.vscode.settings["python.defaultInterpreterPath"] = "/devbox/.devbox/nix/profile/default/bin/python3";
+            devcontainerObject.customizations.vscode.extensions.push("ms-python.python");
+        }
+        if (pkg.includes("go_1_") || pkg === "go") {
+            devcontainerObject.customizations.vscode.extensions.push("golang.go");
+        }
+        //TODO: add support for other common languages
+    });
+
+    return JSON.stringify(devcontainerObject, null, 4);
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,6 +1,9 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
+import * as cp from 'child_process';
+import * as util from 'util';
+import { posix } from 'path';
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
@@ -11,16 +14,53 @@ export function activate(context: vscode.ExtensionContext) {
 	vscode.window.onDidOpenTerminal(async (event) => {
 		runDevboxShell();
 	});
+
+	const setupDevcontainer = vscode.commands.registerCommand('devbox.setupDevContainer', async () => {
+		return setupDevContainer();
+	});
+
+	context.subscriptions.push(setupDevcontainer);
 }
 
 async function runDevboxShell() {
-
+	const exec = util.promisify(cp.exec);
 	const result = await vscode.workspace.findFiles('devbox.json');
 	if (result.length > 0) {
-		vscode.commands.executeCommand('workbench.action.terminal.sendSequence', {
-			'text': 'devbox shell \r\n'
+		// const { stdout, stderr } = await exec('devbox shell');
+		// console.log('stdout:', stdout);
+		// console.log('stderr:', stderr);
+		let response = "test";
+		response = await vscode.commands.executeCommand('workbench.action.terminal.sendSequence', {
+			'text': 'devbox shell\r\nopen .\r\nexit\r\n'
 		});
+		setTimeout(() => { vscode.commands.executeCommand('workbench.action.closeWindow'); }, 10000);
+
 	}
+}
+
+async function setupDevContainer() {
+	try {
+		if (!vscode.workspace.workspaceFolders) {
+			return vscode.window.showInformationMessage('No folder or workspace opened');
+		}
+		const workspaceUri = vscode.workspace.workspaceFolders[0].uri;
+		const devboxJson = await readDevboxJson(workspaceUri);
+		await vscode.workspace.fs.createDirectory(vscode.Uri.joinPath(workspaceUri, '.devcontainer/'));
+		// console.log(devboxJson);
+		vscode.window.showInformationMessage(devboxJson["packages"].toString());
+	} catch (error) {
+		console.error('there was an error', error);
+	}
+	// Display a message box to the user
+}
+
+async function readDevboxJson(workspaceUri: vscode.Uri) {
+	const fileUri = workspaceUri.with({ path: posix.join(workspaceUri.path, 'devbox.json') });
+	const readData = await vscode.workspace.fs.readFile(fileUri);
+	const readStr = Buffer.from(readData).toString('utf8');
+	const devboxJsonData = JSON.parse(readStr);
+	return devboxJsonData;
+
 }
 
 // This method is called when your extension is deactivated

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -58,11 +58,6 @@ export function activate(context: ExtensionContext) {
 		}
 	});
 
-	const devboxInstall = commands.registerCommand('devbox.install', async () => {
-		// todo: add support for --config path to devbox.json
-		await runInTerminal('devbox shell -- echo "Packages installed""');
-	});
-
 	const devboxInit = commands.registerCommand('devbox.init', async () => {
 		await runInTerminal('devbox init');
 		commands.executeCommand('setContext', 'devbox.configFileExists', true);

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,7 +1,6 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
-import { workspace, window, commands, Uri, ExtensionContext } from 'vscode';
-import * as vscode from 'vscode';
+import { workspace, window, commands, extensions, Uri, ExtensionContext } from 'vscode';
 import * as process from 'process';
 import * as cp from 'child_process';
 import * as util from 'util';
@@ -82,17 +81,17 @@ function updateSettings(workspacePath: String, devboxJson: any) {
 	// For now we only update Go, Python3, and Nodejs language extensions
 	devboxJson["packages"].forEach((pkg: String) => {
 		if (pkg.startsWith("python3")) {
-			if (vscode.extensions.getExtension("ms-python.python")?.isActive) {
+			if (extensions.getExtension("ms-python.python")?.isActive) {
 				workspace.getConfiguration("python").update("defaultInterpreterPath", workspacePath + "/.devbox/nix/profile/default/bin/python3");
 			}
 		}
 		if (pkg.startsWith("go_1_") || pkg === "go") {
-			if (vscode.extensions.getExtension("golang.go")?.isActive) {
+			if (extensions.getExtension("golang.go")?.isActive) {
 				workspace.getConfiguration("go").update("gopath", workspacePath + "/.devbox/nix/profile/default/bin/go");
 			}
 		}
 		if (pkg.startsWith("nodejs-") || pkg === "nodejs") {
-			if (vscode.extensions.getExtension("eslint")?.isActive) {
+			if (extensions.getExtension("eslint")?.isActive) {
 				workspace.getConfiguration("eslint").update("nodepath", workspacePath + "/.devbox/nix/profile/default/bin/node");
 			}
 		}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,10 +1,8 @@
 // The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
-import { workspace, window, commands, extensions, Uri, ExtensionContext } from 'vscode';
-import * as process from 'process';
-import * as cp from 'child_process';
 import * as util from 'util';
-import { posix } from 'path';
+import * as cp from 'child_process';
+import { workspace, window, commands, Uri, ExtensionContext, QuickPickItem } from 'vscode';
+import { setupDevContainerFiles, readDevboxJson } from './devcontainer';
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
@@ -13,26 +11,61 @@ export function activate(context: ExtensionContext) {
 	initialCheckDevboxJSON();
 	// Creating file watchers to watch for events on devbox.json
 	const fswatcher = workspace.createFileSystemWatcher("**/devbox.json", false, false, false);
-	fswatcher.onDidDelete(e => {
-		commands.executeCommand('setContext', 'devbox.configFileExists', false);
-	});
-	fswatcher.onDidCreate(e => {
-		commands.executeCommand('setContext', 'devbox.configFileExists', true);
-	});
-	fswatcher.onDidChange(e => {
-		initialCheckDevboxJSON();
-	});
+	fswatcher.onDidDelete(e => commands.executeCommand('setContext', 'devbox.configFileExists', false));
+	fswatcher.onDidCreate(e => commands.executeCommand('setContext', 'devbox.configFileExists', true));
+	fswatcher.onDidChange(e => initialCheckDevboxJSON());
 
 	// Check for devbox.json when a new folder is opened
-	workspace.onDidChangeWorkspaceFolders(async (e) => {
-		initialCheckDevboxJSON();
-	});
+	workspace.onDidChangeWorkspaceFolders(async (e) => initialCheckDevboxJSON());
 
 	// run devbox shell when terminal is opened
 	window.onDidOpenTerminal(async (e) => {
 		if (workspace.getConfiguration("devbox").get("autoShellOnTerminal")) {
-			runDevboxShell();
+			await runInTerminal('devbox shell');
 		}
+	});
+
+	const devboxAdd = commands.registerCommand('devbox.add', async () => {
+		const result = await window.showInputBox({
+			value: '',
+			placeHolder: 'Package to add to devbox. E.g., python39',
+		});
+		await runInTerminal(`devbox add ${result}`);
+	});
+
+	const devboxRun = commands.registerCommand('devbox.run', async () => {
+		const items = await getDevboxScripts();
+		if (items.length > 0) {
+			const result = await window.showQuickPick(items);
+			await runInTerminal(`devbox run ${result}`);
+		} else {
+			window.showInformationMessage("No scripts found in devbox.json");
+		}
+	});
+
+	const devboxShell = commands.registerCommand('devbox.shell', async () => {
+		// todo: add support for --config path to devbox.json
+		await runInTerminal('devbox shell');
+	});
+
+	const devboxRemove = commands.registerCommand('devbox.remove', async () => {
+		const items = await getDevboxPackages();
+		if (items.length > 0) {
+			const result = await window.showQuickPick(items);
+			await runInTerminal(`devbox rm ${result}`);
+		} else {
+			window.showInformationMessage("No packages found in devbox.json");
+		}
+	});
+
+	const devboxInstall = commands.registerCommand('devbox.install', async () => {
+		// todo: add support for --config path to devbox.json
+		await runInTerminal('devbox shell -- echo "Packages installed""');
+	});
+
+	const devboxInit = commands.registerCommand('devbox.init', async () => {
+		await runInTerminal('devbox init');
+		commands.executeCommand('setContext', 'devbox.configFileExists', true);
 	});
 
 	const setupDevcontainer = commands.registerCommand('devbox.setupDevContainer', async () => {
@@ -47,48 +80,14 @@ export function activate(context: ExtensionContext) {
 				"Yes",
 				"No",
 			);
-			cpuArch = response === "Yes" ? "arm64" : "something else";
+			cpuArch = response === "Yes" ? "arm64" : "undefined";
 		}
-		setupDevContainerFiles(cpuArch);
+		await setupDevContainerFiles(cpuArch);
 
-	});
-
-	const devboxAdd = commands.registerCommand('devbox.add', async () => {
-		const result = await window.showInputBox({
-			value: '',
-			placeHolder: 'Package to add to devbox. E.g., python39',
-		});
-		ensureTerminalExists();
-		await commands.executeCommand('workbench.action.terminal.sendSequence', {
-			'text': `devbox add ${result}\r\n`
-		});
-	});
-
-	const devboxShell = commands.registerCommand('devbox.shell', async () => {
-		// todo: add support for --config path to devbox.json
-		ensureTerminalExists();
-		await commands.executeCommand('workbench.action.terminal.sendSequence', {
-			'text': 'devbox shell\r\n'
-		});
-	});
-
-	const devboxInstall = commands.registerCommand('devbox.install', async () => {
-		// todo: add support for --config path to devbox.json
-		ensureTerminalExists();
-		await commands.executeCommand('workbench.action.terminal.sendSequence', {
-			'text': 'devbox shell -- echo "installed packages!""\r\n'
-		});
-	});
-
-	const devboxInit = commands.registerCommand('devbox.init', async () => {
-		ensureTerminalExists();
-		await commands.executeCommand('workbench.action.terminal.sendSequence', {
-			'text': 'devbox init\r\n'
-		});
-		commands.executeCommand('setContext', 'devbox.configFileExists', true);
 	});
 
 	context.subscriptions.push(devboxAdd);
+	context.subscriptions.push(devboxRun);
 	context.subscriptions.push(devboxInit);
 	context.subscriptions.push(devboxShell);
 	context.subscriptions.push(devboxInstall);
@@ -105,20 +104,6 @@ async function initialCheckDevboxJSON() {
 			// devbox.json exists setcontext for devbox commands to be available
 			commands.executeCommand('setContext', 'devbox.configFileExists', true);
 
-			if (workspace.getConfiguration("devbox").get("promptUpdateSettings")) {
-				const response = await window.showInformationMessage(
-					"A Devbox project is opened. Do you want to project settings with Devbox environment?",
-					"Update Settings",
-					"Don't show again"
-				);
-				if (response === "Update Settings") {
-					const devboxJson = await readDevboxJson(workspaceUri);
-
-					updateSettings(workspaceUri.path, devboxJson);
-				} else if (response === "Don't show again") {
-					workspace.getConfiguration("devbox").update("promptUpdateSettings", false);
-				}
-			}
 		} catch (err) {
 			console.log(err);
 			// devbox.json does not exist
@@ -128,162 +113,49 @@ async function initialCheckDevboxJSON() {
 	}
 }
 
-function updateSettings(workspacePath: String, devboxJson: any) {
-	// Updating process.env.PATH
-	process.env["PATH"] = process.env["PATH"] + ":" + workspacePath + "/.devbox/nix/profile/default/bin";
-	// Updating language extension settings
-	// For now we only update Go, Python3, and Nodejs language extensions
-	devboxJson["packages"].forEach((pkg: String) => {
-		if (pkg.startsWith("python3")) {
-			if (extensions.getExtension("ms-python.python")?.isActive) {
-				workspace.getConfiguration("python").update("defaultInterpreterPath", workspacePath + "/.devbox/nix/profile/default/bin/python3");
-			}
-		}
-		if (pkg.startsWith("go_1_") || pkg === "go") {
-			if (extensions.getExtension("golang.go")?.isActive) {
-				workspace.getConfiguration("go").update("gopath", workspacePath + "/.devbox/nix/profile/default/bin/go");
-			}
-		}
-		if (pkg.startsWith("nodejs-") || pkg === "nodejs") {
-			if (extensions.getExtension("eslint")?.isActive) {
-				workspace.getConfiguration("eslint").update("nodepath", workspacePath + "/.devbox/nix/profile/default/bin/node");
-			}
-		}
-		//TODO: add support for other common languages
-	});
-
-}
-
-async function runDevboxShell() {
-	const result = await workspace.findFiles('devbox.json');
-	if (result.length > 0) {
-		await commands.executeCommand('workbench.action.terminal.sendSequence', {
-			'text': 'devbox shell\r\n'
-		});
-
-	}
-}
-
-async function setupDevContainerFiles(cpuArch: String) {
-	try {
-		if (!workspace.workspaceFolders) {
-			return window.showInformationMessage('No folder or workspace opened');
-		}
-		const workspaceUri = workspace.workspaceFolders[0].uri;
-		const devcontainerUri = Uri.joinPath(workspaceUri, '.devcontainer/');
-		// Parsing devbox.json data
-		const devboxJson = await readDevboxJson(workspaceUri);
-		// creating .devcontainer directory and its files
-		await workspace.fs.createDirectory(devcontainerUri);
-		const dockerfileContent = getDockerfileContent();
-		await workspace.fs.writeFile(
-			Uri.joinPath(devcontainerUri, 'Dockerfile'),
-			Buffer.from(dockerfileContent, 'utf8')
-		);
-
-		const devContainerJSON = getDevcontainerJSON(devboxJson, cpuArch);
-		await workspace.fs.writeFile(
-			Uri.joinPath(devcontainerUri, 'devcontainer.json'),
-			Buffer.from(devContainerJSON, 'utf8')
-		);
-	} catch (error) {
-		console.error('there was an error', error);
-	}
-	// Display a message box to the user
-}
-
-async function readDevboxJson(workspaceUri: Uri) {
-	const fileUri = workspaceUri.with({ path: posix.join(workspaceUri.path, 'devbox.json') });
-	const readData = await workspace.fs.readFile(fileUri);
-	const readStr = Buffer.from(readData).toString('utf8');
-	const devboxJsonData = JSON.parse(readStr);
-	return devboxJsonData;
-
-}
-
-function ensureTerminalExists(): void {
+async function runInTerminal(cmd: string) {
 	// ensure a terminal is open
 	// This check has to exist since there is no way for extension to run code in
 	// the terminal, unless a terminal session is already open.
 	if ((<any>window).terminals.length === 0) {
 		window.showErrorMessage('No active terminals. Re-run the command without closing the opened terminal.');
-		const terminal = window.createTerminal({ name: `Terminal` });
-		terminal.show();
+		window.createTerminal({ name: `Terminal` }).show();
+	} else { // A terminal is open
+		// run the given cmd in terminal
+		await commands.executeCommand('workbench.action.terminal.sendSequence', {
+			'text': `${cmd}\r\n`
+		});
 	}
 }
 
-function getDockerfileContent(): String {
-	return `
-	# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/debian/.devcontainer/base.Dockerfile
-
-	# [Choice] Debian version (use bullseye on local arm64/Apple Silicon): bullseye, buster
-	ARG VARIANT="buster"
-	FROM mcr.microsoft.com/vscode/devcontainers/base:0-\${VARIANT}
-
-	# These dependencies are required by Nix.
-	RUN apt update -y
-	RUN apt -y install --no-install-recommends curl xz-utils
-
-	USER vscode
-
-	# Install nix
-	ARG NIX_INSTALL_SCRIPT=https://nixos.org/nix/install
-	RUN curl -fsSL \${NIX_INSTALL_SCRIPT} | sh -s -- --no-daemon
-	ENV PATH /home/vscode/.nix-profile/bin:\${PATH}
-
-	# Install devbox
-	RUN sudo mkdir /devbox && sudo chown vscode /devbox
-	RUN curl -fsSL https://get.jetpack.io/devbox | bash -s -- -f
-
-	# Setup devbox environment
-	COPY --chown=vscode ./devbox.json /devbox/devbox.json
-	RUN devbox shell --config /devbox/devbox.json -- echo "Nix Store Populated"
-	ENV PATH /devbox/.devbox/nix/profile/default/bin:\${PATH}
-	ENTRYPOINT devbox shell
-	`;
+async function getDevboxScripts(): Promise<string[]> {
+	try {
+		if (!workspace.workspaceFolders) {
+			window.showInformationMessage('No folder or workspace opened');
+			return [];
+		}
+		const workspaceUri = workspace.workspaceFolders[0].uri;
+		const devboxJson = await readDevboxJson(workspaceUri);
+		return Object.keys(devboxJson['shell']['scripts']);
+	} catch (error) {
+		console.error('Error processing devbox.json - ', error);
+		return [];
+	}
 }
 
-function getDevcontainerJSON(devboxJson: any, cpuArch: String): String {
-
-	let devcontainerObject: any = {};
-	devcontainerObject = {
-		// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-		// https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/debian
-		"name": "Devbox Remote Container",
-		"build": {
-			"dockerfile": "./Dockerfile",
-			// Update 'VARIANT' to pick a Debian version: bullseye, buster
-			// Use bullseye on local arm64/Apple Silicon.
-			"args": {
-				"VARIANT": cpuArch.trim() === "arm64" ? "bullseye" : "buster"
-			}
-		},
-		"customizations": {
-			"vscode": {
-				"settings": {
-					// Add custom vscode settings for remote environment here
-				},
-				"extensions": [
-					// Add custom vscode extensions for remote environment here
-				]
-			}
-		},
-		// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-		"remoteUser": "vscode"
-	};
-
-	devboxJson["packages"].forEach((pkg: String) => {
-		if (pkg.includes("python3")) {
-			devcontainerObject.customizations.vscode.settings["python.defaultInterpreterPath"] = "/devbox/.devbox/nix/profile/default/bin/python3";
-			devcontainerObject.customizations.vscode.extensions.push("ms-python.python");
+async function getDevboxPackages(): Promise<string[]> {
+	try {
+		if (!workspace.workspaceFolders) {
+			window.showInformationMessage('No folder or workspace opened');
+			return [];
 		}
-		if (pkg.includes("go_1_") || pkg === "go") {
-			devcontainerObject.customizations.vscode.extensions.push("golang.go");
-		}
-		//TODO: add support for other common languages
-	});
-
-	return JSON.stringify(devcontainerObject, null, 4);
+		const workspaceUri = workspace.workspaceFolders[0].uri;
+		const devboxJson = await readDevboxJson(workspaceUri);
+		return devboxJson['packages'];
+	} catch (error) {
+		console.error('Error processing devbox.json - ', error);
+		return [];
+	}
 }
 
 // This method is called when your extension is deactivated

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -44,9 +44,23 @@ async function setupDevContainer() {
 			return vscode.window.showInformationMessage('No folder or workspace opened');
 		}
 		const workspaceUri = vscode.workspace.workspaceFolders[0].uri;
+		const devcontainerUri = vscode.Uri.joinPath(workspaceUri, '.devcontainer/');
+		// Parsing devbox.json data
 		const devboxJson = await readDevboxJson(workspaceUri);
-		await vscode.workspace.fs.createDirectory(vscode.Uri.joinPath(workspaceUri, '.devcontainer/'));
-		// console.log(devboxJson);
+		// creating .devcontainer directory and its files
+		await vscode.workspace.fs.createDirectory(devcontainerUri);
+		const dockerfileContent = getDockerfileContent();
+		await vscode.workspace.fs.writeFile(
+			vscode.Uri.joinPath(devcontainerUri, 'Dockerfile'),
+			Buffer.from(dockerfileContent, 'utf8')
+		);
+
+		const devContainerJSON = getDevcontainerJSON();
+		await vscode.workspace.fs.writeFile(
+			vscode.Uri.joinPath(devcontainerUri, 'devcontainer.json'),
+			Buffer.from(devContainerJSON, 'utf8')
+		);
+
 		vscode.window.showInformationMessage(devboxJson["packages"].toString());
 	} catch (error) {
 		console.error('there was an error', error);
@@ -61,6 +75,64 @@ async function readDevboxJson(workspaceUri: vscode.Uri) {
 	const devboxJsonData = JSON.parse(readStr);
 	return devboxJsonData;
 
+}
+
+function getDockerfileContent(): String {
+	return `
+	# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/debian/.devcontainer/base.Dockerfile
+
+	# [Choice] Debian version (use bullseye on local arm64/Apple Silicon): bullseye, buster
+	ARG VARIANT="buster"
+	FROM mcr.microsoft.com/vscode/devcontainers/base:0-\${VARIANT}
+	
+	# These dependencies are required by Nix.
+	RUN apt update -y
+	RUN apt -y install --no-install-recommends curl xz-utils
+	
+	USER vscode
+	
+	# Install nix
+	ARG NIX_INSTALL_SCRIPT=https://nixos.org/nix/install
+	RUN curl -fsSL \${NIX_INSTALL_SCRIPT} | sh -s -- --no-daemon
+	ENV PATH /home/vscode/.nix-profile/bin:\${PATH}
+	
+	# install devbox
+	RUN sudo mkdir /devbox && sudo chown vscode /devbox
+	RUN curl -fsSL https://get.jetpack.io/devbox | FORCE=1 bash
+	COPY --chown=vscode devbox.json /devbox/devbox.json
+	RUN devbox shell --config /devbox/devbox.json -- echo "Nix Store Populated"
+	ENV PATH /devbox/.devbox/nix/profile/default/bin:\${PATH}
+	`;
+}
+
+function getDevcontainerJSON(): String {
+	return `
+	// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+	// https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/debian
+	{
+		"name": "Debian",
+		"build": {
+			"dockerfile": "./Dockerfile",
+			// Update 'VARIANT' to pick an Debian version: bullseye, buster
+			// Use bullseye on local arm64/Apple Silicon.
+			"args": {
+				"VARIANT": "bullseye"
+			}
+		},
+		"customizations": {
+			"vscode": {
+				"settings": {
+					"python.defaultInterpreterPath": "/devbox/.devbox/nix/profile/default/bin/python3"
+				},
+				"extensions": [
+					"ms-python.python",
+					"golang.go"
+				]
+			}
+		},
+		// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+		"remoteUser": "vscode"
+	}`;
 }
 
 // This method is called when your extension is deactivated


### PR DESCRIPTION
## Summary
This doesn't fully implement the behaviour we discussed. But it does update the python interpreter and go path for the user.
The dev container setup is also possible via command palette (cmd + shift + P) in vscode.
- Added settings to the extension
- Added auto generating dev container config files
- cleaned up the code for more readability
- Added devbox commands (`devbox init | add | shell | install`) to the extension

## How was it tested?
- Open vscode-extensions/ in vscode
- press Run+debug
- check the prompt for update settings from devbox extension
- press cmd+shift+p and type devbox > choose "Devbox: Generate Dev Containers config files"
- check the generated files in .devcontainer/
