### PR TITLE
[add] Show better message if package is missing. Specify exact version after installing

### DIFF
--- a/internal/boxcli/add.go
+++ b/internal/boxcli/add.go
@@ -4,6 +4,7 @@
 package boxcli
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/pkg/errors"
@@ -22,9 +23,16 @@ func AddCmd() *cobra.Command {
 	command := &cobra.Command{
 		Use:               "add <pkg>...",
 		Short:             "Add a new package to your devbox",
-		Args:              cobra.MinimumNArgs(1),
 		PersistentPreRunE: nix.EnsureInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				fmt.Fprintf(
+					cmd.OutOrStdout(),
+					"Usage: %s\n\nTo search for packages use https://search.nixos.org/packages\n",
+					cmd.UseLine(),
+				)
+				return nil
+			}
 			return addCmdFunc(cmd, args, flags)
 		},
 	}

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -530,13 +530,14 @@ func (d *Devbox) ensurePackagesAreInstalled(mode installMode) error {
 
 func (d *Devbox) printPackageUpdateMessage(mode installMode, pkgs []string) error {
 	installedVerb := "installed"
+	info, _ := nix.PkgInfo(d.cfg.Nixpkgs.Commit, pkgs[0])
 	if mode == uninstall {
 		installedVerb = "removed"
 	}
 
 	if len(pkgs) > 0 {
 
-		successMsg := fmt.Sprintf("%s is now %s.", pkgs[0], installedVerb)
+		successMsg := fmt.Sprintf("%s (%s) is now %s.", pkgs[0], info, installedVerb)
 		if len(pkgs) > 1 {
 			successMsg = fmt.Sprintf("%s are now %s.", strings.Join(pkgs, ", "), installedVerb)
 		}

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -528,31 +528,49 @@ func (d *Devbox) ensurePackagesAreInstalled(mode installMode) error {
 	return nil
 }
 
-func (d *Devbox) printPackageUpdateMessage(mode installMode, pkgs []string) error {
-	installedVerb := "installed"
-	info, _ := nix.PkgInfo(d.cfg.Nixpkgs.Commit, pkgs[0])
+func (d *Devbox) printPackageUpdateMessage(
+	mode installMode,
+	pkgs []string,
+) error {
+	verb := "installed"
+	var infos []*nix.Info
+	for _, pkg := range pkgs {
+		info, _ := nix.PkgInfo(d.cfg.Nixpkgs.Commit, pkg)
+		infos = append(infos, info)
+	}
 	if mode == uninstall {
-		installedVerb = "removed"
+		verb = "removed"
 	}
 
 	if len(pkgs) > 0 {
 
-		successMsg := fmt.Sprintf("%s (%s) is now %s.", pkgs[0], info, installedVerb)
+		successMsg := fmt.Sprintf("%s (%s) is now %s.", pkgs[0], infos[0], verb)
 		if len(pkgs) > 1 {
-			successMsg = fmt.Sprintf("%s are now %s.", strings.Join(pkgs, ", "), installedVerb)
+			pkgsWithVersion := []string{}
+			for idx, pkg := range pkgs {
+				pkgsWithVersion = append(
+					pkgsWithVersion,
+					fmt.Sprintf("%s (%s)", pkg, infos[idx]),
+				)
+			}
+			successMsg = fmt.Sprintf(
+				"%s are now %s.",
+				strings.Join(pkgsWithVersion, ", "),
+				verb,
+			)
 		}
 		fmt.Fprint(d.writer, successMsg)
 
-		// (Only when in devbox shell) Prompt the user to run `hash -r` to ensure their
-		// shell can access the most recently installed binaries, or ensure their
-		// recently uninstalled binaries are not accidentally still available.
+		// (Only when in devbox shell) Prompt the user to run `hash -r` to ensure
+		// their shell can access the most recently installed binaries, or ensure
+		// their recently uninstalled binaries are not accidentally still available.
 		if !IsDevboxShellEnabled() {
 			fmt.Fprintln(d.writer)
 		} else {
 			fmt.Fprintln(d.writer, " Run `hash -r` to ensure your shell is updated.")
 		}
 	} else {
-		fmt.Fprintf(d.writer, "No packages %s.\n", installedVerb)
+		fmt.Fprintf(d.writer, "No packages %s.\n", verb)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Minor UX improvements:

* Using devbox add without specifying a package shows a helpful message.
* After installing a package we show the exact version that was installed.

## How was it tested?


```sh
➜ devbox add
Usage: devbox add <pkg>... [flags]

To search for packages use https://search.nixos.org/packages
```

```sh
➜  devbox add curl
Installing nix packages. This may take a while... done.

curl (curl-7.86.0) is now installed.
```
