### PR TITLE
Fix Example: A Rust Devbox

### DIFF
--- a/docs/app/docs/configuration.md
+++ b/docs/app/docs/configuration.md
@@ -119,9 +119,9 @@ An example of a devbox configuration for a Rust project called `hello_world` mig
 ```json
 {
     "packages": [
-        "rustc"
+        "rustc",
         "cargo",
-        "libiconv",
+        "libiconv"
     ],
     "shell": {
         "init_hook": [


### PR DESCRIPTION
## Summary

Fix Example: A Rust Devbox. This Example had some syntax errors in it.