### PR TITLE
[midcobra] split Telemetry middleware into sentry and segment middlewares

### DIFF
--- a/boxcli/midcobra/sentry.go
+++ b/boxcli/midcobra/sentry.go
@@ -1,0 +1,74 @@
+package midcobra
+
+import (
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/spf13/cobra"
+)
+
+func Sentry(opts *SentryOpts) Middleware {
+	return &sentryMiddleware{
+		opts:     *opts,
+		disabled: doNotTrack() || opts.SentryDSN == "",
+	}
+}
+
+type SentryOpts struct {
+	AppName    string
+	AppVersion string
+	SentryDSN  string // used by error reporting
+}
+
+type sentryMiddleware struct {
+	// Setup:
+	opts     SentryOpts
+	disabled bool
+
+	executionID string
+}
+
+// sentryMiddleware implements interface Middleware (compile-time check)
+var _ Middleware = (*sentryMiddleware)(nil)
+
+func (m *sentryMiddleware) preRun(cmd *cobra.Command, args []string) {
+
+}
+
+func (m *sentryMiddleware) postRun(cmd *cobra.Command, args []string, runErr error) {
+	if m.disabled {
+		return
+	}
+	initSentry(m.opts, m.executionID)
+}
+
+func (m *sentryMiddleware) withExecutionID(execID string) Middleware {
+	m.executionID = execID
+	return m
+}
+
+func initSentry(opts SentryOpts, executionID string) {
+	sentrySyncTransport := sentry.NewHTTPSyncTransport()
+	sentrySyncTransport.Timeout = time.Second * 2
+	release := opts.AppName + "@" + opts.AppVersion
+	environment := "production"
+	if opts.AppVersion == "0.0.0-dev" {
+		environment = "development"
+	}
+
+	_ = sentry.Init(sentry.ClientOptions{
+		Dsn:              opts.SentryDSN,
+		Environment:      environment,
+		Release:          release,
+		Transport:        sentrySyncTransport,
+		TracesSampleRate: 1,
+		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			for i := range event.Exception {
+				// edit in place and remove error message from tracking
+				event.Exception[i].Value = ""
+			}
+			event.EventID = sentry.EventID(executionID)
+			return event
+		},
+	})
+}

--- a/boxcli/root.go
+++ b/boxcli/root.go
@@ -51,17 +51,21 @@ func RootCmd() *cobra.Command {
 func Execute(ctx context.Context, args []string) int {
 	defer debug.Recover()
 	exe := midcobra.New(RootCmd())
-	exe.AddMiddleware(midcobra.Telemetry(&midcobra.TelemetryOpts{
-		AppName:      "devbox",
+	appName := "devbox"
+	exe.AddMiddleware(midcobra.Sentry(&midcobra.SentryOpts{
+		AppName:    appName,
+		AppVersion: build.Version,
+		SentryDSN:  build.SentryDSN,
+	}))
+	exe.AddMiddleware(midcobra.Segment(&midcobra.SegmentOpts{
+		AppName:      appName,
 		AppVersion:   build.Version,
-		SentryDSN:    build.SentryDSN,
 		TelemetryKey: build.TelemetryKey,
 	}))
 	exe.AddMiddleware(debugMiddleware)
 	return exe.Execute(ctx, args)
 }
 
-// TODO savil. Add Sentry and other monitoring.
 func executeSSH() int {
 	sshshim.EnableDebug() // Always enable for now.
 	debug.Log("os.Args: %v", os.Args)


### PR DESCRIPTION
## Summary

see previous PR for motivational context.

This PR just does a split of the code, but is a functional no-op

## How was it tested?

1. compiles
2. sanity check: opened `devbox shell`

but didn't really verify that the sentry or segment are being logged properly.
