### PR TITLE
[bug] Fix nil pointer dereference in go planner

### DIFF
--- a/planner/languages/golang/golang_planner.go
+++ b/planner/languages/golang/golang_planner.go
@@ -97,6 +97,9 @@ func parseGoVersion(gomodPath string) string {
 	if err != nil {
 		return ""
 	}
+	if parsed.Go == nil {
+		return ""
+	}
 	return parsed.Go.Version
 }
 


### PR DESCRIPTION
## Summary
TSIA

## How was it tested?
`devbox shell` after doing `touch go.mod`. Output:
```
> ../devbox shell
Installing nix packages. This may take a while... done.
We detected extra packages you may need. To install them, run `devbox add go_1_19`
Starting a devbox shell...
```