### PR TITLE
[CLI] Added quiet mode to devbox run, init, and shell

### DIFF
--- a/internal/boxcli/init.go
+++ b/internal/boxcli/init.go
@@ -10,31 +10,24 @@ import (
 	"go.jetpack.io/devbox/internal/boxcli/writer"
 )
 
-type initCmdFlags struct {
-	quiet bool
-}
-
 func InitCmd() *cobra.Command {
-	flags := initCmdFlags{}
 	command := &cobra.Command{
 		Use:   "init [<dir>]",
 		Short: "Initialize a directory as a devbox project",
 		Long:  "Initialize a directory as a devbox project. This will create an empty devbox.json in the current directory. You can then add packages using `devbox add`",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runInitCmd(cmd, args, flags)
+			return runInitCmd(cmd, args)
 		},
 	}
-	command.Flags().BoolVarP(
-		&flags.quiet, "quiet", "q", false, "Quiet mode: Suppresses logs.")
 
 	return command
 }
 
-func runInitCmd(cmd *cobra.Command, args []string, flags initCmdFlags) error {
+func runInitCmd(cmd *cobra.Command, args []string) error {
 	path := pathArg(args)
 
-	w := &writer.DevboxIOWriter{W: cmd.OutOrStderr(), Quiet: flags.quiet}
+	w := writer.New(cmd)
 	_, err := devbox.InitConfig(path, w)
 	if err != nil {
 		return errors.WithStack(err)

--- a/internal/boxcli/init.go
+++ b/internal/boxcli/init.go
@@ -7,26 +7,35 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
+	"go.jetpack.io/devbox/internal/boxcli/writer"
 )
 
+type initCmdFlags struct {
+	quiet bool
+}
+
 func InitCmd() *cobra.Command {
+	flags := initCmdFlags{}
 	command := &cobra.Command{
 		Use:   "init [<dir>]",
 		Short: "Initialize a directory as a devbox project",
 		Long:  "Initialize a directory as a devbox project. This will create an empty devbox.json in the current directory. You can then add packages using `devbox add`",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runInitCmd(cmd, args)
+			return runInitCmd(cmd, args, flags)
 		},
 	}
+	command.Flags().BoolVarP(
+		&flags.quiet, "quiet", "q", false, "Quiet mode: Suppresses logs.")
 
 	return command
 }
 
-func runInitCmd(cmd *cobra.Command, args []string) error {
+func runInitCmd(cmd *cobra.Command, args []string, flags initCmdFlags) error {
 	path := pathArg(args)
 
-	_, err := devbox.InitConfig(path, cmd.OutOrStderr())
+	w := &writer.DevboxIOWriter{W: cmd.OutOrStderr(), Quiet: flags.quiet}
+	_, err := devbox.InitConfig(path, w)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -17,7 +17,12 @@ import (
 
 var debugMiddleware *midcobra.DebugMiddleware = &midcobra.DebugMiddleware{}
 
+type rootCmdFlags struct {
+	quiet bool
+}
+
 func RootCmd() *cobra.Command {
+	flags := rootCmdFlags{}
 	command := &cobra.Command{
 		Use:   "devbox",
 		Short: "Instant, easy, predictable development environments",
@@ -42,6 +47,8 @@ func RootCmd() *cobra.Command {
 	command.AddCommand(VersionCmd())
 	command.AddCommand(genDocsCmd())
 
+	command.PersistentFlags().BoolVarP(
+		&flags.quiet, "quiet", "q", false, "Quiet mode: Suppresses logs.")
 	debugMiddleware.AttachToFlag(command.PersistentFlags(), "debug")
 
 	return command

--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -10,14 +10,13 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
-	writer "go.jetpack.io/devbox/internal/boxcli/writer"
+	"go.jetpack.io/devbox/internal/boxcli/writer"
 	"go.jetpack.io/devbox/internal/nix"
 	"golang.org/x/exp/slices"
 )
 
 type runCmdFlags struct {
 	config configFlags
-	quiet  bool
 }
 
 func RunCmd() *cobra.Command {
@@ -32,8 +31,7 @@ func RunCmd() *cobra.Command {
 			return runScriptCmd(cmd, args, flags)
 		},
 	}
-	command.Flags().BoolVarP(
-		&flags.quiet, "quiet", "q", false, "Quiet mode: Suppresses logs.")
+
 	flags.config.register(command)
 
 	return command
@@ -41,7 +39,7 @@ func RunCmd() *cobra.Command {
 
 func runScriptCmd(cmd *cobra.Command, args []string, flags runCmdFlags) error {
 
-	w := &writer.DevboxIOWriter{W: cmd.OutOrStderr(), Quiet: flags.quiet}
+	w := writer.New(cmd)
 	path, script, err := parseScriptArgs(args, flags)
 	if err != nil {
 		return err

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -17,7 +17,6 @@ import (
 type shellCmdFlags struct {
 	config   configFlags
 	PrintEnv bool
-	quiet    bool
 }
 
 func ShellCmd() *cobra.Command {
@@ -39,8 +38,7 @@ func ShellCmd() *cobra.Command {
 
 	command.Flags().BoolVar(
 		&flags.PrintEnv, "print-env", false, "Print script to setup shell environment")
-	command.Flags().BoolVarP(
-		&flags.quiet, "quiet", "q", false, "Quiet mode: Suppresses logs.")
+
 	flags.config.register(command)
 	return command
 }
@@ -50,7 +48,7 @@ func runShellCmd(cmd *cobra.Command, args []string, flags shellCmdFlags) error {
 	if err != nil {
 		return err
 	}
-	w := &writer.DevboxIOWriter{W: cmd.OutOrStderr(), Quiet: flags.quiet}
+	w := writer.New(cmd)
 	// Check the directory exists.
 	box, err := devbox.Open(path, w)
 	if err != nil {

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -5,18 +5,19 @@ package boxcli
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
+	"go.jetpack.io/devbox/internal/boxcli/writer"
 	"go.jetpack.io/devbox/internal/nix"
 )
 
 type shellCmdFlags struct {
 	config   configFlags
 	PrintEnv bool
+	quiet    bool
 }
 
 func ShellCmd() *cobra.Command {
@@ -38,6 +39,8 @@ func ShellCmd() *cobra.Command {
 
 	command.Flags().BoolVar(
 		&flags.PrintEnv, "print-env", false, "Print script to setup shell environment")
+	command.Flags().BoolVarP(
+		&flags.quiet, "quiet", "q", false, "Quiet mode: Suppresses logs.")
 	flags.config.register(command)
 	return command
 }
@@ -47,9 +50,9 @@ func runShellCmd(cmd *cobra.Command, args []string, flags shellCmdFlags) error {
 	if err != nil {
 		return err
 	}
-
+	w := &writer.DevboxIOWriter{W: cmd.OutOrStderr(), Quiet: flags.quiet}
 	// Check the directory exists.
-	box, err := devbox.Open(path, os.Stdout)
+	box, err := devbox.Open(path, w)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/internal/boxcli/writer/writer.go
+++ b/internal/boxcli/writer/writer.go
@@ -2,16 +2,20 @@
 // Use of this source code is governed by the license in the LICENSE file.
 package writer
 
-import "io"
+import (
+	"io"
 
-type DevboxIOWriter struct {
-	W     io.Writer
-	Quiet bool
+	"github.com/spf13/cobra"
+)
+
+type devboxIOWriter struct {
+	w     io.Writer
+	quiet bool
 }
 
-func (d DevboxIOWriter) Write(p []byte) (int, error) {
-	if !d.Quiet {
-		n, err := d.W.Write(p)
+func (d devboxIOWriter) Write(p []byte) (int, error) {
+	if !d.quiet {
+		n, err := d.w.Write(p)
 		if err != nil {
 			return n, err
 		}
@@ -20,4 +24,13 @@ func (d DevboxIOWriter) Write(p []byte) (int, error) {
 		}
 	}
 	return len(p), nil
+}
+
+func New(cmd *cobra.Command) *devboxIOWriter {
+	quiet, err := cmd.Flags().GetBool("quiet")
+	if err != nil {
+		// default value for quiet/q flag
+		quiet = false
+	}
+	return &devboxIOWriter{w: cmd.ErrOrStderr(), quiet: quiet}
 }

--- a/internal/boxcli/writer/writer.go
+++ b/internal/boxcli/writer/writer.go
@@ -1,0 +1,23 @@
+// Copyright 2023 Jetpack Technologies Inc and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+package writer
+
+import "io"
+
+type DevboxIOWriter struct {
+	W     io.Writer
+	Quiet bool
+}
+
+func (d DevboxIOWriter) Write(p []byte) (int, error) {
+	if !d.Quiet {
+		n, err := d.W.Write(p)
+		if err != nil {
+			return n, err
+		}
+		if n != len(p) {
+			return n, io.ErrShortWrite
+		}
+	}
+	return len(p), nil
+}

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -202,6 +202,7 @@ func (d *Devbox) Shell() error {
 	if err := d.ensurePackagesAreInstalled(install); err != nil {
 		return err
 	}
+	fmt.Fprintln(d.writer, "Starting a devbox shell...")
 
 	profileDir, err := d.profileDir()
 	if err != nil {
@@ -275,6 +276,7 @@ func (d *Devbox) RunScript(scriptName string) error {
 	if err := d.ensurePackagesAreInstalled(install); err != nil {
 		return err
 	}
+	fmt.Fprintln(d.writer, "Starting a devbox shell...")
 
 	profileDir, err := d.profileDir()
 	if err != nil {

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -526,7 +526,7 @@ func (d *Devbox) ensurePackagesAreInstalled(mode installMode) error {
 		fmt.Println()
 		return errors.Wrap(err, "apply Nix derivation")
 	}
-	fmt.Println("done.")
+	fmt.Fprintln(d.writer, "done.")
 
 	if featureflag.PKGConfig.Enabled() {
 		if err := plugin.RemoveInvalidSymlinks(d.configDir); err != nil {

--- a/internal/impl/tmpl/shell.nix.tmpl
+++ b/internal/impl/tmpl/shell.nix.tmpl
@@ -22,8 +22,6 @@ in with pkgs;
 mkShell {
   shellHook =
     ''
-      echo "Starting a devbox shell..."
-
       # We're technically no longer in a Nix shell after this hook because we
       # exec a devbox shell.
       export IN_NIX_SHELL=0


### PR DESCRIPTION
## Summary
- Wrote a custom IOWriter
- Added `--quiet`/`-q` flag to run, init, and shell commands
- Devbox init doesn't produce any output right now, but it will start suggesting packages after #385 is merged
- Addresses #406 
## How was it tested?
1. Compile
2. `devbox init -q`
3. Add scripts to devbox.json
4. `devbox run <script> -q`
5. `devbox shell -q`
6. Assert in all cases devbox logs aren't printed
