### PR TITLE
[midcobra] add executionID

### DIFF
--- a/boxcli/midcobra/debug.go
+++ b/boxcli/midcobra/debug.go
@@ -16,7 +16,8 @@ import (
 )
 
 type DebugMiddleware struct {
-	flag *pflag.Flag
+	executionID string // uuid
+	flag        *pflag.Flag
 }
 
 var _ Middleware = (*DebugMiddleware)(nil)
@@ -62,5 +63,10 @@ func (d *DebugMiddleware) postRun(cmd *cobra.Command, args []string, runErr erro
 	}
 
 	st := debug.EarliestStackTrace(runErr)
-	debug.Log("Error: %v\n%+v", runErr, st)
+	debug.Log("Error: %v\nexecutionID:%s\n%+v\n", runErr, d.executionID, st)
+}
+
+func (d *DebugMiddleware) withExecutionID(execID string) Middleware {
+	d.executionID = execID
+	return d
 }

--- a/boxcli/midcobra/debug.go
+++ b/boxcli/midcobra/debug.go
@@ -63,7 +63,7 @@ func (d *DebugMiddleware) postRun(cmd *cobra.Command, args []string, runErr erro
 	}
 
 	st := debug.EarliestStackTrace(runErr)
-	debug.Log("Error: %v\nexecutionID:%s\n%+v\n", runErr, d.executionID, st)
+	debug.Log("Error: %v\nExecutionID:%s\n%+v\n", runErr, d.executionID, st)
 }
 
 func (d *DebugMiddleware) withExecutionID(execID string) Middleware {

--- a/boxcli/midcobra/midcobra.go
+++ b/boxcli/midcobra/midcobra.go
@@ -5,7 +5,7 @@ package midcobra
 
 import (
 	"context"
-	"strings"
+	"encoding/hex"
 
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
@@ -85,5 +85,6 @@ func executionID() string {
 	// An EventID must be 32 characters long, lowercase and not have any dashes.
 	//
 	// so we pre-process to match sentry's requirements:
-	return strings.ToLower(strings.ReplaceAll(uuid.New().String(), "-", ""))
+	id := uuid.New()
+	return hex.EncodeToString(id[:])
 }

--- a/boxcli/midcobra/midcobra.go
+++ b/boxcli/midcobra/midcobra.go
@@ -5,7 +5,9 @@ package midcobra
 
 import (
 	"context"
+	"strings"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 )
 
@@ -17,23 +19,32 @@ type Executable interface {
 type Middleware interface {
 	preRun(cmd *cobra.Command, args []string)
 	postRun(cmd *cobra.Command, args []string, runErr error)
+	withExecutionID(execID string) Middleware
 }
 
 func New(cmd *cobra.Command) Executable {
 	return &midcobraExecutable{
 		cmd:         cmd,
+		executionID: executionID(),
 		middlewares: []Middleware{},
 	}
 }
 
 type midcobraExecutable struct {
-	cmd         *cobra.Command
+	cmd *cobra.Command
+
+	// executionID identifies a unique execution of the devbox CLI
+	executionID string // uuid
+
 	middlewares []Middleware
 }
 
 var _ Executable = (*midcobraExecutable)(nil)
 
 func (ex *midcobraExecutable) AddMiddleware(mids ...Middleware) {
+	for index, m := range mids {
+		mids[index] = m.withExecutionID(ex.executionID)
+	}
 	ex.middlewares = append(ex.middlewares, mids...)
 }
 
@@ -62,4 +73,17 @@ func (ex *midcobraExecutable) Execute(ctx context.Context, args []string) int {
 	} else {
 		return 0
 	}
+}
+
+func executionID() string {
+	// google/uuid package's String() returns a value of the form:
+	// xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+	//
+	// but sentry's EventID specifies:
+	//
+	// > EventID is a hexadecimal string representing a unique uuid4 for an Event.
+	// An EventID must be 32 characters long, lowercase and not have any dashes.
+	//
+	// so we pre-process to match sentry's requirements:
+	return strings.ToLower(strings.ReplaceAll(uuid.New().String(), "-", ""))
 }

--- a/boxcli/midcobra/sentry.go
+++ b/boxcli/midcobra/sentry.go
@@ -1,1 +1,0 @@
-package midcobra

--- a/boxcli/midcobra/sentry.go
+++ b/boxcli/midcobra/sentry.go
@@ -1,0 +1,1 @@
+package midcobra


### PR DESCRIPTION
## Summary

**Motivation**
The sshshim command path bypasses the existing cobra stack. We need to add some basic telemetry around error tracking so we have visibility into errors users may run into (due to our programming mistakes).

We would like to reuse the existing `midcobra` abstraction which has a `telemetry` middleware that does both sentry and segment tracking. However, for sshshim we desire just sentry, not segment. So we want to:
1. split telemetry middleware into sentry and segment middlewares
2. set a common sentryID for both sentry and segment to correlate the corresponding events/data.

**Implemention**
This PR adds an executionID to `midCobra.Middleware`.

We use this executionID in two ways:

1. We set executionID in both sentry.EventID and segment's sentry_event_id
2. For an error and stack trace reported when `DEVBOX_DEBUG=1`, we also print this executionID.
  If a user reports a reproducible error, then we can ask them to enable DEVBOX_DEBUG to reproduce
  it and report the executionID to us. We can then look up the corresponding events in both
  sentry and segment to construct an understanding of the problem the user is facing.


In the next PRs, I will:
1. split telemetry into sentry and segment middleware
2. call the sentry middleware for the sshshim command path

## How was it tested?

Set up:
1. via code changes, forced the `midcobra.telemetry` middleware to be enabled.
2. added a print statement where the segment.sentry_event_id is set to print
   both the executionID and the eventID returned by sentry's CaptureException. 
3. Manually inserted an error in `devbox.Open` and ran a CLI command to trigger it.

Observed:
1. executionID and eventID from sentry's CaptureException are the same.
2. the executionID is printed prior to the stack trace of the error.
