### PR TITLE
improve installing devbox docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ Your application often needs the same set of dependencies when you are developin
 
 ## Installing Devbox
 
-In addition to installing Devbox itself, you will need to install `nix` and `docker` since Devbox depends on them:
+Devbox requires `nix` to be installed.
 
 1. Install [Nix Package Manager](https://nixos.org/download.html). (Don't worry, you don't need to learn Nix.)
 
-2. Install [Docker Engine](https://docs.docker.com/engine/install/) or [Docker Desktop](https://www.docker.com/get-started/). Note that docker is only needed if you want to create containers – the shell functionality works without it.
+2. Optionally, if you would like to build a container image, you will need Docker. Docker is not required for using the shell functionality. Install [Docker Engine](https://docs.docker.com/engine/install/) or [Docker Desktop](https://www.docker.com/get-started/).
 
 3. Install Devbox:
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,7 @@ Devbox requires `nix` to be installed.
 
 1. Install [Nix Package Manager](https://nixos.org/download.html). (Don't worry, you don't need to learn Nix.)
 
-2. Optionally, if you would like to build a container image, you will need Docker. Docker is not required for using the shell functionality. Install [Docker Engine](https://docs.docker.com/engine/install/) or [Docker Desktop](https://www.docker.com/get-started/).
-
-3. Install Devbox:
+2. Install Devbox:
 
    ```sh
    curl -fsSL https://get.jetpack.io/devbox | bash
@@ -129,6 +127,8 @@ Read more on the [Devbox docs Quickstart](https://www.jetpack.io/devbox/docs/qui
 ## Quickstart: Instant Docker Image
 
 Devbox makes it easy to package your application into an OCI-compliant container image. Devbox analyzes your code, automatically identifies the right toolchain needed by your project, and builds it into a docker image.
+
+For now, Devbox requires Docker. Support for alternatives like Podman is still experimental. If you don't yet have it, do install [Docker Engine](https://docs.docker.com/engine/install/) or [Docker Desktop](https://www.docker.com/get-started/).
 
 1. Initialize your project with `devbox init` if you haven't already.
 

--- a/docs/app/docs/installing_devbox.md
+++ b/docs/app/docs/installing_devbox.md
@@ -5,10 +5,13 @@ sidebar_position: 2
 
 ## Prerequisities
 
-In addition to installing Devbox itself, you will need to install nix and docker since Devbox depends on them:
+Devbox requires `nix` to be installed.
 
-1. Install [Nix Package Manager](https://nixos.org/download.html). (Don't worry, you don't need to learn Nix.)
+- Install [Nix Package Manager](https://nixos.org/download.html). (Don't worry, you don't need to learn Nix.)
 
+Optionally, if you would like to build a container image, you will need Docker.
+
+- Install [Docker](https://docs.docker.com/get-docker/). 
 
 ## Install Devbox
 

--- a/docs/app/docs/installing_devbox.md
+++ b/docs/app/docs/installing_devbox.md
@@ -9,10 +9,6 @@ Devbox requires `nix` to be installed.
 
 - Install [Nix Package Manager](https://nixos.org/download.html). (Don't worry, you don't need to learn Nix.)
 
-Optionally, if you would like to build a container image, you will need Docker.
-
-- Install [Docker](https://docs.docker.com/get-docker/). 
-
 ## Install Devbox
 
 Use the following install script to get the latest version of Devbox:


### PR DESCRIPTION
## Summary

I think clarifying that `nix` is required, while `docker` is optional would be good.

## How was it tested?

will view the preview docs from CICD.
