### PR TITLE
[cloud shell] skip comments and empty lines when adding --ignore to mutagen

### DIFF
--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -240,6 +240,12 @@ func gitIgnorePaths(configDir string) ([]string, error) {
 		return nil, errors.WithStack(err)
 	}
 
-	result = append(result, strings.Split(string(contents), "\n")...)
+	for _, line := range strings.Split(string(contents), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "#") && line != "" {
+			result = append(result, line)
+		}
+	}
+
 	return result, nil
 }


### PR DESCRIPTION
## Summary

Cleans up the values we were adding to the `--ignore` in `mutagen sync create`

## How was it tested?

Did `DEVBOX_DEBUG=1 devbox cloud shell` in devbox-repo root folder.
Observed printed output that prints the mutagen commands used.
Saw that the `--ignore` flags used were the minimal set ignoring comments and empty lines
