### PR TITLE
Default shellrc to profile for shells that are not commonly seen

### DIFF
--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -90,6 +90,7 @@ func DetectShell(opts ...ShellOption) (*Shell, error) {
 		}
 	default:
 		sh.name = shUnknown
+		sh.userShellrcPath = rcfilePath(".profile")
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
## Summary
Default shellrc file path to `.profile` for shells that are not commonly seen. `devbox shell` does not execute `init_hook` and `scripts` for an unrecognized shell (For example Fish).

Seems like `.profile` is the most commonly used for various shell. Is this a good idea? If not, is there a way to solve this more gracefully?

## How was it tested?
devbox shell