### PR TITLE
[nix-installer] auto-install nix if we detect it's missing

### DIFF
--- a/boxcli/add.go
+++ b/boxcli/add.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
+	"go.jetpack.io/devbox/nix"
 )
 
 type addCmdFlags struct {
@@ -22,7 +23,7 @@ func AddCmd() *cobra.Command {
 		Use:               "add <pkg>...",
 		Short:             "Add a new package to your devbox",
 		Args:              cobra.MinimumNArgs(1),
-		PersistentPreRunE: nixShellPersistentPreRunE,
+		PersistentPreRunE: nix.EnsureInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return addCmdFunc(cmd, args, flags)
 		},

--- a/boxcli/featureflag/nixinstaller.go
+++ b/boxcli/featureflag/nixinstaller.go
@@ -1,0 +1,3 @@
+package featureflag
+
+var NixInstaller = disabled("NIX_INSTALLER") // DEVBOX_FEATURE_NIX_INSTALLER

--- a/boxcli/info.go
+++ b/boxcli/info.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
 	"go.jetpack.io/devbox/boxcli/featureflag"
+	"go.jetpack.io/devbox/nix"
 )
 
 type infoCmdFlags struct {
@@ -23,7 +24,7 @@ func InfoCmd() *cobra.Command {
 		Hidden:            !featureflag.PKGConfig.Enabled(),
 		Short:             "Display package info",
 		Args:              cobra.ExactArgs(1),
-		PersistentPreRunE: nixShellPersistentPreRunE,
+		PersistentPreRunE: nix.EnsureInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return infoCmdFunc(cmd, args[0], flags)
 		},

--- a/boxcli/midcobra/debug.go
+++ b/boxcli/midcobra/debug.go
@@ -52,7 +52,11 @@ func (d *DebugMiddleware) postRun(cmd *cobra.Command, args []string, runErr erro
 		return
 	}
 	if usererr.HasUserMessage(runErr) {
-		color.Red("\nError: " + runErr.Error() + "\n\n")
+		if usererr.IsWarning(runErr) {
+			color.Yellow("\nWarning: %s\n\n", runErr.Error())
+		} else {
+			color.Red("\nError: " + runErr.Error() + "\n\n")
+		}
 	} else {
 		fmt.Printf("Error: %v\n", runErr)
 	}

--- a/boxcli/run.go
+++ b/boxcli/run.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
+	"go.jetpack.io/devbox/nix"
 	"golang.org/x/exp/slices"
 )
 
@@ -25,7 +26,7 @@ func RunCmd() *cobra.Command {
 		Short:             "Starts a new devbox shell and runs the target script",
 		Long:              "Starts a new interactive shell and runs your target script in it. The shell will exit once your target script is completed or when it is terminated via CTRL-C. Scripts can be defined in your `devbox.json`",
 		Args:              cobra.MaximumNArgs(1),
-		PersistentPreRunE: nixShellPersistentPreRunE,
+		PersistentPreRunE: nix.EnsureInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runScriptCmd(args, flags)
 		},

--- a/boxcli/shell.go
+++ b/boxcli/shell.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
+	"go.jetpack.io/devbox/nix"
 )
 
 type shellCmdFlags struct {
@@ -29,7 +30,7 @@ func ShellCmd() *cobra.Command {
 			"In both cases, the shell will be started using the devbox.json found in the --config flag directory. " +
 			"If --config isn't set, then devbox recursively searches the current directory and its parents.",
 		Args:              validateShellArgs,
-		PersistentPreRunE: nixShellPersistentPreRunE,
+		PersistentPreRunE: nix.EnsureInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runShellCmd(cmd, args, flags)
 		},
@@ -73,14 +74,6 @@ func runShellCmd(cmd *cobra.Command, args []string, flags shellCmdFlags) error {
 		return nil
 	}
 	return err
-}
-
-func nixShellPersistentPreRunE(cmd *cobra.Command, args []string) error {
-	_, err := exec.LookPath("nix-shell")
-	if err != nil {
-		return errors.New("could not find nix in your PATH\nInstall nix by following the instructions at https://nixos.org/download.html and make sure you've set up your PATH correctly")
-	}
-	return nil
 }
 
 func validateShellArgs(cmd *cobra.Command, args []string) error {

--- a/boxcli/usererr/usererr.go
+++ b/boxcli/usererr/usererr.go
@@ -6,14 +6,29 @@ import (
 	"github.com/pkg/errors"
 )
 
+type level int
+
+const (
+	levelError level = iota
+	levelWarning
+)
+
 type combined struct {
 	source      error
 	userMessage string
+	level       level
 }
 
 func New(msg string, args ...any) error {
 	return errors.WithStack(&combined{
 		userMessage: fmt.Sprintf(msg, args...),
+	})
+}
+
+func NewWarning(msg string, args ...any) error {
+	return errors.WithStack(&combined{
+		userMessage: fmt.Sprintf(msg, args...),
+		level:       levelWarning,
 	})
 }
 
@@ -30,6 +45,14 @@ func WithUserMessage(source error, msg string, args ...any) error {
 func HasUserMessage(err error) bool {
 	c := &combined{}
 	return errors.As(err, &c) // note double pointer
+}
+
+func IsWarning(err error) bool {
+	c := &combined{}
+	if errors.As(err, &c) {
+		return c.level == levelWarning
+	}
+	return false
 }
 
 func (c *combined) Error() string {

--- a/nix/install.go
+++ b/nix/install.go
@@ -1,7 +1,6 @@
 package nix
 
 import (
-	"bufio"
 	_ "embed"
 	"fmt"
 	"io"
@@ -50,18 +49,48 @@ func Install() error {
 }
 
 func EnsureInstalled(cmd *cobra.Command, args []string) error {
-	_, err := exec.LookPath("nix-shell")
-	if err == nil {
+	if nixBinaryInstalled() {
 		return nil
+	}
+	if nixDirExists() {
+		// TODO: We may be able to patch the rc files to add nix to the path.
+		return usererr.New(
+			"We found a /nix directory but nix binary is not in your PATH. " +
+				"Try restarting your terminal and running devbox again. If after " +
+				"restarting you still get this message it's possible nix setup is " +
+				"missing from your shell rc file. See " +
+				"https://github.com/NixOS/nix/issues/3616#issuecomment-903869569 for " +
+				"more details.",
+		)
 	}
 
 	if featureflag.NixInstaller.Enabled() {
-		color.Yellow("\nNix is not installed. Devbox will attempt to install it. \n\nPress enter to continue.\n")
+		color.Yellow(
+			"\nNix is not installed. Devbox will attempt to install it. " +
+				"\n\nPress enter to continue or ctrl-c to exit.\n",
+		)
 		fmt.Scanln()
-		if err = Install(); err != nil {
+		if err := Install(); err != nil {
 			return err
 		}
-		return usererr.NewWarning("Nix requires reopening terminal to function correctly. Please open new terminal and try again.")
+		return usererr.NewWarning(
+			"Nix requires reopening terminal to function correctly. Please open new" +
+				" terminal and try again.",
+		)
 	}
-	return usererr.New("could not find nix in your PATH\nInstall nix by following the instructions at https://nixos.org/download.html and make sure you've set up your PATH correctly")
+	return usererr.New(
+		"could not find nix in your PATH\nInstall nix by following the " +
+			"instructions at https://nixos.org/download.html and make sure you've " +
+			"set up your PATH correctly",
+	)
+}
+
+func nixBinaryInstalled() bool {
+	_, err := exec.LookPath("nix-shell")
+	return err == nil
+}
+
+func nixDirExists() bool {
+	_, err := os.Stat("/nix")
+	return err == nil
 }

--- a/nix/install.go
+++ b/nix/install.go
@@ -1,13 +1,18 @@
 package nix
 
 import (
+	"bufio"
 	_ "embed"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 
+	"github.com/fatih/color"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"go.jetpack.io/devbox/boxcli/featureflag"
+	"go.jetpack.io/devbox/boxcli/usererr"
 )
 
 //go:embed install.sh
@@ -42,4 +47,21 @@ func Install() error {
 	}()
 
 	return errors.WithStack(cmd.Wait())
+}
+
+func EnsureInstalled(cmd *cobra.Command, args []string) error {
+	_, err := exec.LookPath("nix-shell")
+	if err == nil {
+		return nil
+	}
+
+	if featureflag.NixInstaller.Enabled() {
+		color.Yellow("\nNix is not installed. Devbox will attempt to install it. \n\nPress enter to continue.\n")
+		_, _ = bufio.NewReader(os.Stdin).ReadBytes('\n')
+		if err = Install(); err != nil {
+			return err
+		}
+		return usererr.NewWarning("Nix requires reopening terminal to function correctly. Please open new terminal and try again.")
+	}
+	return usererr.New("could not find nix in your PATH\nInstall nix by following the instructions at https://nixos.org/download.html and make sure you've set up your PATH correctly")
 }

--- a/nix/install.go
+++ b/nix/install.go
@@ -57,7 +57,7 @@ func EnsureInstalled(cmd *cobra.Command, args []string) error {
 
 	if featureflag.NixInstaller.Enabled() {
 		color.Yellow("\nNix is not installed. Devbox will attempt to install it. \n\nPress enter to continue.\n")
-		_, _ = bufio.NewReader(os.Stdin).ReadBytes('\n')
+		fmt.Scanln()
 		if err = Install(); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

This change makes devbox attempt to install nix if it is missing and the command the user ran requires it. It shows yellow text alerting the user before it starts (otherwise it is really jarring). One improvement could be to combine the sudo warning into the yellow text.

If the installation fails we show the error that caused it. If the installation succeeds we show a user warning which is yellow text. This warning is an error which causes the CLI execution to end. We need this because nix requires restarting the terminal. This is another area where having a pkg installer may be an improvement. 

cc: @Lagoja 
## How was it tested?

Ran `devbox add mariadb` without having nix installed. Got:

<img width="471" alt="image" src="https://user-images.githubusercontent.com/544948/205784786-c76d90f2-9846-418e-93db-d2605eddfc32.png">

Pressing enter started the installation.

After installation we show:

<img width="741" alt="image" src="https://user-images.githubusercontent.com/544948/205785207-da291c1b-2c5f-4004-9bb5-a3a3e053e94c.png">


