### PR TITLE
[plugins] Use relative paths or env variables in configs DEV-1272

### DIFF
--- a/internal/boxcli/services.go
+++ b/internal/boxcli/services.go
@@ -49,8 +49,17 @@ func ServicesCmd() *cobra.Command {
 		},
 	}
 
+	restartCommand := &cobra.Command{
+		Use:   "restart [service]...",
+		Short: "Restarts service. If no service is specified, restarts all services",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return restartServices(cmd, args, flags)
+		},
+	}
+
 	flags.config.register(servicesCommand)
 	servicesCommand.AddCommand(lsCommand)
+	servicesCommand.AddCommand(restartCommand)
 	servicesCommand.AddCommand(startCommand)
 	servicesCommand.AddCommand(stopCommand)
 	return servicesCommand
@@ -117,4 +126,13 @@ func serviceNames(box devbox.Devbox) ([]string, error) {
 		names = append(names, service.Name)
 	}
 	return names, nil
+}
+
+func restartServices(
+	cmd *cobra.Command,
+	services []string,
+	flags servicesCmdFlags,
+) error {
+	_ = stopServices(cmd, services, flags)
+	return startServices(cmd, services, flags)
 }

--- a/internal/plugin/pkgcfg.go
+++ b/internal/plugin/pkgcfg.go
@@ -71,6 +71,7 @@ func (m *Manager) CreateFilesAndShowReadme(pkg, rootDir string) error {
 		}
 		var buf bytes.Buffer
 		if err = t.Execute(&buf, map[string]string{
+			"DevboxConfigDir":      rootDir,
 			"DevboxDir":            filepath.Join(rootDir, devboxDirName, pkg),
 			"DevboxDirRoot":        filepath.Join(rootDir, devboxDirName),
 			"DevboxProfileDefault": filepath.Join(rootDir, nix.ProfilePath),
@@ -144,6 +145,7 @@ func buildConfig(pkg, rootDir, content string) (*config, error) {
 	}
 	var buf bytes.Buffer
 	if err = t.Execute(&buf, map[string]string{
+		"DevboxConfigDir":      rootDir,
 		"DevboxDir":            filepath.Join(rootDir, devboxDirName, pkg),
 		"DevboxDirRoot":        filepath.Join(rootDir, devboxDirName),
 		"DevboxProfileDefault": filepath.Join(rootDir, nix.ProfilePath),

--- a/plugins/apache/httpd.conf
+++ b/plugins/apache/httpd.conf
@@ -26,8 +26,8 @@ LoadModule alias_module modules/mod_alias.so
     Require all denied
 </Directory>
 
-DocumentRoot  "{{ .DevboxDirRoot }}/web"
-<Directory "{{ .DevboxDirRoot }}/web">
+DocumentRoot  "${HTTPD_CONFDIR}/../web"
+<Directory "${HTTPD_CONFDIR}/../web">
     Options Indexes FollowSymLinks
     AllowOverride None
     Require all granted
@@ -46,9 +46,9 @@ ErrorLog "${HTTPD_CONFDIR}/error.log"
     ServerName  php_localhost
 
     UseCanonicalName    Off
-    DocumentRoot "{{ .DevboxDirRoot }}/web"
+    DocumentRoot "${HTTPD_CONFDIR}/../web"
 
-    <Directory "{{ .DevboxDirRoot }}/web">
+    <Directory "${HTTPD_CONFDIR}/../web">
         Options All
         AllowOverride All
         <IfModule mod_authz_host.c>
@@ -57,7 +57,7 @@ ErrorLog "${HTTPD_CONFDIR}/error.log"
     </Directory>
 
     ## Added for php-fpm
-    ProxyPassMatch ^/(.*\.php(/.*)?)$ fcgi://127.0.0.1:8082/{{ .DevboxDirRoot }}/web/$1
+    ProxyPassMatch ^/(.*\.php(/.*)?)$ fcgi://127.0.0.1:8082/${HTTPD_DEVBOX_CONFIG_DIR}/devbox.d/web/$1
     DirectoryIndex index.html 
 
 </VirtualHost>

--- a/plugins/apache/httpd.conf
+++ b/plugins/apache/httpd.conf
@@ -36,7 +36,7 @@ DocumentRoot  "${HTTPD_CONFDIR}/../web"
 <Files ".ht*">
     Require all denied
 </Files>
-ErrorLog "${HTTPD_CONFDIR}/error.log"
+ErrorLog "${HTTPD_ERROR_LOG_FILE}"
 <IfModule headers_module>
     RequestHeader unset Proxy early
 </IfModule>

--- a/plugins/apacheHttpd.json
+++ b/plugins/apacheHttpd.json
@@ -4,7 +4,8 @@
   "readme": "If you with to edit the config file, please copy it out of the .devbox directory.",
   "env": {
     "HTTPD_CONFDIR": "{{ .DevboxDir }}",
-    "HTTPD_PORT": "8080"
+    "HTTPD_PORT": "8080",
+    "HTTPD_DEVBOX_CONFIG_DIR": "{{ .DevboxConfigDir }}"
   },
   "create_files": {
     "{{ .DevboxDir }}/httpd.conf": "apache/httpd.conf",

--- a/plugins/apacheHttpd.json
+++ b/plugins/apacheHttpd.json
@@ -3,9 +3,10 @@
   "version": "0.0.1",
   "readme": "If you with to edit the config file, please copy it out of the .devbox directory.",
   "env": {
+    "HTTPD_DEVBOX_CONFIG_DIR": "{{ .DevboxConfigDir }}",
     "HTTPD_CONFDIR": "{{ .DevboxDir }}",
-    "HTTPD_PORT": "8080",
-    "HTTPD_DEVBOX_CONFIG_DIR": "{{ .DevboxConfigDir }}"
+    "HTTPD_ERROR_LOG_FILE": "{{ .Virtenv }}/error.log",
+    "HTTPD_PORT": "8080"
   },
   "create_files": {
     "{{ .DevboxDir }}/httpd.conf": "apache/httpd.conf",

--- a/plugins/nginx/nginx.conf
+++ b/plugins/nginx/nginx.conf
@@ -4,7 +4,7 @@ server {
          listen       80;
          listen       [::]:80;
          server_name  localhost;
-         root         {{ .DevboxDirRoot }}/web;
+         root         ../../../devbox.d/web;
 
          error_log error.log error;
          access_log access.log;

--- a/plugins/php.json
+++ b/plugins/php.json
@@ -4,8 +4,9 @@
   "match": "^php[0-9]*$",
   "readme": "PHP is compiled with default extensions. If you would like to use non-default extensions you can add them with devbox add php81Extensions.{extension} . For example, for the memcache extension you can do `devbox add php81Extensions.memcached`.",
   "env": {
-    "PHPFPM_PORT": "8082",
-    "PHP_VIRTENV": "{{ .Virtenv }}"
+    "PHPFPM_ERROR_LOG_FILE": "{{ .Virtenv }}/php-fpm.log",
+    "PHPFPM_PID_FILE": "{{ .Virtenv }}/php-fpm.log",
+    "PHPFPM_PORT": "8082"
   },
   "create_files": {
     "{{ .DevboxDir }}/php-fpm.conf": "php/php-fpm.conf"

--- a/plugins/php.json
+++ b/plugins/php.json
@@ -4,7 +4,8 @@
   "match": "^php[0-9]*$",
   "readme": "PHP is compiled with default extensions. If you would like to use non-default extensions you can add them with devbox add php81Extensions.{extension} . For example, for the memcache extension you can do `devbox add php81Extensions.memcached`.",
   "env": {
-    "PHPFPM_PORT": "8082"
+    "PHPFPM_PORT": "8082",
+    "PHP_VIRTENV": "{{ .Virtenv }}"
   },
   "create_files": {
     "{{ .DevboxDir }}/php-fpm.conf": "php/php-fpm.conf"

--- a/plugins/php/php-fpm.conf
+++ b/plugins/php/php-fpm.conf
@@ -1,6 +1,6 @@
 [global]
-pid = {{ .Virtenv }}/php-fpm.pid
-error_log = {{ .Virtenv }}/php-fpm.log
+pid = ${PHP_VIRTENV}/php-fpm.pid
+error_log = ${PHP_VIRTENV}/php-fpm.log
 daemonize = yes
 
 [www]

--- a/plugins/php/php-fpm.conf
+++ b/plugins/php/php-fpm.conf
@@ -1,6 +1,6 @@
 [global]
-pid = ${PHP_VIRTENV}/php-fpm.pid
-error_log = ${PHP_VIRTENV}/php-fpm.log
+pid = ${PHPFPM_PID_FILE}
+error_log = ${PHPFPM_ERROR_LOG_FILE}
 daemonize = yes
 
 [www]


### PR DESCRIPTION
## Summary

@Lagoja called out that we were using absolute paths in conf files. Since the conf files are checked-in, they need to be env variables or relative paths if the file doesn't support env variables.

I also added `services restart` which really helped me test this out.

## How was it tested?

```
devbox add nginx apacheHttpd php
devbox services start
curl localhost
curl localhost:8080
curl localhost:8080/index.php
```
