### PR TITLE
[github actions] add workflow_dispatch and pull_request_target events to previews and tests Actions

### DIFF
--- a/.github/workflows/previews.yaml
+++ b/.github/workflows/previews.yaml
@@ -1,10 +1,11 @@
 name: docs-preview
 
 on:
-  workflow_dispatch:
+  pull_request_target:
   push:
     branches-ignore:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,10 +5,12 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  pull_request_target:
   push:
     branches-ignore:
       - main
   workflow_call:
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

The PR at #288 has pending workflows. However, the workflows are not running because
they are triggered by the `push` event, which doesn't get triggered for public forks.
This PR adds `pull_request_target` event for them.

It also adds `workflow_dispatch` for manually triggering the workflow.

## How was it tested?

not tested.
