### PR TITLE
[pkgcfg] Show readme when adding packages. Add info command

### DIFF
--- a/boxcli/info.go
+++ b/boxcli/info.go
@@ -17,7 +17,7 @@ type infoCmdFlags struct {
 }
 
 func InfoCmd() *cobra.Command {
-	flags := addCmdFlags{}
+	flags := infoCmdFlags{}
 
 	command := &cobra.Command{
 		Use:               "info <pkg>",
@@ -34,7 +34,7 @@ func InfoCmd() *cobra.Command {
 	return command
 }
 
-func infoCmdFunc(_ *cobra.Command, pkg string, flags addCmdFlags) error {
+func infoCmdFunc(_ *cobra.Command, pkg string, flags infoCmdFlags) error {
 	box, err := devbox.Open(flags.config.path, os.Stdout)
 	if err != nil {
 		return errors.WithStack(err)

--- a/boxcli/info.go
+++ b/boxcli/info.go
@@ -1,0 +1,44 @@
+// Copyright 2022 Jetpack Technologies Inc and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package boxcli
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"go.jetpack.io/devbox"
+	"go.jetpack.io/devbox/boxcli/featureflag"
+)
+
+type infoCmdFlags struct {
+	config configFlags
+}
+
+func InfoCmd() *cobra.Command {
+	flags := addCmdFlags{}
+
+	command := &cobra.Command{
+		Use:               "info <pkg>",
+		Hidden:            !featureflag.Get(featureflag.PKGConfig).Enabled(),
+		Short:             "Display package info",
+		Args:              cobra.ExactArgs(1),
+		PersistentPreRunE: nixShellPersistentPreRunE,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return infoCmdFunc(cmd, args[0], flags)
+		},
+	}
+
+	flags.config.register(command)
+	return command
+}
+
+func infoCmdFunc(_ *cobra.Command, pkg string, flags addCmdFlags) error {
+	box, err := devbox.Open(flags.config.path, os.Stdout)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return box.Info(pkg)
+}

--- a/boxcli/root.go
+++ b/boxcli/root.go
@@ -28,6 +28,7 @@ func RootCmd() *cobra.Command {
 	command.AddCommand(AddCmd())
 	command.AddCommand(BuildCmd())
 	command.AddCommand(GenerateCmd())
+	command.AddCommand(InfoCmd())
 	command.AddCommand(InitCmd())
 	command.AddCommand(PlanCmd())
 	command.AddCommand(RemoveCmd())

--- a/devbox.go
+++ b/devbox.go
@@ -111,6 +111,13 @@ func (d *Devbox) Add(pkgs ...string) error {
 	if err := d.ensurePackagesAreInstalled(install); err != nil {
 		return err
 	}
+	if featureflag.Get(featureflag.PKGConfig).Enabled() {
+		for _, pkg := range pkgs {
+			if _, err := pkgcfg.PrintReadme(pkg, d.srcDir, d.writer); err != nil {
+				return err
+			}
+		}
+	}
 	return d.printPackageUpdateMessage(install, pkgs)
 }
 
@@ -335,6 +342,17 @@ func (d *Devbox) PrintShellEnv() error {
 	// to essentially a parsed shellrc.tmpl
 	fmt.Fprintf(d.writer, "export PATH=\"%s:$PATH\"", profileBinDir)
 	return nil
+}
+
+func (d *Devbox) Info(pkg string) error {
+	hasReadme, err := pkgcfg.PrintReadme(pkg, d.srcDir, d.writer)
+	if err != nil {
+		return err
+	}
+	if !hasReadme {
+		_, err = fmt.Fprintf(d.writer, "No info available for %s\n", pkg)
+	}
+	return errors.WithStack(err)
 }
 
 // saveCfg writes the config file to the devbox directory.

--- a/devbox.go
+++ b/devbox.go
@@ -113,7 +113,7 @@ func (d *Devbox) Add(pkgs ...string) error {
 	}
 	if featureflag.Get(featureflag.PKGConfig).Enabled() {
 		for _, pkg := range pkgs {
-			if _, err := pkgcfg.PrintReadme(pkg, d.srcDir, d.writer); err != nil {
+			if _, err := pkgcfg.PrintReadme(pkg, d.configDir, d.writer); err != nil {
 				return err
 			}
 		}
@@ -348,7 +348,7 @@ func (d *Devbox) PrintShellEnv() error {
 }
 
 func (d *Devbox) Info(pkg string) error {
-	hasReadme, err := pkgcfg.PrintReadme(pkg, d.srcDir, d.writer)
+	hasReadme, err := pkgcfg.PrintReadme(pkg, d.configDir, d.writer)
 	if err != nil {
 		return err
 	}

--- a/devbox.json
+++ b/devbox.json
@@ -1,10 +1,7 @@
 {
   "packages": [
     "go_1_19",
-    "golangci-lint",
-    "mariadb",
-    "nginx",
-    "postgresql"
+    "golangci-lint"
   ],
   "shell": {
     "init_hook": "export \"GOROOT=$(go env GOROOT)\""

--- a/devbox.json
+++ b/devbox.json
@@ -1,7 +1,10 @@
 {
   "packages": [
     "go_1_19",
-    "golangci-lint"
+    "golangci-lint",
+    "mariadb",
+    "nginx",
+    "postgresql"
   ],
   "shell": {
     "init_hook": "export \"GOROOT=$(go env GOROOT)\""

--- a/generate.go
+++ b/generate.go
@@ -52,7 +52,7 @@ func generateForShell(rootPath string, plan *plansdk.ShellPlan) error {
 
 	if featureflag.Get(featureflag.PKGConfig).Enabled() {
 		for _, pkg := range plan.DevPackages {
-			if err := pkgcfg.CreateFiles(pkg, rootPath); err != nil {
+			if err := pkgcfg.CreateFilesAndShowReadme(pkg, rootPath); err != nil {
 				return err
 			}
 		}

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -30,6 +30,10 @@ type Info struct {
 	System  string
 }
 
+func (i *Info) String() string {
+	return fmt.Sprintf("%s-%s-%s", i.Name, i.Version, i.System)
+}
+
 func Exec(path string, command []string) error {
 	runCmd := strings.Join(command, " ")
 	cmd := exec.Command("nix-shell", path, "--run", runCmd)

--- a/pkgcfg/package-configuration/mariadb.json
+++ b/pkgcfg/package-configuration/mariadb.json
@@ -1,6 +1,7 @@
 {
   "name": "mariadb",
   "version": "0.0.1",
+  "readme": "* This package creates shims and stores them in .devbox/conf/mariadb/bin\n* Use mysql_install_db to initialize data directory\n* Use mysqld to start the server",
   "env": {
     "MYSQL_BASEDIR": "{{ .DevboxProfileDefault }}",
     "MYSQL_HOME": "{{ .DevboxRoot }}/conf/mariadb/run",

--- a/pkgcfg/package-configuration/nginx.json
+++ b/pkgcfg/package-configuration/nginx.json
@@ -1,7 +1,7 @@
 {
   "name": "nginx",
   "version": "0.0.1",
-  "readme": "To start nginx use command \"nginx\". nginx is configured to use .devbox/conf/nginx.conf. Use $NGINX_CONFDIR to change the configuration directory. Use $NGINX_LOGDIR to change the log directory. Use $NGINX_PIDDIR to change the pid directory. Use $NGINX_RUNDIR to change the run directory. Use $NGINX_SITESDIR to change the sites directory. Use $NGINX_TMPDIR to change the tmp directory. Use $NGINX_USER to change the user. Use $NGINX_GROUP to customize.",
+  "readme": "To start nginx use command \"nginx\"\nnginx is configured to use .devbox/conf/nginx.conf\n\nTo customize:\n* Use $NGINX_CONFDIR to change the configuration directory\n* Use $NGINX_LOGDIR to change the log directory\n* Use $NGINX_PIDDIR to change the pid directory\n* Use $NGINX_RUNDIR to change the run directory\n* Use $NGINX_SITESDIR to change the sites directory\n* Use $NGINX_TMPDIR to change the tmp directory. Use $NGINX_USER to change the user\n* Use $NGINX_GROUP to customize.",
   "env": {
     "NGINX_CONFDIR": "{{ .DevboxRoot }}/conf/nginx"
   },

--- a/pkgcfg/package-configuration/postgresql*.json
+++ b/pkgcfg/package-configuration/postgresql*.json
@@ -1,7 +1,7 @@
 {
   "name": "postgresql",
   "version": "0.0.1",
-  "readme": "To initialize the database, run `initdb`. To start the database, run `pg_ctl -l .devbox/conf/postgresql/logfile start`. To stop use `pg_ctl stop`.",
+  "readme": "To initialize the database run `initdb`.\nTo start the database run `pg_ctl -l .devbox/conf/postgresql/logfile start`.\nTo stop use `pg_ctl stop`.",
   "env": {
     "PGDATA": "{{ .DevboxRoot }}/conf/postgresql/data"
   },

--- a/pkgcfg/pkgcfg.go
+++ b/pkgcfg/pkgcfg.go
@@ -145,13 +145,13 @@ func createSymlink(root, filePath string) error {
 	return nil
 }
 
-func PrintReadme(pkg, rootDir string, w io.Writer) (bool, error) {
+func PrintReadme(pkg, rootDir string, w io.Writer) error {
 	cfg, err := get(pkg, rootDir)
 	if err != nil {
-		return false, err
+		return err
 	}
 	if cfg.Readme == "" {
-		return false, nil
+		return nil
 	}
 	_, err = fmt.Fprintf(
 		w,
@@ -160,5 +160,5 @@ func PrintReadme(pkg, rootDir string, w io.Writer) (bool, error) {
 		cfg.Readme,
 		cfg.Name,
 	)
-	return true, errors.WithStack(err)
+	return errors.WithStack(err)
 }

--- a/pkgcfg/pkgcfg.go
+++ b/pkgcfg/pkgcfg.go
@@ -3,6 +3,8 @@ package pkgcfg
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -20,10 +22,11 @@ type config struct {
 	Version         string            `json:"version"`
 	CreateFiles     map[string]string `json:"create_files"`
 	Env             map[string]string `json:"env"`
+	Readme          string            `json:"readme"`
 	localConfigPath string            `json:"-"`
 }
 
-func CreateFiles(pkg, rootDir string) error {
+func CreateFilesAndShowReadme(pkg, rootDir string) error {
 	cfg, err := get(pkg, rootDir)
 	if err != nil {
 		return err
@@ -140,4 +143,22 @@ func createSymlink(root, filePath string) error {
 		return errors.WithStack(err)
 	}
 	return nil
+}
+
+func PrintReadme(pkg, rootDir string, w io.Writer) (bool, error) {
+	cfg, err := get(pkg, rootDir)
+	if err != nil {
+		return false, err
+	}
+	if cfg.Readme == "" {
+		return false, nil
+	}
+	_, err = fmt.Fprintf(
+		w,
+		"\n%s NOTES:\n\n%s\n\nto show these notes use `devbox info %s`\n\n",
+		cfg.Name,
+		cfg.Readme,
+		cfg.Name,
+	)
+	return true, errors.WithStack(err)
 }


### PR DESCRIPTION
## Summary

This shows notes whenever a package configuration has a non-empty "readme" field. It also adds a new (hidden) command `devbox info <pkg>` that displays said info.

I also updated a few readme fields to make them look better.

## How was it tested?

`devbox add mariadb`
`devbox add nginx`
`devbox info mariadb`

<img width="671" alt="image" src="https://user-images.githubusercontent.com/544948/202824692-dca9f514-797a-4417-9e4a-c478c7af9174.png">

