### PR TITLE
Fixed github action workflow publishing vscode extension

### DIFF
--- a/.github/workflows/release-extension.yaml
+++ b/.github/workflows/release-extension.yaml
@@ -20,8 +20,10 @@ jobs:
           yarn install
         working-directory: vscode-extension
       - name: publish
+        env:
+          VS_MARKETPLACE_TOKEN: ${{ secrets.VS_MARKETPLACE_TOKEN }}
         run: |
-          echo ${{ secrets.VS_MARKETPLACE_TOKEN }} | vsce login jetpack-io
+          echo $VS_MARKETPLACE_TOKEN | vsce login jetpack-io
           vsce package --yarn
           vsce publish --yarn
         working-directory: vscode-extension

--- a/.github/workflows/release-extension.yaml
+++ b/.github/workflows/release-extension.yaml
@@ -20,8 +20,6 @@ jobs:
           yarn install
         working-directory: vscode-extension
       - name: publish
-        env:
-          VS_MARKETPLACE_TOKEN: ${{ secrets.VS_MARKETPLACE_TOKEN }}
         run: |
           vsce publish -p ${{ secrets.VS_MARKETPLACE_TOKEN }} --yarn
         working-directory: vscode-extension

--- a/.github/workflows/release-extension.yaml
+++ b/.github/workflows/release-extension.yaml
@@ -23,7 +23,5 @@ jobs:
         env:
           VS_MARKETPLACE_TOKEN: ${{ secrets.VS_MARKETPLACE_TOKEN }}
         run: |
-          echo $VS_MARKETPLACE_TOKEN | vsce login jetpack-io
-          vsce package --yarn
-          vsce publish --yarn
+          vsce publish -p ${{ secrets.VS_MARKETPLACE_TOKEN }} --yarn
         working-directory: vscode-extension


### PR DESCRIPTION
## Summary
Title says it.
The fix was to use `vsce publish -p <token>` rather than `echo <token> vsce login` then `vsce publish`.
For some reason github actions didn't like the 2 step method. 

## How was it tested?
Manually ran the github action workflow and it published the extension.
