### PR TITLE
Point the cli to the production gateway

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -76,9 +76,15 @@ type authResponse struct {
 }
 
 func getVirtualMachine(username string) string {
+	// When developing we can use this env variable to point
+	// to a different gateway
+	hostname := os.Getenv("DEVBOX_GATEWAY")
+	if hostname == "" {
+		hostname = "gateway.devbox.sh"
+	}
 	client := sshclient.Client{
 		Username: username,
-		Hostname: "gateway.devbox.sh",
+		Hostname: hostname,
 	}
 	bytes, err := client.Exec("auth")
 	if err != nil {

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -78,8 +78,7 @@ type authResponse struct {
 func getVirtualMachine(username string) string {
 	client := sshclient.Client{
 		Username: username,
-		// TODO: change gateway to prod by default before relesing.
-		Hostname: "gateway.dev.devbox.sh",
+		Hostname: "gateway.devbox.sh",
 	}
 	bytes, err := client.Exec("auth")
 	if err != nil {


### PR DESCRIPTION
## Summary
Point the CLI to the production gateway (`gateway.devbox.sh`) by default.

Note that this means that if you're working on the gateway, you'll need to re-compile the devbox binary to test against your development version. Let me know if you prefer I add an (internal) flag to select which gateway to talk to.

## How was it tested?
Didn't.