### PR TITLE
[cloud] ssh shim part 4: detect stopped vm, and terminate mutagen sessions

### DIFF
--- a/boxcli/root.go
+++ b/boxcli/root.go
@@ -61,11 +61,21 @@ func Execute(ctx context.Context, args []string) int {
 	return exe.Execute(ctx, args)
 }
 
+// TODO savil. Add Sentry and other monitoring.
 func executeSSH() int {
 	sshshim.EnableDebug() // Always enable for now.
 	debug.Log("os.Args: %v", os.Args)
+
+	if alive, err := sshshim.EnsureLiveVMOrTerminateMutagenSessions(os.Args[1:]); err != nil {
+		debug.Log("EnsureLiveVMOrTerminateMutagenSessions error: %v", err)
+		fmt.Fprintf(os.Stderr, "%v", err)
+		return 1
+	} else if !alive {
+		return 0
+	}
+
 	if err := sshshim.InvokeSSHOrSCPCommand(os.Args); err != nil {
-		debug.Log("ERROR: %v", err)
+		debug.Log("InvokeSSHorSCPCommand error: %v", err)
 		fmt.Fprintf(os.Stderr, "%v", err)
 		return 1
 	}

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -18,6 +18,7 @@ import (
 	"github.com/fatih/color"
 	"go.jetpack.io/devbox/boxcli/featureflag"
 	"go.jetpack.io/devbox/cloud/mutagen"
+	"go.jetpack.io/devbox/cloud/mutagenbox"
 	"go.jetpack.io/devbox/cloud/openssh"
 	"go.jetpack.io/devbox/cloud/openssh/sshshim"
 	"go.jetpack.io/devbox/cloud/stepper"
@@ -136,11 +137,11 @@ func syncFiles(username, hostname, configDir string) error {
 
 	// TODO: instead of id, have the server return the machine's name and use that
 	// here to. It'll make things easier to debug.
-	id, _, _ := strings.Cut(hostname, ".")
+	machineID, _, _ := strings.Cut(hostname, ".")
 	_, err = mutagen.Sync(&mutagen.SessionSpec{
 		// If multiple projects can sync to the same machine, we need the name to also include
 		// the project's id.
-		Name:        fmt.Sprintf("devbox-%s", id),
+		Name:        fmt.Sprintf("devbox-%s", machineID),
 		AlphaPath:   configDir,
 		BetaAddress: fmt.Sprintf("%s@%s", username, hostname),
 		// It's important that the beta path is a "clean" directory that will contain *only*
@@ -151,6 +152,7 @@ func syncFiles(username, hostname, configDir string) error {
 		EnvVars:   envVars,
 		IgnoreVCS: true,
 		SyncMode:  "two-way-resolved",
+		Labels:    mutagenbox.MutagenSyncLabels(machineID),
 	})
 	if err != nil {
 		return err

--- a/cloud/mutagen/wrapper.go
+++ b/cloud/mutagen/wrapper.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -152,7 +153,7 @@ func debugPrintExecCmd(cmd *exec.Cmd) {
 
 // envAsKeyValueStrings prepares the env-vars in key=value format to add to the command to be run
 func envAsKeyValueStrings(envVars map[string]string) []string {
-	newEnv := []string{}
+	newEnv := os.Environ()
 	for k, v := range envVars {
 		newEnv = append(newEnv, fmt.Sprintf("%s=%s", k, v))
 	}

--- a/cloud/mutagen/wrapper.go
+++ b/cloud/mutagen/wrapper.go
@@ -62,7 +62,7 @@ func List(envVars map[string]string, names ...string) ([]Session, error) {
 	out, err := cmd.CombinedOutput()
 
 	if err != nil {
-		debug.Log("List error: %s, and out: %s", err, out)
+		debug.Log("List error: %s, and out: %s", err, string(out))
 		if e := (&exec.ExitError{}); errors.As(err, &e) {
 			errMsg := strings.TrimSpace(string(out))
 			// Special handle the case where no sessions are found:
@@ -110,10 +110,8 @@ func Reset(envVars map[string]string, names ...string) error {
 func Terminate(env map[string]string, labels map[string]string, names ...string) error {
 	args := []string{"sync", "terminate"}
 
-	if len(labels) > 0 {
-		for k, v := range labels {
-			args = append(args, "--label-selector", fmt.Sprintf("%s=%s", k, v))
-		}
+	for k, v := range labels {
+		args = append(args, "--label-selector", fmt.Sprintf("%s=%s", k, v))
 	}
 
 	args = append(args, names...)
@@ -129,7 +127,7 @@ func execMutagen(args []string, envVars map[string]string) error {
 	out, err := cmd.CombinedOutput()
 
 	if err != nil {
-		debug.Log("execMutagen error: %s, out: %s", err, out)
+		debug.Log("execMutagen error: %s, out: %s", err, string(out))
 		if e := (&exec.ExitError{}); errors.As(err, &e) {
 			return errors.New(strings.TrimSpace(string(out)))
 		}
@@ -182,7 +180,7 @@ func envAsKeyValueStrings(userEnv map[string]string) []string {
 	}
 
 	// Convert the envMap to an envList
-	envList := []string{}
+	envList := make([]string, 0, len(envMap))
 	for k, v := range envMap {
 		envList = append(envList, fmt.Sprintf("%s=%s", k, v))
 	}

--- a/cloud/mutagenbox/doc.go
+++ b/cloud/mutagenbox/doc.go
@@ -4,5 +4,5 @@ package mutagenbox
 // we need to manage mutagen for the devbox cloud.
 //
 // Also, resolves some compile cycles:
-// cloud depends on [mutagenbox, sshshim, mutagen]
-// sshhim depends on [mutagenbox, mutagen]
+//   - [cloud] depends on [mutagenbox], [sshshim], and [mutagen].
+//   - [sshshim] depends on [mutagenbox] and [mutagen].

--- a/cloud/mutagenbox/doc.go
+++ b/cloud/mutagenbox/doc.go
@@ -1,0 +1,8 @@
+package mutagenbox
+
+// mutagenbox is a package that encapsulates state and logic specific to how
+// we need to manage mutagen for the devbox cloud.
+//
+// Also, resolves some compile cycles:
+// cloud depends on [mutagenbox, sshshim, mutagen]
+// sshhim depends on [mutagenbox, mutagen]

--- a/cloud/mutagenbox/mutagenbox.go
+++ b/cloud/mutagenbox/mutagenbox.go
@@ -4,8 +4,10 @@ import (
 	"go.jetpack.io/devbox/cloud/mutagen"
 )
 
-// TerminateForMachine is a devbox-specific API that calls the generic mutagen terminate API.
-func TerminateForMachine(machineID string, env map[string]string) error {
+// TerminateSessionsForMachine is a devbox-specific API that calls the generic mutagen terminate API.
+// It relies on the mutagen-sync-session's labels to identify which sessions to terminate for
+// a particular machine (fly VM).
+func TerminateSessionsForMachine(machineID string, env map[string]string) error {
 	labels := MutagenSyncLabels(machineID)
 	return mutagen.Terminate(env, labels)
 }

--- a/cloud/mutagenbox/mutagenbox.go
+++ b/cloud/mutagenbox/mutagenbox.go
@@ -1,0 +1,18 @@
+package mutagenbox
+
+import (
+	"go.jetpack.io/devbox/cloud/mutagen"
+)
+
+// TerminateForMachine is a devbox-specific API that calls the generic mutagen terminate API.
+func TerminateForMachine(machineID string, envVars map[string]string) error {
+	labels := MutagenSyncLabels(machineID)
+	return mutagen.Terminate(envVars, labels)
+}
+
+// Ideally, this should be in the cloud package but it leads to a compile cycle.
+func MutagenSyncLabels(machineID string) map[string]string {
+	return map[string]string{
+		"devbox-vm": machineID,
+	}
+}

--- a/cloud/mutagenbox/mutagenbox.go
+++ b/cloud/mutagenbox/mutagenbox.go
@@ -5,9 +5,9 @@ import (
 )
 
 // TerminateForMachine is a devbox-specific API that calls the generic mutagen terminate API.
-func TerminateForMachine(machineID string, envVars map[string]string) error {
+func TerminateForMachine(machineID string, env map[string]string) error {
 	labels := MutagenSyncLabels(machineID)
-	return mutagen.Terminate(envVars, labels)
+	return mutagen.Terminate(env, labels)
 }
 
 // Ideally, this should be in the cloud package but it leads to a compile cycle.

--- a/cloud/openssh/sshshim/logger.go
+++ b/cloud/openssh/sshshim/logger.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	logFileName = "ssh.log"
+	logFileName = "logs.txt"
 )
 
 func EnableDebug() {

--- a/cloud/openssh/sshshim/mutagen.go
+++ b/cloud/openssh/sshshim/mutagen.go
@@ -45,7 +45,7 @@ func terminateMutagenSessions(vmAddr string) error {
 				"For completeness, VmAddr is %s", hostname, vmAddr)
 	}
 
-	return mutagenbox.TerminateForMachine(machineID, nil /*env*/)
+	return mutagenbox.TerminateSessionsForMachine(machineID, nil /*env*/)
 }
 
 func checkActiveVM(vmAddr string) (bool, error) {

--- a/cloud/openssh/sshshim/mutagen.go
+++ b/cloud/openssh/sshshim/mutagen.go
@@ -45,14 +45,7 @@ func terminateMutagenSessions(vmAddr string) error {
 				"For completeness, VmAddr is %s", hostname, vmAddr)
 	}
 
-	envVars := map[string]string{
-		// Mutagen sets this variable for ssh/scp scenarios, which then expect interactivity?
-		// https://github.com/mutagen-io/mutagen/blob/b97ff3764a6a6cb91b48ad27def078f6d6a76e24/cmd/mutagen/main.go#L89-L94
-		//
-		// We turn it off, otherwise it rejects the mutagen command we are about to invoke.
-		"MUTAGEN_PROMPTER": "",
-	}
-	return mutagenbox.TerminateForMachine(machineID, envVars)
+	return mutagenbox.TerminateForMachine(machineID, nil /*env*/)
 }
 
 func checkActiveVM(vmAddr string) (bool, error) {

--- a/cloud/openssh/sshshim/mutagen.go
+++ b/cloud/openssh/sshshim/mutagen.go
@@ -1,0 +1,96 @@
+package sshshim
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+
+	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/cloud/mutagenbox"
+	"go.jetpack.io/devbox/debug"
+)
+
+// returns true if a liveVM is found, OR sshArgs were connecting to a server that is not a devbox-VM.
+// returns false iff the sshArgs were connecting to a devbox VM AND a deadVM is found.
+func EnsureLiveVMOrTerminateMutagenSessions(sshArgs []string) (bool, error) {
+	vmAddr := vmAddressIfAny(sshArgs)
+
+	debug.Log("Found vmAddr: %s", vmAddr)
+	if vmAddr == "" {
+		// We support the no Vm scenario, in case mutagen ssh-es into another server
+		// TODO savil. Revisit the no VM scenario if we can control the mutagen daemon for devbox-only
+		// syncing via MUTAGEN_DATA_DIRECTORY.
+		return true, nil
+	}
+
+	if isActive, err := checkActiveVM(vmAddr); err != nil {
+		return false, errors.WithStack(err)
+	} else if !isActive {
+		debug.Log("terminating mutagen session for vm: %s", vmAddr)
+		// If no vm is active, then we should terminate the running mutagen sessions
+		return false, terminateMutagenSessions(vmAddr)
+	}
+	return true, nil
+}
+
+func terminateMutagenSessions(vmAddr string) error {
+	username, hostname, found := strings.Cut(vmAddr, "@")
+	if !found {
+		hostname = username
+	}
+	machineID, _, found := strings.Cut(hostname, ".")
+	if !found {
+		return errors.Errorf(
+			"expected to find a period (.) in hostname (%s), but did not. "+
+				"For completeness, VmAddr is %s", hostname, vmAddr)
+	}
+
+	envVars := map[string]string{
+		// Mutagen sets this variable for ssh/scp scenarios, which then expect interactivity?
+		// https://github.com/mutagen-io/mutagen/blob/b97ff3764a6a6cb91b48ad27def078f6d6a76e24/cmd/mutagen/main.go#L89-L94
+		//
+		// We turn it off, otherwise it rejects the mutagen command we are about to invoke.
+		"MUTAGEN_PROMPTER": "",
+	}
+	return mutagenbox.TerminateForMachine(machineID, envVars)
+}
+
+func checkActiveVM(vmAddr string) (bool, error) {
+
+	cmd := exec.Command("ssh", vmAddr, "echo 'alive'")
+
+	var bufErr, bufOut bytes.Buffer
+	cmd.Stderr = &bufErr
+	cmd.Stdout = &bufOut
+
+	err := cmd.Run()
+	if err != nil {
+		if err.Error() == "exit status 255" {
+			return false, nil
+		}
+		// For now, any error is deemed to indicate a VM that is no longer running.
+		// We can tighten this by listening for the specific exit error code (255)
+		debug.Log("Error checking for Active VM: %s. Stdout: %s, Stderr: %s, cmd.Run err: %s\n",
+			vmAddr,
+			bufOut.String(),
+			bufErr.String(),
+			err,
+		)
+		return false, errors.WithStack(err)
+	}
+	return true, nil
+}
+
+// vmAddressIfAny will seek to find the devbox-vm hostname if it exists
+// in the sshArgs. If not, it returns an empty string.
+func vmAddressIfAny(sshArgs []string) string {
+
+	const devboxVMAddressSuffix = "devbox-vms.internal"
+	for _, sshArg := range sshArgs {
+		if strings.HasSuffix(sshArg, devboxVMAddressSuffix) {
+			return sshArg
+		}
+	}
+	debug.Log("Did not find vm address in ssh args: %v", sshArgs)
+	return ""
+}


### PR DESCRIPTION
## Summary

This PR adds logic for the `sshshim` to check for a live VM. If the VM is not reachable,
then it should terminate the sync session. We label each sync with the machineID
so that cloud-shells to the same vm get the same label for their mutagen sync.

To test for liveness, I currently execute a `echo "alive"` command in the VM. There
are likely better ways to do this. Suggestions welcome!

NOTE:
For now, I pass-thru the ssh/scp command if the arguments indicate that the server
is not a devbox-vm. In the next PR, I'll see if we can have a dedicated mutagen daemon
via setting MUTAGEN_DATA_DIRECTORY, in which case we can more strongly impose
that the ssh/scp command can be executed only with a liveVM. UPDATE: this works!

NOTE:
I also discovered that I need to manually empty-out the MUTAGEN_PROMPTER env-var.
This is done, because mutagen otherwise will expect a certain (interactive?) prompt
in the arguments to the mutagen CLI. Mutagen does set this env-var on all ssh/scp executions, but I'm a bit unclear on why this is hooked up. 

## How was it tested?

0. ensure no active mutagen daemon (next PR should take away this step)

1. manually start a vm (command omitted due to closed source, but happy to share)
2. `DEVBOX_FEATURE_SSH_SHIM=1 DEVBOX_VM=username@vmaddress devbox cloud shell`
3. `cd ~/.config/devbox/ssh/shims` and `tail -f logs.txt` to monitor the shim.
4. exit the cloud shell 
5. `fly m stop <id>` to stop the vm
6. `touch foo.txt` in the devbox project folder to trigger a sync action
7. wait for the `logs.txt` to show the `mutagen sync terminate` command.
8. `~/.cache/mutagen/bin/mutagen sync list` to confirm the session is terminated.
