### PR TITLE
devbox run inside shell

### DIFF
--- a/boxcli/run.go
+++ b/boxcli/run.go
@@ -57,10 +57,10 @@ func runScriptCmd(args []string, flags runCmdFlags) error {
 	}
 
 	if devbox.IsDevboxShellEnabled() {
-		return errors.New("You are already in an active devbox shell.\nRun 'exit' before calling devbox run again. Shell inception is not supported yet.")
+		err = box.RunScriptInShell(script)
+	} else {
+		err = box.RunScript(script)
 	}
-
-	err = box.RunScript(script)
 
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {

--- a/devbox.go
+++ b/devbox.go
@@ -304,7 +304,6 @@ func (d *Devbox) RunScriptInShell(scriptName string) error {
 		shell = &nix.Shell{}
 	}
 
-	shell.UserInitHook = d.cfg.Shell.InitHook.String()
 	return shell.RunInShell()
 }
 

--- a/devbox.go
+++ b/devbox.go
@@ -281,6 +281,33 @@ func (d *Devbox) Shell() error {
 	return shell.Run(nixShellFilePath)
 }
 
+func (d *Devbox) RunScriptInShell(scriptName string) error {
+	profileDir, err := d.profileDir()
+	if err != nil {
+		return err
+	}
+
+	script := d.cfg.Shell.Scripts[scriptName]
+	if script == nil {
+		return errors.Errorf("unable to find a script with name %s", scriptName)
+	}
+
+	shell, err := nix.DetectShell(
+		nix.WithProfile(profileDir),
+		nix.WithHistoryFile(filepath.Join(d.configDir, shellHistoryFile)),
+		nix.WithUserScript(scriptName, script.String()),
+		nix.WithConfigDir(d.configDir),
+	)
+
+	if err != nil {
+		fmt.Print(err)
+		shell = &nix.Shell{}
+	}
+
+	shell.UserInitHook = d.cfg.Shell.InitHook.String()
+	return shell.RunInShell()
+}
+
 // TODO: consider unifying the implementations of RunScript and Shell.
 func (d *Devbox) RunScript(scriptName string) error {
 	if err := d.ensurePackagesAreInstalled(install); err != nil {

--- a/nix/shell.go
+++ b/nix/shell.go
@@ -272,13 +272,13 @@ func (s *Shell) RunInShell() error {
 		// inside the devbox shell.
 		"__ETC_PROFILE_NIX_SOURCED=1",
 	)
-	debug.Log("Running nix-shell with environment: %v", env)
+	debug.Log("Running inside devbox shell with environment: %v", env)
 	cmd := exec.Command(s.execCommandInShell())
 	cmd.Env = env
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	debug.Log("Executing command form inside devbox shell: %v", cmd.Args)
+	debug.Log("Executing command from inside devbox shell: %v", cmd.Args)
 	return errors.WithStack(cmd.Run())
 }
 

--- a/nix/shell.go
+++ b/nix/shell.go
@@ -265,6 +265,32 @@ func (s *Shell) execCommand() string {
 	return strings.Join(args, " ")
 }
 
+func (s *Shell) RunInShell() error {
+	env := append(
+		os.Environ(),
+		// Prevent the user's shellrc from re-sourcing nix-daemon.sh
+		// inside the devbox shell.
+		"__ETC_PROFILE_NIX_SOURCED=1",
+	)
+	debug.Log("Running nix-shell with environment: %v", env)
+	cmd := exec.Command(s.execCommandInShell())
+	cmd.Env = env
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	debug.Log("Executing command form inside devbox shell: %v", cmd.Args)
+	return errors.WithStack(cmd.Run())
+}
+
+func (s *Shell) execCommandInShell() (string, string, string) {
+	args := []string{}
+
+	if s.ScriptCommand != "" {
+		args = append(args, "-ic")
+	}
+	return s.binPath, strings.Join(args, " "), s.ScriptCommand
+}
+
 func (s *Shell) writeDevboxShellrc() (path string, err error) {
 	if s.userShellrcPath == "" {
 		// If this happens, then there's a bug with how we detect shells


### PR DESCRIPTION
## Summary
Added support for running devbox run when inside a devbox shell
## How was it tested?
- Compile devbox
- `./devbox shell`
- `./devbox run <script_name>`
example output:
devbox.json
```json
{
  "packages": [
    "python38"
  ],
  "shell": {
    "init_hook": null,
    "scripts": {
      "test": [
        "echo helloworldtest",
        "ls -l"
      ]
    }
  },
  "nixpkgs": {
    "commit": "af9e00071d0971eb292fd5abef334e66eda3cb69"
  }
}
```

output:
```sh
(devbox) ➜  sample1 ./devbox run test
helloworldtest
total 23700
-rwxr-xr-x 1 mohsenansari 21500226 Nov 30 18:41 devbox
-rw-r--r-- 1 mohsenansari      250 Nov 30 22:26 devbox.json
-rw-r--r-- 1 mohsenansari        0 Oct  5 18:27 requirements.txt
-rw-r--r-- 1 mohsenansari        0 Oct  5 18:26 setup.py
```

