### PR TITLE
Refactor var filtering; check var in posix way

### DIFF
--- a/internal/impl/tmpl/shell.nix.tmpl
+++ b/internal/impl/tmpl/shell.nix.tmpl
@@ -31,10 +31,10 @@ mkShell {
 
       # Undo the effects of `nix-shell --pure` on SSL certs.
       # See https://github.com/NixOS/nixpkgs/blob/dae204faa0243b4d0c0234a5f5f83a2549ecb5b7/pkgs/stdenv/generic/setup.sh#L677-L685
-      if [ "$NIX_SSL_CERT_FILE" == "/no-cert-file.crt" ]; then
+      if [ "$NIX_SSL_CERT_FILE" = "/no-cert-file.crt" ]; then
       	unset NIX_SSL_CERT_FILE
       fi
-      if [ "$SSL_CERT_FILE" == "/no-cert-file.crt" ]; then
+      if [ "$SSL_CERT_FILE" = "/no-cert-file.crt" ]; then
       	unset SSL_CERT_FILE
       fi
 

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -460,6 +460,17 @@ func buildAllowList(allowList []string) map[string]bool {
 	return envToKeep
 }
 
+func filterVars(env []string, allowList map[string]bool) []string {
+	vars := make([]string, 0, len(allowList))
+	for _, kv := range env {
+		key, _, _ := strings.Cut(kv, "=")
+		if allowList[key] {
+			vars = append(vars, kv)
+		}
+	}
+	return vars
+}
+
 // toKeepArgs takes a slice of environment variables in key=value format and
 // builds a slice of "--keep" arguments that tell nix-shell which ones to
 // keep.
@@ -468,11 +479,9 @@ func buildAllowList(allowList []string) map[string]bool {
 // We also --keep any variables set by package configuration.
 func toKeepArgs(env []string, allowList map[string]bool) []string {
 	args := make([]string, 0, len(allowList)*2)
-	for _, kv := range env {
+	for _, kv := range filterVars(env, allowList) {
 		key, _, _ := strings.Cut(kv, "=")
-		if allowList[key] {
-			args = append(args, "--keep", key)
-		}
+		args = append(args, "--keep", key)
 	}
 	return args
 }


### PR DESCRIPTION
## Summary
This change is a no-op, and is just in preparation for a larger change that will stop using `nix-shell` as the implementation for `devbox shell`. Separating these changes in their own PR allow the other change to be a bit more self-contained.

## How was it tested?
Building and running `devbox` locally.