### PR TITLE
[cloud] emulate user's local directory structure in VM

### DIFF
--- a/internal/cloud/cloud_test.go
+++ b/internal/cloud/cloud_test.go
@@ -10,10 +10,11 @@ func TestProjectDirName(t *testing.T) {
 
 	testCases := []struct {
 		projectDir string
-		dirName    string
+		dirPath    string
 	}{
-		{"/", defaultProjectDirName},
-		{".", defaultProjectDirName},
+		// TODO revisit
+		//{"/", defaultProjectDirName},
+		//{".", defaultProjectDirName},
 		{"/foo", "foo"},
 		{"foo/bar", "bar"},
 		{"foo/bar/", "bar"},
@@ -23,7 +24,9 @@ func TestProjectDirName(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.projectDir, func(t *testing.T) {
 			assert := assert.New(t)
-			assert.Equal(testCase.dirName, projectDirName(testCase.projectDir))
+			path, err := projectDirPath(testCase.projectDir)
+			assert.NoError(err)
+			assert.Equal(testCase.dirPath, path)
 		})
 	}
 }

--- a/internal/cloud/cloud_test.go
+++ b/internal/cloud/cloud_test.go
@@ -30,17 +30,17 @@ func TestProjectDirName(t *testing.T) {
 		{filepath.Join(homeDir, "foo/bar"), "foo/bar"},
 
 		// non-home-dir
-		{"/", "/"},
-		{"/foo", "/foo"},
-		{"/foo/bar", "/foo/bar"},
-		{"/foo/bar/", "/foo/bar"},
-		{"/foo/bar///", "/foo/bar"},
+		{"/", filepath.Join(outsideHomedirDirectory, "/")},
+		{"/foo", filepath.Join(outsideHomedirDirectory, "/foo")},
+		{"/foo/bar", filepath.Join(outsideHomedirDirectory, "/foo/bar")},
+		{"/foo/bar/", filepath.Join(outsideHomedirDirectory, "/foo/bar")},
+		{"/foo/bar///", filepath.Join(outsideHomedirDirectory, "/foo/bar")},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.projectDir, func(t *testing.T) {
 			assert := assert.New(t)
-			path, err := projectDirPath(testCase.projectDir)
+			path, err := relativeProjectPathInVM(testCase.projectDir)
 			assert.NoError(err)
 			assert.Equal(testCase.dirPath, path)
 		})

--- a/internal/cloud/cloud_test.go
+++ b/internal/cloud/cloud_test.go
@@ -1,24 +1,40 @@
 package cloud
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestProjectDirName(t *testing.T) {
+	assertion := assert.New(t)
+
+	homeDir, err := os.UserHomeDir()
+	assertion.NoError(err)
+
+	workingDir, err := os.Getwd()
+	assertion.NoError(err)
+
+	relWorkingDir, err := filepath.Rel(homeDir, workingDir)
+	assertion.NoError(err)
 
 	testCases := []struct {
 		projectDir string
 		dirPath    string
 	}{
-		// TODO revisit
-		//{"/", defaultProjectDirName},
-		//{".", defaultProjectDirName},
-		{"/foo", "foo"},
-		{"foo/bar", "bar"},
-		{"foo/bar/", "bar"},
-		{"foo/bar///", "bar"},
+		// inside homedir
+		{".", relWorkingDir},
+		{filepath.Join(homeDir, "foo"), "foo"},
+		{filepath.Join(homeDir, "foo/bar"), "foo/bar"},
+
+		// non-home-dir
+		{"/", "/"},
+		{"/foo", "/foo"},
+		{"/foo/bar", "/foo/bar"},
+		{"/foo/bar/", "/foo/bar"},
+		{"/foo/bar///", "/foo/bar"},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/cloud/openssh/client.go
+++ b/internal/cloud/openssh/client.go
@@ -17,14 +17,14 @@ import (
 )
 
 type Client struct {
-	Username       string
-	Addr           string
-	ProjectDirPath string
+	Username string
+	Addr     string
+	PathInVM string
 }
 
 func (c *Client) Shell() error {
 	cmd := c.cmd("-t")
-	remoteCmd := fmt.Sprintf(`bash -l -c "start_devbox_shell.sh \"%s\""`, c.ProjectDirPath)
+	remoteCmd := fmt.Sprintf(`bash -l -c "start_devbox_shell.sh \"%s\""`, c.PathInVM)
 	cmd.Args = append(cmd.Args, remoteCmd)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/internal/cloud/openssh/client.go
+++ b/internal/cloud/openssh/client.go
@@ -19,12 +19,12 @@ import (
 type Client struct {
 	Username       string
 	Addr           string
-	ProjectDirName string
+	ProjectDirPath string
 }
 
 func (c *Client) Shell() error {
 	cmd := c.cmd("-t")
-	remoteCmd := fmt.Sprintf(`bash -l -c "start_devbox_shell.sh \"%s\""`, c.ProjectDirName)
+	remoteCmd := fmt.Sprintf(`bash -l -c "start_devbox_shell.sh \"%s\""`, c.ProjectDirPath)
 	cmd.Args = append(cmd.Args, remoteCmd)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
## Summary

**Problem**
A scenario we want to protect against is two distinct projects sharing the same directory name. For example, consider projects located at `~/customer1/my_project` and `~/customer2/my_project`. Prior to this PR, we would attempt to sync both projects to the same folder in the VM: `~/code/my_project`.

**Approach**
This PR attempts to solve this conflict by seeking to emulate the user's directory structure in the VM. So, for the aforementioned example projects, they will sync to `~/customer1/my_project` and `~/customer2/my_project` in the VM as well. This has the additional benefit that if a user has relative paths between two projects they are actively developing (for example, a golang library and golang application that uses that library), then these relative paths will continue working in the cloud-shell, in accordance with our desires to make the cloud-shell experience akin to local shells.

**Edge case: projects outside homedir**
An edge case is for projects that are located locally outside the user's homedir. For security reasons, in the VM, we do not want to give the user root access, or access to folders outside their homedir. We choose to sync to a special folder called: `~/outside-homedir-code/<absolute path>`. For example, a project located locally at `/my_company/my_project` will sync to `~/outside-homedir-code/my_company/my_project`. There are two downsides to this which are tolerable IMO:
1. If a user _also has_ a local folder called `~/devbox-cloud` and they want to sync those projects then there will be a conflict. 
2. Relative paths between a project in homedir and outside the homedir will not work. The user can inspect the paths in the cloud-shells via `pwd` and update the relative paths to match that.



## How was it tested?

for `testdata/go/go-1.19`: could sync to VM via `devbox cloud shell`, and inspect directory in VM with `pwd`.


for edge case: projects outside homedir:
1. copied `examples/testdata/rust/rust-stable` to `/usr/local/testy-nonhome-dir/rust-stable`
2. fixed permissions: `sudo chown savil:staff /usr/local/testy-nonhome-dir/rust-stable`
3. `devbox cloud shell` to VM
4. `pwd` in VM gave: `/home/savil/outside-homedir-code/usr/local/testy-nonhome-dir/rust-stable`
5. `devbox add gcc` and then `cargo run` ran successfully.
