### PR TITLE
Add golangci-lint to devbox.json

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -1,8 +1,12 @@
 {
   "packages": [
-    "go_1_19"
+    "go_1_19",
+    "golangci-lint"
   ],
   "shell": {
-    "init_hook": null
+    "init_hook": "export \"GOROOT=$(go env GOROOT)\""
+  },
+  "nixpkgs": {
+    "commit": "d01cb18be494e3d860fcfe6be4ad63614360333c"
   }
 }


### PR DESCRIPTION
## Summary

So that we can run the linter locally and not only when pushing to Github.

## How was it tested?
```
golangci-lint version
golangci-lint run
```