### PR TITLE
Extract shell-specific init file injection into own func

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 require golang.org/x/net v0.2.0 // indirect
 
 require (
+	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/cockroachdb/apd/v2 v2.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/AlecAivazis/survey/v2 v2.3.6 h1:NvTuVHISgTHEHeBFqt6BHOe4Ny/NwGZr7w+F8
 github.com/AlecAivazis/survey/v2 v2.3.6/go.mod h1:4AuI9b7RjAR+G7v9+C4YSlX/YL3K3cWNXgWXOhllqvI=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
+github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
+github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/bmatcuk/doublestar/v4 v4.4.0 h1:LmAwNwhjEbYtyVLzjcP/XeVw4nhuScHGkF/XWXnvIic=

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -276,7 +276,7 @@ func (s *Shell) shellRCOverrides(shellrc string) (extraEnv []string, extraArgs [
 	// look at the name to know which env vars or args to set when launching the shell.
 	switch s.name {
 	case shBash:
-		extraArgs = []string{"--rcfile", fmt.Sprintf(`%s`, shellrc)}
+		extraArgs = []string{"--rcfile", shellrc}
 	case shZsh:
 		extraEnv = []string{fmt.Sprintf(`ZDOTDIR=%s`, filepath.Dir(shellrc))}
 	case shKsh, shPosix:

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -243,20 +243,7 @@ func (s *Shell) execCommand() string {
 	// Link other files that affect the shell settings and environments.
 	s.linkShellStartupFiles(filepath.Dir(shellrc))
 
-	// Shells have different ways of overriding the shellrc, so we need to
-	// look at the name to know which env vars or args to set.
-	var (
-		extraEnv  []string
-		extraArgs []string
-	)
-	switch s.name {
-	case shBash:
-		extraArgs = []string{"--rcfile", fmt.Sprintf(`"%s"`, shellrc)}
-	case shZsh:
-		extraEnv = []string{fmt.Sprintf(`"ZDOTDIR=%s"`, filepath.Dir(shellrc))}
-	case shKsh, shPosix:
-		extraEnv = []string{fmt.Sprintf(`"ENV=%s"`, shellrc)}
-	}
+	extraEnv, extraArgs := s.shellRCOverrides(shellrc)
 	args = append(args, extraEnv...)
 	args = append(args, s.binPath)
 	if s.ScriptCommand != "" {
@@ -282,6 +269,20 @@ func (s *Shell) RunInShell() error {
 	cmd.Stderr = os.Stderr
 	debug.Log("Executing command from inside devbox shell: %v", cmd.Args)
 	return errors.WithStack(cmd.Run())
+}
+
+func (s *Shell) shellRCOverrides(shellrc string) (extraEnv []string, extraArgs []string) {
+	// Shells have different ways of overriding the shellrc, so we need to
+	// look at the name to know which env vars or args to set when launching the shell.
+	switch s.name {
+	case shBash:
+		extraArgs = []string{"--rcfile", fmt.Sprintf(`%s`, shellrc)}
+	case shZsh:
+		extraEnv = []string{fmt.Sprintf(`ZDOTDIR=%s`, filepath.Dir(shellrc))}
+	case shKsh, shPosix:
+		extraEnv = []string{fmt.Sprintf(`ENV=%s`, shellrc)}
+	}
+	return extraEnv, extraArgs
 }
 
 func (s *Shell) execCommandInShell() (string, string, string) {

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/alessio/shellescape"
 	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/internal/debug"
 )
@@ -276,11 +277,11 @@ func (s *Shell) shellRCOverrides(shellrc string) (extraEnv []string, extraArgs [
 	// look at the name to know which env vars or args to set when launching the shell.
 	switch s.name {
 	case shBash:
-		extraArgs = []string{"--rcfile", shellrc}
+		extraArgs = []string{"--rcfile", shellescape.Quote(shellrc)}
 	case shZsh:
-		extraEnv = []string{fmt.Sprintf(`ZDOTDIR=%s`, filepath.Dir(shellrc))}
+		extraEnv = []string{fmt.Sprintf(`ZDOTDIR=%s`, shellescape.Quote(filepath.Dir(shellrc)))}
 	case shKsh, shPosix:
-		extraEnv = []string{fmt.Sprintf(`ENV=%s`, shellrc)}
+		extraEnv = []string{fmt.Sprintf(`ENV=%s`, shellescape.Quote(shellrc))}
 	}
 	return extraEnv, extraArgs
 }


### PR DESCRIPTION
## Summary

While this seems like a no-op, please note that I removed the quotes around the formatted string in each of the cases. I was finding that the rc files weren't being executed when using the quotes (and while using nixless shell).

## How was it tested?
Add a var into `shellrc.tmpl`, build devbox, run `./devbox shell`, and check if the var is defined. Do this for bash, zsh, ksh.