### PR TITLE
[pkgcfg] show shims and env variables in info command. Add markdown flag

### DIFF
--- a/boxcli/info.go
+++ b/boxcli/info.go
@@ -13,7 +13,8 @@ import (
 )
 
 type infoCmdFlags struct {
-	config configFlags
+	config   configFlags
+	markdown bool
 }
 
 func InfoCmd() *cobra.Command {
@@ -30,6 +31,7 @@ func InfoCmd() *cobra.Command {
 	}
 
 	flags.config.register(command)
+	command.Flags().BoolVar(&flags.markdown, "markdown", false, "Output in markdown format")
 	return command
 }
 
@@ -39,5 +41,5 @@ func infoCmdFunc(_ *cobra.Command, pkg string, flags infoCmdFlags) error {
 		return errors.WithStack(err)
 	}
 
-	return box.Info(pkg)
+	return box.Info(pkg, flags.markdown)
 }

--- a/pkgcfg/info.go
+++ b/pkgcfg/info.go
@@ -1,0 +1,123 @@
+package pkgcfg
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+	"github.com/samber/lo"
+)
+
+func PrintReadme(
+	pkg, rootDir string,
+	w io.Writer,
+	showSourceEnv, markdown bool,
+) error {
+	cfg, err := getConfig(pkg, rootDir)
+
+	if err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintln(w, "")
+
+	if err = printReadme(cfg, w, markdown); err != nil {
+		return err
+	}
+
+	if err = printCreateFiles(cfg, w, markdown); err != nil {
+		return err
+	}
+
+	if err = printEnv(cfg, w, markdown); err != nil {
+		return err
+	}
+
+	if err = printInfoInstructions(pkg, w); err != nil {
+		return err
+	}
+
+	if showSourceEnv {
+		err = printSourceEnvMessage(pkg, rootDir, w)
+	}
+	return err
+}
+
+func printReadme(cfg *config, w io.Writer, markdown bool) error {
+	if cfg.Readme == "" {
+		return nil
+	}
+	_, err := fmt.Fprintf(
+		w,
+		"%s%s NOTES:\n%s\n\n",
+		lo.Ternary(markdown, "### ", ""),
+		cfg.Name,
+		cfg.Readme,
+	)
+	return errors.WithStack(err)
+}
+
+func printCreateFiles(cfg *config, w io.Writer, markdown bool) error {
+	if len(cfg.CreateFiles) == 0 {
+		return nil
+	}
+
+	shims := ""
+	for name, src := range cfg.CreateFiles {
+		if src != "" {
+			shims += fmt.Sprintf("* %s\n", name)
+		}
+	}
+
+	_, err := fmt.Fprintf(
+		w,
+		"%sThis configuration creates the following helper shims:\n%s\n",
+		lo.Ternary(markdown, "### ", ""),
+		shims,
+	)
+	return errors.WithStack(err)
+}
+
+func printEnv(cfg *config, w io.Writer, markdown bool) error {
+	if len(cfg.Env) == 0 {
+		return nil
+	}
+
+	envVars := ""
+	for name, value := range cfg.Env {
+		envVars += fmt.Sprintf("* %s=%s\n", name, value)
+	}
+
+	_, err := fmt.Fprintf(
+		w,
+		"%sThis configuration sets the following environment variables:\n%s\n",
+		lo.Ternary(markdown, "### ", ""),
+		envVars,
+	)
+	return errors.WithStack(err)
+}
+
+func printInfoInstructions(pkg string, w io.Writer) error {
+	_, err := fmt.Fprintf(
+		w,
+		"To show this information, run `devbox info %s`\n\n",
+		pkg,
+	)
+	return errors.WithStack(err)
+}
+
+func printSourceEnvMessage(pkg, rootDir string, w io.Writer) error {
+	env, err := Env([]string{pkg}, rootDir)
+	if err != nil {
+		return err
+	}
+	if len(env) > 0 {
+		_, err = fmt.Fprintf(
+			w,
+			"To ensure environment is set, run `source %s/%s/env`\n\n",
+			confPath,
+			pkg,
+		)
+	}
+	return errors.WithStack(err)
+}

--- a/pkgcfg/pkgcfg.go
+++ b/pkgcfg/pkgcfg.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -158,44 +157,4 @@ func createSymlink(root, filePath string) error {
 		return errors.WithStack(err)
 	}
 	return nil
-}
-
-func PrintReadme(pkg, rootDir string, w io.Writer, showSourceEnv bool) error {
-	cfg, err := getConfig(pkg, rootDir)
-	if err != nil {
-		return err
-	}
-	if cfg.Readme == "" {
-		return nil
-	}
-	_, err = fmt.Fprintf(
-		w,
-		"\n%s NOTES:\n\n%s\n\nto show these notes use `devbox info %s`\n\n",
-		cfg.Name,
-		cfg.Readme,
-		cfg.Name,
-	)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	if showSourceEnv {
-		err = displaySourceEnvMessage(pkg, rootDir, w)
-	}
-	return err
-}
-
-func displaySourceEnvMessage(pkg, rootDir string, w io.Writer) error {
-	env, err := Env([]string{pkg}, rootDir)
-	if err != nil {
-		return err
-	}
-	if len(env) > 0 {
-		_, err = fmt.Fprintf(
-			w,
-			"\nTo ensure environment is set, run `source %s/%s/env`\n\n",
-			confPath,
-			pkg,
-		)
-	}
-	return errors.WithStack(err)
 }


### PR DESCRIPTION
## Summary

Improved package configuration info by including created shims and environment variables. Also added a new `--markdown` flag to the info command which produces the output in markdown format. We can use this to automate doc generation. 

@Lagoja let me know if this is useful. It didn't take me to long, so not a bit deal if you prefer not to merge in. I was hoping this might make it transparent enough that we might be able to turn it on.

## How was it tested?

Default (non-markdown):

```bash
> devbox info mariadb
mariadb-server-10.6.10

mariadb NOTES:
* This package creates shims and stores them in .devbox/conf/mariadb/bin
* Use mysql_install_db to initialize data directory
* Use mysqld to start the server

This configuration creates the following helper shims:
* .devbox/conf/mariadb/bin/mysqld
* .devbox/conf/mariadb/bin/mysql
* .devbox/conf/mariadb/bin/mysql_install_db
* .devbox/conf/mariadb/bin/mysqladmin

This configuration sets the following environment variables:
* MYSQL_BASEDIR=/Users/mike/dev/jetpack-repos/devbox/.devbox/nix/profile/default
* MYSQL_HOME=/Users/mike/dev/jetpack-repos/devbox/.devbox/conf/mariadb/run
* MYSQL_DATADIR=/Users/mike/dev/jetpack-repos/devbox/.devbox/conf/mariadb/data
* MYSQL_UNIX_PORT=/Users/mike/dev/jetpack-repos/devbox/.devbox/conf/mariadb/run/mysql.sock
* MYSQL_PID_FILE=/Users/mike/dev/jetpack-repos/devbox/.devbox/conf/mariadb/run/mysql.pid

To show this information, run `devbox info mariadb`
```

# Markdown version

```bash
> devbox info mariadb --markdown
```

## mariadb-server-10.6.10

### mariadb NOTES:
* This package creates shims and stores them in .devbox/conf/mariadb/bin
* Use mysql_install_db to initialize data directory
* Use mysqld to start the server

### This configuration creates the following helper shims:
* .devbox/conf/mariadb/bin/mysql_install_db
* .devbox/conf/mariadb/bin/mysqladmin
* .devbox/conf/mariadb/bin/mysqld
* .devbox/conf/mariadb/bin/mysql

### This configuration sets the following environment variables:
* MYSQL_BASEDIR=/Users/mike/dev/jetpack-repos/devbox/.devbox/nix/profile/default
* MYSQL_HOME=/Users/mike/dev/jetpack-repos/devbox/.devbox/conf/mariadb/run
* MYSQL_DATADIR=/Users/mike/dev/jetpack-repos/devbox/.devbox/conf/mariadb/data
* MYSQL_UNIX_PORT=/Users/mike/dev/jetpack-repos/devbox/.devbox/conf/mariadb/run/mysql.sock
* MYSQL_PID_FILE=/Users/mike/dev/jetpack-repos/devbox/.devbox/conf/mariadb/run/mysql.pid

To show this information, run `devbox info mariadb`