### PR TITLE
cloud: change ControlMaster to auto and add sockets dir

### DIFF
--- a/internal/cloud/openssh/config.go
+++ b/internal/cloud/openssh/config.go
@@ -56,6 +56,11 @@ func setupDevbox(debugHost string, debugPort int) error {
 		return err
 	}
 
+	// Ensure ~/.config/devbox/ssh/sockets exists.
+	if _, err := devboxSocketsDir(); err != nil {
+		return err
+	}
+
 	// Try to remove any old debug host keys. It's okay if this fails.
 	devboxKnownHostsDebug := filepath.Join(devboxSSHDir, "known_hosts_debug")
 	_ = os.Remove(devboxKnownHostsDebug)
@@ -255,6 +260,18 @@ func devboxKeysDir() (string, error) {
 		return "", err
 	}
 	return keysDir, nil
+}
+
+func devboxSocketsDir() (string, error) {
+	sshDir, err := devboxSSHDir()
+	if err != nil {
+		return "", err
+	}
+	sockets := filepath.Join(sshDir, "sockets")
+	if err := EnsureDirExists(sockets, 0700, true); err != nil {
+		return "", err
+	}
+	return sockets, nil
 }
 
 // atomicEdit reads from a source file and writes changes to a separate

--- a/internal/cloud/openssh/config_test.go
+++ b/internal/cloud/openssh/config_test.go
@@ -86,6 +86,7 @@ func TestSetupDevbox(t *testing.T) {
 			Data: sshKnownHosts,
 			Mode: 0644,
 		},
+		".config/devbox/ssh/sockets": &fstest.MapFile{Mode: fs.ModeDir | 0700},
 
 		".ssh": &fstest.MapFile{Mode: fs.ModeDir | 0700},
 		".ssh/config": &fstest.MapFile{
@@ -164,6 +165,7 @@ func TestSetupInsecureDebug(t *testing.T) {
 			Mode: 0644,
 		},
 		".config/devbox/ssh/known_hosts_debug": &fstest.MapFile{Mode: 0644},
+		".config/devbox/ssh/sockets":           &fstest.MapFile{Mode: fs.ModeDir | 0700},
 
 		".ssh": &fstest.MapFile{Mode: fs.ModeDir | 0700},
 		".ssh/config": &fstest.MapFile{

--- a/internal/cloud/openssh/sshconfig.tmpl
+++ b/internal/cloud/openssh/sshconfig.tmpl
@@ -19,8 +19,8 @@ Host *.devbox-vms.internal
 	UserKnownHostsFile "{{ .ConfigDir }}/known_hosts"
 	ServerAliveInterval 50
 	ServerAliveCountMax 3
-	ControlMaster yes
-	ControlPath "{{ .ConfigDir }}/%h"
+	ControlMaster auto
+	ControlPath "{{ .ConfigDir }}/sockets/%h"
 	ControlPersist 300
 
 {{- if .DebugGateway.Host }}

--- a/internal/cloud/openssh/testdata/devbox-ssh-config.golden
+++ b/internal/cloud/openssh/testdata/devbox-ssh-config.golden
@@ -19,6 +19,6 @@ Host *.devbox-vms.internal
 	UserKnownHostsFile "$HOME/.config/devbox/ssh/known_hosts"
 	ServerAliveInterval 50
 	ServerAliveCountMax 3
-	ControlMaster yes
-	ControlPath "$HOME/.config/devbox/ssh/%h"
+	ControlMaster auto
+	ControlPath "$HOME/.config/devbox/ssh/sockets/%h"
 	ControlPersist 300

--- a/internal/cloud/openssh/testdata/devbox-ssh-debug-config.golden
+++ b/internal/cloud/openssh/testdata/devbox-ssh-debug-config.golden
@@ -19,8 +19,8 @@ Host *.devbox-vms.internal
 	UserKnownHostsFile "$HOME/.config/devbox/ssh/known_hosts"
 	ServerAliveInterval 50
 	ServerAliveCountMax 3
-	ControlMaster yes
-	ControlPath "$HOME/.config/devbox/ssh/%h"
+	ControlMaster auto
+	ControlPath "$HOME/.config/devbox/ssh/sockets/%h"
 	ControlPersist 300
 
 Host gateway.devbox-debug 127.0.0.1


### PR DESCRIPTION
## Summary

Setting ControlMaster to auto prevents a warning from being shown when there's already a ControlMaster process running. Put the control sockets in a separate directory in case we later support multiple VMs per user.

Also move the socket-specific code to the openssh package so that hostname parsing lives with sshconfig.tmpl.

## How was it tested?

Unit tests and connecting to a VM multiple times.