### PR TITLE
[sshshim] turn on gate

### DIFF
--- a/internal/boxcli/featureflag/sshshim.go
+++ b/internal/boxcli/featureflag/sshshim.go
@@ -1,3 +1,3 @@
 package featureflag
 
-var SSHShim = disabled("SSH_SHIM")
+var SSHShim = enabled("SSH_SHIM")


### PR DESCRIPTION
## Summary

Turns on this feature for all `devbox cloud shell` users.

## How was it tested?

- started a fly VM
- started a `devbox cloud shell` to that VM
- inspected ~/.config/devbox/ssh/shims` to see files created and `logs.txt` to see operations running well
- `MUTAGEN_DATA_DIRECTORY=~/.config/devbox/mutagen sync list` to inspect active sync sessions.
- stop VM
- `MUTAGEN_DATA_DIRECTORY=~/.config/devbox/mutagen sync list` to confirm no more active sync sessions.
