### PR TITLE
Respect nixpkgs commit in devbox add by using nix search

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -91,7 +91,7 @@ func Open(dir string, writer io.Writer) (*Devbox, error) {
 func (d *Devbox) Add(pkgs ...string) error {
 	// Check packages are valid before adding.
 	for _, pkg := range pkgs {
-		ok := nix.PkgExists(pkg)
+		ok := nix.PkgExists(d.cfg.Nixpkgs.Commit, pkg)
 		if !ok {
 			return errors.Errorf("package %s not found", pkg)
 		}
@@ -348,7 +348,7 @@ func (d *Devbox) PrintShellEnv() error {
 }
 
 func (d *Devbox) Info(pkg string) error {
-	info, hasInfo := nix.PkgInfo(pkg)
+	info, hasInfo := nix.PkgInfo(d.cfg.Nixpkgs.Commit, pkg)
 	if !hasInfo {
 		_, err := fmt.Fprintf(d.writer, "Package %s not found\n", pkg)
 		return errors.WithStack(err)

--- a/nix/nix_test.go
+++ b/nix/nix_test.go
@@ -7,7 +7,8 @@ func TestPkgExists(t *testing.T) {
 	// missing packages, which was leading to a panic. "rust" happens to be
 	// one of those packages.
 	pkg := "rust"
-	exists := PkgExists(pkg)
+	nixpkgsCommit := "af9e00071d0971eb292fd5abef334e66eda3cb69"
+	exists := PkgExists(nixpkgsCommit, pkg)
 	if exists {
 		t.Errorf("got PkgExists(%q) = true, want false.", pkg)
 	}


### PR DESCRIPTION
## Summary

Devbox was not respecting the `nixpkgs.commit` from `devbox.json` for some operations
like `devbox info` and `devbox add`.

This PR fixes this by changing the `PkgInfo` function to rely on the `nix search` 
command, which lets us query for the exact package when given a nixpkgs commit.

For now, we strictly fail if the exact match was not found.  In the future, we could
improve the error message to suggest some of the specific alternatives that `nix search`
can provide.


Alternatives include:
1. `nix-env --json --file https://github.com/nixos/nixpkgs/archive/af9e00071d0971eb292fd5abef334e66eda3cb69.tar.gz  -qa pulumi`, but this takes 13 seconds.
2. Using `nix-instantiate`, but this doesn't let us later suggest specific alternatives like `nix search` does.
```
nix-instantiate --eval --strict --json --expr 'let
  pkgs = import
    (fetchTarball {
      url = "https://github.com/nixos/nixpkgs/archive/af9e00071d0971eb292fd5abef334e66eda3cb69.tar.gz";
    })
    { };
in { inherit (pkgs.pulumi-bin) name pname version system; }'
```

NOTE:
The current implementation will re-download the nixpkgs, even if `devbox shell` has downloaded it once. I anticipate that moving to `nix develop` and flakes will get rid of this problem.

## How was it tested?

```
❯ devbox info pulumi
Package pulumi not found
```

and

```
❯ devbox info pulumi-bin
pulumi-3.37.2-x86_64-darwin

```

Also, verified that `devbox add` now works, including inside a `devbox shell`.
```
testdata/rust/rust-stable on  savil/nix-search is 📦 v0.1.0 via 🦀 v1.61.0 on ☁️  (us-east-2) on ☁️  savil.srivastava@jetpack.io
❯ devbox shell
Installing nix packages. This may take a while... done.
Starting a devbox shell...
project dir is /Users/savil/code/jetpack/devbox/testdata/rust/rust-stable
info: using existing install for 'stable-x86_64-apple-darwin'
info: default toolchain set to 'stable-x86_64-apple-darwin'

  stable-x86_64-apple-darwin unchanged - rustc 1.64.0 (a55dd71d5 2022-09-19)

(devbox)
testdata/rust/rust-stable on  savil/nix-search is 📦 v0.1.0 via 🦀 v1.64.0 on ☁️  (us-east-2) on ☁️  savil.srivastava@jetpack.io
❯ devbox add pulumi-bin
Installing nix packages. This may take a while... done.
pulumi-bin is now installed. Run `hash -r` to ensure your shell is updated.
(devbox)
testdata/rust/rust-stable on  savil/nix-search [!] is 📦 v0.1.0 via 🦀 v1.64.0 on ☁️  (us-east-2) on ☁️  savil.srivastava@jetpack.io
❯ which pulumi
/usr/local/bin/pulumi
(devbox)
testdata/rust/rust-stable on  savil/nix-search [!] is 📦 v0.1.0 via 🦀 v1.64.0 on ☁️  (us-east-2) on ☁️  savil.srivastava@jetpack.io
❯ hash -r
(devbox)
testdata/rust/rust-stable on  savil/nix-search [!] is 📦 v0.1.0 via 🦀 v1.64.0 on ☁️  (us-east-2) on ☁️  savil.srivastava@jetpack.io
❯ which pulumi
/Users/savil/code/jetpack/devbox/testdata/rust/rust-stable/.devbox/nix/profile/default/bin/pulumi
```

Since `pulumi` doesn't exist in the stable `nixpkgs` channel, this would previously fail
