### PR TITLE
Small fixes for devcontainers in WSL

### DIFF
--- a/vscode-extension/src/devcontainer.ts
+++ b/vscode-extension/src/devcontainer.ts
@@ -57,6 +57,7 @@ function getDockerfileContent(): String {
 	# Install nix
 	ARG NIX_INSTALL_SCRIPT=https://nixos.org/nix/install
 	RUN curl -fsSL \${NIX_INSTALL_SCRIPT} | sh -s -- --no-daemon
+    RUN . ~/.nix-profile/etc/profile.d/nix.sh
 	ENV PATH /home/vscode/.nix-profile/bin:\${PATH}
 
 	# Install devbox
@@ -93,6 +94,7 @@ function getDevcontainerJSON(devboxJson: any, cpuArch: String): String {
                     // Add custom vscode settings for remote environment here
                 },
                 "extensions": [
+                    "jetpack-io.devbox"
                     // Add custom vscode extensions for remote environment here
                 ]
             }


### PR DESCRIPTION
## Summary
2 small changes:
1. added devbox extension to the remote vscode environment so that it's installed when user runs vscode in a devcontainer
2. fixed `nix` not being in PATH when installed in WSL

## How was it tested?
ran on my windows machine with WSL2