### PR TITLE
vscode extension terminal behavior fixes + readme update

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -6,9 +6,24 @@ This is the official VSCode extension for [devbox](https://github.com/jetpack-io
 
 ### Auto Shell on a devbox project
 
-When VScode Terminal is opened on a devbox project, this extension detects `devbox.json` and runs `devbox shell` so terminal is automatically in devbox shell environment.
+When VScode Terminal is opened on a devbox project, this extension detects `devbox.json` and runs `devbox shell` so terminal is automatically in devbox shell environment. Can be turned off in settings.
+
+### Run devbox commands from command palette
+
+`cmd/ctrl + shift + p` opens vscode's command palette. Typing devbox filters all available commands devbox extension can run. Those commands are:
+
+- **Init:** Creates a devbox.json file
+- **Add:** adds a package to devbox.json
+- **Remove:** Removes a package from devbox.json
+- **Shell:** Opens a terminal and runs devbox shell
+- **Run:** Runs a script from devbox.json if specified
+- **Generate DevContainer files:** Generates devcontainer.json & Dockerfile inside .devcontainers directory. This allows for running vscode in a container or Github Codespaces.
 
 ## Release Notes
+
+### 0.0.2
+
+Added devbox commands to command palette
 
 ### 0.0.1
 
@@ -20,4 +35,4 @@ Initial release of devbox VSCode extension
 
 Ensure that you've read through the extensions guidelines and follow the best practices for creating your extension.
 
-* [Extension Guidelines](https://code.visualstudio.com/api/references/extension-guidelines)
+- [Extension Guidelines](https://code.visualstudio.com/api/references/extension-guidelines)

--- a/vscode-extension/src/devcontainer.ts
+++ b/vscode-extension/src/devcontainer.ts
@@ -80,6 +80,7 @@ function getDevcontainerJSON(devboxJson: any, cpuArch: String): String {
         "name": "Devbox Remote Container",
         "build": {
             "dockerfile": "./Dockerfile",
+            "context": "..",
             // Update 'VARIANT' to pick a Debian version: bullseye, buster
             // Use bullseye on local arm64/Apple Silicon.
             "args": {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -111,7 +111,8 @@ async function initialCheckDevboxJSON() {
 async function runInTerminal(cmd: string, showTerminal: boolean) {
 	// check if a terminal is open
 	if ((<any>window).terminals.length === 0) {
-		const terminal = window.createTerminal({ name: 'DevboxTerminal' });
+		const terminalName = 'DevboxTerminal';
+		const terminal = window.createTerminal({ name: terminalName });
 		if (showTerminal) {
 			terminal.show();
 		}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,7 +1,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 import * as util from 'util';
 import * as cp from 'child_process';
-import { workspace, window, commands, Uri, ExtensionContext, QuickPickItem } from 'vscode';
+import { workspace, window, commands, Uri, ExtensionContext } from 'vscode';
 import { setupDevContainerFiles, readDevboxJson } from './devcontainer';
 
 // This method is called when your extension is activated
@@ -20,8 +20,8 @@ export function activate(context: ExtensionContext) {
 
 	// run devbox shell when terminal is opened
 	window.onDidOpenTerminal(async (e) => {
-		if (workspace.getConfiguration("devbox").get("autoShellOnTerminal")) {
-			await runInTerminal('devbox shell');
+		if (workspace.getConfiguration("devbox").get("autoShellOnTerminal") && e.name !== "DevboxTerminal") {
+			await runInTerminal('devbox shell', true);
 		}
 	});
 
@@ -30,14 +30,14 @@ export function activate(context: ExtensionContext) {
 			value: '',
 			placeHolder: 'Package to add to devbox. E.g., python39',
 		});
-		await runInTerminal(`devbox add ${result}`);
+		await runInTerminal(`devbox add ${result}`, false);
 	});
 
 	const devboxRun = commands.registerCommand('devbox.run', async () => {
 		const items = await getDevboxScripts();
 		if (items.length > 0) {
 			const result = await window.showQuickPick(items);
-			await runInTerminal(`devbox run ${result}`);
+			await runInTerminal(`devbox run ${result}`, true);
 		} else {
 			window.showInformationMessage("No scripts found in devbox.json");
 		}
@@ -45,21 +45,21 @@ export function activate(context: ExtensionContext) {
 
 	const devboxShell = commands.registerCommand('devbox.shell', async () => {
 		// todo: add support for --config path to devbox.json
-		await runInTerminal('devbox shell');
+		await runInTerminal('devbox shell', true);
 	});
 
 	const devboxRemove = commands.registerCommand('devbox.remove', async () => {
 		const items = await getDevboxPackages();
 		if (items.length > 0) {
 			const result = await window.showQuickPick(items);
-			await runInTerminal(`devbox rm ${result}`);
+			await runInTerminal(`devbox rm ${result}`, false);
 		} else {
 			window.showInformationMessage("No packages found in devbox.json");
 		}
 	});
 
 	const devboxInit = commands.registerCommand('devbox.init', async () => {
-		await runInTerminal('devbox init');
+		await runInTerminal('devbox init', false);
 		commands.executeCommand('setContext', 'devbox.configFileExists', true);
 	});
 
@@ -84,6 +84,7 @@ export function activate(context: ExtensionContext) {
 	context.subscriptions.push(devboxAdd);
 	context.subscriptions.push(devboxRun);
 	context.subscriptions.push(devboxInit);
+	context.subscriptions.push(devboxRemove);
 	context.subscriptions.push(devboxShell);
 	context.subscriptions.push(setupDevcontainer);
 }
@@ -107,11 +108,13 @@ async function initialCheckDevboxJSON() {
 	}
 }
 
-async function runInTerminal(cmd: string) {
+async function runInTerminal(cmd: string, showTerminal: boolean) {
 	// check if a terminal is open
 	if ((<any>window).terminals.length === 0) {
-		const terminal = window.createTerminal({ name: `Terminal` });
-		terminal.show();
+		const terminal = window.createTerminal({ name: 'DevboxTerminal' });
+		if (showTerminal) {
+			terminal.show();
+		}
 		terminal.sendText(cmd, true);
 	} else {
 		// A terminal is open


### PR DESCRIPTION
## Summary
Based on feedback from @Lagoja I added the following fixes:
- terminal only pops in and shows for devbox run and shell
- autoshell to a terminal doesn't happen when the opened terminal is from running devbox run/shell from extension's command palette (example: preventing duplicate devbox shell bug)
- updated readme to include features for version 0.0.2

## How was it tested?
- running the extension in vscode