### PR TITLE
[sshshim] add sentry without using middleware

### DIFF
--- a/internal/boxcli/midcobra/midcobra.go
+++ b/internal/boxcli/midcobra/midcobra.go
@@ -25,7 +25,7 @@ type Middleware interface {
 func New(cmd *cobra.Command) Executable {
 	return &midcobraExecutable{
 		cmd:         cmd,
-		executionID: executionID(),
+		executionID: ExecutionID(),
 		middlewares: []Middleware{},
 	}
 }
@@ -75,7 +75,7 @@ func (ex *midcobraExecutable) Execute(ctx context.Context, args []string) int {
 	}
 }
 
-func executionID() string {
+func ExecutionID() string {
 	// google/uuid package's String() returns a value of the form:
 	// xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 	//

--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -5,7 +5,6 @@ package boxcli
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"strings"
 
@@ -61,31 +60,10 @@ func Execute(ctx context.Context, args []string) int {
 	return exe.Execute(ctx, args)
 }
 
-// TODO savil. Add Sentry and other monitoring.
-func executeSSH() int {
-	sshshim.EnableDebug() // Always enable for now.
-	debug.Log("os.Args: %v", os.Args)
-
-	if alive, err := sshshim.EnsureLiveVMOrTerminateMutagenSessions(os.Args[1:]); err != nil {
-		debug.Log("EnsureLiveVMOrTerminateMutagenSessions error: %v", err)
-		fmt.Fprintf(os.Stderr, "%v", err)
-		return 1
-	} else if !alive {
-		return 0
-	}
-
-	if err := sshshim.InvokeSSHOrSCPCommand(os.Args); err != nil {
-		debug.Log("InvokeSSHorSCPCommand error: %v", err)
-		fmt.Fprintf(os.Stderr, "%v", err)
-		return 1
-	}
-	return 0
-}
-
 func Main() {
 	if strings.HasSuffix(os.Args[0], "ssh") ||
 		strings.HasSuffix(os.Args[0], "scp") {
-		code := executeSSH()
+		code := sshshim.Execute(context.Background(), os.Args)
 		os.Exit(code)
 	}
 	code := Execute(context.Background(), os.Args[1:])

--- a/internal/cloud/openssh/sshshim/command.go
+++ b/internal/cloud/openssh/sshshim/command.go
@@ -1,0 +1,52 @@
+package sshshim
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"go.jetpack.io/devbox/internal/boxcli/midcobra"
+	"go.jetpack.io/devbox/internal/build"
+	"go.jetpack.io/devbox/internal/debug"
+	"go.jetpack.io/devbox/internal/telemetry"
+)
+
+func Execute(ctx context.Context, args []string) int {
+	defer debug.Recover()
+
+	err := execute(args)
+
+	logSentry(err)
+
+	if err != nil {
+		return 1
+	}
+	return 0
+}
+
+func execute(args []string) error {
+	EnableDebug() // Always enable for now.
+	debug.Log("os.Args: %v", args)
+
+	if alive, err := EnsureLiveVMOrTerminateMutagenSessions(args[1:]); err != nil {
+		debug.Log("ensureLiveVMOrTerminateMutagenSessions error: %v", err)
+		fmt.Fprintf(os.Stderr, "%v", err)
+		return err
+	} else if !alive {
+		return nil
+	}
+
+	if err := InvokeSSHOrSCPCommand(args); err != nil {
+		debug.Log("InvokeSSHorSCPCommand error: %v", err)
+		fmt.Fprintf(os.Stderr, "%v", err)
+		return err
+	}
+	return nil
+}
+
+func logSentry(runErr error) {
+	const appName = "devbox-sshshim"
+	s := telemetry.NewSentry(build.SentryDSN)
+	s.Init(appName, build.Version, midcobra.ExecutionID())
+	s.CaptureException(runErr)
+}

--- a/internal/telemetry/sentry.go
+++ b/internal/telemetry/sentry.go
@@ -1,0 +1,64 @@
+package telemetry
+
+import (
+	"time"
+
+	"github.com/getsentry/sentry-go"
+)
+
+type Sentry struct {
+	disabled bool
+
+	dsn string
+}
+
+func NewSentry(dsn string) *Sentry {
+	return &Sentry{
+		disabled: DoNotTrack() || dsn == "",
+		dsn:      dsn,
+	}
+}
+
+func (s *Sentry) Init(appName, appVersion, executionID string) {
+	if s.disabled {
+		return
+	}
+
+	sentrySyncTransport := sentry.NewHTTPSyncTransport()
+	sentrySyncTransport.Timeout = time.Second * 2
+	release := appName + "@" + appVersion
+	environment := "production"
+	if appVersion == "0.0.0-dev" {
+		environment = "development"
+	}
+
+	_ = sentry.Init(sentry.ClientOptions{
+		Dsn:              s.dsn,
+		Environment:      environment,
+		Release:          release,
+		Transport:        sentrySyncTransport,
+		TracesSampleRate: 1,
+		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			for i := range event.Exception {
+				// edit in place and remove error message from tracking
+				event.Exception[i].Value = ""
+			}
+			event.EventID = sentry.EventID(executionID)
+			return event
+		},
+	})
+}
+
+// CaptureException
+func (s *Sentry) CaptureException(runErr error) string {
+	if s.disabled || runErr == nil {
+		return ""
+	}
+	defer sentry.Flush(2 * time.Second)
+
+	eventIDPointer := sentry.CaptureException(runErr)
+	if eventIDPointer == nil {
+		return ""
+	}
+	return string(*eventIDPointer)
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,0 +1,15 @@
+package telemetry
+
+import (
+	"os"
+	"strconv"
+)
+
+func DoNotTrack() bool {
+	// https://consoledonottrack.com/
+	doNotTrack_, err := strconv.ParseBool(os.Getenv("DO_NOT_TRACK"))
+	if err != nil {
+		doNotTrack_ = false
+	}
+	return doNotTrack_
+}


### PR DESCRIPTION
## Summary

This PR is an alternative to both #361 and #363.

This PR's approach is lighterweight:
1. refactor sentry code into its new `telemetry` package.
2. directly call that in the sshshim command execution function.

The advantages it has are:
1. Major: The implementation in #363 is rather gross because we need to introduce an interface equivalent of cobra.Command. This is really ugly, and not very maintainable. If new middleware uses other functions of cobra commands, then we'll have to add those to the interface and also handle them in the sshshim-command version.
2. Minor: We keep the `midcobra.telemetry` middleware for the regular devbox command.

Disadvantages are:
1. We may in the future need to incorporate new middleware into the sshshim command in a non-middleware manner.

## How was it tested?

compiles.

Tested via:
1. Look up sentryDSN in sentry dashboard > Settings > Project (devbox) > ClientKeys (DSN)
2. Inserted that in `internal/build/build.go`
3. Manually inserted errors in devbox.Open and invokeSSHOrSCPCommand. Ran devbox commands that triggered them.
4. verified in sentry dashboard that the errors were logged.
