### PR TITLE
ci: suffix Jetpack preview namespaces with "-ref"

### DIFF
--- a/.github/workflows/previews.yaml
+++ b/.github/workflows/previews.yaml
@@ -63,4 +63,4 @@ jobs:
           curl https://get.jetpack.io -fsSL | bash -s -- -y
           jetpack up docs \
             --ttl 300 --debug \
-            -n jetpack-io-preview-$(echo "${GITHUB_REF_NAME}" | sed "s/[^0-9a-zA-Z]/-/g")
+            -n jetpack-io-preview-$(echo "${GITHUB_REF_NAME}-ref" | sed "s/[^0-9a-zA-Z]/-/g")


### PR DESCRIPTION
## Summary

Kubernetes namespaces can't end in a number, so Jetpack errors when trying to deploy a PR that ends in one. Suffix all of the preview namespaces with "-ref" to ensure a valid name.

## How was it tested?

CI