### PR TITLE
[cloud] ensure devbox.json exists and pass devbox struct to cloud.Shell functions

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -8,20 +8,21 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/fatih/color"
+	"go.jetpack.io/devbox"
 	"go.jetpack.io/devbox/cloud/mutagen"
 	"go.jetpack.io/devbox/cloud/sshclient"
 	"go.jetpack.io/devbox/cloud/sshconfig"
 	"go.jetpack.io/devbox/cloud/stepper"
+	"go.jetpack.io/devbox/debug"
 )
 
-func Shell() error {
-	// TODO: check if `devbox.json` exists.
-	// TODO: find project's "root" directory based on `devbox.json` location.
+func Shell(box *devbox.Devbox) error {
 	setupSSHConfig()
 
 	c := color.New(color.FgMagenta).Add(color.Bold)
@@ -35,7 +36,7 @@ func Shell() error {
 	s1.Success("Created virtual machine")
 
 	s2 := stepper.Start("Starting file syncing...")
-	err := syncFiles(username, vmHostname)
+	err := syncFiles(username, vmHostname, box)
 	if err != nil {
 		s2.Fail("Starting file syncing [FAILED]")
 		log.Fatal(err)
@@ -93,7 +94,10 @@ func getVirtualMachine(username string) string {
 	return resp.VMHostname
 }
 
-func syncFiles(username string, hostname string) error {
+func syncFiles(username string, hostname string, box *devbox.Devbox) error {
+	dirName := projectDirName(box.GetConfigDir())
+	debug.Log("Will sync files to directory: %s", dirName)
+
 	// TODO: instead of id, have the server return the machine's name and use that
 	// here to. It'll make things easier to debug.
 	id, _, _ := strings.Cut(hostname, ".")
@@ -101,13 +105,13 @@ func syncFiles(username string, hostname string) error {
 		// If multiple projects can sync to the same machine, we need the name to also include
 		// the project's id.
 		Name:        fmt.Sprintf("devbox-%s", id),
-		AlphaPath:   ".", // We should use location of `devbox.json`
+		AlphaPath:   box.GetConfigDir(),
 		BetaAddress: fmt.Sprintf("%s@%s", username, hostname),
 		// It's important that the beta path is a "clean" directory that will contain *only*
 		// the projects files. If we pick a pre-existing directories with other files, those
 		// files will be synced back to the local directory (due to two-way-sync) and pollute
 		// the user's local project
-		BetaPath:  "~/Code/",
+		BetaPath:  "~/Code/", // Use ~/Code/{dirName}, where dirName is the variable above
 		IgnoreVCS: true,
 		SyncMode:  "two-way-resolved",
 	})
@@ -124,4 +128,16 @@ func shell(username string, hostname string) error {
 		Hostname: hostname,
 	}
 	return client.Shell()
+}
+
+const defaultProjectDirName = "DevboxProject"
+
+// Ideally, we'd pass in devbox.Devbox struct and call GetConfigDir but it
+// makes it hard to wrap this in a test
+func projectDirName(configDir string) string {
+	name := filepath.Base(configDir)
+	if name == "/" || name == "." {
+		return defaultProjectDirName
+	}
+	return name
 }

--- a/cloud/cloud_test.go
+++ b/cloud/cloud_test.go
@@ -1,0 +1,29 @@
+package cloud
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigDirName(t *testing.T) {
+
+	testCases := []struct {
+		configDir string
+		dirName   string
+	}{
+		{"/", defaultProjectDirName},
+		{".", defaultProjectDirName},
+		{"/foo", "foo"},
+		{"foo/bar", "bar"},
+		{"foo/bar/", "bar"},
+		{"foo/bar///", "bar"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.configDir, func(t *testing.T) {
+			assert := assert.New(t)
+			assert.Equal(testCase.dirName, projectDirName(testCase.configDir))
+		})
+	}
+}

--- a/devbox.go
+++ b/devbox.go
@@ -85,6 +85,10 @@ func Open(dir string, writer io.Writer) (*Devbox, error) {
 	return box, nil
 }
 
+func (d *Devbox) GetConfigDir() string {
+	return d.configDir
+}
+
 // Add adds a Nix package to the config so that it's available in the devbox
 // environment. It validates that the Nix package exists, but doesn't install
 // it. Adding a duplicate package is a no-op.


### PR DESCRIPTION
## Summary

This does some preliminary work to ensure that `devbox cloud shell`:
1. a devbox.json exists and we handle the `--config` flag like all the other commands.
2. can use the devbox.ConfigDir for syncing from
3. can use the name of the devbox.ConfigDir to eventually sync to in the vm. Not hooked up since we need VM changes for this.

## How was it tested?

TODO
