### PR TITLE
[cloud] set ssh ControlPath and use it to detect existing VM Host

### DIFF
--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -68,7 +68,7 @@ func Shell(configDir string) error {
 	}
 
 	if vmHostname == "" {
-		s1 := stepper.Start("Creating a virtual machine on the cloud...")
+		stepVM := stepper.Start("Creating a virtual machine on the cloud...")
 		// Inspect the ssh ControlPath to check for existing connections
 		var err error
 		vmHostname, err = vmHostnameFromSSHControlPath()
@@ -77,10 +77,10 @@ func Shell(configDir string) error {
 		}
 		if vmHostname != "" {
 			debug.Log("Using vmHostname from ssh socket: %v", vmHostname)
-			s1.Success("Detected existing virtual machine")
+			stepVM.Success("Detected existing virtual machine")
 		} else {
 			vmHostname = getVirtualMachine(sshClient)
-			s1.Success("Created virtual machine")
+			stepVM.Success("Created virtual machine")
 		}
 	}
 	debug.Log("vm_hostname: %s", vmHostname)

--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -6,6 +6,7 @@ package cloud
 import (
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"log"
 	"os"
 	"os/exec"
@@ -45,6 +46,7 @@ func Shell(configDir string) error {
 		}
 	}
 	debug.Log("username: %s", username)
+
 	sshClient := openssh.Client{
 		Username: username,
 		Addr:     "gateway.devbox.sh",
@@ -67,8 +69,19 @@ func Shell(configDir string) error {
 
 	if vmHostname == "" {
 		s1 := stepper.Start("Creating a virtual machine on the cloud...")
-		vmHostname = getVirtualMachine(sshClient)
-		s1.Success("Created virtual machine")
+		// Inspect the ssh ControlPath to check for existing connections
+		var err error
+		vmHostname, err = vmHostnameFromSSHControlPath()
+		if err != nil {
+			debug.Log("Error from vmHostnameFromSSHControlPath: %v", err)
+		}
+		if vmHostname != "" {
+			debug.Log("Using vmHostname from ssh socket: %v", vmHostname)
+			s1.Success("Detected existing virtual machine")
+		} else {
+			vmHostname = getVirtualMachine(sshClient)
+			s1.Success("Created virtual machine")
+		}
 	}
 	debug.Log("vm_hostname: %s", vmHostname)
 
@@ -364,4 +377,25 @@ func gitIgnorePaths(configDir string) ([]string, error) {
 	}
 
 	return result, nil
+}
+
+func vmHostnameFromSSHControlPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	entries, err := os.ReadDir(filepath.Join(home, ".config/devbox/ssh"))
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	for _, entry := range entries {
+		if entry.Type() == fs.ModeSocket && strings.HasSuffix(entry.Name(), "vm.devbox-vms.internal") {
+			return entry.Name(), nil
+		}
+	}
+
+	// empty string means that no socket for the VM Host is currently active.
+	return "", nil
 }

--- a/internal/cloud/openssh/sshconfig.tmpl
+++ b/internal/cloud/openssh/sshconfig.tmpl
@@ -20,7 +20,7 @@ Host *.devbox-vms.internal
 	ServerAliveInterval 50
 	ServerAliveCountMax 3
 	ControlMaster yes
-	ControlPath ~/.config/devbox/ssh/%h
+	ControlPath "{{ .ConfigDir }}/%h"
 	ControlPersist 300
 
 {{- if .DebugGateway.Host }}

--- a/internal/cloud/openssh/sshconfig.tmpl
+++ b/internal/cloud/openssh/sshconfig.tmpl
@@ -19,6 +19,9 @@ Host *.devbox-vms.internal
 	UserKnownHostsFile "{{ .ConfigDir }}/known_hosts"
 	ServerAliveInterval 50
 	ServerAliveCountMax 3
+	ControlMaster yes
+	ControlPath ~/.config/devbox/ssh/%h
+	ControlPersist 300
 
 {{- if .DebugGateway.Host }}
 

--- a/internal/cloud/openssh/testdata/devbox-ssh-config.golden
+++ b/internal/cloud/openssh/testdata/devbox-ssh-config.golden
@@ -19,3 +19,6 @@ Host *.devbox-vms.internal
 	UserKnownHostsFile "$HOME/.config/devbox/ssh/known_hosts"
 	ServerAliveInterval 50
 	ServerAliveCountMax 3
+	ControlMaster yes
+	ControlPath "$HOME/.config/devbox/ssh/%h"
+	ControlPersist 300

--- a/internal/cloud/openssh/testdata/devbox-ssh-debug-config.golden
+++ b/internal/cloud/openssh/testdata/devbox-ssh-debug-config.golden
@@ -19,6 +19,9 @@ Host *.devbox-vms.internal
 	UserKnownHostsFile "$HOME/.config/devbox/ssh/known_hosts"
 	ServerAliveInterval 50
 	ServerAliveCountMax 3
+	ControlMaster yes
+	ControlPath "$HOME/.config/devbox/ssh/%h"
+	ControlPersist 300
 
 Host gateway.devbox-debug 127.0.0.1
 	Hostname 127.0.0.1


### PR DESCRIPTION
## Summary

We would like `devbox cloud shell` sessions in multiple terminal tabs to connect
to the same VM Host. Reason:
1. Speed: that VM host already has the correct packages installed
2. User may want to monitor some existing process from the other tab

Unfortunately, fly.io isn't reliably connecting to the gateway of the same region,
so we need to implement a manual solution.

Solution:
1. Use a single ssh connection using `ControlMaster` and `ControlPath` in ssh config.
Set its timeout to be 300 seconds, which matches the scale-to-zero timeout in the VM's
docker image for when it shuts down.
2. Inspect the `~/.config/devbox/ssh` directory for a ControlPath socket, and derive
the existing VM hostname from the socket name.

## How was it tested?

started devbox cloud shells in two tabs and ensured it reuses the VM hostname from
the socket of the ControlPath
