### PR TITLE
[cloud] ssh shim part 2: invoke ssh

### DIFF
--- a/boxcli/root.go
+++ b/boxcli/root.go
@@ -5,6 +5,7 @@ package boxcli
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
@@ -60,20 +61,20 @@ func Execute(ctx context.Context, args []string) int {
 	return exe.Execute(ctx, args)
 }
 
-func executeSSH(sshArgs []string) int {
+func executeSSH() int {
 	sshshim.EnableDebug() // Always enable for now.
-	//debug.Log("os.Args: %v", os.Args)
-	if err := sshshim.InvokeSSHCommand(sshArgs); err != nil {
+	debug.Log("os.Args: %v", os.Args)
+	if err := sshshim.InvokeSSHCommand(); err != nil {
 		debug.Log("ERROR: %v", err)
-		//fmt.Fprintf(os.Stderr, "%v", err)
+		fmt.Fprintf(os.Stderr, "%v", err)
 		return 1
 	}
 	return 0
 }
 
 func Main() {
-	if !strings.HasSuffix(os.Args[0], "devbox") {
-		code := executeSSH(os.Args[1:])
+	if strings.HasSuffix(os.Args[0], "ssh") {
+		code := executeSSH()
 		os.Exit(code)
 	}
 	code := Execute(context.Background(), os.Args[1:])

--- a/boxcli/root.go
+++ b/boxcli/root.go
@@ -6,10 +6,12 @@ package boxcli
 import (
 	"context"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox/boxcli/midcobra"
 	"go.jetpack.io/devbox/build"
+	"go.jetpack.io/devbox/cloud/openssh/sshshim"
 	"go.jetpack.io/devbox/debug"
 )
 
@@ -58,7 +60,22 @@ func Execute(ctx context.Context, args []string) int {
 	return exe.Execute(ctx, args)
 }
 
+func executeSSH(sshArgs []string) int {
+	sshshim.EnableDebug() // Always enable for now.
+	//debug.Log("os.Args: %v", os.Args)
+	if err := sshshim.InvokeSSHCommand(sshArgs); err != nil {
+		debug.Log("ERROR: %v", err)
+		//fmt.Fprintf(os.Stderr, "%v", err)
+		return 1
+	}
+	return 0
+}
+
 func Main() {
+	if !strings.HasSuffix(os.Args[0], "devbox") {
+		code := executeSSH(os.Args[1:])
+		os.Exit(code)
+	}
 	code := Execute(context.Background(), os.Args[1:])
 	os.Exit(code)
 }

--- a/cloud/mutagen/install.go
+++ b/cloud/mutagen/install.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 
 	"github.com/cavaliergopher/grab/v3"
+	"go.jetpack.io/devbox/debug"
 )
 
 func InstallMutagenOnce(binPath string) error {
@@ -25,6 +26,7 @@ func InstallMutagenOnce(binPath string) error {
 }
 
 func Install(url string, installDir string) error {
+	debug.Log("installing mutagen from %s to %s", url, installDir)
 	err := os.MkdirAll(installDir, 0755)
 	if err != nil {
 		return err
@@ -51,7 +53,7 @@ func Install(url string, installDir string) error {
 func mutagenURL() string {
 	repo := "mutagen-io/mutagen"
 	pkg := "mutagen"
-	version := "v0.16.1" // Hard-coded for now, but change to always get the latest?
+	version := "v0.16.2" // Hard-coded for now, but change to always get the latest?
 	platform := detectPlatform()
 
 	return fmt.Sprintf("https://github.com/%s/releases/download/%s/%s_%s_%s.tar.gz", repo, version, pkg, platform, version)

--- a/cloud/mutagen/wrapper.go
+++ b/cloud/mutagen/wrapper.go
@@ -62,6 +62,7 @@ func List(envVars map[string]string, names ...string) ([]Session, error) {
 	out, err := cmd.CombinedOutput()
 
 	if err != nil {
+		debug.Log("List error: %s", err)
 		if e := (&exec.ExitError{}); errors.As(err, &e) {
 			errMsg := strings.TrimSpace(string(out))
 			// Special handle the case where no sessions are found:
@@ -121,6 +122,7 @@ func execMutagen(args []string, envVars map[string]string) error {
 	out, err := cmd.CombinedOutput()
 
 	if err != nil {
+		debug.Log("execMutagen error: %s", err)
 		if e := (&exec.ExitError{}); errors.As(err, &e) {
 			return errors.New(strings.TrimSpace(string(out)))
 		}

--- a/cloud/openssh/sshshim/generate.go
+++ b/cloud/openssh/sshshim/generate.go
@@ -28,27 +28,40 @@ func Setup() error {
 		return err
 	}
 
+	// create ssh symlink
 	devboxExecutablePath, err := os.Executable()
 	if err != nil {
 		return errors.WithStack(err)
 	}
-
-	if err := os.Symlink(devboxExecutablePath, filepath.Join(shimDir, "ssh")); err != nil {
-		if !os.IsExist(err) {
-			return errors.WithStack(err)
-		}
+	sshSymlink := filepath.Join(shimDir, "ssh")
+	if err := makeSymlink(sshSymlink, devboxExecutablePath); err != nil {
+		return errors.WithStack(err)
 	}
 
+	// create scp symlink
 	scpExecutablePath, err := exec.LookPath("scp")
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	if err := os.Symlink(scpExecutablePath, filepath.Join(shimDir, "scp")); err != nil {
+	scpSymlink := filepath.Join(shimDir, "scp")
+	if err := makeSymlink(scpSymlink, scpExecutablePath); err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}
+
+func makeSymlink(from string, target string) error {
+
+	if err := os.Remove(from); err != nil && !os.IsNotExist(err) {
+		return errors.WithStack(err)
+	}
+
+	if err := os.Symlink(target, from); err != nil {
 		if !os.IsExist(err) {
 			return errors.WithStack(err)
 		}
 	}
-
 	return nil
 }
 

--- a/cloud/openssh/sshshim/generate.go
+++ b/cloud/openssh/sshshim/generate.go
@@ -28,17 +28,12 @@ func Setup() error {
 		return err
 	}
 
-	// TODO use in the next PR instead of sshExecutablePath
-	//devboxExecutablePath, err := os.Executable()
-	//if err != nil {
-	//	return errors.WithStack(err)
-	//}
-	sshExecutablePath, err := exec.LookPath("ssh")
+	devboxExecutablePath, err := os.Executable()
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	if err := os.Symlink(sshExecutablePath, filepath.Join(shimDir, "ssh")); err != nil {
+	if err := os.Symlink(devboxExecutablePath, filepath.Join(shimDir, "ssh")); err != nil {
 		if !os.IsExist(err) {
 			return errors.WithStack(err)
 		}

--- a/cloud/openssh/sshshim/invoke.go
+++ b/cloud/openssh/sshshim/invoke.go
@@ -3,20 +3,35 @@ package sshshim
 import (
 	"os"
 	"os/exec"
+	"syscall"
 
 	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/debug"
 )
 
-func InvokeSSHCommand(sshArgs []string) error {
+func InvokeSSHCommand() error {
 
-	cmd := exec.Command("ssh", sshArgs...)
-	debug.Log("executing command: %s\n", cmd)
+	// We need to look for ssh in PATH. If we directly call "ssh", then we recursively
+	// loop into calling the ssh-named symlink that points to devbox.
+	sshPath, err := exec.LookPath("ssh")
+	if err != nil {
+		return errors.WithStack(err)
+	}
 
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	// We set sshPath to the first argument in `args` because:
+	//
+	// https://man7.org/linux/man-pages/man2/execve.2.html
+	// argv is an array of pointers to strings passed to the new program
+	//       as its command-line arguments.  By convention, the first of these
+	//       strings (i.e., argv[0]) should contain the filename associated
+	//       with the file being executed.
+	args := os.Args
+	args[0] = sshPath
+	debug.Log("invoking ssh with args: %v", args)
 
-	err := cmd.Run()
-	return errors.WithStack(err)
+	// Choose syscall.Exec instead of exec.Cmd so that we preserve the exit code
+	// and environment, and the current process is replaced by ssh.
+	// Without this, we'd see errors during mutagen sync: the mutagen binary
+	// would fail to be copied to Beta, the remote machine.
+	return errors.WithStack(syscall.Exec(sshPath, args, os.Environ()))
 }

--- a/cloud/openssh/sshshim/invoke.go
+++ b/cloud/openssh/sshshim/invoke.go
@@ -1,0 +1,22 @@
+package sshshim
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/debug"
+)
+
+func InvokeSSHCommand(sshArgs []string) error {
+
+	cmd := exec.Command("ssh", sshArgs...)
+	debug.Log("executing command: %s\n", cmd)
+
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Run()
+	return errors.WithStack(err)
+}

--- a/cloud/openssh/sshshim/logger.go
+++ b/cloud/openssh/sshshim/logger.go
@@ -1,0 +1,48 @@
+package sshshim
+
+// The sshshim is invoked by mutagen daemon, so we log errors to a file which
+// we can inspect.
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/debug"
+)
+
+const (
+	logFileName = "ssh.log"
+)
+
+func EnableDebug() {
+	if w, err := logFile(); err == nil {
+		debug.SetOutput(w)
+	} else {
+		fmt.Fprintf(os.Stderr, "failed to init ssh log file: %s", err)
+	}
+	debug.Enable()
+	debug.Log("started sshshim\n")
+}
+
+// logFile captures output when there is a failure
+// NOTE: we should limit the size of this log file.
+func logFile() (io.Writer, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	dirPath := filepath.Join(home, configShimDir)
+
+	file, err := os.OpenFile(
+		filepath.Join(dirPath, logFileName),
+		os.O_RDWR|os.O_CREATE|os.O_TRUNC,
+		0700,
+	)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return file, nil
+}

--- a/cloud/openssh/sshshim/logger.go
+++ b/cloud/openssh/sshshim/logger.go
@@ -27,8 +27,10 @@ func EnableDebug() {
 	debug.Log("started sshshim\n")
 }
 
-// logFile captures output when there is a failure
-// NOTE: we should limit the size of this log file.
+// logFile captures output for logging and when there is a failure
+// NOTE: Ideally, we should limit the size of this log file, but it is always truncated
+// because only the last ssh invocation (which may have failed) has its output saved.
+// So size should hopefully not be crazy big.
 func logFile() (io.Writer, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/debug/debug.go
+++ b/debug/debug.go
@@ -2,6 +2,7 @@ package debug
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"strconv"
@@ -22,6 +23,10 @@ func Enable() {
 	log.SetPrefix("[DEBUG] ")
 	log.SetFlags(log.Llongfile | log.Ldate | log.Ltime)
 	_ = log.Output(2, "Debug mode enabled.")
+}
+
+func SetOutput(w io.Writer) {
+	log.SetOutput(w)
 }
 
 func Log(format string, v ...any) {


### PR DESCRIPTION
## Summary

This PR hooks up the ssh command invocation.

Two design choices:

1. Choose to have the `ssh` symlink in `~/.config/devbox/ssh/shims` point to `devbox` binary, and have devbox first check if the `args[0]` is `ssh` before starting the cobra logic for regular commands. This ensures that all flags are handled directly by ssh, instead of cobra. The alternate design would be implementing `devbox cloud ssh` command which relies on cobra parsing flags, and any global devbox flags would interfere.

2. Choose syscall.Exec instead of exec.Cmd so that we preserve the exit code and environment, and the current process is replaced by ssh. Without this, we'd see errors during mutagen sync: the mutagen binary would fail to be copied to Beta, the remote machine. 

Also make a small fix to ensure we always overwrite the ssh and scp symlinks to point to the most-recent devbox (for ssh) and scp (for scp) binary locations.

## How was it tested?

```
>  mutagen sync terminate -a && mutagen daemon stop
>  DEVBOX_FEATURE_SSH_SHIM=1 DEVBOX_DEBUG=1 DEVBOX_VM=savil@21781990f34e89.vm.devbox-vms.internal devbox cloud shell
```

NOTE: future work would require managing any running mutagen daemon so it is started with the MUTAGEN_SSH_PATH 



