### PR TITLE
[github workflows] remove pull_request event from doc-preview Action

### DIFF
--- a/.github/workflows/previews.yaml
+++ b/.github/workflows/previews.yaml
@@ -1,7 +1,6 @@
 name: docs-preview
 
 on:
-  pull_request:
   push:
     branches-ignore:
       - main


### PR DESCRIPTION
## Summary

Following #290 and #291, I enabled the doc-preview action to run on `pull_request` event.

I then made a test PR with my own forked repo (#292). The CICD run for that succeeded
for the `tests` workflow, but failed for the `doc-preview` workflow.

The reason for the failure is that `doc-preview` relies on `launchpad up` which
relies on the `JETPACK_SECRET_KEY` github secret. But `pull_request` workflows from external forked
repos lack access to github secrets (see security blog at https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)
and so this failed.

I think for now we can turn off doc-preview for PRs from forked repos, and can manually run it
if needed.

## How was it tested?

no test
