### PR TITLE
[pkgcfg] Ensure php-fpm works out of the box

### DIFF
--- a/pkgcfg/package-configuration/apache/httpd.conf
+++ b/pkgcfg/package-configuration/apache/httpd.conf
@@ -57,7 +57,7 @@ ErrorLog "${HTTPD_CONFDIR}/error.log"
     </Directory>
 
     ## Added for php-fpm
-    # ProxyPassMatch ^/(.*\.php(/.*)?)$ fcgi://{LOCALHOST}:{PHPFPM_PORT}/<?php echo $root ?>/$1
+    ProxyPassMatch ^/(.*\.php(/.*)?)$ fcgi://127.0.0.1:8082/${PWD}/web/$1
     DirectoryIndex index.html 
 
 </VirtualHost>

--- a/pkgcfg/package-configuration/apacheHttpd.json
+++ b/pkgcfg/package-configuration/apacheHttpd.json
@@ -1,9 +1,10 @@
 {
   "name": "apache",
   "version": "0.0.1",
-  "readme": "To start use \"apachectl start -f $HTTPD_CONFDIR/httpd.conf\".",
+  "readme": "To start use \"apachectl start -f $HTTPD_CONFDIR/httpd.conf\".\n\nIf you with to edit the config file, please copy it out of the .devbox directory.",
   "env": {
-    "HTTPD_CONFDIR": "{{ .DevboxRoot }}/conf/apache"
+    "HTTPD_CONFDIR": "{{ .DevboxRoot }}/conf/apache",
+    "HTTPD_PORT": "8080"
   },
   "create_files": {
     ".devbox/conf/apache/httpd.conf": "apache/httpd.conf"

--- a/pkgcfg/package-configuration/php.json
+++ b/pkgcfg/package-configuration/php.json
@@ -2,5 +2,12 @@
   "name": "php",
   "version": "0.0.1",
   "match": "^php[0-9]*$",
-  "readme": "PHP is compiled with default extensions. If you would like to use non-default extensions you can add them with devbox add php81Extensions.{extension} . For example, for the memcache extension you can do `devbox add php81Extensions.memcached`"
+  "readme": "PHP is compiled with default extensions. If you would like to use non-default extensions you can add them with devbox add php81Extensions.{extension} . For example, for the memcache extension you can do `devbox add php81Extensions.memcached`.\n\nTo run with apache/nginx you may want to use the php-fpm shim.",
+  "env": {
+    "PHPFPM_PORT": "8082"
+  },
+  "create_files": {
+    ".devbox/conf/php/php-fpm": "php/php-fpm",
+    ".devbox/conf/php/php-fpm.conf": "php/php-fpm.conf"
+  }
 }

--- a/pkgcfg/package-configuration/php/php-fpm
+++ b/pkgcfg/package-configuration/php/php-fpm
@@ -1,0 +1,1 @@
+{{ .DevboxProfileDefault }}/bin/php-fpm -y {{ .DevboxRoot }}/conf/php/php-fpm.conf -p $PWD

--- a/pkgcfg/package-configuration/php/php-fpm.conf
+++ b/pkgcfg/package-configuration/php/php-fpm.conf
@@ -1,0 +1,17 @@
+[global]
+pid = .devbox/conf/php/php-fpm.pid
+error_log = .devbox/conf/php/php-fpm.log
+daemonize = yes
+
+[www]
+; user = www-data
+; group = www-data
+listen = 127.0.0.1:${PHPFPM_PORT}
+; listen.owner = www-data
+; listen.group = www-data
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+chdir = /


### PR DESCRIPTION
## Summary

This makes php-fpm work pretty much out of the box. It creates an php-fpm config (deamonized). Adds default ports and always includes `ProxyPassMatch` in the apache config (because it should not break anything if even if not used)

## How was it tested?

```
devbox add php apacheHttpd
devbox shell
php-from
apachectl start -f $HTTPD_CONFDIR/httpd.conf
```
