### PR TITLE
[experimental] add ssh shim in devbox cloud for mutagen

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -61,6 +61,12 @@ func Shell(configDir string) error {
 	return shell(username, vmHostname, configDir)
 }
 
+func MutagenSyncLabels(machineID string) map[string]string {
+	return map[string]string{
+		"devbox-vm": machineID,
+	}
+}
+
 func promptUsername() string {
 	username := ""
 	prompt := &survey.Input{
@@ -125,11 +131,11 @@ func syncFiles(username, hostname, configDir string) error {
 
 	// TODO: instead of id, have the server return the machine's name and use that
 	// here to. It'll make things easier to debug.
-	id, _, _ := strings.Cut(hostname, ".")
+	machineID, _, _ := strings.Cut(hostname, ".")
 	_, err := mutagen.Sync(&mutagen.SessionSpec{
 		// If multiple projects can sync to the same machine, we need the name to also include
 		// the project's id.
-		Name:        fmt.Sprintf("devbox-%s", id),
+		Name:        fmt.Sprintf("devbox-%s", machineID),
 		AlphaPath:   configDir,
 		BetaAddress: fmt.Sprintf("%s@%s", username, hostname),
 		// It's important that the beta path is a "clean" directory that will contain *only*
@@ -139,6 +145,7 @@ func syncFiles(username, hostname, configDir string) error {
 		BetaPath:  fmt.Sprintf("~/code/%s", projectName),
 		IgnoreVCS: true,
 		SyncMode:  "two-way-resolved",
+		Labels:    MutagenSyncLabels(machineID),
 	})
 	if err != nil {
 		return err

--- a/cloud/mutagen/install.go
+++ b/cloud/mutagen/install.go
@@ -51,7 +51,7 @@ func Install(url string, installDir string) error {
 func mutagenURL() string {
 	repo := "mutagen-io/mutagen"
 	pkg := "mutagen"
-	version := "v0.16.1" // Hard-coded for now, but change to always get the latest?
+	version := "v0.16.2" // Hard-coded for now, but change to always get the latest?
 	platform := detectPlatform()
 
 	return fmt.Sprintf("https://github.com/%s/releases/download/%s/%s_%s_%s.tar.gz", repo, version, pkg, platform, version)

--- a/cloud/mutagen/wrapper.go
+++ b/cloud/mutagen/wrapper.go
@@ -110,6 +110,7 @@ func Terminate(names ...string) error {
 func execMutagen(args []string) error {
 	binPath := ensureMutagen()
 	cmd := exec.Command(binPath, args...)
+	//cmd.Env = os.Environ()
 
 	out, err := cmd.CombinedOutput()
 

--- a/cloud/mutagen/wrapper.go
+++ b/cloud/mutagen/wrapper.go
@@ -101,8 +101,17 @@ func Reset(names ...string) error {
 	return execMutagen(args)
 }
 
-func Terminate(names ...string) error {
+func Terminate(labels map[string]string, names ...string) error {
 	args := []string{"sync", "terminate"}
+
+	if len(labels) > 0 {
+		var labelSelector string
+		for k, v := range labels {
+			labelSelector = fmt.Sprintf("%s,%s", labelSelector, fmt.Sprintf("%s=%s", k, v))
+		}
+		args = append(args, "--label-selector", labelSelector)
+	}
+
 	args = append(args, names...)
 	return execMutagen(args)
 }
@@ -110,7 +119,6 @@ func Terminate(names ...string) error {
 func execMutagen(args []string) error {
 	binPath := ensureMutagen()
 	cmd := exec.Command(binPath, args...)
-	//cmd.Env = os.Environ()
 
 	out, err := cmd.CombinedOutput()
 

--- a/cloud/vmssh/logger.go
+++ b/cloud/vmssh/logger.go
@@ -1,0 +1,66 @@
+package vmssh
+
+// The vmssh shim is invoked by mutagen daemon, so we log errors to a file which
+// we can inspect.
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	logDir      = ".config/devbox/log"
+	logFileName = "devbox_cloud_ssh.log"
+)
+
+var logger *sshLogger = NewSSHLogger()
+
+type sshLogger struct {
+	writer io.Writer
+}
+
+func NewSSHLogger() *sshLogger {
+	w, err := logFile()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to init ssh log file: %s", err)
+		return nil
+	}
+
+	return &sshLogger{
+		writer: w,
+	}
+}
+
+func (l *sshLogger) log(msg string, args ...any) {
+	if l == nil {
+		return
+	}
+	fmt.Fprintf(l.writer, msg, args...)
+}
+
+// logFile captures output when there is a failure
+// NOTE: we should limit the size of this log file.
+func logFile() (io.Writer, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	dirPath := filepath.Join(home, logDir)
+	if err = os.MkdirAll(dirPath, 0700); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	file, err := os.OpenFile(
+		filepath.Join(dirPath, logFileName),
+		os.O_RDWR|os.O_CREATE|os.O_TRUNC,
+		0700,
+	)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return file, nil
+}

--- a/cloud/vmssh/vmssh.go
+++ b/cloud/vmssh/vmssh.go
@@ -1,0 +1,88 @@
+package vmssh
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/cloud"
+	"go.jetpack.io/devbox/cloud/mutagen"
+)
+
+func SSHIfVMExists(sshArgs []string) error {
+	vmAddr := vmAddressIfAny(sshArgs)
+
+	if vmAddr != "" {
+		if isActive, err := checkActiveVM(vmAddr); err != nil {
+			return errors.WithStack(err)
+		} else if !isActive {
+			logger.log("terminating mutagen session for vm: %s", vmAddr)
+			// If no vm is active, then we should terminate the running mutagen sessions
+			return terminateMutagenSessions(vmAddr)
+		}
+	}
+
+	return invokeSSHCmd(sshArgs)
+}
+
+func terminateMutagenSessions(vmAddr string) error {
+	machineID, _, _ := strings.Cut(vmAddr, ".")
+
+	labels := cloud.MutagenSyncLabels(machineID)
+	return mutagen.Terminate(labels)
+}
+
+func checkActiveVM(vmAddr string) (bool, error) {
+
+	cmd := exec.Command("ssh", vmAddr, "echo 'alive'")
+
+	var bufErr, bufOut bytes.Buffer
+	cmd.Stderr = &bufErr
+	cmd.Stdout = &bufOut
+
+	err := cmd.Run()
+	if err != nil {
+		if err.Error() == "exit status 255" {
+			return false, nil
+		}
+		// For now, any error is deemed to indicate a VM that is no longer running.
+		// We can tighten this by listening for the specific exit error code (255)
+		logger.log("Error checking for Active VM: %s. Stdout: %s, Stderr: %s, cmd.Run err: %s\n",
+			vmAddr,
+			bufOut.String(),
+			bufErr.String(),
+			err,
+		)
+		return false, errors.WithStack(err)
+	}
+	return true, nil
+}
+
+// vmAddressIfAny will seek to find the devbox-vm hostname if it exists
+// in the sshArgs. If not, it returns an empty string.
+func vmAddressIfAny(sshArgs []string) string {
+
+	const devboxVMAddressSuffix = "devbox-vms.internal"
+	for _, sshArg := range sshArgs {
+		if strings.HasSuffix(sshArg, devboxVMAddressSuffix) {
+			return sshArg
+		}
+	}
+	logger.log("Did not find vm address in ssh args: %v", sshArgs)
+	return ""
+}
+
+func invokeSSHCmd(sshArgs []string) error {
+
+	cmd := exec.Command("ssh", sshArgs...)
+	logger.log("executing command: %s\n", cmd)
+
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Run()
+	return errors.WithStack(err)
+}


### PR DESCRIPTION
## Summary

this introduces a command that is a shim for the `ssh` command.

The idea is that `devbox cloud ssh` will first verify that the machine is active
before invoking ssh on it. Mutagen says that it uses `MUTAGEN_SSH_PATH` to find
the ssh and scp binaries, so we intend to set this env-var before starting
the sync-sessions.

- [ ] generate the ssh and scp shim files
- [ ] test



## How was it tested?


**ssh shim**
Manually made two executable files as shims for ssh and scp:
```
❯ cat ~/.config/devbox/shims/ssh
#!/bin/bash

devbox cloud ssh "$@"

❯ cat ~/.config/devbox/shims/scp
#!/bin/bash

scp "$@"
```

Sanity-test for ssh shim. I could call this and get a remote shell:
```
> ~/.config/devbox/shims/ssh savil@<machine>.vm.devbox-vms.internal 
```


**Using the ssh shim with devbox cloud shell**
Close old mutagen daemon: `mutagen daemon stop`. NOTE: This was needed to ensure a new daemon is started. This will be a problem for users who already are running a mutagen daemon.

But this does NOT yet work, in terms of calling the ssh shim in `~/.config/devbox/shims`:
```
MUTAGEN_SSH_PATH=/Users/savil/.config/devbox/shims DEVBOX_DEBUG=1 DEVBOX_VM=savil@e286072fe29986.vm.devbox-vms.internal devbox cloud shell
...
✘ Starting file syncing [FAILED]
Connecting to agent (POSIX)...                                                  Creating session...
Error: unable to connect to beta: unable to connect to endpoint: unable to dial agent endpoint: unable to handshake with agent process: server magic number incorrect (error output: [DEBUG] 2022/12/05 20:30:33 /Users/savil/code/jetpack/devbox/boxcli/midcobra/debug.go:46: Debug mode enabled.
bash: line 1: .mutagen/agents/0.16.1/mutagen-agent: No such file or directory
```
This error is arising from mutagen invoking this command via `devbox cloud ssh`:
```
executing command: /usr/bin/ssh -oConnectTimeout=5 -oServerAliveInterval=10 -oServerAliveCountMax=1 savil@e148e446b51189.vm.devbox-vms.internal .mutagen/agents/0.16.1/mutagen-agent synchronizer --log-level=info
```
I've been trying to locate where `.mutagen/agents/` should be, or how it is configured on the Beta machine.
