### PR TITLE
flakes etude (with gating fix)

### DIFF
--- a/internal/boxcli/featureflag/flakes.go
+++ b/internal/boxcli/featureflag/flakes.go
@@ -1,0 +1,3 @@
+package featureflag
+
+var Flakes = disabled("FLAKES")

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -524,7 +524,7 @@ func (d *Devbox) ensurePackagesAreInstalled(mode installMode) error {
 	_, _ = fmt.Fprintf(d.writer, "%s nix packages. This may take a while... ", installingVerb)
 
 	// We need to re-install the packages
-	if err := d.applyDevNixDerivation(); err != nil {
+	if err := d.installNixProfile(); err != nil {
 		fmt.Fprintln(d.writer)
 		return errors.Wrap(err, "apply Nix derivation")
 	}
@@ -586,32 +586,44 @@ func (d *Devbox) printPackageUpdateMessage(
 	return nil
 }
 
-// applyDevNixDerivation installs or uninstalls packages to or from this
-// devbox's Nix profile so that it matches what's in development.nix.
-func (d *Devbox) applyDevNixDerivation() error {
+// installNixProfile installs or uninstalls packages to or from this
+// devbox's Nix profile so that it matches what's in development.nix or flake.nix
+func (d *Devbox) installNixProfile() (err error) {
 	profileDir, err := d.profileDir()
 	if err != nil {
 		return err
 	}
 
-	cmd := exec.Command("nix-env",
-		"--profile", profileDir,
-		"--install",
-		"-f", filepath.Join(d.configDir, ".devbox/gen/development.nix"),
-	)
+	var cmd *exec.Cmd
+	if featureflag.Flakes.Enabled() {
+		cmd = d.installNixProfileFlakeCommand(profileDir)
+		defer func() {
+			if err == nil {
+				_ = d.copyFlakeLockToDevboxLock()
+			}
+		}()
+	} else {
+		cmd = exec.Command(
+			"nix-env",
+			"--profile", profileDir,
+			"--install",
+			"-f", filepath.Join(d.configDir, ".devbox/gen/development.nix"),
+		)
+	}
 
 	debug.Log("Running command: %s\n", cmd.Args)
 	_, err = cmd.Output()
 
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
-		return errors.Errorf("running command %s: exit status %d with command output: %s",
+		return errors.Errorf("running command %s: exit status %d with command stderr: %s",
 			cmd, exitErr.ExitCode(), string(exitErr.Stderr))
 	}
 	if err != nil {
 		return errors.Errorf("running command %s: %v", cmd, err)
 	}
-	return nil
+
+	return
 }
 
 // Move to a utility package?

--- a/internal/impl/flake.go
+++ b/internal/impl/flake.go
@@ -1,0 +1,78 @@
+package impl
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+func (d *Devbox) installNixProfileFlakeCommand(profileDir string) *exec.Cmd {
+	cmd := exec.Command(
+		"nix", "profile", "install",
+		"--profile", profileDir,
+		"--extra-experimental-features", "nix-command flakes",
+		filepath.Join(d.configDir, ".devbox/gen/flake/"), // installables
+	)
+	if d.hasDevboxLockFile() {
+		_ = d.copyDevboxLockToFlakeLock()
+		cmd.Args = append(cmd.Args, "--no-write-lock-file")
+	} else {
+		cmd.Args = append(cmd.Args, "--recreate-lock-file")
+	}
+	return cmd
+}
+
+func (d *Devbox) copyFlakeLockToDevboxLock() error {
+
+	flakeLock, err := os.Open(d.flakeLockPath())
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	devboxLock, err := os.Create(d.devboxLockPath())
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	_, err = io.Copy(devboxLock, flakeLock)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+func (d *Devbox) copyDevboxLockToFlakeLock() error {
+	if !d.hasDevboxLockFile() {
+		return errors.New("devbox.lock file does not exist")
+	}
+
+	devboxLock, err := os.Open(d.devboxLockPath())
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	flakeLock, err := os.Create(d.flakeLockPath())
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	_, err = io.Copy(flakeLock, devboxLock)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+func (d *Devbox) hasDevboxLockFile() bool {
+	if _, err := os.Stat(d.devboxLockPath()); err != nil {
+		return false
+	}
+	return true
+}
+
+func (d *Devbox) devboxLockPath() string {
+	return filepath.Join(d.configDir, "devbox.lock")
+}
+
+func (d *Devbox) flakeLockPath() string {
+	return filepath.Join(d.configDir, ".devbox/gen/flake/flake.lock")
+}

--- a/internal/impl/generate.go
+++ b/internal/impl/generate.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -38,6 +39,11 @@ func generateForShell(rootPath string, plan *plansdk.ShellPlan, pluginManager *p
 	// TODO savil. Remove this hardcode from here, so this function can be generically defined again
 	//    by accepting the files list parameter.
 	err := writeFromTemplate(filepath.Join(rootPath, ".devbox"), plan, ".gitignore")
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	err = makeFlakeFile(outPath, plan)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -91,4 +97,37 @@ var templateFuncs = template.FuncMap{
 	"json":     toJSON,
 	"contains": strings.Contains,
 	"debug":    debug.IsEnabled,
+}
+
+func makeFlakeFile(outPath string, plan *plansdk.ShellPlan) error {
+
+	flakeDir := filepath.Join(outPath, "flake")
+	err := writeFromTemplate(flakeDir, plan, "flake.nix")
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	// make an empty git repo
+	// Alternatively consider: git add intent-to-add path/to/flake.nix, and
+	// git update-index --assume-unchanged path/to/flake.nix
+	// https://nixos.wiki/wiki/Flakes#How_to_add_a_file_locally_in_git_but_not_include_it_in_commits
+	cmd := exec.Command("git", "-C", flakeDir, "init")
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	// add the flake.nix file to git
+	cmd = exec.Command("git", "-C", flakeDir, "add", "flake.nix")
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
 }

--- a/internal/impl/generate.go
+++ b/internal/impl/generate.go
@@ -101,6 +101,10 @@ var templateFuncs = template.FuncMap{
 
 func makeFlakeFile(outPath string, plan *plansdk.ShellPlan) error {
 
+	if featureflag.Flakes.Disabled() {
+		return nil
+	}
+
 	flakeDir := filepath.Join(outPath, "flake")
 	err := writeFromTemplate(flakeDir, plan, "flake.nix")
 	if err != nil {

--- a/internal/impl/tmpl/flake.nix.tmpl
+++ b/internal/impl/tmpl/flake.nix.tmpl
@@ -1,0 +1,70 @@
+{
+    description = "A devbox shell";
+
+    inputs = {
+        # master branch can be slow because not all binaries are built and populated in the cache.
+        # using the nixpkgs-unstable tag ensures everything has been built and populated in the cache.
+        # https://www.reddit.com/r/NixOS/comments/ydr4po/comment/itv6oqo/?utm_source=reddit&utm_medium=web2x&context=3
+        nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+        flake-utils.url = "github:numtide/flake-utils";
+    };
+
+    outputs = { self, nixpkgs, flake-utils }:
+        flake-utils.lib.eachDefaultSystem (system:
+        let pkgs = nixpkgs.legacyPackages.${system};
+
+        in {
+            defaultPackage = pkgs.buildEnv {
+                name="devbox-shell-env";
+                paths = [
+                  {{- range .DevPackages}}
+                    pkgs.{{.}}
+                  {{end -}}
+                ];
+            };
+            devShell = pkgs.mkShell {
+              shellHook =
+                ''
+                  echo "Starting a devbox shell..."
+
+                  # We're technically no longer in a Nix shell after this hook because we
+                  # exec a devbox shell.
+                  export IN_NIX_SHELL=0
+                  export DEVBOX_SHELL_ENABLED=1
+
+                  # Undo the effects of `nix-shell --pure` on SSL certs.
+                  # See https://github.com/NixOS/nixpkgs/blob/dae204faa0243b4d0c0234a5f5f83a2549ecb5b7/pkgs/stdenv/generic/setup.sh#L677-L685
+                  if [ "$NIX_SSL_CERT_FILE" == "/no-cert-file.crt" ]; then
+                     unset NIX_SSL_CERT_FILE
+                  fi
+                  if [ "$SSL_CERT_FILE" == "/no-cert-file.crt" ]; then
+                     unset SSL_CERT_FILE
+                  fi
+
+                  # Append the parent shell's PATH so that we retain access to
+                  # non-Nix programs, while still preferring the Nix ones.
+                  export "PATH=$PATH:$PARENT_PATH"
+
+                  {{ if debug }}
+                  echo "pwd is: $(pwd)"
+                  echo "PARENT_PATH=$PARENT_PATH"
+                  echo "PATH=$PATH"
+                  {{- end }}
+
+                  # exec env "SHELL=/bin/zsh" "ZDOTDIR=/var/folders/zv/r3sx92_94gq86_rq3yn1ky2h0000gn/T/devbox3840985630" /bin/zsh
+                '';
+
+              # We do not need to install these because we do `nix profile install`
+              # using the defaultPackages above.
+              # BUT leaving this comment in place to revisit once I understand the environment implications more.
+              # TODO savil. Revisit.
+              buildInputs = [
+                  {{- range .DevPackages}}
+                    # pkgs.{{.}}
+                  {{end -}}
+              ];
+            };
+        }
+        );
+}

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -15,6 +15,7 @@ import (
 	"text/template"
 
 	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/debug"
 )
 
@@ -179,7 +180,35 @@ func (s *Shell) Run(nixShellFilePath string) error {
 		// inside the devbox shell.
 		"__ETC_PROFILE_NIX_SOURCED=1",
 	)
-	debug.Log("Running nix-shell with environment: %v", env)
+
+	if featureflag.Flakes.Enabled() {
+		if s.binPath == "" {
+			return errors.New("Unsupported for flakes: shell having no binPath")
+		}
+		cmd := exec.Command("nix", "develop", ".devbox/gen/flake",
+			"--extra-experimental-features", "nix-command flakes",
+			"--verbose",
+			"--ignore-environment",
+			"--command", "/bin/bash", "-c", s.execCommand(),
+			"--keep", "PARENT_PATH", // TODO savil. Why does it not show up inside devbox shell?
+		)
+
+		for _, keyVal := range env {
+			if strings.HasPrefix(keyVal, "PARENT_PATH") {
+				debug.Log("PARENT_PATH in env is %s\n", keyVal)
+			}
+		}
+
+		cmd.Args = append(cmd.Args, toKeepArgs(env, buildAllowList(s.env))...)
+		cmd.Env = env
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		debug.Log("Executing nix develop command: %v", cmd.Args)
+		debug.Log("Executing nix develop command with env: %v", cmd.Environ())
+		return errors.WithStack(cmd.Run())
+	}
 
 	// Launch a fallback shell if we couldn't find the path to the user's
 	// default shell.
@@ -215,6 +244,7 @@ func (s *Shell) execCommand() string {
 	// additional environment variables before any of the shell's init
 	// scripts run.
 	args := []string{
+
 		"exec",
 		"env",
 
@@ -339,8 +369,19 @@ func (s *Shell) writeDevboxShellrc() (path string, err error) {
 		pathPrepend = s.pkgConfigDir + ":" + pathPrepend
 	}
 
+	envToKeepFlakes := map[string]string{}
+	if featureflag.Flakes.Enabled() {
+		// `nix develop` has a list of ignoreVars, which we may want to not-ignore.
+		// For now, including just TERM since it affects shell cursor movement UX.
+		// https://github.com/NixOS/nix/blob/master/src/nix/develop.cc#L241-L259
+		envToKeepFlakes = map[string]string{
+			"TERM": os.Getenv("TERM"),
+		}
+	}
+
 	err = shellrcTmpl.Execute(shellrcf, struct {
 		ConfigDir        string
+		EnvToKeep        map[string]string
 		OriginalInit     string
 		OriginalInitPath string
 		UserHook         string
@@ -351,6 +392,7 @@ func (s *Shell) writeDevboxShellrc() (path string, err error) {
 		HistoryFile      string
 	}{
 		ConfigDir:        s.configDir,
+		EnvToKeep:        envToKeepFlakes,
 		OriginalInit:     string(bytes.TrimSpace(userShellrc)),
 		OriginalInitPath: filepath.Clean(s.userShellrcPath),
 		UserHook:         strings.TrimSpace(s.UserInitHook),

--- a/internal/nix/shellrc.tmpl
+++ b/internal/nix/shellrc.tmpl
@@ -34,6 +34,11 @@ PATH="{{ .PathPrepend }}:$PATH"
 HISTFILE={{.HistoryFile}}
 {{- end }}
 
+# Export env-vars which nix may remove by default, but are needed for shell UX
+{{ range $name, $value := .EnvToKeep }}
+export {{ $name }}={{ $value }}
+{{ end }}
+
 # Prepend to the prompt to make it clear we're in a devbox shell.
 export PS1="(devbox) $PS1"
 

--- a/internal/nix/testdata/shellrc/basic/shellrc.golden
+++ b/internal/nix/testdata/shellrc/basic/shellrc.golden
@@ -44,6 +44,9 @@ zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
 
 PATH="./.devbox/profile/bin:$PATH"
 
+# Export env-vars which nix may remove by default, but are needed for shell UX
+
+
 # Prepend to the prompt to make it clear we're in a devbox shell.
 export PS1="(devbox) $PS1"
 

--- a/internal/nix/testdata/shellrc/nohook/shellrc.golden
+++ b/internal/nix/testdata/shellrc/nohook/shellrc.golden
@@ -44,6 +44,9 @@ zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
 
 PATH="./.devbox/profile/bin:$PATH"
 
+# Export env-vars which nix may remove by default, but are needed for shell UX
+
+
 # Prepend to the prompt to make it clear we're in a devbox shell.
 export PS1="(devbox) $PS1"
 

--- a/internal/nix/testdata/shellrc/noshellrc/shellrc.golden
+++ b/internal/nix/testdata/shellrc/noshellrc/shellrc.golden
@@ -2,6 +2,9 @@
 
 PATH="./.devbox/profile/bin:$PATH"
 
+# Export env-vars which nix may remove by default, but are needed for shell UX
+
+
 # Prepend to the prompt to make it clear we're in a devbox shell.
 export PS1="(devbox) $PS1"
 


### PR DESCRIPTION
## Summary

re-submit of https://github.com/jetpack-io/devbox/pull/247
with an additional commit to gate the code in `generate.go`

## How was it tested?

Did `devbox shell` in a project
Previously, it would print info about initializing the inner git repo.
Now, it does not do that. 

Also inspected `.devbox/gen` to verify no flakes are generated.
