### PR TITLE
Add packages info in telemetry to get better understanding

### DIFF
--- a/boxcli/args.go
+++ b/boxcli/args.go
@@ -4,10 +4,8 @@
 package boxcli
 
 import (
-	"fmt"
 	"path/filepath"
 
-	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/boxcli/usererr"
 )
@@ -30,12 +28,13 @@ func configPathFromUser(args []string, flags *configFlags) (string, error) {
 	}
 
 	if len(args) > 0 {
-		fmt.Printf(
-			"%s devbox <command> <path> is deprecated, use devbox <command> --config <path> instead\n",
-			color.HiYellowString("Warning:"),
+		return "", usererr.New(
+			"devbox <command> <path> is deprecated, use devbox <command> --config <path> instead.",
 		)
 	}
-	return pathArg(args), nil
+
+	// current directory is ""
+	return "", nil
 }
 
 func pathArg(args []string) string {

--- a/devbox.go
+++ b/devbox.go
@@ -89,6 +89,10 @@ func (d *Devbox) ConfigDir() string {
 	return d.configDir
 }
 
+func (d *Devbox) Config() *Config {
+	return d.cfg
+}
+
 // Add adds a Nix package to the config so that it's available in the devbox
 // environment. It validates that the Nix package exists, but doesn't install
 // it. Adding a duplicate package is a no-op.


### PR DESCRIPTION
## Summary
Add packages info in telemetry to get better understanding.

Note that different command behaves differently:
- for devbox shell, run, and add command, path can be set via --config
- for devbox init. path is set via args

## How was it tested?
go build
devbox shell