### PR TITLE
openssh: improve command errors and debug logging

### DIFF
--- a/internal/cloud/openssh/client.go
+++ b/internal/cloud/openssh/client.go
@@ -4,6 +4,7 @@
 package openssh
 
 import (
+	"bytes"
 	"fmt"
 	"net"
 	"os"
@@ -23,21 +24,29 @@ func (c *Client) Shell() error {
 	cmd := c.cmd("-t")
 	remoteCmd := fmt.Sprintf(`bash -l -c "start_devbox_shell.sh \"%s\""`, c.ProjectDirName)
 	cmd.Args = append(cmd.Args, remoteCmd)
-	debug.Log("running command: %s", cmd)
-
-	// Setup stdin, stdout, stderr
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-
-	return cmd.Run()
+	return logCmdRun(cmd)
 }
 
 func (c *Client) Exec(remoteCmd string) ([]byte, error) {
 	sshCmd := c.cmd()
 	sshCmd.Args = append(sshCmd.Args, remoteCmd)
-	debug.Log("cmd/exec: %s", sshCmd)
-	return sshCmd.Output()
+
+	var stdout, stderr bytes.Buffer
+	sshCmd.Stdout = &stdout
+	sshCmd.Stderr = &stderr
+
+	err := logCmdRun(sshCmd)
+	logCmdOutput(sshCmd, "stderr", stderr.Bytes())
+	if err != nil {
+		// Only log output if there was an error, otherwise we might log
+		// a VM's private key.
+		logCmdOutput(sshCmd, "stdout", stdout.Bytes())
+		return nil, err
+	}
+	return stdout.Bytes(), nil
 }
 
 func (c *Client) cmd(sshArgs ...string) *exec.Cmd {
@@ -72,4 +81,42 @@ func destination(username, hostname string) string {
 	}
 
 	return result
+}
+
+func logCmdRun(cmd *exec.Cmd) error {
+	// Use cmd.Start so we can log the pid. Don't bother writing errors to
+	// the debug log since those will be printed anyway.
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("openssh: start command %q: %w", cmd, err)
+	}
+	debug.Log("openssh: started process %d with command %q", cmd.Process.Pid, cmd)
+
+	if err := cmd.Wait(); err != nil {
+		return fmt.Errorf("openssh: process %d with command %q: %w",
+			cmd.Process.Pid, cmd, err)
+	}
+	debug.Log("openssh: process %d with command %q: exit status 0", cmd.Process.Pid, cmd)
+	return nil
+}
+
+func logCmdOutput(cmd *exec.Cmd, stdstream string, out []byte) {
+	out = bytes.TrimSpace(out)
+	if len(out) == 0 {
+		debug.Log("openssh: process %d with command %q: exit status %d: %s is empty",
+			cmd.Process.Pid, cmd, cmd.ProcessState.ExitCode(), stdstream)
+		return
+	}
+
+	out = bytes.ReplaceAll(out, []byte{'\n'}, []byte{'\n', '\t'})
+	max := 1 << 16 // 64 KiB
+	if overflow := len(out) - max; overflow > 0 {
+		out = bytes.TrimSpace(out[:max])
+		if overflow == 1 {
+			out = append(out, "...truncated 1 byte."...)
+		} else {
+			out = fmt.Appendf(out, "...truncated %d bytes.", overflow)
+		}
+	}
+	debug.Log("openssh: process %d with command %q: exit status %d: %s text:\n\t%s",
+		cmd.Process.Pid, cmd, cmd.ProcessState.ExitCode(), stdstream, out)
 }


### PR DESCRIPTION
Consistently return a more informative error message when an SSH command fails. The errors now contain the pid, the quoted command, and exit code.

When debug logging is enabled, also write the full command when the process starts and when it exits. If the command fails, indent and log its stdout and stderr buffers. If it succeeds, only log stderr to avoid logging private VM keys. Instead, the caller will redact, format, and log a successful JSON response.