### PR TITLE
[services] Add services to package configs (plugins)

### DIFF
--- a/boxcli/root.go
+++ b/boxcli/root.go
@@ -34,6 +34,7 @@ func RootCmd() *cobra.Command {
 	command.AddCommand(PlanCmd())
 	command.AddCommand(RemoveCmd())
 	command.AddCommand(RunCmd())
+	command.AddCommand(ServicesCmd())
 	command.AddCommand(SetupCmd())
 	command.AddCommand(ShellCmd())
 	command.AddCommand(VersionCmd())

--- a/boxcli/services.go
+++ b/boxcli/services.go
@@ -1,0 +1,98 @@
+// Copyright 2022 Jetpack Technologies Inc and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package boxcli
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"go.jetpack.io/devbox"
+	"go.jetpack.io/devbox/boxcli/featureflag"
+)
+
+type servicesCmdFlags struct {
+	config configFlags
+}
+
+func ServicesCmd() *cobra.Command {
+	flags := servicesCmdFlags{}
+	servicesCommand := &cobra.Command{
+		Use:    "services",
+		Hidden: !featureflag.PKGConfig.Enabled(),
+		Short:  "Interact with devbox services",
+	}
+
+	lsCommand := &cobra.Command{
+		Use:   "ls",
+		Short: "List available services",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listServices(cmd, flags)
+		},
+	}
+
+	startCommand := &cobra.Command{
+		Use:   "start [service]",
+		Short: "Starts service",
+		Args:  cobra.ExactArgs(1),
+		PersistentPreRunE: validateInShell(
+			"You must be in devbox shell to start services. Please run " +
+				"`devbox shell` first.",
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return startService(args[0], flags)
+		},
+	}
+
+	stopCommand := &cobra.Command{
+		Use:   "stop [service]",
+		Short: "Stops service",
+		Args:  cobra.ExactArgs(1),
+		PersistentPreRunE: validateInShell(
+			"You must be in devbox shell to stop services. Please run " +
+				"`devbox shell` first.",
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return stopService(args[0], flags)
+		},
+	}
+
+	flags.config.register(servicesCommand)
+	servicesCommand.AddCommand(lsCommand)
+	servicesCommand.AddCommand(startCommand)
+	servicesCommand.AddCommand(stopCommand)
+	return servicesCommand
+}
+
+func listServices(cmd *cobra.Command, flags servicesCmdFlags) error {
+	box, err := devbox.Open(flags.config.path, os.Stdout)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	services, err := box.Services()
+	if err != nil {
+		return err
+	}
+	for _, service := range services {
+		cmd.Println(service.Name)
+	}
+	return nil
+}
+
+func startService(service string, flags servicesCmdFlags) error {
+	box, err := devbox.Open(flags.config.path, os.Stdout)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	return box.StartService(service)
+}
+
+func stopService(service string, flags servicesCmdFlags) error {
+	box, err := devbox.Open(flags.config.path, os.Stdout)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	return box.StopService(service)
+}

--- a/boxcli/shell.go
+++ b/boxcli/shell.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
+	"go.jetpack.io/devbox/boxcli/usererr"
 	"go.jetpack.io/devbox/nix"
 )
 
@@ -101,4 +102,13 @@ func parseShellArgs(cmd *cobra.Command, args []string, flags shellCmdFlags) (str
 	cmds := args[index:]
 
 	return path, cmds, nil
+}
+
+func validateInShell(msg string) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if devbox.IsDevboxShellEnabled() {
+			return nil
+		}
+		return usererr.New(msg)
+	}
 }

--- a/devbox.go
+++ b/devbox.go
@@ -422,6 +422,18 @@ func (d *Devbox) convertToBuildPlan() *plansdk.BuildPlan {
 	}
 }
 
+func (d *Devbox) Services() (pkgcfg.Services, error) {
+	return pkgcfg.GetServices(d.cfg.Packages, d.configDir)
+}
+
+func (d *Devbox) StartService(serviceName string) error {
+	return pkgcfg.StartService(d.cfg.Packages, serviceName, d.configDir, d.writer)
+}
+
+func (d *Devbox) StopService(serviceName string) error {
+	return pkgcfg.StopService(d.cfg.Packages, serviceName, d.configDir, d.writer)
+}
+
 func (d *Devbox) generateShellFiles() error {
 	plan, err := d.ShellPlan()
 	if err != nil {

--- a/devbox.json
+++ b/devbox.json
@@ -1,7 +1,10 @@
 {
   "packages": [
     "go_1_19",
-    "golangci-lint"
+    "golangci-lint",
+    "apacheHttpd",
+    "nginx",
+    "php"
   ],
   "shell": {
     "init_hook": "export \"GOROOT=$(go env GOROOT)\""

--- a/devbox.json
+++ b/devbox.json
@@ -1,10 +1,7 @@
 {
   "packages": [
     "go_1_19",
-    "golangci-lint",
-    "apacheHttpd",
-    "nginx",
-    "php"
+    "golangci-lint"
   ],
   "shell": {
     "init_hook": "export \"GOROOT=$(go env GOROOT)\""

--- a/pkgcfg/info.go
+++ b/pkgcfg/info.go
@@ -25,6 +25,10 @@ func PrintReadme(
 		return err
 	}
 
+	if err = printServices(cfg, w, markdown); err != nil {
+		return err
+	}
+
 	if err = printCreateFiles(cfg, w, markdown); err != nil {
 		return err
 	}
@@ -57,6 +61,24 @@ func printReadme(cfg *config, w io.Writer, markdown bool) error {
 	return errors.WithStack(err)
 }
 
+func printServices(cfg *config, w io.Writer, markdown bool) error {
+	if len(cfg.Services) == 0 {
+		return nil
+	}
+	services := ""
+	for _, service := range cfg.Services {
+		services += fmt.Sprintf("* %[1]s\n", service.Name)
+	}
+
+	_, err := fmt.Fprintf(
+		w,
+		"%sServices:\n%s\nUse `devbox services start|stop [service]` to interact with services\n\n",
+		lo.Ternary(markdown, "### ", ""),
+		services,
+	)
+	return errors.WithStack(err)
+}
+
 func printCreateFiles(cfg *config, w io.Writer, markdown bool) error {
 	if len(cfg.CreateFiles) == 0 {
 		return nil
@@ -71,7 +93,7 @@ func printCreateFiles(cfg *config, w io.Writer, markdown bool) error {
 
 	_, err := fmt.Fprintf(
 		w,
-		"%sThis configuration creates the following helper shims:\n%s\n",
+		"%sThis configuration creates the following helper files:\n%s\n",
 		lo.Ternary(markdown, "### ", ""),
 		shims,
 	)

--- a/pkgcfg/package-configuration/apacheHttpd.json
+++ b/pkgcfg/package-configuration/apacheHttpd.json
@@ -1,12 +1,18 @@
 {
   "name": "apache",
   "version": "0.0.1",
-  "readme": "To start use \"apachectl start -f $HTTPD_CONFDIR/httpd.conf\".\n\nIf you with to edit the config file, please copy it out of the .devbox directory.",
+  "readme": "If you with to edit the config file, please copy it out of the .devbox directory.",
   "env": {
     "HTTPD_CONFDIR": "{{ .DevboxRoot }}/conf/apache",
     "HTTPD_PORT": "8080"
   },
   "create_files": {
     ".devbox/conf/apache/httpd.conf": "apache/httpd.conf"
+  },
+  "services": {
+    "apache": {
+      "start": "apachectl start -f $HTTPD_CONFDIR/httpd.conf",
+      "stop": "apachectl stop -f $HTTPD_CONFDIR/httpd.conf"
+    }
   }
 }

--- a/pkgcfg/package-configuration/nginx.json
+++ b/pkgcfg/package-configuration/nginx.json
@@ -1,14 +1,19 @@
 {
   "name": "nginx",
   "version": "0.0.1",
-  "readme": "To start nginx use command \"nginx\"\nnginx is configured to use .devbox/conf/nginx.conf\n\nTo customize:\n* Use $NGINX_CONFDIR to change the configuration directory\n* Use $NGINX_LOGDIR to change the log directory\n* Use $NGINX_PIDDIR to change the pid directory\n* Use $NGINX_RUNDIR to change the run directory\n* Use $NGINX_SITESDIR to change the sites directory\n* Use $NGINX_TMPDIR to change the tmp directory. Use $NGINX_USER to change the user\n* Use $NGINX_GROUP to customize.",
+  "readme": "nginx is configured to use .devbox/conf/nginx.conf\n\nTo customize:\n* Use $NGINX_CONFDIR to change the configuration directory\n* Use $NGINX_LOGDIR to change the log directory\n* Use $NGINX_PIDDIR to change the pid directory\n* Use $NGINX_RUNDIR to change the run directory\n* Use $NGINX_SITESDIR to change the sites directory\n* Use $NGINX_TMPDIR to change the tmp directory. Use $NGINX_USER to change the user\n* Use $NGINX_GROUP to customize.",
   "env": {
     "NGINX_CONFDIR": "{{ .DevboxRoot }}/conf/nginx"
   },
   "create_files": {
     ".devbox/conf/nginx/temp": "",
     ".devbox/conf/nginx/nginx.conf": "nginx/nginx.conf",
-    ".devbox/conf/nginx/fastcgi.conf": "nginx/fastcgi.conf",
-    ".devbox/conf/nginx/bin/nginx": "nginx/nginx"
+    ".devbox/conf/nginx/fastcgi.conf": "nginx/fastcgi.conf"
+  },
+  "services": {
+    "nginx": {
+      "start": "nginx -p $NGINX_CONFDIR -c nginx.conf -e error.log -g \"pid nginx.pid;\"",
+      "stop": "pkill nginx"
+    }
   }
 }

--- a/pkgcfg/package-configuration/nginx/nginx
+++ b/pkgcfg/package-configuration/nginx/nginx
@@ -1,3 +1,0 @@
-echo "Starting nginx with command:"
-echo "{{ .DevboxProfileDefault }}/bin/nginx -p $NGINX_CONFDIR -c nginx.conf -e error.log -g \"pid nginx.pid;\""
-{{ .DevboxProfileDefault }}/bin/nginx -p $NGINX_CONFDIR -c nginx.conf -e error.log -g "pid nginx.pid;"

--- a/pkgcfg/package-configuration/php.json
+++ b/pkgcfg/package-configuration/php.json
@@ -2,12 +2,17 @@
   "name": "php",
   "version": "0.0.1",
   "match": "^php[0-9]*$",
-  "readme": "PHP is compiled with default extensions. If you would like to use non-default extensions you can add them with devbox add php81Extensions.{extension} . For example, for the memcache extension you can do `devbox add php81Extensions.memcached`.\n\nTo run with apache/nginx you may want to use the php-fpm shim.",
+  "readme": "PHP is compiled with default extensions. If you would like to use non-default extensions you can add them with devbox add php81Extensions.{extension} . For example, for the memcache extension you can do `devbox add php81Extensions.memcached`.",
   "env": {
     "PHPFPM_PORT": "8082"
   },
   "create_files": {
-    ".devbox/conf/php/php-fpm": "php/php-fpm",
     ".devbox/conf/php/php-fpm.conf": "php/php-fpm.conf"
+  },
+  "services": {
+    "php-fpm": {
+      "start": "php-fpm -y {{ .DevboxRoot }}/conf/php/php-fpm.conf -p $PWD",
+      "stop": "pkill php-fpm"
+    }
   }
 }

--- a/pkgcfg/package-configuration/php/php-fpm
+++ b/pkgcfg/package-configuration/php/php-fpm
@@ -1,1 +1,0 @@
-{{ .DevboxProfileDefault }}/bin/php-fpm -y {{ .DevboxRoot }}/conf/php/php-fpm.conf -p $PWD

--- a/pkgcfg/pkgcfg.go
+++ b/pkgcfg/pkgcfg.go
@@ -22,6 +22,7 @@ type config struct {
 	CreateFiles map[string]string `json:"create_files"`
 	Env         map[string]string `json:"env"`
 	Readme      string            `json:"readme"`
+	Services    Services          `json:"services"`
 }
 
 func CreateFilesAndShowReadme(pkg, rootDir string) error {

--- a/pkgcfg/services.go
+++ b/pkgcfg/services.go
@@ -1,0 +1,84 @@
+package pkgcfg
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+
+	"go.jetpack.io/devbox/boxcli/usererr"
+)
+
+type Services map[string]service
+
+type service struct {
+	Name  string `json:"name"`
+	Start string `json:"start"`
+	Stop  string `json:"stop"`
+}
+
+func GetServices(pkgs []string, rootDir string) (Services, error) {
+	services := map[string]service{}
+	for _, pkg := range pkgs {
+		c, err := getConfig(pkg, rootDir)
+		if err != nil {
+			return nil, err
+		}
+		for name, svc := range c.Services {
+			svc.Name = name
+			services[name] = svc
+		}
+	}
+	return services, nil
+}
+
+func (s *Services) UnmarshalJSON(b []byte) error {
+	var m map[string]service
+	if err := json.Unmarshal(b, &m); err != nil {
+		return err
+	}
+	*s = make(Services)
+	for name, svc := range m {
+		svc.Name = name
+		(*s)[name] = svc
+	}
+	return nil
+}
+
+func StartService(pkgs []string, name, rootDir string, out io.Writer) error {
+	services, err := GetServices(pkgs, rootDir)
+	if err != nil {
+		return err
+	}
+	service, found := services[name]
+	if !found {
+		return usererr.New("Service not found")
+	}
+	cmd := exec.Command("sh", "-c", service.Start)
+	cmd.Stdout = out
+	cmd.Stderr = out
+	err = cmd.Run()
+	if err == nil {
+		fmt.Fprintf(out, "Service %q started", name)
+	}
+	return usererr.WithUserMessage(err, "Service %q failed to start", name)
+}
+
+func StopService(pkgs []string, name, rootDir string, out io.Writer) error {
+	services, err := GetServices(pkgs, rootDir)
+	if err != nil {
+		return err
+	}
+	service, found := services[name]
+	if !found {
+		return usererr.New("Service not found")
+	}
+	cmd := exec.Command("sh", "-c", service.Stop)
+	cmd.Stdout = out
+	cmd.Stderr = out
+	err = cmd.Run()
+	if err == nil {
+		fmt.Fprintf(out, "Service %q stopped", name)
+	}
+	return usererr.WithUserMessage(err, "Service %q failed to stop", name)
+}


### PR DESCRIPTION
## Summary

This adds new `services` command (behind flag). It allows:

`devbox services ls`
`devbox services start|stop [service]`

Services are configured using package configuration (plugins)

Also modified `info` command to include services instructions.

## How was it tested?

```
devbox services ls
devbox services start nginx
devbox services start apache
devbox services start php-fpm
...
devbox services stop nginx
devbox services stop apache
devbox services stop php-fpm
```