### PR TITLE
[plugins] Only create devbox.d files on add

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -50,8 +50,9 @@ func InitConfig(dir string) (created bool, err error) {
 type Devbox struct {
 	cfg *Config
 	// configDir is the directory where the config file (devbox.json) resides
-	configDir string
-	writer    io.Writer
+	configDir     string
+	pluginManager *pkgcfg.Manager
+	writer        io.Writer
 }
 
 // TODO savil. dir is technically path since it could be a dir or file
@@ -73,9 +74,10 @@ func Open(dir string, writer io.Writer) (*Devbox, error) {
 	}
 
 	box := &Devbox{
-		cfg:       cfg,
-		configDir: cfgDir,
-		writer:    writer,
+		cfg:           cfg,
+		configDir:     cfgDir,
+		pluginManager: pkgcfg.NewManager(),
+		writer:        writer,
 	}
 	return box, nil
 }
@@ -108,6 +110,7 @@ func (d *Devbox) Add(pkgs ...string) error {
 		return err
 	}
 
+	d.pluginManager.ApplyOptions(pkgcfg.WithAddMode())
 	if err := d.ensurePackagesAreInstalled(install); err != nil {
 		return err
 	}
@@ -473,7 +476,7 @@ func (d *Devbox) generateShellFiles() error {
 	if err != nil {
 		return err
 	}
-	return generateForShell(d.configDir, plan)
+	return generateForShell(d.configDir, plan, d.pluginManager)
 }
 
 func (d *Devbox) profileDir() (string, error) {

--- a/internal/impl/generate.go
+++ b/internal/impl/generate.go
@@ -24,7 +24,7 @@ var tmplFS embed.FS
 
 var shellFiles = []string{"development.nix", "shell.nix"}
 
-func generateForShell(rootPath string, plan *plansdk.ShellPlan) error {
+func generateForShell(rootPath string, plan *plansdk.ShellPlan, pluginManager *pkgcfg.Manager) error {
 	outPath := filepath.Join(rootPath, ".devbox/gen")
 
 	for _, file := range shellFiles {
@@ -51,7 +51,7 @@ func generateForShell(rootPath string, plan *plansdk.ShellPlan) error {
 
 	if featureflag.PKGConfig.Enabled() {
 		for _, pkg := range plan.DevPackages {
-			if err := pkgcfg.CreateFilesAndShowReadme(pkg, rootPath); err != nil {
+			if err := pluginManager.CreateFilesAndShowReadme(pkg, rootPath); err != nil {
 				return err
 			}
 		}

--- a/internal/pkgcfg/manager.go
+++ b/internal/pkgcfg/manager.go
@@ -1,0 +1,25 @@
+package pkgcfg
+
+type Manager struct {
+	addMode bool
+}
+
+type managerOption func(*Manager)
+
+func NewManager(opts ...managerOption) *Manager {
+	m := &Manager{}
+	m.ApplyOptions(opts...)
+	return m
+}
+
+func WithAddMode() managerOption {
+	return func(m *Manager) {
+		m.addMode = true
+	}
+}
+
+func (m *Manager) ApplyOptions(opts ...managerOption) {
+	for _, opt := range opts {
+		opt(m)
+	}
+}


### PR DESCRIPTION
## Summary

This changes plugins so that `devbox.d` files are only created on `add` and not on other commands.

Following discussion with @loreto I was going to return error if any of the files are missing, but I'm afraid this will backfire. Specifically there are plugin files that are non-essential to plugin. Two immediate examples:

* nginx plugin creates a `web/index.html` example page.
* php plugin creates a php-fpm config  which is not needed if you don't want to use php-fpm.

Currently this PR simply takes no action if a given file is missing. I think that's probably Ok for now.

Some possible solutions:

* We could mark certain files as "optional" but this would complicate the plugin json.
* We could save some data in `devbox.d/devbox.lock` to keep track of plugins we've already generated files for so we don't go it again.
* We could move optional files to `.devbox`. This makes sense for web/index.html but for some files like php-fpm.conf it doesn't.

## How was it tested?

```sh
devbox add nginx
rm devbox.d/nginx/nginx.conf
devbox add nginx
# verified it got recreated
rm devbox.d/nginx/nginx.conf
devbox shell
# verified it was not recreated
```
