### PR TITLE
Return exit code of the exec call

### DIFF
--- a/internal/boxcli/midcobra/midcobra.go
+++ b/internal/boxcli/midcobra/midcobra.go
@@ -6,6 +6,8 @@ package midcobra
 import (
 	"context"
 	"encoding/hex"
+	"errors"
+	"os/exec"
 
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
@@ -69,6 +71,11 @@ func (ex *midcobraExecutable) Execute(ctx context.Context, args []string) int {
 	}
 
 	if err != nil {
+		// If the error is from the exec call, return the exit code of the exec call.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return exitErr.ExitCode()
+		}
 		return 1 // Error exit code
 	} else {
 		return 0

--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -4,7 +4,6 @@
 package boxcli
 
 import (
-	"os/exec"
 	"sort"
 
 	"github.com/pkg/errors"
@@ -60,11 +59,6 @@ func runScriptCmd(cmd *cobra.Command, args []string, flags runCmdFlags) error {
 		err = box.RunScriptInShell(script)
 	} else {
 		err = box.RunScript(script)
-	}
-
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
-		return nil
 	}
 	return err
 }

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -5,6 +5,7 @@ package boxcli
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -5,8 +5,6 @@ package boxcli
 
 import (
 	"fmt"
-	"os/exec"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
@@ -64,11 +62,6 @@ func runShellCmd(cmd *cobra.Command, args []string, flags shellCmdFlags) error {
 		err = box.Exec(cmds...)
 	} else {
 		err = box.Shell()
-	}
-
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
-		return nil
 	}
 	return err
 }


### PR DESCRIPTION
## Summary

Currently, there is no way to figuring out if the shell / run command succeeded or not in the CI-like environment.

This commit fixes this issue by returning exit code of the exec call if errored.

## How was it tested?

- Running `shell` with the failing command

```sh
❯ ./devbox shell -- exit 1
Installing nix packages. This may take a while... done.
Error: exit status 1

❯ echo $?
1
```
 
- Running `script` with the failing command

```json
{
  "shell": {
    "scripts": {
      "failing_script": "exit 1"
    }
  }
}
```

```sh
❯ ./devbox run failing_script
Installing nix packages. This may take a while... done.
Starting a devbox shell...
Error: exit status 1

❯ echo $?
1
```
 