### PR TITLE
[cloud shell polish] query Github to get username

### DIFF
--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -78,12 +78,20 @@ func Shell(configDir string) error {
 }
 
 func promptUsername() string {
+	defaultUsername, err := queryGithubUsername()
+	if err != nil || defaultUsername == "" {
+		// The query for Github username is best effort, and if it fails we fallback
+		// to the local computer user.
+		defaultUsername = os.Getenv("USER")
+		debug.Log("Failed to get username from Github. Falling back to $USER: %s", defaultUsername)
+	}
+
 	username := ""
 	prompt := &survey.Input{
 		Message: "What is your github username?",
-		Default: os.Getenv("USER"),
+		Default: defaultUsername,
 	}
-	err := survey.AskOne(prompt, &username, survey.WithValidator(survey.Required))
+	err = survey.AskOne(prompt, &username, survey.WithValidator(survey.Required))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/cloud/user.go
+++ b/internal/cloud/user.go
@@ -16,30 +16,38 @@ var githubSSHRegexp = regexp.MustCompile("Hi (.+)! You've successfully authentic
 // with a friendly rejection message that contains the user's username (if they have github
 // credentials set up correctly). We parse the username from the error message.
 func queryGithubUsername() (string, error) {
-	cmd := exec.Command("ssh", "-T", "git@github.com")
+	cmd := exec.Command("ssh", "-T", "-o", "NumberOfPasswordPrompts=0", "git@github.com")
 	var bufOut, bufErr bytes.Buffer
+	cmd.Stdin = nil
 	cmd.Stdout = &bufOut
 	cmd.Stderr = &bufErr
 	err := cmd.Run()
 
-	var errorMessage string
 	if err != nil {
+
 		if e := (&exec.ExitError{}); errors.As(err, &e) && e.ExitCode() == 1 {
-			debug.Log("Received expected (this is good) error for cmd `%s` had exit code 1 with stderr: %v", cmd,
-				bufErr.String())
-			errorMessage = bufErr.String()
+			// This is the Happy case, and we can parse out the error message
+			debug.Log(
+				"Received expected (this is good) error for cmd `%s` had exit code 1 with stderr: %v", cmd,
+				bufErr.String(),
+			)
+			return parseUsernameFromErrorMessage(bufErr.String()), nil
 		} else {
+			// This is the sad case, and we should let the caller figure out how to proceed with the user
 			debug.Log("error from command `%s`: %v, out: %v, stderr: %v", cmd, err, bufOut.String(), bufErr.String())
 			return "", errors.WithStack(err)
 		}
 	}
 
-	// parse output
+	return "", nil
+}
+
+func parseUsernameFromErrorMessage(errorMessage string) string {
 	matchedUsernames := githubSSHRegexp.FindSubmatch([]byte(errorMessage))
 	if len(matchedUsernames) < 2 {
 		debug.Log("Did not find a username from github. Message is: %s", errorMessage)
-		return "", nil
+		return ""
 	}
 	debug.Log("matched username from github is: %s\n", matchedUsernames[1])
-	return string(matchedUsernames[1]), nil
+	return string(matchedUsernames[1])
 }

--- a/internal/cloud/user.go
+++ b/internal/cloud/user.go
@@ -1,0 +1,45 @@
+package cloud
+
+import (
+	"bytes"
+	"os/exec"
+	"regexp"
+
+	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/internal/debug"
+)
+
+var githubSSHRegexp = regexp.MustCompile("Hi (.+)! You've successfully authenticated, " +
+	"but GitHub does not provide shell access")
+
+// queryGithubUsername attempts to make an ssh connection to github, which replies
+// with a friendly rejection message that contains the user's username (if they have github
+// credentials set up correctly). We parse the username from the error message.
+func queryGithubUsername() (string, error) {
+	cmd := exec.Command("ssh", "-T", "git@github.com")
+	var bufOut, bufErr bytes.Buffer
+	cmd.Stdout = &bufOut
+	cmd.Stderr = &bufErr
+	err := cmd.Run()
+
+	var errorMessage string
+	if err != nil {
+		if e := (&exec.ExitError{}); errors.As(err, &e) && e.ExitCode() == 1 {
+			debug.Log("Received expected (this is good) error for cmd `%s` had exit code 1 with stderr: %v", cmd,
+				bufErr.String())
+			errorMessage = bufErr.String()
+		} else {
+			debug.Log("error from command `%s`: %v, out: %v, stderr: %v", cmd, err, bufOut.String(), bufErr.String())
+			return "", errors.WithStack(err)
+		}
+	}
+
+	// parse output
+	matchedUsernames := githubSSHRegexp.FindSubmatch([]byte(errorMessage))
+	if len(matchedUsernames) < 2 {
+		debug.Log("Did not find a username from github. Message is: %s", errorMessage)
+		return "", nil
+	}
+	debug.Log("matched username from github is: %s\n", matchedUsernames[1])
+	return string(matchedUsernames[1]), nil
+}

--- a/internal/cloud/user_test.go
+++ b/internal/cloud/user_test.go
@@ -1,0 +1,1 @@
+package cloud

--- a/internal/cloud/user_test.go
+++ b/internal/cloud/user_test.go
@@ -1,1 +1,39 @@
 package cloud
+
+import (
+	"testing"
+)
+
+func TestParseUsernameFromErrorMessage(t *testing.T) {
+
+	testCases := []struct {
+		name       string
+		errMessage string
+		username   string
+	}{
+		{
+
+			"success_case",
+			"Hi myDearUsername! You've successfully authenticated, but GitHub does not provide shell access.",
+			"myDearUsername",
+		},
+		{
+			// NOTE this case won't actually occur because parseUsernameFromErrorMessage
+			// is only run for ExitCode == 1, but pub_key_denied is a local ssh error with ExitCode == 255
+			//
+			// Adding the test case to exercise the scenario where the error message doesn't match the regexp.
+			"pub_key_denied_case",
+			"public key denied",
+			"",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := parseUsernameFromErrorMessage(testCase.errMessage)
+			if result != testCase.username {
+				t.Errorf("expected %s username but got %s username", testCase.username, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR makes an `ssh -T git@github.com` query that is rejected with a friendly error
message of the form:
```
Hi savil! You've successfully authenticated, but GitHub does not provide shell access.
```
We can parse the username (`savil`, for me) from this response.

In a future PR, we can cache this value in `~/.cache/devbox/user.yaml` to reduce
the number of network calls

## How was it tested?

Not the most extensive testing. In my case, `savil` is used on both my local
laptop and github, so the usernames match. 

1. Github auth is set up
`DEVBOX_DEBUG=1 devbox cloud shell` and saw the printed output matches the code paths
for successfully parsing the github username.

2. Github auth is not set up
(see comment below)

Used Stepper UI:

When we cannot resolve the username, we'll ask as before:
<img width="928" alt="Screenshot 2022-12-20 at 11 38 37 AM" src="https://user-images.githubusercontent.com/676452/208761612-b5bead9f-1b98-4087-86cb-94972cdd5c7a.png">

and when we can resolve the username, it'll appear like this
<img width="514" alt="Screenshot 2022-12-20 at 11 40 22 AM" src="https://user-images.githubusercontent.com/676452/208761639-6494d6a6-108f-418c-b056-5c52d71ca7fb.png">
