### PR TITLE
[cloud] set KeepAlive setting for ssh to vm

### DIFF
--- a/cloud/openssh/sshconfig.tmpl
+++ b/cloud/openssh/sshconfig.tmpl
@@ -13,3 +13,4 @@ Host *.devbox-vms.internal
 	StrictHostKeyChecking no
 	UserKnownHostsFile "{{ .ConfigDir }}/known_hosts"
 	ServerAliveInterval 50
+	ServerAliveCountMax 3

--- a/cloud/openssh/sshconfig.tmpl
+++ b/cloud/openssh/sshconfig.tmpl
@@ -12,3 +12,4 @@ Host *.devbox-vms.internal
 	PreferredAuthentications publickey
 	StrictHostKeyChecking no
 	UserKnownHostsFile "{{ .ConfigDir }}/known_hosts"
+	ServerAliveInterval 50

--- a/cloud/openssh/testdata/already-setup/in/.config/devbox/ssh/config
+++ b/cloud/openssh/testdata/already-setup/in/.config/devbox/ssh/config
@@ -15,3 +15,4 @@ Host *.devbox-vms.internal
 	StrictHostKeyChecking no
 	UserKnownHostsFile "$HOME/.config/devbox/ssh/known_hosts"
 	ServerAliveInterval 50
+	ServerAliveCountMax 3

--- a/cloud/openssh/testdata/already-setup/in/.config/devbox/ssh/config
+++ b/cloud/openssh/testdata/already-setup/in/.config/devbox/ssh/config
@@ -14,3 +14,4 @@ Host *.devbox-vms.internal
 	PreferredAuthentications publickey
 	StrictHostKeyChecking no
 	UserKnownHostsFile "$HOME/.config/devbox/ssh/known_hosts"
+	ServerAliveInterval 50

--- a/cloud/openssh/testdata/already-setup/out/.config/devbox/ssh/config
+++ b/cloud/openssh/testdata/already-setup/out/.config/devbox/ssh/config
@@ -13,3 +13,4 @@ Host *.devbox-vms.internal
 	StrictHostKeyChecking no
 	UserKnownHostsFile "$HOME/.config/devbox/ssh/known_hosts"
 	ServerAliveInterval 50
+	ServerAliveCountMax 3

--- a/cloud/openssh/testdata/already-setup/out/.config/devbox/ssh/config
+++ b/cloud/openssh/testdata/already-setup/out/.config/devbox/ssh/config
@@ -12,3 +12,4 @@ Host *.devbox-vms.internal
 	PreferredAuthentications publickey
 	StrictHostKeyChecking no
 	UserKnownHostsFile "$HOME/.config/devbox/ssh/known_hosts"
+	ServerAliveInterval 50

--- a/cloud/openssh/testdata/existing-config/out/.config/devbox/ssh/config
+++ b/cloud/openssh/testdata/existing-config/out/.config/devbox/ssh/config
@@ -13,3 +13,4 @@ Host *.devbox-vms.internal
 	StrictHostKeyChecking no
 	UserKnownHostsFile "$HOME/.config/devbox/ssh/known_hosts"
 	ServerAliveInterval 50
+	ServerAliveCountMax 3

--- a/cloud/openssh/testdata/existing-config/out/.config/devbox/ssh/config
+++ b/cloud/openssh/testdata/existing-config/out/.config/devbox/ssh/config
@@ -12,3 +12,4 @@ Host *.devbox-vms.internal
 	PreferredAuthentications publickey
 	StrictHostKeyChecking no
 	UserKnownHostsFile "$HOME/.config/devbox/ssh/known_hosts"
+	ServerAliveInterval 50

--- a/cloud/openssh/testdata/no-config/out/.config/devbox/ssh/config
+++ b/cloud/openssh/testdata/no-config/out/.config/devbox/ssh/config
@@ -13,3 +13,4 @@ Host *.devbox-vms.internal
 	StrictHostKeyChecking no
 	UserKnownHostsFile "$HOME/.config/devbox/ssh/known_hosts"
 	ServerAliveInterval 50
+	ServerAliveCountMax 3

--- a/cloud/openssh/testdata/no-config/out/.config/devbox/ssh/config
+++ b/cloud/openssh/testdata/no-config/out/.config/devbox/ssh/config
@@ -12,3 +12,4 @@ Host *.devbox-vms.internal
 	PreferredAuthentications publickey
 	StrictHostKeyChecking no
 	UserKnownHostsFile "$HOME/.config/devbox/ssh/known_hosts"
+	ServerAliveInterval 50


### PR DESCRIPTION
## Summary

The ssh session to my vm would auto-close with this output:

```
❯ time ssh savil@91859edc4e2783.vm.devbox-vms.internal
Welcome to Devbox Cloud!


(devbox) savil in 🌐 91859edc4e2783 in ~
❯ Connection to proxy.devbox.sh closed by remote host.
Connection to 91859edc4e2783.vm.devbox-vms.internal closed by remote host.
Connection to 91859edc4e2783.vm.devbox-vms.internal closed.
ssh savil@91859edc4e2783.vm.devbox-vms.internal  0.08s user 0.01s system 0% cpu 1:01.30 total
```

Setting this value in the config would result in the ssh connection staying active
for longer than a minute.

## How was it tested?

1. Set the config value, and could keep the connection alive.
2. As a sanity test, I removed the value and tried again: connection terminated at one minute again.
