### PR TITLE
[nix] nix install without using daemon flag DEV-1266

### DIFF
--- a/internal/nix/install.go
+++ b/internal/nix/install.go
@@ -25,7 +25,7 @@ func Install() error {
 	defer r.Close()
 	defer w.Close()
 
-	cmd := exec.Command("sh", "-c", installScript, "--", "--daemon")
+	cmd := exec.Command("sh", "-c", installScript)
 	// Attach stdout but no stdin. This makes the command run in non-TTY mode
 	// which skips the interactive prompts.
 	// We could attach stderr? but the stdout prompt is pretty useful.


### PR DESCRIPTION
## Summary

Previously we were using `--daemon` to force multi-user on all platforms. This doesn't work on WSL, so omit the flag. This means on macOS it will use multi-user and on linux it will install as single user.

## How was it tested?

Untested, but this is what it used to be and was tested previously. 
