### PR TITLE
[nix] Improve nix installer

### DIFF
--- a/nix/install.go
+++ b/nix/install.go
@@ -25,13 +25,13 @@ func Install() error {
 	defer r.Close()
 	defer w.Close()
 
-	cmd := exec.Command("sudo", "sh", "-c", installScript)
+	cmd := exec.Command("sh", "-c", installScript, "--", "--daemon")
 	// Attach stdout but no stdin. This makes the command run in non-TTY mode
 	// which skips the interactive prompts.
 	// We could attach stderr? but the stdout prompt is pretty useful.
 	cmd.Stdin = nil
 	cmd.Stdout = w
-	cmd.Stderr = nil
+	cmd.Stderr = w
 
 	fmt.Println("Installing Nix. This will require sudo access.")
 	if err = cmd.Start(); err != nil {


### PR DESCRIPTION
## Summary

A few small changes:

* No more sudo up-front. This breaks situations where user is already root but sudo is not available
* Default to `--daemon` (multi-user) install. This makes the macOS and linux installs the same
* pipe error to stdout. Helps debug issues

## How was it tested?

* Ran `devbox setup nix` on mac and ubuntu (via docker)
