### PR TITLE
[github actions] s/pull_request_target/pull_request for previews and tests Actions

### DIFF
--- a/.github/workflows/previews.yaml
+++ b/.github/workflows/previews.yaml
@@ -1,7 +1,7 @@
 name: docs-preview
 
 on:
-  pull_request_target:
+  pull_request:
   push:
     branches-ignore:
       - main

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,7 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request_target:
+  pull_request:
   push:
     branches-ignore:
       - main


### PR DESCRIPTION
## Summary

Reading more about pull_request_target, it looks like it may not be what we want. 
> Due to the dangers inherent to automatic processing of PRs, GitHub’s standard pull_requestworkflow trigger by default prevents write permissions and secrets access to the target repository. However, in some scenarios such access is needed to properly process the PR. To this end the pull_request_target workflow trigger was introduced.

https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

I think we want pull_request type:
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request


## How was it tested?

not tested
