### PR TITLE
[cloud] client directly calls start_devbox_server.sh <project dir>

### DIFF
--- a/boxcli/cloud.go
+++ b/boxcli/cloud.go
@@ -49,5 +49,5 @@ func runCloudShellCmd(flags *cloudShellCmdFlags) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	return cloud.Shell(box)
+	return cloud.Shell(box.ConfigDir())
 }

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -34,6 +34,7 @@ func Shell(box *devbox.Devbox) error {
 	s1 := stepper.Start("Creating a virtual machine on the cloud...")
 	vmHostname := getVirtualMachine(username)
 	s1.Success("Created virtual machine")
+	debug.Log("vmHostname: %s", vmHostname)
 
 	s2 := stepper.Start("Starting file syncing...")
 	err := syncFiles(username, vmHostname, box)
@@ -90,6 +91,7 @@ func getVirtualMachine(username string) string {
 	if err != nil {
 		log.Fatal(err)
 	}
+	debug.Log("gateway.devbox.sh auth response: %s", string(bytes))
 	resp := &authResponse{}
 	err = json.Unmarshal(bytes, resp)
 	if err != nil {

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -29,7 +29,7 @@ func Shell(configDir string) error {
 	fmt.Println("Blazingly fast remote development that feels local")
 	fmt.Print("\n")
 
-	username, vmHostname := parseVmEnvVar()
+	username, vmHostname := parseVMEnvVar()
 	if username == "" {
 		username = promptUsername()
 	}
@@ -155,7 +155,7 @@ func projectDirName(configDir string) string {
 	return name
 }
 
-func parseVmEnvVar() (username string, vmHostname string) {
+func parseVMEnvVar() (username string, vmHostname string) {
 	vmEnvVar := os.Getenv("DEVBOX_VM")
 	if vmEnvVar == "" {
 		return "", ""

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -31,10 +31,14 @@ func Shell(box *devbox.Devbox) error {
 	fmt.Print("\n")
 
 	username := promptUsername()
-	s1 := stepper.Start("Creating a virtual machine on the cloud...")
-	vmHostname := getVirtualMachine(username)
-	s1.Success("Created virtual machine")
-	debug.Log("vmHostname: %s", vmHostname)
+
+	vmHostname := os.Getenv("DEVBOX_VM")
+	if vmHostname == "" {
+		s1 := stepper.Start("Creating a virtual machine on the cloud...")
+		vmHostname = getVirtualMachine(username)
+		s1.Success("Created virtual machine")
+	}
+	debug.Log("vm_hostname: %s", vmHostname)
 
 	s2 := stepper.Start("Starting file syncing...")
 	err := syncFiles(username, vmHostname, box)
@@ -47,7 +51,6 @@ func Shell(box *devbox.Devbox) error {
 	s3 := stepper.Start("Connecting to virtual machine...")
 	time.Sleep(1 * time.Second)
 	s3.Stop("Connecting to virtual machine")
-
 	fmt.Print("\n")
 
 	return shell(username, vmHostname, box)

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -49,7 +49,7 @@ func Shell(box *devbox.Devbox) error {
 
 	fmt.Print("\n")
 
-	return shell(username, vmHostname)
+	return shell(username, vmHostname, box)
 }
 
 func setupSSHConfig() {
@@ -116,7 +116,7 @@ func syncFiles(username string, hostname string, box *devbox.Devbox) error {
 		// the projects files. If we pick a pre-existing directories with other files, those
 		// files will be synced back to the local directory (due to two-way-sync) and pollute
 		// the user's local project
-		BetaPath:  "~/Code/", // TODO Use ~/code/{projectName}
+		BetaPath:  fmt.Sprintf("~/code/%s", projectName),
 		IgnoreVCS: true,
 		SyncMode:  "two-way-resolved",
 	})
@@ -127,15 +127,16 @@ func syncFiles(username string, hostname string, box *devbox.Devbox) error {
 	return nil
 }
 
-func shell(username string, hostname string) error {
+func shell(username string, hostname string, box *devbox.Devbox) error {
 	client := &sshclient.Client{
-		Username: username,
-		Hostname: hostname,
+		Username:       username,
+		Hostname:       hostname,
+		ProjectDirName: projectDirName(box.ConfigDir()),
 	}
 	return client.Shell()
 }
 
-const defaultProjectDirName = "DevboxProject"
+const defaultProjectDirName = "devbox_project"
 
 // Ideally, we'd pass in devbox.Devbox struct and call ConfigDir but it
 // makes it hard to wrap this in a test

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -29,9 +29,12 @@ func Shell(configDir string) error {
 	fmt.Println("Blazingly fast remote development that feels local")
 	fmt.Print("\n")
 
-	username := promptUsername()
+	username, vmHostname := parseVmEnvVar()
+	if username == "" {
+		username = promptUsername()
+	}
+	debug.Log("username: %s", username)
 
-	vmHostname := os.Getenv("DEVBOX_VM")
 	if vmHostname == "" {
 		s1 := stepper.Start("Creating a virtual machine on the cloud...")
 		vmHostname = getVirtualMachine(username)
@@ -150,4 +153,23 @@ func projectDirName(configDir string) string {
 		return defaultProjectDirName
 	}
 	return name
+}
+
+func parseVmEnvVar() (username string, vmHostname string) {
+	vmEnvVar := os.Getenv("DEVBOX_VM")
+	if vmEnvVar == "" {
+		return "", ""
+	}
+	parts := strings.Split(vmEnvVar, "@")
+
+	// DEVBOX_VM = <hostname>
+	if len(parts) == 1 {
+		vmHostname = parts[0]
+		return
+	}
+
+	// DEVBOX_VM = <username>@<hostname>
+	username = parts[0]
+	vmHostname = parts[1]
+	return
 }

--- a/cloud/sshclient/sshclient.go
+++ b/cloud/sshclient/sshclient.go
@@ -19,7 +19,7 @@ type Client struct {
 
 func (c *Client) Shell() error {
 	cmd := c.cmd("-t")
-	remoteCmd := fmt.Sprintf("bash -l -c \"start_devbox_shell.sh %s 300\"", c.ProjectDirName)
+	remoteCmd := fmt.Sprintf(`bash -l -c "start_devbox_shell.sh \"%s\""`, c.ProjectDirName)
 	cmd.Args = append(cmd.Args, remoteCmd)
 	debug.Log("running command: %s", cmd)
 

--- a/cloud/sshclient/sshclient.go
+++ b/cloud/sshclient/sshclient.go
@@ -18,9 +18,8 @@ type Client struct {
 }
 
 func (c *Client) Shell() error {
-	cmd := c.cmd()
-	remoteCmd := fmt.Sprintf("bash -l -c \"start_devbox_shell.sh %s 300\"",
-		c.ProjectDirName)
+	cmd := c.cmd("-t")
+	remoteCmd := fmt.Sprintf("bash -l -c \"start_devbox_shell.sh %s 300\"", c.ProjectDirName)
 	cmd.Args = append(cmd.Args, remoteCmd)
 	debug.Log("running command: %s", cmd)
 
@@ -45,9 +44,10 @@ func (c *Client) Exec(remoteCmd string) ([]byte, error) {
 	return bytes, err
 }
 
-func (c *Client) cmd() *exec.Cmd {
+func (c *Client) cmd(sshArgs ...string) *exec.Cmd {
 
-	cmd := exec.Command("ssh", "-t", destination(c.Username, c.Hostname))
+	cmd := exec.Command("ssh", sshArgs...)
+	cmd.Args = append(cmd.Args, destination(c.Username, c.Hostname))
 
 	// Add any necessary flags:
 	if c.Port != 0 {

--- a/cloud/sshclient/sshclient.go
+++ b/cloud/sshclient/sshclient.go
@@ -19,6 +19,9 @@ type Client struct {
 
 func (c *Client) Shell() error {
 	cmd := c.cmd()
+	remoteCmd := fmt.Sprintf("bash -l -c \"start_devbox_shell.sh %s 300\"",
+		c.ProjectDirName)
+	cmd.Args = append(cmd.Args, remoteCmd)
 	debug.Log("running command: %s", cmd)
 
 	// Setup stdin, stdout, stderr
@@ -44,8 +47,7 @@ func (c *Client) Exec(remoteCmd string) ([]byte, error) {
 
 func (c *Client) cmd() *exec.Cmd {
 
-	remoteCmd := fmt.Sprintf("bash -l -c \"start_devbox_shell.sh %s\"", c.ProjectDirName)
-	cmd := exec.Command("ssh", "-t", destination(c.Username, c.Hostname), remoteCmd)
+	cmd := exec.Command("ssh", "-t", destination(c.Username, c.Hostname))
 
 	// Add any necessary flags:
 	if c.Port != 0 {

--- a/cloud/sshclient/sshclient.go
+++ b/cloud/sshclient/sshclient.go
@@ -2,15 +2,17 @@ package sshclient
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
 )
 
 type Client struct {
-	Username string
-	Hostname string
-	Port     int
+	Username       string
+	Hostname       string
+	Port           int
+	ProjectDirName string
 }
 
 func (c *Client) Shell() error {
@@ -38,7 +40,9 @@ func (c *Client) Exec(remoteCmd string) ([]byte, error) {
 }
 
 func (c *Client) cmd() *exec.Cmd {
-	cmd := exec.Command("ssh", destination(c.Username, c.Hostname))
+
+	remoteCmd := fmt.Sprintf("bash -l -c \"start_devbox_shell.sh %s\"", c.ProjectDirName)
+	cmd := exec.Command("ssh", "-t", destination(c.Username, c.Hostname), remoteCmd)
 
 	// Add any necessary flags:
 	if c.Port != 0 {

--- a/cloud/sshclient/sshclient.go
+++ b/cloud/sshclient/sshclient.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+
+	"go.jetpack.io/devbox/debug"
 )
 
 type Client struct {
@@ -17,6 +19,7 @@ type Client struct {
 
 func (c *Client) Shell() error {
 	cmd := c.cmd()
+	debug.Log("running command: %s", cmd)
 
 	// Setup stdin, stdout, stderr
 	cmd.Stdin = os.Stdin


### PR DESCRIPTION
## Summary

This PR updates the cloud client to call `ssh -t <server> "bash -l -c \"start_devbox_server.sh <project-name>\""`.
This informs the server about which project to start the `devbox shell` for.

## How was it tested?

setup:
```
fly machines run --port 22:2222/tcp -e SSH_USER=savil --name=savil-test --region=sjc .
```

ran:
```
DEVBOX_DEBUG=1 DEVBOX_VM=savil@0e286003ad5486.vm.devbox-vms.internal devbox cloud shell
```
and got a `devbox shell` and could see the project's files and execute it.