### PR TITLE
[cloud shell] always ignore .devbox directory

### DIFF
--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -220,10 +220,16 @@ func parseVMEnvVar() (username string, vmHostname string) {
 //     rules to be relative to configDir.
 func gitIgnorePaths(configDir string) ([]string, error) {
 
+	// We must always ignore .devbox folder. It can contain information that
+	// is platform-specific, and so we should not sync it to the cloud-shell.
+	// Platform-specific info includes nix profile links to the nix store,
+	// and in the future, versions of specific packages in the flakes.lock file.
+	result := []string{".devbox"}
+
 	fpath := filepath.Join(configDir, ".gitignore")
 	if _, err := os.Stat(fpath); err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return result, nil
 		} else {
 			return nil, errors.WithStack(err)
 		}
@@ -234,6 +240,6 @@ func gitIgnorePaths(configDir string) ([]string, error) {
 		return nil, errors.WithStack(err)
 	}
 
-	result := strings.Split(string(contents), "\n")
+	result = append(result, strings.Split(string(contents), "\n")...)
 	return result, nil
 }


### PR DESCRIPTION
## Summary

We should always ignore the `.devbox` directory, even if the user has not explicitly
added a `.gitignore` in their devbox-project.

## How was it tested?

1. did cloud shell.

in local directory:
```
❯ readlink -f .devbox/nix/profile/default
/nix/store/aszi29qz92wlsllyh0hzcf6qxvs71hzf-user-environment
```

in remote cloud shell:
```
(devbox) savil in 🌐 239080d49b6875 in ~
❯ readlink -f code/go-1.19/.devbox/nix/profile/default
/nix/store/5l1i25kli85b0870bbcab90haclmam4z-user-environment

```

note that these are different
