### PR TITLE
[cloud | polish] update intro text, and display VM region

### DIFF
--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -17,6 +17,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/internal/cloud/fly"
 	"go.jetpack.io/devbox/internal/cloud/mutagen"
 	"go.jetpack.io/devbox/internal/cloud/mutagenbox"
 	"go.jetpack.io/devbox/internal/cloud/openssh"
@@ -28,7 +29,7 @@ import (
 func Shell(configDir string) error {
 	c := color.New(color.FgMagenta).Add(color.Bold)
 	c.Println("Devbox Cloud")
-	fmt.Println("Blazingly fast remote development that feels local")
+	fmt.Println("Remote development environments powered by Nix")
 	fmt.Print("\n")
 
 	username, vmHostname := parseVMEnvVar()
@@ -79,8 +80,9 @@ func Shell(configDir string) error {
 			debug.Log("Using vmHostname from ssh socket: %v", vmHostname)
 			stepVM.Success("Detected existing virtual machine")
 		} else {
-			vmHostname = getVirtualMachine(sshClient)
-			stepVM.Success("Created virtual machine")
+			var region string
+			vmHostname, region = getVirtualMachine(sshClient)
+			stepVM.Success("Created a virtual machine in %s", fly.RegionName(region))
 		}
 	}
 	debug.Log("vm_hostname: %s", vmHostname)
@@ -130,7 +132,7 @@ func (vm vm) redact() *vm {
 	return &vm
 }
 
-func getVirtualMachine(client openssh.Client) string {
+func getVirtualMachine(client openssh.Client) (vmHost string, region string) {
 	sshOut, err := client.Exec("auth")
 	if err != nil {
 		log.Fatalln("error requesting VM:", err)
@@ -142,15 +144,15 @@ func getVirtualMachine(client openssh.Client) string {
 	if redacted, err := json.MarshalIndent(resp.redact(), "\t", "  "); err == nil {
 		debug.Log("got gateway response:\n\t%s", redacted)
 	}
-	if resp.VMPrivateKey == "" {
-		return resp.VMHost
+	if resp.VMPrivateKey != "" {
+		err = openssh.AddVMKey(resp.VMHost, resp.VMPrivateKey)
+		if err != nil {
+			log.Fatalf("error adding new VM key: %v", err)
+		}
 	}
-
-	err = openssh.AddVMKey(resp.VMHost, resp.VMPrivateKey)
-	if err != nil {
-		log.Fatalf("error adding new VM key: %v", err)
-	}
-	return resp.VMHost
+	vmHost = resp.VMHost
+	region = resp.VMRegion
+	return
 }
 
 func syncFiles(username, hostname, configDir string) error {

--- a/internal/cloud/fly/region.go
+++ b/internal/cloud/fly/region.go
@@ -1,0 +1,37 @@
+package fly
+
+func RegionName(code string) string {
+	if name, ok := regions[code]; ok {
+		return name
+	}
+	return code
+}
+
+var regions = map[string]string{
+	"ams": "Amsterdam, Netherlands",
+	"cdg": "Paris, France",
+	"den": "Denver, Colorado (US)",
+	"dfw": "Dallas, Texas (US)",
+	"ewr": "Secaucus, NJ (US)",
+	"fra": "Frankfurt, Germany",
+	"gru": "São Paulo",
+	"hkg": "Hong Kong, Hong Kong",
+	"iad": "Ashburn, Virginia (US)",
+	"jnb": "Johannesburg, South Africa",
+	"lax": "Los Angeles, California (US)",
+	"lhr": "London, United Kingdom",
+	"maa": "Chennai (Madras), India",
+	"mad": "Madrid, Spain",
+	"mia": "Miami, Florida (US)",
+	"nrt": "Tokyo, Japan",
+	"ord": "Chicago, Illinois (US)",
+	"otp": "Bucharest, Romania",
+	"scl": "Santiago, Chile",
+	"sea": "Seattle, Washington (US)",
+	"sin": "Singapore",
+	"sjc": "Sunnyvale, California (US)",
+	"syd": "Sydney, Australia",
+	"waw": "Warsaw, Poland",
+	"yul": "Montreal, Canada",
+	"yyz": "Toronto, Canada",
+}


### PR DESCRIPTION
## Summary

Two changes:
1. Update the introductory text
2. Update the stepper-success message to include the region the VM was created in.

For the second change, there are two scenarios:
1. New VM -> `Created a virtual machine in <location>`
2. Existing VM -> `Detected an existing virtual machine`. We don't include location information because we don't have it. This scenario occurs either when opening another cloud-shell in another terminal tab OR when starting a new cloud-shell within 300 seconds (`ControlPersist` time in sshconfig).

I copied the region names table from https://fly.io/docs/reference/regions/. I did not editorialize the names, but of course we can: for example, someone connecting to a region near them called `Sunnyvale, California` likely doesn't need the `(US)` part since they presumably know the California they are near.

## How was it tested?

opened cloud shells
