### PR TITLE
Rename CICD workflows to be more descriptive

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,6 +1,7 @@
-name: release
+name: cli-release
+# Releases the Devbox CLI
 
-concurrency: deployment
+concurrency: cli-release
 
 on:
   # Build/Release on demand
@@ -23,7 +24,7 @@ permissions:
 
 jobs:
   tests:
-    uses: ./.github/workflows/tests.yaml
+    uses: ./.github/workflows/cli-tests.yaml
 
   prerelease:
     runs-on: ubuntu-latest

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -1,4 +1,5 @@
-name: tests
+name: cli-tests
+# Runs the Devbox CLI tests
 
 concurrency:
   group: ${{ github.ref }}

--- a/.github/workflows/docs-deploy-preview.yaml
+++ b/.github/workflows/docs-deploy-preview.yaml
@@ -1,4 +1,5 @@
-name: docs-preview
+name: docs-deploy-preview
+# Deploys a preview of the docs website using launchpad.
 
 on:
   push:
@@ -30,7 +31,7 @@ jobs:
           files: docs/app/docs
           config_file: docs/.markdownlint.yaml
 
-  deploy-to-preview:
+  docs-deploy-preview:
     runs-on: ubuntu-latest
     needs: markdown-lint
     steps:

--- a/.github/workflows/docs-deploy-prod.yaml
+++ b/.github/workflows/docs-deploy-prod.yaml
@@ -1,6 +1,7 @@
-name: docs-deployment
+name: docs-deploy-prod
+# Deploys the prod version of the docs website.
 
-concurrency: deployment
+concurrency: docs-deployment
 
 on:
   workflow_dispatch:

--- a/.github/workflows/vscode-ext-release.yaml
+++ b/.github/workflows/vscode-ext-release.yaml
@@ -1,4 +1,7 @@
-name: release-extension
+name: vscode-ext-release
+# Releases the Devbox VSCode extension to the marketplace
+
+concurrency: vscode-ext-release
 
 on: workflow_dispatch
 


### PR DESCRIPTION
## Summary
Rename CICD workflows to be more descriptive. I was getting confused with the meaning of each workflow based on the filename. Adopting a naming convention of `<artifact>-<workflow>` so that all the worflows related to the same artifact are next to each other (i.e. `cli` worfklows are together, `doc` workflows are together and so on) 

## How was it tested?
Can't test until I merge this PR