### PR TITLE
[config] update default nixpkgs commit to most recent nixos-22.11

### DIFF
--- a/config.go
+++ b/config.go
@@ -76,13 +76,10 @@ func ReadConfig(path string) (*Config, error) {
 
 func upgradeConfig(cfg *Config, absFilePath string) error {
 	if cfg.Nixpkgs.Commit == "" {
-		// For now, we add the hardcoded value corresponding to the commit hash as of 2022-08-16 in:
-		// `git ls-remote https://github.com/nixos/nixpkgs nixos-unstable`
-		// In the near future, this will be changed to the commit-hash of the unstable tag in nixpkgs github repository
-		const defaultCommitHash = "af9e00071d0971eb292fd5abef334e66eda3cb69"
-		debug.Log("Missing nixpkgs.version from config, so adding the default value of %s", defaultCommitHash)
+		debug.Log("Missing nixpkgs.version from config, so adding the default value of %s",
+			plansdk.DefaultNixpkgsCommit)
 
-		cfg.Nixpkgs.Commit = defaultCommitHash
+		cfg.Nixpkgs.Commit = plansdk.DefaultNixpkgsCommit
 		return WriteConfig(absFilePath, cfg)
 	}
 	return nil

--- a/examples/default_nixpkgs/devbox.json
+++ b/examples/default_nixpkgs/devbox.json
@@ -1,0 +1,11 @@
+{
+  "packages": [
+    "go"
+  ],
+  "shell": {
+    "init_hook": null
+  },
+  "nixpkgs": {
+    "commit": "52e3e80afff4b16ccb7c52e9f0f5220552f03d04"
+  }
+}

--- a/planner/plansdk/plansdk.go
+++ b/planner/plansdk/plansdk.go
@@ -217,9 +217,8 @@ type NixpkgsInfo struct {
 	Sha256 string
 }
 
-// Commit hash as of 2022-08-16
-// `git ls-remote https://github.com/nixos/nixpkgs nixos-unstable`
-const DefaultNixpkgsCommit = "af9e00071d0971eb292fd5abef334e66eda3cb69"
+// The commit hash for nixos-22.11 on 2022-12-06 from status.nixos.org
+const DefaultNixpkgsCommit = "52e3e80afff4b16ccb7c52e9f0f5220552f03d04"
 
 func GetNixpkgsInfo(commitHash string) (*NixpkgsInfo, error) {
 	return &NixpkgsInfo{


### PR DESCRIPTION
## Summary

This PR updates the default nixpkgs commit to the most recent commit of nixos-22.11,
as taken from https://status.nixos.org


## How was it tested?

Added an example project, and verified that `devbox shell` for it works
