### PR TITLE
golangci-lint offending line is displayed in error logs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,6 +37,8 @@ jobs:
           cache: false # use golangci cache instead
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.2.0
+        with:
+          args: "--out-${NO_FUTURE}format colored-line-number"
 
   test:
     strategy:

--- a/devbox.go
+++ b/devbox.go
@@ -213,10 +213,10 @@ func (d *Devbox) Shell() error {
 	if err := d.ensurePackagesAreInstalled(install); err != nil {
 		return err
 	}
-	plan := d.ShellPlan()
-	//if err != nil {
-	//	return err
-	//}
+	plan, err := d.ShellPlan()
+	if err != nil {
+		return err
+	}
 	profileDir, err := d.profileDir()
 	if err != nil {
 		return err

--- a/devbox.go
+++ b/devbox.go
@@ -213,10 +213,10 @@ func (d *Devbox) Shell() error {
 	if err := d.ensurePackagesAreInstalled(install); err != nil {
 		return err
 	}
-	plan, err := d.ShellPlan()
-	if err != nil {
-		return err
-	}
+	plan := d.ShellPlan()
+	//if err != nil {
+	//	return err
+	//}
 	profileDir, err := d.profileDir()
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
Before:
It shows you the error but _not_ where it happens!
<img width="563" alt="Screen Shot 2022-11-10 at 4 32 53 PM" src="https://user-images.githubusercontent.com/1203781/201210508-fc97d536-0dbd-4cc7-8407-72005a507ee7.png">

After: shows you both:
<img width="644" alt="Screen Shot 2022-11-10 at 4 33 04 PM" src="https://user-images.githubusercontent.com/1203781/201210470-9cb99259-f306-4b7d-8d70-f859f8d765a2.png">

## How was it tested?
CICD on this very PR.