### PR TITLE
[services] Allow running services out of shell

### DIFF
--- a/boxcli/services.go
+++ b/boxcli/services.go
@@ -37,10 +37,6 @@ func ServicesCmd() *cobra.Command {
 		Use:   "start [service]",
 		Short: "Starts service",
 		Args:  cobra.ExactArgs(1),
-		PersistentPreRunE: validateInShell(
-			"You must be in devbox shell to start services. Please run " +
-				"`devbox shell` first.",
-		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return startService(args[0], flags)
 		},
@@ -50,10 +46,6 @@ func ServicesCmd() *cobra.Command {
 		Use:   "stop [service]",
 		Short: "Stops service",
 		Args:  cobra.ExactArgs(1),
-		PersistentPreRunE: validateInShell(
-			"You must be in devbox shell to stop services. Please run " +
-				"`devbox shell` first.",
-		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return stopService(args[0], flags)
 		},

--- a/boxcli/shell.go
+++ b/boxcli/shell.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
-	"go.jetpack.io/devbox/boxcli/usererr"
 	"go.jetpack.io/devbox/nix"
 )
 
@@ -102,13 +101,4 @@ func parseShellArgs(cmd *cobra.Command, args []string, flags shellCmdFlags) (str
 	cmds := args[index:]
 
 	return path, cmds, nil
-}
-
-func validateInShell(msg string) func(cmd *cobra.Command, args []string) error {
-	return func(cmd *cobra.Command, args []string) error {
-		if devbox.IsDevboxShellEnabled() {
-			return nil
-		}
-		return usererr.New(msg)
-	}
 }

--- a/nix/nix.go
+++ b/nix/nix.go
@@ -33,12 +33,13 @@ func (i *Info) String() string {
 	return fmt.Sprintf("%s-%s", i.Name, i.Version)
 }
 
-func Exec(path string, command []string) error {
+func Exec(path string, command []string, env []string) error {
 	runCmd := strings.Join(command, " ")
 	cmd := exec.Command("nix-shell", path, "--run", runCmd)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.Env = append(os.Environ(), env...)
 	return errors.WithStack(cmd.Run())
 }
 


### PR DESCRIPTION
## Summary

This change allows starting and stopping services out of shell.

This PR exposed a few bugs in package configuration. Specifically we were not setting up the bin path and environment variables for package configuration when running scripts and when doing nix.Exec.

We have 3 different functions that need very similar setup:

* shell
* RunScript
* Exec

They all need path and environment variables to be setup in the same way. Currently we have a lot of copy paste between shell and RunScript, and Exec is done in a different way. Maybe we can unify all of these?

## How was it tested?

Tested out of shell

```
devbox add nginx
devbox services start nginx
```

To test RunScript added new script:

```json
"scripts": {
  "foo": "echo NGINX_CONFDIR=$NGINX_CONFDIR"
}
```

and ran

```
devbox run foo
```


