### PR TITLE
[feature flag] respect env-var of feature flag (even if turned off) and default enable Nixpkg Version FF

### DIFF
--- a/boxcli/featureflag/feature.go
+++ b/boxcli/featureflag/feature.go
@@ -30,9 +30,13 @@ func (f *feature) Enabled() bool {
 	if f == nil {
 		return false
 	}
-	if on, _ := strconv.ParseBool(os.Getenv("DEVBOX_FEATURE_" + f.name)); on {
-		debug.Log("Feature %q enabled via environment variable.", f.name)
-		return true
+	if on, err := strconv.ParseBool(os.Getenv("DEVBOX_FEATURE_" + f.name)); err == nil {
+		status := "enabled"
+		if !on {
+			status = "disabled"
+		}
+		debug.Log("Feature %q %s via environment variable.", f.name, status)
+		return on
 	}
 	return f.enabled
 }

--- a/boxcli/featureflag/nixpkgversion.go
+++ b/boxcli/featureflag/nixpkgversion.go
@@ -3,5 +3,5 @@ package featureflag
 const NixpkgVersion = "NIXPKG_VERSION"
 
 func init() {
-	disabled(NixpkgVersion)
+	enabled(NixpkgVersion)
 }


### PR DESCRIPTION
## Summary

1. The Feature Flag library should respect the value of the env-var, whether ON or OFF.
2. Turn on the default value of the nixpkgs version FF.

## How was it tested?

For change #1: respecting the env-var:
```
> DEVBOX_FEATURE_NIXPKG_VERSION=0 DEVBOX_DEBUG=1 devbox shell
> git status
# saw no changes to devbox.json as expected
```

For change #2: enabling the nixpkgs version
```
> devbox shell
> git status
# saw changes to devbox.json that adds the default commit hash
```
