### PR TITLE
[cloud] enable multiple projects opening shells in same VM

### DIFF
--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -141,7 +141,7 @@ func syncFiles(username, hostname, configDir string) error {
 	_, err = mutagen.Sync(&mutagen.SessionSpec{
 		// If multiple projects can sync to the same machine, we need the name to also include
 		// the project's id.
-		Name:        fmt.Sprintf("devbox-%s", machineID),
+		Name:        fmt.Sprintf("devbox-%s-%s", projectName, machineID),
 		AlphaPath:   configDir,
 		BetaAddress: fmt.Sprintf("%s@%s", username, hostname),
 		// It's important that the beta path is a "clean" directory that will contain *only*

--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -141,7 +141,7 @@ func syncFiles(username, hostname, configDir string) error {
 	_, err = mutagen.Sync(&mutagen.SessionSpec{
 		// If multiple projects can sync to the same machine, we need the name to also include
 		// the project's id.
-		Name:        fmt.Sprintf("devbox-%s-%s", projectName, machineID),
+		Name:        mutagen.SanitizeSessionName(fmt.Sprintf("devbox-%s-%s", projectName, machineID)),
 		AlphaPath:   configDir,
 		BetaAddress: fmt.Sprintf("%s@%s", username, hostname),
 		// It's important that the beta path is a "clean" directory that will contain *only*

--- a/internal/cloud/mutagen/types.go
+++ b/internal/cloud/mutagen/types.go
@@ -1,6 +1,9 @@
 package mutagen
 
-import "errors"
+import (
+	"errors"
+	"strings"
+)
 
 type SessionSpec struct {
 	AlphaAddress string
@@ -23,6 +26,12 @@ func (s *SessionSpec) Validate() error {
 		return errors.New("beta path is required")
 	}
 	return nil
+}
+
+// TODO savil. Refactor SessionSpec so that this is always applied.
+// We can make it a struct that uses a constructor, and make Sync a method on the struct.
+func SanitizeSessionName(input string) string {
+	return strings.ReplaceAll(input, ".", "-")
 }
 
 // Based on the structs available at: https://github.com/mutagen-io/mutagen/blob/master/pkg/api/models/synchronization/session.go


### PR DESCRIPTION
## Summary

This minimal fix creates a mutagen session for each code project that a user
starts a `devbox cloud shell` for.

In a future PR, we can refactor SessionSpec so that sanitize name is always applied
by adding `WithName` options to a constructor function.

## How was it tested?

started cloud shells for rust and golang example projects. Synced files in each.
`MUTAGEN_DATA_DIRECTORY=~/.config/devbox/mutagen mutagen sync list` -> reports 2 active sessions.

Closed shells. Stopped VM. 
`MUTAGEN_DATA_DIRECTORY=~/.config/devbox/mutagen mutagen sync list` -> reports no active sessions.
