### PR TITLE
[devbox testdata] improve rust testdata's init script to work over ssh

### DIFF
--- a/testdata/rust/rust-1.62.0/init-shell.sh
+++ b/testdata/rust/rust-1.62.0/init-shell.sh
@@ -1,8 +1,6 @@
+#!/usr/bin/env bash
 
-# TODO this only works when devbox shell is started in this directory. Using
-# the --config flag to start the shell will break this.
-# We could inject $JETPACK_CONFIG env-var into the shell environment to replace this.
-projectDir=$(dirname $(readlink -f "$0"))
+projectDir=$(dirname $(readlink -f "${BASH_SOURCE:-$0}"))
 echo "project dir is $projectDir"
 
 rustupHomeDir="$projectDir"/.rustup

--- a/testdata/rust/rust-stable/init-shell.sh
+++ b/testdata/rust/rust-stable/init-shell.sh
@@ -1,8 +1,6 @@
+#!/usr/bin/env bash
 
-# TODO this only works when devbox shell is started in this directory. Using
-# the --config flag to start the shell will break this.
-# We could inject $JETPACK_CONFIG env-var into the shell environment to replace this.
-projectDir=$(dirname $(readlink -f "$0"))
+projectDir=$(dirname $(readlink -f "${BASH_SOURCE:-$0}"))
 echo "project dir is $projectDir"
 
 rustupHomeDir="$projectDir"/.rustup


### PR DESCRIPTION
## Summary

Updating the init-scripts here so that they can work, when invoked 
1. locally from a sub-directory using the --config flag
2. over an ssh connection

## How was it tested?


For scenario 1.
```
> cd testdata/rust
> devbox shell --config rust-stable

# saw that the init script ran fine.
```

For scenario 2.
the set up is more complicated.
1. set up containers as per https://github.com/jetpack-io/axiom/pull/2877 (sorry, this is closed source, but happy to explain)
2. did ssh to the vm container and had the devbox shell start
