### PR TITLE
[config-directory] run shell.initHooks and shell.scripts relative to --config dir

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -54,6 +54,7 @@ func InitConfig(dir string) (created bool, err error) {
 type Devbox struct {
 	cfg *Config
 	// srcDir is the directory where the config file (devbox.json) resides
+	// TODO savil. Rename to configDir.
 	srcDir string
 	writer io.Writer
 }
@@ -228,6 +229,7 @@ func (d *Devbox) Shell() error {
 		nix.WithPlanInitHook(strings.Join(plan.ShellInitHook, "\n")),
 		nix.WithProfile(profileDir),
 		nix.WithHistoryFile(filepath.Join(d.srcDir, shellHistoryFile)),
+		nix.WithConfigDir(d.srcDir),
 	}
 
 	if featureflag.Get(featureflag.PKGConfig).Enabled() {
@@ -288,7 +290,9 @@ func (d *Devbox) RunScript(scriptName string) error {
 		nix.WithPlanInitHook(strings.Join(plan.ShellInitHook, "\n")),
 		nix.WithProfile(profileDir),
 		nix.WithHistoryFile(filepath.Join(d.srcDir, shellHistoryFile)),
-		nix.WithUserScript(scriptName, script.String()))
+		nix.WithUserScript(scriptName, script.String()),
+		nix.WithConfigDir(d.srcDir),
+	)
 
 	if err != nil {
 		fmt.Print(err)

--- a/nix/shell.go
+++ b/nix/shell.go
@@ -37,6 +37,7 @@ const (
 type Shell struct {
 	name            name
 	binPath         string
+	configDir       string // path to where devbox.json config resides
 	pkgConfigDir    string
 	env             []string
 	userShellrcPath string
@@ -137,6 +138,12 @@ func WithUserScript(name string, command string) ShellOption {
 func WithPKGCOnfigDir(pkgConfigDir string) ShellOption {
 	return func(s *Shell) {
 		s.pkgConfigDir = pkgConfigDir
+	}
+}
+
+func WithConfigDir(configDir string) ShellOption {
+	return func(s *Shell) {
+		s.configDir = configDir
 	}
 }
 
@@ -305,6 +312,7 @@ func (s *Shell) writeDevboxShellrc() (path string, err error) {
 	}
 
 	err = shellrcTmpl.Execute(shellrcf, struct {
+		ConfigDir        string
 		OriginalInit     string
 		OriginalInitPath string
 		UserHook         string
@@ -314,6 +322,7 @@ func (s *Shell) writeDevboxShellrc() (path string, err error) {
 		ProfileBinDir    string
 		HistoryFile      string
 	}{
+		ConfigDir:        s.configDir,
 		OriginalInit:     string(bytes.TrimSpace(userShellrc)),
 		OriginalInitPath: filepath.Clean(s.userShellrcPath),
 		UserHook:         strings.TrimSpace(s.UserInitHook),

--- a/nix/shell_test.go
+++ b/nix/shell_test.go
@@ -49,6 +49,7 @@ func TestWriteDevboxShellrc(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			s := &Shell{
+				configDir:       "path/to/configDir",
 				userShellrcPath: test.shellrcPath,
 				UserInitHook:    test.hook,
 				planInitHook:    `echo "Welcome to the devbox!"`,

--- a/nix/shellrc.tmpl
+++ b/nix/shellrc.tmpl
@@ -43,7 +43,13 @@ export PS1="(devbox) $PS1"
 
 # Begin Devbox User Hook
 
+# Switch to the directory where devbox.json config is
+workingDir=$(pwd)
+cd {{ .ConfigDir }}
+
 {{ .UserHook }}
+
+cd $workingDir
 
 # End Devbox User Hook
 
@@ -64,7 +70,12 @@ export PS1="(devbox) $PS1"
 {{- if .ScriptCommand }}
 
 function run_script {
+    workingDir=$(pwd)
+    cd {{ .ConfigDir }}
+
     {{  .ScriptCommand }}
+
+    cd $workingDir
 }
 
 {{- end }}

--- a/nix/testdata/shellrc/basic/shellrc.golden
+++ b/nix/testdata/shellrc/basic/shellrc.golden
@@ -51,7 +51,13 @@ export PS1="(devbox) $PS1"
 
 # Begin Devbox User Hook
 
+# Switch to the directory where devbox.json config is
+workingDir=$(pwd)
+cd path/to/configDir
+
 echo "Hello from a devbox shell hook!"
+
+cd $workingDir
 
 # End Devbox User Hook
 

--- a/nix/testdata/shellrc/noshellrc/shellrc.golden
+++ b/nix/testdata/shellrc/noshellrc/shellrc.golden
@@ -9,7 +9,13 @@ export PS1="(devbox) $PS1"
 
 # Begin Devbox User Hook
 
+# Switch to the directory where devbox.json config is
+workingDir=$(pwd)
+cd path/to/configDir
+
 echo "Hello from a devbox shell hook!"
+
+cd $workingDir
 
 # End Devbox User Hook
 

--- a/testdata/rust/rust-stable/devbox.json
+++ b/testdata/rust/rust-stable/devbox.json
@@ -6,7 +6,10 @@
   "shell": {
     "init_hook": [
       "source init-shell.sh"
-    ]
+    ],
+    "scripts": {
+      "cargo-run": "cargo run"
+    }
   },
   "nixpkgs": {
     "commit": "af9e00071d0971eb292fd5abef334e66eda3cb69"


### PR DESCRIPTION
## Summary

This shell init-hooks and scripts should be run relative to the `--config` directory.
Previously, they assumed `--config` was always the current-working-directory. 

This PR fixes this by doing some manual change-directory calls. Is there a more elegant way?

## How was it tested?

Test cases:

1. using `--config` dir and `devbox run`
```
> cd testdata/rust

> devbox run --config rust-stable cargo-run
# ran cargo run successfully
```

2. using `--config` dir and `devbox shell`
```
> cd testdata/rust

> devbox shell --config rust-stable

(devbox) > cd rust-stable && cargo run
# ran successfully
```

3. NOTE: this does NOT work because the implementation of `devbox shell -- <cmd>` 
doesn't share the core `devbox shell` implementation.
```
> cd testdata/rust

> devbox shell --config rust-stable -- cargo run
```

Control cases:

1. `devbox run`
```
> cd testdata/rust/rust-stable
> devbox run rust-stable cargo-run
```

2.
```
> cd testdata/rust/rust-stable
> devbox shell
(devbox) > cargo run
``` 


