### PR TITLE
[UX] Improve post-install readme, improve message if package not found

### DIFF
--- a/internal/boxcli/add.go
+++ b/internal/boxcli/add.go
@@ -10,8 +10,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
+	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/nix"
 )
+
+const toSearchForPackages = "To search for packages use https://search.nixos.org/packages"
 
 type addCmdFlags struct {
 	config configFlags
@@ -28,12 +31,17 @@ func AddCmd() *cobra.Command {
 			if len(args) == 0 {
 				fmt.Fprintf(
 					cmd.OutOrStdout(),
-					"Usage: %s\n\nTo search for packages use https://search.nixos.org/packages\n",
+					"Usage: %s\n\n%s\n",
 					cmd.UseLine(),
+					toSearchForPackages,
 				)
 				return nil
 			}
-			return addCmdFunc(cmd, args, flags)
+			err := addCmdFunc(cmd, args, flags)
+			if errors.Is(err, nix.ErrPackageNotFound) {
+				return usererr.New("%s\n\n%s", err, toSearchForPackages)
+			}
+			return err
 		},
 	}
 

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -95,7 +95,7 @@ func (d *Devbox) Add(pkgs ...string) error {
 	for _, pkg := range pkgs {
 		ok := nix.PkgExists(d.cfg.Nixpkgs.Commit, pkg)
 		if !ok {
-			return errors.Errorf("package %s not found", pkg)
+			return errors.WithMessage(nix.ErrPackageNotFound, pkg)
 		}
 	}
 

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -18,6 +18,8 @@ import (
 // Instead of using directory, prefer using the devbox.ProfilePath() function that ensures the directory exists.
 const ProfilePath = ".devbox/nix/profile/default"
 
+var ErrPackageNotFound = errors.New("package not found")
+
 func PkgExists(nixpkgsCommit, pkg string) bool {
 	_, found := PkgInfo(nixpkgsCommit, pkg)
 	return found

--- a/internal/pkgcfg/files.go
+++ b/internal/pkgcfg/files.go
@@ -43,7 +43,7 @@ func getConfig(pkg, rootDir string) (*config, error) {
 		}
 		return cfg, nil
 	}
-	return &config{}, nil
+	return nil, nil
 }
 
 func getFileContent(contentPath string) ([]byte, error) {

--- a/internal/pkgcfg/files.go
+++ b/internal/pkgcfg/files.go
@@ -14,7 +14,7 @@ const pkgCfgDir = "package-configuration"
 //go:embed package-configuration/*
 var packageConfiguration embed.FS
 
-func getConfig(pkg, rootDir string) (*config, error) {
+func getConfigIfAny(pkg, rootDir string) (*config, error) {
 	configFiles, err := packageConfiguration.ReadDir(pkgCfgDir)
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/internal/pkgcfg/info.go
+++ b/internal/pkgcfg/info.go
@@ -13,7 +13,7 @@ func PrintReadme(
 	w io.Writer,
 	showSourceEnv, markdown bool,
 ) error {
-	cfg, err := getConfig(pkg, rootDir)
+	cfg, err := getConfigIfAny(pkg, rootDir)
 
 	if err != nil {
 		return err

--- a/internal/pkgcfg/info.go
+++ b/internal/pkgcfg/info.go
@@ -19,6 +19,10 @@ func PrintReadme(
 		return err
 	}
 
+	if cfg == nil {
+		return nil
+	}
+
 	_, _ = fmt.Fprintln(w, "")
 
 	if err = printReadme(cfg, w, markdown); err != nil {

--- a/internal/pkgcfg/pkgcfg.go
+++ b/internal/pkgcfg/pkgcfg.go
@@ -33,7 +33,7 @@ type config struct {
 }
 
 func (m *Manager) CreateFilesAndShowReadme(pkg, rootDir string) error {
-	cfg, err := getConfig(pkg, rootDir)
+	cfg, err := getConfigIfAny(pkg, rootDir)
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func (m *Manager) CreateFilesAndShowReadme(pkg, rootDir string) error {
 func Env(pkgs []string, rootDir string) (map[string]string, error) {
 	env := map[string]string{}
 	for _, pkg := range pkgs {
-		cfg, err := getConfig(pkg, rootDir)
+		cfg, err := getConfigIfAny(pkg, rootDir)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pkgcfg/pkgcfg.go
+++ b/internal/pkgcfg/pkgcfg.go
@@ -37,6 +37,10 @@ func (m *Manager) CreateFilesAndShowReadme(pkg, rootDir string) error {
 	if err != nil {
 		return err
 	}
+	if cfg == nil {
+		return nil
+	}
+
 	debug.Log("Creating files for package %q create files", pkg)
 	for filePath, contentPath := range cfg.CreateFiles {
 
@@ -98,6 +102,9 @@ func Env(pkgs []string, rootDir string) (map[string]string, error) {
 		cfg, err := getConfig(pkg, rootDir)
 		if err != nil {
 			return nil, err
+		}
+		if cfg == nil {
+			continue
 		}
 		for k, v := range cfg.Env {
 			env[k] = v

--- a/internal/pkgcfg/services.go
+++ b/internal/pkgcfg/services.go
@@ -24,6 +24,9 @@ func GetServices(pkgs []string, rootDir string) (Services, error) {
 		if err != nil {
 			return nil, err
 		}
+		if c == nil {
+			continue
+		}
 		for name, svc := range c.Services {
 			svc.Name = name
 			services[name] = svc

--- a/internal/pkgcfg/services.go
+++ b/internal/pkgcfg/services.go
@@ -20,7 +20,7 @@ type service struct {
 func GetServices(pkgs []string, rootDir string) (Services, error) {
 	services := map[string]service{}
 	for _, pkg := range pkgs {
-		c, err := getConfig(pkg, rootDir)
+		c, err := getConfigIfAny(pkg, rootDir)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

UX improvements:

* If user adds a package without a readme, don't show any readme. (previously we would show: "To show this information, run `devbox info %s")
* If user tries to add non-existent package show better message.

## How was it tested?

```sh
devbox add curl
Installing nix packages. This may take a while... done.
curl (curl-7.86.0) is now installed.
```

```sh
devbox add foobar

Error: foobar: package not found

To search for packages use https://search.nixos.org/packages
```