### PR TITLE
referencing vscode token from env variable

### DIFF
--- a/.github/workflows/release-extension.yaml
+++ b/.github/workflows/release-extension.yaml
@@ -20,8 +20,10 @@ jobs:
           yarn install
         working-directory: vscode-extension
       - name: publish
+        env:
+          VS_MARKETPLACE_TOKEN: ${{ secrets.VS_MARKETPLACE_TOKEN }}
         run: |
-          echo ${{ secrets.VS_MARKETPLACE_TOKEN }} | vsce login jetpack-io
+          echo $VS_MARKETPLACE_TOKEN | vsce login jetpack-io
           vsce package --yarn
           vsce publish --yarn
         working-directory: vscode-extension


### PR DESCRIPTION
## Summary
changed how we reference vscode marketplace token

## How was it tested?
will have to be tested in github actions