### PR TITLE
[Generate] Added devbox generate direnv command

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -26,6 +26,7 @@ type Devbox interface {
 	Generate() error
 	GenerateDevcontainer(force bool) error
 	GenerateDockerfile(force bool) error
+	GenerateEnvrc(force bool) error
 	Info(pkg string, markdown bool) error
 	ListScripts() []string
 	PrintShellEnv() error

--- a/internal/boxcli/generate/devcontainer_util.go
+++ b/internal/boxcli/generate/devcontainer_util.go
@@ -72,6 +72,23 @@ func CreateDevcontainer(path string, pkgs []string) error {
 	return nil
 }
 
+func CreateEnvrc(tmplFS embed.FS, path string) error {
+	// create dockerfile
+	file, err := os.Create(filepath.Join(path, ".envrc"))
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	// get dockerfile content
+	tmplName := "envrc.tmpl"
+	t := template.Must(template.ParseFS(tmplFS, "tmpl/"+tmplName))
+	// write content into file
+	err = t.Execute(file, nil)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
 func getDevcontainerContent(pkgs []string) *devcontainerObject {
 	// object that gets written in devcontainer.json
 	devcontainerContent := &devcontainerObject{

--- a/internal/boxcli/generate/devcontainer_util.go
+++ b/internal/boxcli/generate/devcontainer_util.go
@@ -73,12 +73,12 @@ func CreateDevcontainer(path string, pkgs []string) error {
 }
 
 func CreateEnvrc(tmplFS embed.FS, path string) error {
-	// create dockerfile
+	// create .envrc file
 	file, err := os.Create(filepath.Join(path, ".envrc"))
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	// get dockerfile content
+	// get .envrc content
 	tmplName := "envrc.tmpl"
 	t := template.Must(template.ParseFS(tmplFS, "tmpl/"+tmplName))
 	// write content into file

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -21,6 +21,7 @@ import (
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/cuecfg"
 	"go.jetpack.io/devbox/internal/debug"
+	"go.jetpack.io/devbox/internal/fileutil"
 	"go.jetpack.io/devbox/internal/initrec"
 	"go.jetpack.io/devbox/internal/nix"
 	"go.jetpack.io/devbox/internal/planner"
@@ -458,7 +459,7 @@ func (d *Devbox) GenerateDockerfile(force bool) error {
 // generates a .envrc file that makes direnv integration convenient
 func (d *Devbox) GenerateEnvrc(force bool) error {
 	envrcfilePath := filepath.Join(d.configDir, ".envrc")
-	filesExist := plansdk.FileExists(envrcfilePath)
+	filesExist := fileutil.Exists(envrcfilePath)
 	// confirm .envrc doesn't exist and don't overwrite an existing .envrc
 	if force || !filesExist {
 		err := generate.CreateEnvrc(tmplFS, d.configDir)

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -460,7 +460,7 @@ func (d *Devbox) GenerateEnvrc(force bool) error {
 	envrcfilePath := filepath.Join(d.configDir, ".envrc")
 	filesExist := plansdk.FileExists(envrcfilePath)
 	// confirm .envrc doesn't exist and don't overwrite an existing .envrc
-	if !filesExist {
+	if force || !filesExist {
 		err := generate.CreateEnvrc(tmplFS, d.configDir)
 		if err != nil {
 			return errors.WithStack(err)

--- a/internal/impl/tmpl/envrc.tmpl
+++ b/internal/impl/tmpl/envrc.tmpl
@@ -1,0 +1,5 @@
+use_devbox() {
+    watch_file devbox.json
+    eval $(devbox shell --print-env)
+}
+use devbox

--- a/internal/impl/tmpl/envrc.tmpl
+++ b/internal/impl/tmpl/envrc.tmpl
@@ -1,3 +1,6 @@
+# Automatically sets up your devbox environment whenever you cd into this
+# directory via our direnv integration:
+
 use_devbox() {
     watch_file devbox.json
     eval $(devbox shell --print-env)

--- a/internal/impl/tmpl/envrc.tmpl
+++ b/internal/impl/tmpl/envrc.tmpl
@@ -6,3 +6,6 @@ use_devbox() {
     eval $(devbox shell --print-env)
 }
 use devbox
+
+# check out https://www.jetpack.io/devbox/docs/ide_configuration/direnv/ 
+# for more details


### PR DESCRIPTION
## Summary
title says it:
this is step 1 of 4 to make integration with direnv more convenient
## How was it tested?
- compile
- run `devbox generate direnv`
- confirm `.envrc` file is generated and works with direnv
