### PR TITLE
[pkgcfg] Add postgresql config

### DIFF
--- a/pkgcfg/package-configuration/postgresql.json
+++ b/pkgcfg/package-configuration/postgresql.json
@@ -1,0 +1,11 @@
+{
+  "name": "postgresql",
+  "version": "0.0.1",
+  "readme": "To initialize the database, run `initdb`. To start the database, run `pg_ctl -l .devbox/conf/postgresql/logfile start`. To stop use `pg_ctl stop`.",
+  "env": {
+    "PGDATA": "{{ .DevboxRoot }}/conf/postgresql/data"
+  },
+  "create_files": {
+    ".devbox/conf/postgresql/data": ""
+  }
+}


### PR DESCRIPTION
## Summary

* postgres is actually pretty simple, does not require shim.
* running initdb will actually tell you how to start it (but uses logfile in root)
* readme text is not currently used

## How was it tested?

```
devbox add postgresql
devbox shell
initdb
pg_ctl start
pg_ctl stop
```
