### PR TITLE
[pkgcfg] Remove config if package is removed

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -143,6 +143,10 @@ func (d *Devbox) Remove(pkgs ...string) error {
 		return err
 	}
 
+	if featureflag.Get(featureflag.PKGConfig).Enabled() {
+		pkgcfg.Remove(d.configDir, uninstalledPackages)
+	}
+
 	if err := d.ensurePackagesAreInstalled(uninstall); err != nil {
 		return err
 	}
@@ -423,11 +427,11 @@ func (d *Devbox) profileBinDir() (string, error) {
 }
 
 // installMode is an enum for helping with ensurePackagesAreInstalled implementation
-type installMode string
+type installMode int
 
 const (
-	install   installMode = "install"
-	uninstall installMode = "uninstall"
+	install   installMode = iota
+	uninstall installMode = iota
 )
 
 func (d *Devbox) ensurePackagesAreInstalled(mode installMode) error {
@@ -447,6 +451,10 @@ func (d *Devbox) ensurePackagesAreInstalled(mode installMode) error {
 		return errors.Wrap(err, "apply Nix derivation")
 	}
 	fmt.Println("done.")
+
+	if featureflag.Get(featureflag.PKGConfig).Enabled() {
+		pkgcfg.RemoveInvalidSymlinks(d.configDir)
+	}
 
 	return nil
 }

--- a/devbox.go
+++ b/devbox.go
@@ -429,11 +429,11 @@ func (d *Devbox) profileBinDir() (string, error) {
 }
 
 // installMode is an enum for helping with ensurePackagesAreInstalled implementation
-type installMode int
+type installMode string
 
 const (
-	install   installMode = iota
-	uninstall installMode = iota
+	install   installMode = "install"
+	uninstall installMode = "uninstall"
 )
 
 func (d *Devbox) ensurePackagesAreInstalled(mode installMode) error {

--- a/devbox.go
+++ b/devbox.go
@@ -144,7 +144,9 @@ func (d *Devbox) Remove(pkgs ...string) error {
 	}
 
 	if featureflag.Get(featureflag.PKGConfig).Enabled() {
-		pkgcfg.Remove(d.configDir, uninstalledPackages)
+		if err := pkgcfg.Remove(d.configDir, uninstalledPackages); err != nil {
+			return err
+		}
 	}
 
 	if err := d.ensurePackagesAreInstalled(uninstall); err != nil {
@@ -453,7 +455,9 @@ func (d *Devbox) ensurePackagesAreInstalled(mode installMode) error {
 	fmt.Println("done.")
 
 	if featureflag.Get(featureflag.PKGConfig).Enabled() {
-		pkgcfg.RemoveInvalidSymlinks(d.configDir)
+		if err := pkgcfg.RemoveInvalidSymlinks(d.configDir); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkgcfg/pkgcfg.go
+++ b/pkgcfg/pkgcfg.go
@@ -101,7 +101,7 @@ func createEnvFile(pkg, rootDir string) error {
 		}
 		env += fmt.Sprintf("export %s=%s\n", k, escaped)
 	}
-	filePath := filepath.Join(rootDir, ".devbox/conf/", pkg, "/env")
+	filePath := filepath.Join(rootDir, confPath, pkg, "/env")
 	if err = createDir(filepath.Dir(filePath)); err != nil {
 		return err
 	}
@@ -192,7 +192,8 @@ func displaySourceEnvMessage(pkg, rootDir string, w io.Writer) error {
 	if len(env) > 0 {
 		_, err = fmt.Fprintf(
 			w,
-			"\nTo ensure environment is set, run `source .devbox/conf/%s/env`\n\n",
+			"\nTo ensure environment is set, run `source %s/%s/env`\n\n",
+			confPath,
 			pkg,
 		)
 	}

--- a/pkgcfg/rm.go
+++ b/pkgcfg/rm.go
@@ -1,0 +1,31 @@
+package pkgcfg
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+func Remove(rootDir string, pkgs []string) error {
+	for _, pkg := range pkgs {
+		if err := os.RemoveAll(filepath.Join(rootDir, confPath, pkg)); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+	return nil
+}
+
+func RemoveInvalidSymlinks(rootDir string) error {
+	dirEntry, err := os.ReadDir(filepath.Join(rootDir, confPath, "bin"))
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	for _, entry := range dirEntry {
+		_, err := os.Stat(filepath.Join(rootDir, confPath, "bin", entry.Name()))
+		if errors.Is(err, os.ErrNotExist) {
+			os.Remove(filepath.Join(rootDir, confPath, "bin", entry.Name()))
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Removes config and broken symlinks when a package is removed. We could also clean up configs as part of `ensurePackagesAreInstalled` (which makes it more reliable) but this requires a bit of refactoring I didn't want to do as part of this PR.

Small unrelated change: made `installMode` type an int using iota (which is a bit more inline with golang quasi-enum pattern)

## How was it tested?

Manual testing:

* Added nginx and mariadb. 
* Inspected conf directory
* Removed one by one
* Inspected conf directory at each step.
