### PR TITLE
[cloud shell] respect gitignore file in --config directory to limit large data syncs

### DIFF
--- a/internal/cloud/mutagen/types.go
+++ b/internal/cloud/mutagen/types.go
@@ -5,6 +5,11 @@ import (
 	"strings"
 )
 
+type SessionIgnore struct {
+	VCS   bool
+	Paths []string
+}
+
 type SessionSpec struct {
 	AlphaAddress string
 	AlphaPath    string
@@ -14,7 +19,7 @@ type SessionSpec struct {
 	Labels       map[string]string
 	Paused       bool
 	SyncMode     string
-	IgnoreVCS    bool
+	Ignore       SessionIgnore
 	EnvVars      map[string]string
 }
 

--- a/internal/cloud/mutagen/wrapper.go
+++ b/internal/cloud/mutagen/wrapper.go
@@ -45,8 +45,14 @@ func Create(spec *SessionSpec) error {
 		args = append(args, "--sync-mode", spec.SyncMode)
 	}
 
-	if spec.IgnoreVCS {
+	if spec.Ignore.VCS {
 		args = append(args, "--ignore-vcs")
+	}
+
+	if len(spec.Ignore.Paths) > 0 {
+		for _, p := range spec.Ignore.Paths {
+			args = append(args, "--ignore", p)
+		}
 	}
 
 	return execMutagen(args, spec.EnvVars)


### PR DESCRIPTION
## Summary

I discovered that the rust-stable project was not syncing, because it stores compiled
artifacts in a child-directory: `.rustup`. This directory is in the `.gitignore` file
but mutagen was syncing it.

In the long run, we should not sync any files that are gitignored (agree?).
However, code for that is a bit more involved, so as a first pass I implement
looking for a .gitignore file in the `configDir` and passing its rules to mutagen
as `--ignore` flags. Thankfully, mutagen's ignore rules match gitignore format.

## How was it tested?

was able to start `devbox cloud shell` in the `rust-stable` example project
