### PR TITLE
[sshshim] use midcobra to execute command with sentry middleware

### DIFF
--- a/boxcli/midcobra/debug.go
+++ b/boxcli/midcobra/debug.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 
 	"github.com/fatih/color"
-	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"go.jetpack.io/devbox/boxcli/usererr"
 	"go.jetpack.io/devbox/debug"
@@ -32,7 +31,7 @@ func (d *DebugMiddleware) AttachToFlag(flags *pflag.FlagSet, flagName string) {
 	d.flag.Hidden = true
 }
 
-func (d *DebugMiddleware) preRun(cmd *cobra.Command, args []string) {
+func (d *DebugMiddleware) preRun(cmd Command, args []string) {
 	if d == nil {
 		return
 	}
@@ -48,7 +47,7 @@ func (d *DebugMiddleware) preRun(cmd *cobra.Command, args []string) {
 	}
 }
 
-func (d *DebugMiddleware) postRun(cmd *cobra.Command, args []string, runErr error) {
+func (d *DebugMiddleware) postRun(cmd Command, args []string, runErr error) {
 	if runErr == nil {
 		return
 	}

--- a/boxcli/midcobra/segment.go
+++ b/boxcli/midcobra/segment.go
@@ -60,11 +60,11 @@ type segmentMiddleware struct {
 // segmentMiddleware implements interface Middleware (compile-time check)
 var _ Middleware = (*segmentMiddleware)(nil)
 
-func (m *segmentMiddleware) preRun(cmd *cobra.Command, args []string) {
+func (m *segmentMiddleware) preRun(cmd Command, args []string) {
 	m.startTime = time.Now()
 }
 
-func (m *segmentMiddleware) postRun(cmd *cobra.Command, args []string, runErr error) {
+func (m *segmentMiddleware) postRun(cmd Command, args []string, runErr error) {
 	if m.disabled {
 		return
 	}
@@ -117,8 +117,8 @@ func deviceID() string {
 	return hashedID
 }
 
-func getSubcommand(c *cobra.Command, args []string) (subcmd *cobra.Command, subargs []string, err error) {
-	if c.TraverseChildren {
+func getSubcommand(c Command, args []string) (subcmd *cobra.Command, subargs []string, err error) {
+	if c.ShouldTraverseChildren() {
 		subcmd, subargs, err = c.Traverse(args)
 	} else {
 		subcmd, subargs, err = c.Find(args)
@@ -126,7 +126,7 @@ func getSubcommand(c *cobra.Command, args []string) (subcmd *cobra.Command, suba
 	return subcmd, subargs, err
 }
 
-func getPackages(c *cobra.Command) []string {
+func getPackages(c Command) []string {
 	configFlag := c.Flag("config")
 	// for shell, run, and add command, path can be set via --config
 	// if --config is not set, default to current directory which is ""

--- a/boxcli/midcobra/sentry.go
+++ b/boxcli/midcobra/sentry.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
-	"github.com/spf13/cobra"
 )
 
 func Sentry(opts *SentryOpts) Middleware {
@@ -31,11 +30,11 @@ type sentryMiddleware struct {
 // sentryMiddleware implements interface Middleware (compile-time check)
 var _ Middleware = (*sentryMiddleware)(nil)
 
-func (m *sentryMiddleware) preRun(cmd *cobra.Command, args []string) {
+func (m *sentryMiddleware) preRun(cmd Command, args []string) {
 
 }
 
-func (m *sentryMiddleware) postRun(cmd *cobra.Command, args []string, runErr error) {
+func (m *sentryMiddleware) postRun(cmd Command, args []string, runErr error) {
 	if m.disabled {
 		return
 	}

--- a/cloud/openssh/sshshim/command.go
+++ b/cloud/openssh/sshshim/command.go
@@ -1,0 +1,72 @@
+package sshshim
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+	"go.jetpack.io/devbox/boxcli/midcobra"
+	"go.jetpack.io/devbox/build"
+	"go.jetpack.io/devbox/debug"
+)
+
+func Execute(ctx context.Context, args []string) int {
+	defer debug.Recover()
+
+	exe := midcobra.New(&sshshimCommand{})
+	exe.AddMiddleware(midcobra.Sentry(&midcobra.SentryOpts{
+		AppName:    "devbox-sshshim",
+		AppVersion: build.Version,
+		SentryDSN:  build.SentryDSN,
+	}))
+	return exe.Execute(ctx, args)
+}
+
+// sshshimCommand implements midcobra.Command
+var _ midcobra.Command = (*sshshimCommand)(nil)
+
+type sshshimCommand struct {
+	args []string
+}
+
+func (cmd *sshshimCommand) ExecuteContext(ctx context.Context) error {
+	return execute(cmd.args)
+}
+
+func (cmd *sshshimCommand) SetArgs(args []string) {
+	cmd.args = args
+}
+func (cmd *sshshimCommand) ShouldTraverseChildren() bool {
+	panic("not implemented")
+}
+func (cmd *sshshimCommand) Traverse(args []string) (*cobra.Command, []string, error) {
+	panic("not implemented")
+}
+func (cmd *sshshimCommand) Find(args []string) (*cobra.Command, []string, error) {
+	panic("not implemented")
+}
+func (cmd *sshshimCommand) Flag(name string) *flag.Flag {
+	panic("not implemented")
+}
+
+func execute(args []string) error {
+	EnableDebug() // Always enable for now.
+	debug.Log("os.Args: %v", args)
+
+	if alive, err := ensureLiveVMOrTerminateMutagenSessions(args[1:]); err != nil {
+		debug.Log("ensureLiveVMOrTerminateMutagenSessions error: %v", err)
+		fmt.Fprintf(os.Stderr, "%v", err)
+		return err
+	} else if !alive {
+		return nil
+	}
+
+	if err := invokeSSHOrSCPCommand(args); err != nil {
+		debug.Log("InvokeSSHorSCPCommand error: %v", err)
+		fmt.Fprintf(os.Stderr, "%v", err)
+		return err
+	}
+	return nil
+}

--- a/cloud/openssh/sshshim/invoke.go
+++ b/cloud/openssh/sshshim/invoke.go
@@ -10,7 +10,7 @@ import (
 	"go.jetpack.io/devbox/debug"
 )
 
-func InvokeSSHOrSCPCommand(args []string) error {
+func invokeSSHOrSCPCommand(args []string) error {
 	if !strings.HasSuffix(args[0], "ssh") && !strings.HasSuffix(args[0], "scp") {
 		return errors.Errorf("received %s for args[0], but expected ssh or scp", args[0])
 	}

--- a/cloud/openssh/sshshim/mutagen.go
+++ b/cloud/openssh/sshshim/mutagen.go
@@ -14,7 +14,7 @@ import (
 
 // returns true if a liveVM is found, OR sshArgs were connecting to a server that is not a devbox-VM.
 // returns false iff the sshArgs were connecting to a devbox VM AND a deadVM is found.
-func EnsureLiveVMOrTerminateMutagenSessions(sshArgs []string) (bool, error) {
+func ensureLiveVMOrTerminateMutagenSessions(sshArgs []string) (bool, error) {
 	vmAddr := vmAddressIfAny(sshArgs)
 
 	debug.Log("Found vmAddr: %s", vmAddr)


### PR DESCRIPTION
## Summary

This PR uses `midcobra` in the sshshim to:
1. drive the execution of the main command.
2. ensure the sentry middleware is run

Design choices:

1. I chose to use the existing `midcobraExecutable` instead of implementing another
struct conforming to the `Executable` interface. The reason is that `midcobraExecutable.Execute()`
function nicely wraps the preRun and postRun functions, in a manner that the middlewares
current expect.

2. Chose to pass `os.Args` into `Executable.Execute` instead of the prior `os.Args[1:]`.
Reason: the sshshim Execute requires the `os.Args[0]` value and I chose to standardize
both sshshim and the regular devbox `boxcli.Execute` to have the same meaning of the
`arg` variable in the `Executable.Execute` function.

3. Added a `Command` interface to `midcobra` so that regular devbox can use cobra.Command
in the middlewares, while sshshim can use a fake sshshimCommand that conforms to this
interface. 

## How was it tested?

This compiles.

Need to test. Will add details here.

