### PR TITLE
Enable all users to install unfree packages

### DIFF
--- a/examples/testdata/unfree-packages/devbox.json
+++ b/examples/testdata/unfree-packages/devbox.json
@@ -1,0 +1,14 @@
+{
+  "packages": [
+    "vscode"
+  ],
+  "shell": {
+    "init_hook": null,
+    "scripts": {
+      "code-version": "code --version"
+    }
+  },
+  "nixpkgs": {
+    "commit": "52e3e80afff4b16ccb7c52e9f0f5220552f03d04"
+  }
+}

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -632,6 +632,8 @@ func (d *Devbox) installNixProfile() (err error) {
 		)
 	}
 
+	cmd.Env = nix.DefaultEnv()
+
 	debug.Log("Running command: %s\n", cmd.Args)
 	_, err = cmd.Output()
 

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -41,7 +41,7 @@ func Exec(path string, command []string, env []string) error {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Env = append(os.Environ(), env...)
+	cmd.Env = append(DefaultEnv(), env...)
 	return errors.WithStack(cmd.Run())
 }
 
@@ -54,6 +54,7 @@ func PkgInfo(nixpkgsCommit, pkg string) (*Info, bool) {
 	cmd := exec.Command("nix", "search",
 		"--extra-experimental-features", "nix-command flakes",
 		"--json", exactPackage)
+	cmd.Env = DefaultEnv()
 	cmd.Stderr = os.Stderr
 	debug.Log("running command: %s\n", cmd)
 	out, err := cmd.Output()
@@ -84,4 +85,8 @@ func parseInfo(pkg string, data []byte) *Info {
 		return pkgInfo
 	}
 	return nil
+}
+
+func DefaultEnv() []string {
+	return append(os.Environ(), "NIXPKGS_ALLOW_UNFREE=1")
 }

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -179,6 +179,8 @@ func (s *Shell) Run(nixShellFilePath string) error {
 		// Prevent the user's shellrc from re-sourcing nix-daemon.sh
 		// inside the devbox shell.
 		"__ETC_PROFILE_NIX_SOURCED=1",
+		// Always allow unfree packages.
+		"NIXPKGS_ALLOW_UNFREE=1",
 	)
 
 	if featureflag.Flakes.Enabled() {
@@ -303,6 +305,7 @@ func (s *Shell) RunInShell() error {
 		// Prevent the user's shellrc from re-sourcing nix-daemon.sh
 		// inside the devbox shell.
 		"__ETC_PROFILE_NIX_SOURCED=1",
+		"NIXPKGS_ALLOW_UNFREE=1",
 	)
 	debug.Log("Running inside devbox shell with environment: %v", env)
 	cmd := exec.Command(s.execCommandInShell())
@@ -492,6 +495,7 @@ var envToKeep = map[string]bool{
 	"__ETC_PROFILE_NIX_SOURCED": true, // Prevents Nix from being sourced again inside a devbox shell.
 	"NIX_SSL_CERT_FILE":         true, // The path to Nix-installed SSL certificates (used by some Nix programs).
 	"SSL_CERT_FILE":             true, // The path to non-Nix SSL certificates (used by some Nix and non-Nix programs).
+	"NIXPKGS_ALLOW_UNFREE":      true, // Whether to allow the use of unfree packages.
 }
 
 func buildAllowList(allowList []string) map[string]bool {


### PR DESCRIPTION
## Summary

We want to enable all users to install unfree packages. In this PR, we do so by
setting the env-var NIXPKGS_ALLOW_UNFREE=1. The wiki mentions also being
able to use config options, but I was unable to use that on a per-command basis.

Implementation note:
1. I define a `nix.DefaultEnv()` function that is used in most commands.
2. For `nix-shell`, because we use the `--pure` function, we need to explicitly
`--keep` this env-var. We also cannot use the `nix.DefaultEnv()` in some places
which already manipulate the environment, and so we manually add the NIXPKGS_ALLOW_UNFREE there.

## How was it tested?

Start a new project:
```
❯ devbox init

examples/testdata/unfree-packages on  savil/allow-unfree [$!+?] on ☁️  (us-east-2) on ☁️  savil.srivastava@jetpack.io 💫 initial project sync
```

Ensure we can add an unfree package:
```
❯ devbox add vscode
Installing nix packages. This may take a while... done.
vscode (vscode-1.73.1) is now installed.

examples/testdata/unfree-packages on  savil/allow-unfree [$!+?] on ☁️  (us-east-2) on ☁️  savil.srivastava@jetpack.io 💫 initial project sync took 28s
❯ code --version
zsh: command not found: code

```

Check that `devbox shell` works
```
examples/testdata/unfree-packages on  savil/allow-unfree [$!+?] on ☁️  (us-east-2) on ☁️  savil.srivastava@jetpack.io 💫 initial project sync
❯ devbox shell
Installing nix packages. This may take a while... done.
Starting a devbox shell...
code --version%
(devbox)
examples/testdata/unfree-packages on  savil/allow-unfree [$!+?] on ☁️  (us-east-2) on ☁️  savil.srivastava@jetpack.io 💫 initial project sync
❯ code --version
exit
1.73.1
6261075646f055b99068d3688932416f2346dd3b
x64
(devbox)
examples/testdata/unfree-packages on  savil/allow-unfree [$!+?] on ☁️  (us-east-2) on ☁️  savil.srivastava@jetpack.io 💫 initial project sync took 2s
❯ exit

examples/testdata/unfree-packages on  savil/allow-unfree [$!+?] on ☁️  (us-east-2) on ☁️  savil.srivastava@jetpack.io 💫 initial project sync took 9s
```

Check that `devbox shell -- <arbitrary command>` works
```
examples/testdata/unfree-packages on  savil/allow-unfree [$!+?] on ☁️  (us-east-2) on ☁️  savil.srivastava@jetpack.io 💫 initial project sync took 2s
❯ devbox shell -- code --version
Installing nix packages. This may take a while... done.
1.73.1
6261075646f055b99068d3688932416f2346dd3b
x64
```

Check that `devbox run` works
```
examples/testdata/unfree-packages on  savil/allow-unfree [$!+?] on ☁️  (us-east-2) on ☁️  savil.srivastava@jetpack.io 💫 initial project sync
❯ vim devbox.json

examples/testdata/unfree-packages on  savil/allow-unfree [$!+?] on ☁️  (us-east-2) on ☁️  savil.srivastava@jetpack.io 💫 initial project sync took 30s
❯ devbox run code-version
Installing nix packages. This may take a while... done.
Starting a devbox shell...
1.73.1
6261075646f055b99068d3688932416f2346dd3b
x64

examples/testdata/unfree-packages on  savil/allow-unfree [$!+?] on ☁️  (us-east-2) on ☁️  savil.srivastava@jetpack.io 💫 initial project sync took 6s
❯ cat devbox.json
{
  "packages": [
    "vscode"
  ],
  "shell": {
    "init_hook": null,
    "scripts": {
      "code-version": "code --version"
    }
  },
  "nixpkgs": {
    "commit": "52e3e80afff4b16ccb7c52e9f0f5220552f03d04"
  }
}
```
