### PR TITLE
Small improvements to telemetry

### DIFF
--- a/internal/boxcli/midcobra/telemetry.go
+++ b/internal/boxcli/midcobra/telemetry.go
@@ -11,7 +11,6 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/denisbrodbeck/machineid"
 	"github.com/getsentry/sentry-go"
 	segment "github.com/segmentio/analytics-go"
 	"github.com/spf13/cobra"
@@ -83,6 +82,16 @@ func (m *telemetryMiddleware) postRun(cmd *cobra.Command, args []string, runErr 
 		return // Ignore invalid commands
 	}
 
+	pkgs := getPackages(cmd)
+
+	sentry.ConfigureScope(func(scope *sentry.Scope) {
+		scope.SetTag("command", subcmd.CommandPath())
+		scope.SetContext("command", map[string]interface{}{
+			"subcommand": subcmd.CommandPath(),
+			"args":       subargs,
+			"packages":   pkgs,
+		})
+	})
 	// verified with manual testing that the sentryID returned by CaptureException
 	// is the same as m.ExecutionID, since we set EventID = m.ExecutionID in sentry.Init
 	sentry.CaptureException(runErr)
@@ -96,23 +105,18 @@ func (m *telemetryMiddleware) postRun(cmd *cobra.Command, args []string, runErr 
 		AppVersion:    m.opts.AppVersion,
 		Command:       subcmd.CommandPath(),
 		CommandArgs:   subargs,
-		DeviceID:      deviceID(),
+		DeviceID:      telemetry.DeviceID(),
 		Duration:      time.Since(m.startTime),
 		Failed:        runErr != nil,
-		Packages:      getPackages(cmd),
+		Packages:      pkgs,
 		SentryEventID: sentryEventID,
+		Shell:         os.Getenv("SHELL"),
 	})
 }
 
 func (m *telemetryMiddleware) withExecutionID(execID string) Middleware {
 	m.executionID = execID
 	return m
-}
-
-func deviceID() string {
-	salt := "64ee464f-9450-4b14-8d9c-014c0012ac1a"
-	hashedID, _ := machineid.ProtectedID(salt) // Ensure machine id is hashed and non-identifiable
-	return hashedID
 }
 
 func getSubcommand(c *cobra.Command, args []string) (subcmd *cobra.Command, subargs []string, err error) {
@@ -154,6 +158,7 @@ type event struct {
 	Failed        bool
 	Packages      []string
 	SentryEventID string
+	Shell         string
 }
 
 func trackEvent(client segment.Client, evt *event) {
@@ -178,6 +183,7 @@ func trackEvent(client segment.Client, evt *event) {
 			Set("failed", evt.Failed).
 			Set("duration", evt.Duration.Milliseconds()).
 			Set("packages", evt.Packages).
-			Set("sentry_event_id", evt.SentryEventID),
+			Set("sentry_event_id", evt.SentryEventID).
+			Set("shell", evt.Shell),
 	})
 }

--- a/internal/telemetry/sentry.go
+++ b/internal/telemetry/sentry.go
@@ -48,6 +48,9 @@ func (s *Sentry) Init(appName, appVersion, executionID string) {
 			return event
 		},
 	})
+	sentry.ConfigureScope(func(scope *sentry.Scope) {
+		scope.SetUser(sentry.User{ID: DeviceID()})
+	})
 }
 
 // CaptureException

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -3,13 +3,21 @@ package telemetry
 import (
 	"os"
 	"strconv"
+
+	"github.com/denisbrodbeck/machineid"
 )
 
 func DoNotTrack() bool {
 	// https://consoledonottrack.com/
-	doNotTrack_, err := strconv.ParseBool(os.Getenv("DO_NOT_TRACK"))
+	doNotTrack, err := strconv.ParseBool(os.Getenv("DO_NOT_TRACK"))
 	if err != nil {
-		doNotTrack_ = false
+		doNotTrack = false
 	}
-	return doNotTrack_
+	return doNotTrack
+}
+
+func DeviceID() string {
+	salt := "64ee464f-9450-4b14-8d9c-014c0012ac1a"
+	hashedID, _ := machineid.ProtectedID(salt) // Ensure machine id is hashed and non-identifiable
+	return hashedID
 }


### PR DESCRIPTION
## Summary
- Add subcommand, args and pkgs information to Sentry (it's already in Amplitude)
- Assign an anonymized user id for Sentry
- Add shell info.

## How was it tested?
Built locally.