### PR TITLE
[cloud] ssh shim part 5: run own mutagen daemon

### DIFF
--- a/cloud/mutagen/wrapper.go
+++ b/cloud/mutagen/wrapper.go
@@ -140,10 +140,10 @@ func execMutagen(args []string, envVars map[string]string) error {
 
 // debugPrintExecCmd prints the command to be run, along with MUTAGEN env-vars
 func debugPrintExecCmd(cmd *exec.Cmd) {
-	envPrint := "No MUTAGEN env vars"
+	envPrint := ""
 	for _, cmdEnv := range cmd.Env {
 		if strings.HasPrefix(cmdEnv, "MUTAGEN") {
-			envPrint = fmt.Sprintf("%s\n", cmdEnv)
+			envPrint = fmt.Sprintf("%s, %s", envPrint, cmdEnv)
 		}
 	}
 	debug.Log("running mutagen cmd %s with MUTAGEN env: %s", cmd.String(), envPrint)

--- a/cloud/mutagenbox/mutagenbox.go
+++ b/cloud/mutagenbox/mutagenbox.go
@@ -67,8 +67,7 @@ func createAndGetDataDir() (string, error) {
 	}
 
 	path := filepath.Join(home, dataDirPath)
-	// TODO savil. tighten the permissions.
-	if err := os.MkdirAll(path, 0777); err != nil {
+	if err := os.MkdirAll(path, 0700); err != nil {
 		return "", errors.WithStack(err)
 	}
 	return path, nil

--- a/cloud/mutagenbox/mutagenbox.go
+++ b/cloud/mutagenbox/mutagenbox.go
@@ -1,20 +1,75 @@
 package mutagenbox
 
 import (
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/boxcli/featureflag"
 	"go.jetpack.io/devbox/cloud/mutagen"
+)
+
+const (
+	// relative to user home i.e. ~
+	dataDirPath = ".config/devbox/mutagen"
 )
 
 // TerminateSessionsForMachine is a devbox-specific API that calls the generic mutagen terminate API.
 // It relies on the mutagen-sync-session's labels to identify which sessions to terminate for
 // a particular machine (fly VM).
-func TerminateSessionsForMachine(machineID string, env map[string]string) error {
-	labels := MutagenSyncLabels(machineID)
+func TerminateSessionsForMachine(machineID string, userEnv map[string]string) error {
+	labels := DefaultSyncLabels(machineID)
+
+	env, err := DefaultEnv()
+	if err != nil {
+		return err
+	}
+	// the user-specified env-vars get precedence over the defaultEnvVars
+	for k, v := range userEnv {
+		env[k] = v
+	}
+
 	return mutagen.Terminate(env, labels)
 }
 
-// Ideally, this should be in the cloud package but it leads to a compile cycle.
-func MutagenSyncLabels(machineID string) map[string]string {
+func DefaultSyncLabels(machineID string) map[string]string {
 	return map[string]string{
 		"devbox-vm": machineID,
 	}
+}
+
+func DefaultEnv() (map[string]string, error) {
+	if featureflag.SSHShim.Disabled() {
+		return map[string]string{}, nil
+	}
+
+	shimDir, err := ShimDir()
+	if err != nil {
+		return nil, err
+	}
+
+	mutagenDir, err := createAndGetDataDir()
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]string{
+		"MUTAGEN_SSH_PATH":       shimDir,
+		"MUTAGEN_DATA_DIRECTORY": mutagenDir,
+	}, nil
+}
+
+// createAndGetDataDir prepares the data directory for devbox's mutagen instance
+func createAndGetDataDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	path := filepath.Join(home, dataDirPath)
+	// TODO savil. tighten the permissions.
+	if err := os.MkdirAll(path, 0777); err != nil {
+		return "", errors.WithStack(err)
+	}
+	return path, nil
 }

--- a/cloud/mutagenbox/shim.go
+++ b/cloud/mutagenbox/shim.go
@@ -1,0 +1,19 @@
+package mutagenbox
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+const shimDirPath = ".config/devbox/ssh/shims"
+
+func ShimDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	shimDir := filepath.Join(home, shimDirPath)
+	return shimDir, nil
+}

--- a/cloud/openssh/sshshim/generate.go
+++ b/cloud/openssh/sshshim/generate.go
@@ -6,11 +6,8 @@ import (
 
 	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/boxcli/featureflag"
+	"go.jetpack.io/devbox/cloud/mutagenbox"
 	"go.jetpack.io/devbox/cloud/openssh"
-)
-
-const (
-	configShimDir = ".config/devbox/ssh/shims"
 )
 
 // Setup creates the ssh and scp symlinks
@@ -18,7 +15,7 @@ func Setup() error {
 	if featureflag.SSHShim.Disabled() {
 		return nil
 	}
-	shimDir, err := Dir()
+	shimDir, err := mutagenbox.ShimDir()
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -59,13 +56,4 @@ func makeSymlink(from string, target string) error {
 		}
 	}
 	return nil
-}
-
-func Dir() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", errors.WithStack(err)
-	}
-	shimDir := filepath.Join(home, configShimDir)
-	return shimDir, nil
 }

--- a/cloud/openssh/sshshim/logger.go
+++ b/cloud/openssh/sshshim/logger.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/cloud/mutagenbox"
 	"go.jetpack.io/devbox/debug"
 )
 
@@ -32,11 +33,10 @@ func EnableDebug() {
 // because only the last ssh invocation (which may have failed) has its output saved.
 // So size should hopefully not be crazy big.
 func logFile() (io.Writer, error) {
-	home, err := os.UserHomeDir()
+	dirPath, err := mutagenbox.ShimDir()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	dirPath := filepath.Join(home, configShimDir)
 
 	file, err := os.OpenFile(
 		filepath.Join(dirPath, logFileName),


### PR DESCRIPTION
## Summary

This PR enables running devbox's own mutagen daemon by setting MUTAGEN_DATA_DIRECTORY.

Refactored code so that more of the devbox-specific logic is centralized in `mutagenbox`
package, which then calls the generic `mutagen` package.

## How was it tested?

```
# start a non-devbox mutagen daemon
> brew install mutagen
> which mutagen 
/usr/local/bin/mutagen
> mutagen daemon start
> ps aux | grep mutagen
# confirm the daemon is running: `mutagen daemon start` will be an active process
```

Then:
1. manually start a vm (command omitted due to closed source, but happy to share)
2. `DEVBOX_FEATURE_SSH_SHIM=1 DEVBOX_VM=username@vmaddress devbox cloud shell`
3. `cd ~/.config/devbox/ssh/shims` and `tail -f logs.txt` to monitor the shim.
4. exit the cloud shell 
5. `fly m stop <id>` to stop the vm
6. `touch foo.txt` in the devbox project folder to trigger a sync action
7. wait for the `logs.txt` to show the `mutagen sync terminate` command.
8. `MUTAGEN_DATA_DIR=~/.config/devbox/mutagen ~/.cache/mutagen/bin/mutagen sync list` to confirm the session is terminated.

To confirm two distinct daemons are running:
- `ps aux | grep mutagen` to see two running mutagen daemons (i.e. two processes listed as `mutagen daemon start`)
- `MUTAGEN_DATA_DIR=~/.config/devbox/mutagen ~/.cache/mutagen/bin/mutagen daemon stop`
- `ps aux | grep mutagen` to see that the non-devbox mutagen daemon is still running.