### PR TITLE
Fixed terminal commands not running when closed

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -108,9 +108,7 @@ async function initialCheckDevboxJSON() {
 }
 
 async function runInTerminal(cmd: string) {
-	// ensure a terminal is open
-	// This check has to exist since there is no way for extension to run code in
-	// the terminal, unless a terminal session is already open.
+	// check if a terminal is open
 	if ((<any>window).terminals.length === 0) {
 		const terminal = window.createTerminal({ name: `Terminal` });
 		terminal.show();

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -85,7 +85,6 @@ export function activate(context: ExtensionContext) {
 	context.subscriptions.push(devboxRun);
 	context.subscriptions.push(devboxInit);
 	context.subscriptions.push(devboxShell);
-	context.subscriptions.push(devboxInstall);
 	context.subscriptions.push(setupDevcontainer);
 }
 
@@ -113,14 +112,17 @@ async function runInTerminal(cmd: string) {
 	// This check has to exist since there is no way for extension to run code in
 	// the terminal, unless a terminal session is already open.
 	if ((<any>window).terminals.length === 0) {
-		window.showErrorMessage('No active terminals. Re-run the command without closing the opened terminal.');
-		window.createTerminal({ name: `Terminal` }).show();
-	} else { // A terminal is open
+		const terminal = window.createTerminal({ name: `Terminal` });
+		terminal.show();
+		terminal.sendText(cmd, true);
+	} else {
+		// A terminal is open
 		// run the given cmd in terminal
 		await commands.executeCommand('workbench.action.terminal.sendSequence', {
 			'text': `${cmd}\r\n`
 		});
 	}
+
 }
 
 async function getDevboxScripts(): Promise<string[]> {


### PR DESCRIPTION
## Summary
fixed running devbox commands from vscode command palette not running when terminal is closed.

## How was it tested?
- make sure no terminal session in open in vscode
- cmd+shift+p
- devbox add python39
- verify terminal opens and runs the devbox add command