### PR TITLE
Add basic Caddy plugin

### DIFF
--- a/plugins/caddy.json
+++ b/plugins/caddy.json
@@ -1,10 +1,9 @@
 {
     "name": "caddy",
     "version": "0.0.1",
-    "readme": "",
+    "readme": "You can customize the config used by the caddy service by modifying the Caddyfile in devbox.d/caddy, or by changing the CADDY_CONFIG environment variable to point to a custom config. The custom config must be either JSON or Caddyfile format.",
     "env": {
-        "CADDYFILE": "{{ .DevboxDir }}/Caddyfile",
-        "CADDY_CONFIG_DIR": "{{ .DevboxDir }}",
+        "CADDY_CONFIG": "{{ .DevboxDir }}/Caddyfile",
         "CADDY_LOG_DIR": "{{ .Virtenv }}/log",
         "CADDY_ROOT_DIR": "{{ .DevboxDirRoot }}/web"
     },
@@ -14,8 +13,8 @@
     },
     "services": {
         "caddy": {
-            "start": "caddy start --config $CADDYFILE",
-            "stop": "caddy stop --config $CADDYFILE"
+            "start": "caddy start --config $CADDY_CONFIG",
+            "stop": "caddy stop --config $CADDY_CONFIG"
         }
     }
 }

--- a/plugins/caddy.json
+++ b/plugins/caddy.json
@@ -1,0 +1,21 @@
+{
+    "name": "caddy",
+    "version": "0.0.1",
+    "readme": "",
+    "env": {
+        "CADDYFILE": "{{ .DevboxDir }}/Caddyfile",
+        "CADDY_CONFIG_DIR": "{{ .DevboxDir }}",
+        "CADDY_LOG_DIR": "{{ .Virtenv }}/log",
+        "CADDY_ROOT_DIR": "{{ .DevboxDirRoot }}/web"
+    },
+    "create_files": {
+        "{{ .DevboxDir }}/Caddyfile": "caddy/Caddyfile",
+        "{{ .DevboxDirRoot }}/web/index.html": "web/index.html"
+    },
+    "services": {
+        "caddy": {
+            "start": "caddy start --config $CADDYFILE",
+            "stop": "caddy stop --config $CADDYFILE"
+        }
+    }
+}

--- a/plugins/caddy/Caddyfile
+++ b/plugins/caddy/Caddyfile
@@ -1,0 +1,9 @@
+# See https://caddyserver.com/docs/caddyfile for more details
+
+localhost:2020 {
+        root * {$CADDY_ROOT_DIR}
+        log {
+            output file {$CADDY_LOG_DIR}/caddy.log
+        }
+        file_server
+}


### PR DESCRIPTION
## Summary

Adds a plugin for the Caddy Server: 

## caddy-2.6.2

### Services:
* caddy

Use `devbox services start|stop [service]` to interact with services

### This plugin creates the following helper files:
* devbox.d/caddy/Caddyfile
* devbox.d/web/index.html

### This plugin sets the following environment variables:
* CADDY_ROOT_DIR=devbox.d/web
* CADDYFILE=devbox.d/caddy/Caddyfile
* CADDY_CONFIG_DIR=devbox.d/caddy
* CADDY_LOG_DIR=.devbox/virtenv/caddy/log

To show this information, run `devbox info caddy`

## How was it tested?

Localhost, following Caddy file serve tutorial
