### PR TITLE
Fix broken link in pinning_packages.md

### DIFF
--- a/docs/app/docs/guides/pinning_packages.md
+++ b/docs/app/docs/guides/pinning_packages.md
@@ -23,13 +23,13 @@ This hash ensures that Devbox will install the same packages whenever you start 
 
 ## Using the latest version of Nixpkgs
 
-To use the latest available packages in Nix, you can replace the commit in `devbox.json` with the latest `nixpkgs-unstable` hash from https://status.nixos.org. 
+To use the latest available packages in Nix, you can replace the commit in `devbox.json` with the latest `nixpkgs-unstable` hash from [https://status.nixos.org](https://status.nixos.org). 
 
 ## Look up a commit hash for a specific package
 
 In most cases, the packages available in Devbox's default commit should suffice for your use cases. However, if you need a specific minor version, or an older version of a package that is no longer included in Nixpkgs, you may need update the commit SHA. Unfortunately, Nix does not have an official way to find the Nixpkg commit SHA for a specific version of a package. 
 
-However, there is an unofficial search tool at https://lazamar.co.uk/nix-versions/ that can be used to list the Nixpkg commits for different versions of a specific package. To find the correct Nixpkg commit hash: 
+However, there is an unofficial search tool at [https://lazamar.co.uk/nix-versions/](https://lazamar.co.uk/nix-versions/) that can be used to list the Nixpkg commits for different versions of a specific package. To find the correct Nixpkg commit hash: 
 1. Select `nixpkgs-unstable` in the dropdown
 2. Enter the name of the package you want to search, and hit Search
 3. In the search results, find the version you want in the Version Column


### PR DESCRIPTION
Link to https://status.nixos.org/ is malformed.

Signed-off-by: Marvin Boothby <boothb@posti.io>

## Summary

Explicitly set all URLs in the document pinning_packages.md

## How was it tested?

Markdown Preview
