### PR TITLE
[cleanup] rename configDir to projectDir

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -19,7 +19,7 @@ type Devbox interface {
 	// it. Adding a duplicate package is a no-op.
 	Add(pkgs ...string) error
 	Config() *impl.Config
-	ConfigDir() string
+	ProjectDir() string
 	Exec(cmds ...string) error
 	// Generate creates the directory of Nix files and the Dockerfile that define
 	// the devbox environment.

--- a/internal/boxcli/cloud.go
+++ b/internal/boxcli/cloud.go
@@ -47,5 +47,5 @@ func runCloudShellCmd(cmd *cobra.Command, flags *cloudShellCmdFlags) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	return cloud.Shell(box.ConfigDir(), cmd.ErrOrStderr())
+	return cloud.Shell(box.ProjectDir(), cmd.ErrOrStderr())
 }

--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -299,7 +299,7 @@ func shell(username, hostname, configDir string) error {
 
 const defaultProjectDirName = "devbox_project"
 
-// Ideally, we'd pass in devbox.Devbox struct and call ConfigDir but it
+// Ideally, we'd pass in devbox.Devbox struct and call ProjectDir but it
 // makes it hard to wrap this in a test
 func projectDirName(configDir string) string {
 	name := filepath.Base(configDir)

--- a/internal/impl/config.go
+++ b/internal/impl/config.go
@@ -92,9 +92,12 @@ func WriteConfig(path string, cfg *Config) error {
 	return cuecfg.WriteFile(path, cfg)
 }
 
-// findConfigDir is a utility for using the path
-func findConfigDir(path string) (string, error) {
-	debug.Log("findConfigDir: path is %s\n", path)
+// findProjectDir walks up the directory tree looking for a devbox.json
+// and upon finding it, will return the directory-path.
+//
+// If it doesn't find any devbox.json, then an error is returned.
+func findProjectDir(path string) (string, error) {
+	debug.Log("findProjectDir: path is %s\n", path)
 
 	// Sanitize the directory and use the absolute path as canonical form
 	absPath, err := filepath.Abs(path)
@@ -105,12 +108,12 @@ func findConfigDir(path string) (string, error) {
 	// If the path  is specified, then we check directly for a config.
 	// Otherwise, we search the parent directories.
 	if path != "" {
-		return findConfigDirAtPath(absPath)
+		return findProjectDirAtPath(absPath)
 	}
-	return findConfigDirFromParentDirSearch("/" /*root*/, absPath)
+	return findProjectDirFromParentDirSearch("/" /*root*/, absPath)
 }
 
-func findConfigDirAtPath(absPath string) (string, error) {
+func findProjectDirAtPath(absPath string) (string, error) {
 	fi, err := os.Stat(absPath)
 	if err != nil {
 		return "", err
@@ -131,7 +134,7 @@ func findConfigDirAtPath(absPath string) (string, error) {
 	}
 }
 
-func findConfigDirFromParentDirSearch(root string, absPath string) (string, error) {
+func findProjectDirFromParentDirSearch(root string, absPath string) (string, error) {
 
 	cur := absPath
 	// Search parent directories for a devbox.json

--- a/internal/impl/config_test.go
+++ b/internal/impl/config_test.go
@@ -8,32 +8,32 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFindConfigDirFromParentDirSearch(t *testing.T) {
+func TestFindProjectDirFromParentDirSearch(t *testing.T) {
 	testCases := []struct {
 		name        string
 		allDirs     string
-		configDir   string
+		projectDir  string
 		searchPath  string
 		expectError bool
 	}{
 		{
 			name:        "search_dir_same_as_config_dir",
 			allDirs:     "a/b/c",
-			configDir:   "a/b",
+			projectDir:  "a/b",
 			searchPath:  "a/b",
 			expectError: false,
 		},
 		{
 			name:        "search_dir_in_nested_folder",
 			allDirs:     "a/b/c",
-			configDir:   "a/b",
+			projectDir:  "a/b",
 			searchPath:  "a/b/c",
 			expectError: false,
 		},
 		{
 			name:        "search_dir_in_parent_folder",
 			allDirs:     "a/b/c",
-			configDir:   "a/b",
+			projectDir:  "a/b",
 			searchPath:  "a",
 			expectError: true,
 		},
@@ -49,58 +49,58 @@ func TestFindConfigDirFromParentDirSearch(t *testing.T) {
 			err = os.MkdirAll(filepath.Join(root, testCase.allDirs), 0777)
 			assert.NoError(err)
 
-			absConfigPath, err := filepath.Abs(filepath.Join(root, testCase.configDir, configFilename))
+			absProjectPath, err := filepath.Abs(filepath.Join(root, testCase.projectDir, configFilename))
 			assert.NoError(err)
-			err = os.WriteFile(absConfigPath, []byte("{}"), 0666)
+			err = os.WriteFile(absProjectPath, []byte("{}"), 0666)
 			assert.NoError(err)
 
 			absSearchPath := filepath.Join(root, testCase.searchPath)
-			result, err := findConfigDirFromParentDirSearch(root, absSearchPath)
+			result, err := findProjectDirFromParentDirSearch(root, absSearchPath)
 
 			if testCase.expectError {
 				assert.Error(err)
 			} else {
 				assert.NoError(err)
-				assert.Equal(filepath.Dir(filepath.Join(absConfigPath)), result)
+				assert.Equal(filepath.Dir(filepath.Join(absProjectPath)), result)
 			}
 		})
 	}
 }
 
-func TestFindConfigDirAtPath(t *testing.T) {
+func TestFindParentDirAtPath(t *testing.T) {
 
 	testCases := []struct {
 		name        string
 		allDirs     string
-		configDir   string
+		projectDir  string
 		flagPath    string
 		expectError bool
 	}{
 		{
 			name:        "flag_path_is_dir_has_config",
 			allDirs:     "a/b/c",
-			configDir:   "a/b",
+			projectDir:  "a/b",
 			flagPath:    "a/b",
 			expectError: false,
 		},
 		{
 			name:        "flag_path_is_dir_missing_config",
 			allDirs:     "a/b/c",
-			configDir:   "", // missing config
+			projectDir:  "", // missing config
 			flagPath:    "a/b",
 			expectError: true,
 		},
 		{
 			name:        "flag_path_is_file_has_config",
 			allDirs:     "a/b/c",
-			configDir:   "a/b",
+			projectDir:  "a/b",
 			flagPath:    "a/b/" + configFilename,
 			expectError: false,
 		},
 		{
 			name:        "flag_path_is_file_missing_config",
 			allDirs:     "a/b/c",
-			configDir:   "", // missing config
+			projectDir:  "", // missing config
 			flagPath:    "a/b/" + configFilename,
 			expectError: true,
 		},
@@ -116,22 +116,22 @@ func TestFindConfigDirAtPath(t *testing.T) {
 			err = os.MkdirAll(filepath.Join(root, testCase.allDirs), 0777)
 			assert.NoError(err)
 
-			var absConfigPath string
-			if testCase.configDir != "" {
-				absConfigPath, err = filepath.Abs(filepath.Join(root, testCase.configDir, configFilename))
+			var absProjectPath string
+			if testCase.projectDir != "" {
+				absProjectPath, err = filepath.Abs(filepath.Join(root, testCase.projectDir, configFilename))
 				assert.NoError(err)
-				err = os.WriteFile(absConfigPath, []byte("{}"), 0666)
+				err = os.WriteFile(absProjectPath, []byte("{}"), 0666)
 				assert.NoError(err)
 			}
 
 			absFlagPath := filepath.Join(root, testCase.flagPath)
-			result, err := findConfigDirAtPath(absFlagPath)
+			result, err := findProjectDirAtPath(absFlagPath)
 
 			if testCase.expectError {
 				assert.Error(err)
 			} else {
 				assert.NoError(err)
-				assert.Equal(filepath.Dir(filepath.Join(absConfigPath)), result)
+				assert.Equal(filepath.Dir(filepath.Join(absProjectPath)), result)
 			}
 		})
 	}

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -64,20 +64,19 @@ func InitConfig(dir string, writer io.Writer) (created bool, err error) {
 
 type Devbox struct {
 	cfg *Config
-	// configDir is the directory where the config file (devbox.json) resides
-	configDir     string
+	// projectDir is the directory where the config file (devbox.json) resides
+	projectDir    string
 	pluginManager *plugin.Manager
 	writer        io.Writer
 }
 
-// TODO savil. dir is technically path since it could be a dir or file
-func Open(dir string, writer io.Writer) (*Devbox, error) {
+func Open(path string, writer io.Writer) (*Devbox, error) {
 
-	cfgDir, err := findConfigDir(dir)
+	projectDir, err := findProjectDir(path)
 	if err != nil {
 		return nil, err
 	}
-	cfgPath := filepath.Join(cfgDir, configFilename)
+	cfgPath := filepath.Join(projectDir, configFilename)
 
 	cfg, err := ReadConfig(cfgPath)
 	if err != nil {
@@ -90,15 +89,15 @@ func Open(dir string, writer io.Writer) (*Devbox, error) {
 
 	box := &Devbox{
 		cfg:           cfg,
-		configDir:     cfgDir,
+		projectDir:    projectDir,
 		pluginManager: plugin.NewManager(),
 		writer:        writer,
 	}
 	return box, nil
 }
 
-func (d *Devbox) ConfigDir() string {
-	return d.configDir
+func (d *Devbox) ProjectDir() string {
+	return d.projectDir
 }
 
 func (d *Devbox) Config() *Config {
@@ -133,7 +132,7 @@ func (d *Devbox) Add(pkgs ...string) error {
 		for _, pkg := range pkgs {
 			if err := plugin.PrintReadme(
 				pkg,
-				d.configDir,
+				d.projectDir,
 				d.writer,
 				IsDevboxShellEnabled(),
 				false, /*markdown*/
@@ -166,7 +165,7 @@ func (d *Devbox) Remove(pkgs ...string) error {
 	}
 
 	if featureflag.PKGConfig.Enabled() {
-		if err := plugin.Remove(d.configDir, uninstalledPackages); err != nil {
+		if err := plugin.Remove(d.projectDir, uninstalledPackages); err != nil {
 			return err
 		}
 	}
@@ -180,7 +179,7 @@ func (d *Devbox) Remove(pkgs ...string) error {
 
 func (d *Devbox) ShellPlan() (*plansdk.ShellPlan, error) {
 	userDefinedPkgs := d.cfg.Packages
-	shellPlan := planner.GetShellPlan(d.configDir, userDefinedPkgs)
+	shellPlan := planner.GetShellPlan(d.projectDir, userDefinedPkgs)
 	shellPlan.DevPackages = userDefinedPkgs
 
 	if nixpkgsInfo, err := plansdk.GetNixpkgsInfo(d.cfg.Nixpkgs.Commit); err != nil {
@@ -210,9 +209,9 @@ func (d *Devbox) Shell() error {
 		return err
 	}
 
-	nixShellFilePath := filepath.Join(d.configDir, ".devbox/gen/shell.nix")
+	nixShellFilePath := filepath.Join(d.projectDir, ".devbox/gen/shell.nix")
 
-	pluginHooks, err := plugin.InitHooks(d.cfg.Packages, d.configDir)
+	pluginHooks, err := plugin.InitHooks(d.cfg.Packages, d.projectDir)
 	if err != nil {
 		return err
 	}
@@ -220,19 +219,19 @@ func (d *Devbox) Shell() error {
 	opts := []nix.ShellOption{
 		nix.WithPluginInitHook(strings.Join(pluginHooks, "\n")),
 		nix.WithProfile(profileDir),
-		nix.WithHistoryFile(filepath.Join(d.configDir, shellHistoryFile)),
-		nix.WithConfigDir(d.configDir),
+		nix.WithHistoryFile(filepath.Join(d.projectDir, shellHistoryFile)),
+		nix.WithConfigDir(d.projectDir),
 	}
 	// TODO: separate package suggestions from shell planners
 	if featureflag.PKGConfig.Enabled() {
-		env, err := plugin.Env(d.cfg.Packages, d.configDir)
+		env, err := plugin.Env(d.cfg.Packages, d.projectDir)
 		if err != nil {
 			return err
 		}
 		opts = append(
 			opts,
 			nix.WithEnvVariables(env),
-			nix.WithPKGConfigDir(filepath.Join(d.configDir, plugin.VirtenvBinPath)),
+			nix.WithPKGConfigDir(filepath.Join(d.projectDir, plugin.VirtenvBinPath)),
 		)
 	}
 
@@ -259,9 +258,9 @@ func (d *Devbox) RunScriptInShell(scriptName string) error {
 
 	shell, err := nix.DetectShell(
 		nix.WithProfile(profileDir),
-		nix.WithHistoryFile(filepath.Join(d.configDir, shellHistoryFile)),
+		nix.WithHistoryFile(filepath.Join(d.projectDir, shellHistoryFile)),
 		nix.WithUserScript(scriptName, script.String()),
-		nix.WithConfigDir(d.configDir),
+		nix.WithConfigDir(d.projectDir),
 	)
 
 	if err != nil {
@@ -284,13 +283,13 @@ func (d *Devbox) RunScript(scriptName string) error {
 		return err
 	}
 
-	nixShellFilePath := filepath.Join(d.configDir, ".devbox/gen/shell.nix")
+	nixShellFilePath := filepath.Join(d.projectDir, ".devbox/gen/shell.nix")
 	script := d.cfg.Shell.Scripts[scriptName]
 	if script == nil {
 		return errors.Errorf("unable to find a script with name %s", scriptName)
 	}
 
-	pluginHooks, err := plugin.InitHooks(d.cfg.Packages, d.configDir)
+	pluginHooks, err := plugin.InitHooks(d.cfg.Packages, d.projectDir)
 	if err != nil {
 		return err
 	}
@@ -298,20 +297,20 @@ func (d *Devbox) RunScript(scriptName string) error {
 	opts := []nix.ShellOption{
 		nix.WithPluginInitHook(strings.Join(pluginHooks, "\n")),
 		nix.WithProfile(profileDir),
-		nix.WithHistoryFile(filepath.Join(d.configDir, shellHistoryFile)),
+		nix.WithHistoryFile(filepath.Join(d.projectDir, shellHistoryFile)),
 		nix.WithUserScript(scriptName, script.String()),
-		nix.WithConfigDir(d.configDir),
+		nix.WithConfigDir(d.projectDir),
 	}
 
 	if featureflag.PKGConfig.Enabled() {
-		env, err := plugin.Env(d.cfg.Packages, d.configDir)
+		env, err := plugin.Env(d.cfg.Packages, d.projectDir)
 		if err != nil {
 			return err
 		}
 		opts = append(
 			opts,
 			nix.WithEnvVariables(env),
-			nix.WithPKGConfigDir(filepath.Join(d.configDir, plugin.VirtenvBinPath)),
+			nix.WithPKGConfigDir(filepath.Join(d.projectDir, plugin.VirtenvBinPath)),
 		)
 	}
 
@@ -349,19 +348,19 @@ func (d *Devbox) Exec(cmds ...string) error {
 	env := []string{}
 	virtenvBinPath := ""
 	if featureflag.PKGConfig.Enabled() {
-		envMap, err := plugin.Env(d.cfg.Packages, d.configDir)
+		envMap, err := plugin.Env(d.cfg.Packages, d.projectDir)
 		if err != nil {
 			return err
 		}
 		for k, v := range envMap {
 			env = append(env, fmt.Sprintf("%s=%s", k, v))
 		}
-		virtenvBinPath = filepath.Join(d.configDir, plugin.VirtenvBinPath) + ":"
+		virtenvBinPath = filepath.Join(d.projectDir, plugin.VirtenvBinPath) + ":"
 	}
 	pathWithProfileBin := fmt.Sprintf("PATH=%s%s:$PATH", virtenvBinPath, profileBinDir)
 	cmds = append([]string{pathWithProfileBin}, cmds...)
 
-	nixDir := filepath.Join(d.configDir, ".devbox/gen/shell.nix")
+	nixDir := filepath.Join(d.projectDir, ".devbox/gen/shell.nix")
 	return nix.Exec(nixDir, cmds, env)
 }
 
@@ -392,7 +391,7 @@ func (d *Devbox) Info(pkg string, markdown bool) error {
 	}
 	return plugin.PrintReadme(
 		pkg,
-		d.configDir,
+		d.projectDir,
 		d.writer,
 		false, /*showSourceEnv*/
 		markdown,
@@ -403,7 +402,7 @@ func (d *Devbox) Info(pkg string, markdown bool) error {
 // and Github Codespaces
 func (d *Devbox) GenerateDevcontainer(force bool) error {
 	// construct path to devcontainer directory
-	devContainerPath := filepath.Join(d.configDir, ".devcontainer/")
+	devContainerPath := filepath.Join(d.projectDir, ".devcontainer/")
 	devContainerJSONPath := filepath.Join(devContainerPath, "devcontainer.json")
 	dockerfilePath := filepath.Join(devContainerPath, "Dockerfile")
 
@@ -437,12 +436,12 @@ func (d *Devbox) GenerateDevcontainer(force bool) error {
 
 // generates a Dockerfile that replicates the devbox shell
 func (d *Devbox) GenerateDockerfile(force bool) error {
-	dockerfilePath := filepath.Join(d.configDir, "Dockerfile")
+	dockerfilePath := filepath.Join(d.projectDir, "Dockerfile")
 	// check if Dockerfile doesn't exist
 	filesExist := plansdk.FileExists(dockerfilePath)
 	if force || !filesExist {
 		// generate dockerfile
-		err := generate.CreateDockerfile(tmplFS, d.configDir)
+		err := generate.CreateDockerfile(tmplFS, d.projectDir)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -458,11 +457,11 @@ func (d *Devbox) GenerateDockerfile(force bool) error {
 
 // generates a .envrc file that makes direnv integration convenient
 func (d *Devbox) GenerateEnvrc(force bool) error {
-	envrcfilePath := filepath.Join(d.configDir, ".envrc")
+	envrcfilePath := filepath.Join(d.projectDir, ".envrc")
 	filesExist := fileutil.Exists(envrcfilePath)
 	// confirm .envrc doesn't exist and don't overwrite an existing .envrc
 	if force || !filesExist {
-		err := generate.CreateEnvrc(tmplFS, d.configDir)
+		err := generate.CreateEnvrc(tmplFS, d.projectDir)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -478,26 +477,26 @@ func (d *Devbox) GenerateEnvrc(force bool) error {
 
 // saveCfg writes the config file to the devbox directory.
 func (d *Devbox) saveCfg() error {
-	cfgPath := filepath.Join(d.configDir, configFilename)
+	cfgPath := filepath.Join(d.projectDir, configFilename)
 	return cuecfg.WriteFile(cfgPath, d.cfg)
 }
 
 func (d *Devbox) Services() (plugin.Services, error) {
-	return plugin.GetServices(d.cfg.Packages, d.configDir)
+	return plugin.GetServices(d.cfg.Packages, d.projectDir)
 }
 
 func (d *Devbox) StartServices(services ...string) error {
 	if !IsDevboxShellEnabled() {
 		return d.Exec(append([]string{"devbox", "services", "start"}, services...)...)
 	}
-	return plugin.StartServices(d.cfg.Packages, services, d.configDir, d.writer)
+	return plugin.StartServices(d.cfg.Packages, services, d.projectDir, d.writer)
 }
 
 func (d *Devbox) StopServices(services ...string) error {
 	if !IsDevboxShellEnabled() {
 		return d.Exec(append([]string{"devbox", "services", "stop"}, services...)...)
 	}
-	return plugin.StopServices(d.cfg.Packages, services, d.configDir, d.writer)
+	return plugin.StopServices(d.cfg.Packages, services, d.projectDir, d.writer)
 }
 
 func (d *Devbox) generateShellFiles() error {
@@ -505,11 +504,11 @@ func (d *Devbox) generateShellFiles() error {
 	if err != nil {
 		return err
 	}
-	return generateForShell(d.configDir, plan, d.pluginManager)
+	return generateForShell(d.projectDir, plan, d.pluginManager)
 }
 
 func (d *Devbox) profileDir() (string, error) {
-	absPath := filepath.Join(d.configDir, nix.ProfilePath)
+	absPath := filepath.Join(d.projectDir, nix.ProfilePath)
 	if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
 		return "", errors.WithStack(err)
 	}
@@ -552,7 +551,7 @@ func (d *Devbox) ensurePackagesAreInstalled(mode installMode) error {
 	fmt.Fprintln(d.writer, "done.")
 
 	if featureflag.PKGConfig.Enabled() {
-		if err := plugin.RemoveInvalidSymlinks(d.configDir); err != nil {
+		if err := plugin.RemoveInvalidSymlinks(d.projectDir); err != nil {
 			return err
 		}
 	}
@@ -628,7 +627,7 @@ func (d *Devbox) installNixProfile() (err error) {
 			"nix-env",
 			"--profile", profileDir,
 			"--install",
-			"-f", filepath.Join(d.configDir, ".devbox/gen/development.nix"),
+			"-f", filepath.Join(d.projectDir, ".devbox/gen/development.nix"),
 		)
 	}
 

--- a/internal/impl/devbox_test.go
+++ b/internal/impl/devbox_test.go
@@ -40,11 +40,11 @@ func testShell(t *testing.T, testPath string) {
 		box, err := Open(baseDir, os.Stdout)
 		assert.NoErrorf(err, "%s should be a valid devbox project", baseDir)
 
-		// Just for tests, we make configDir be a relative path so that the paths in plan.json
+		// Just for tests, we make projectDir be a relative path so that the paths in plan.json
 		// of various test cases have relative paths. Absolute paths are a no-go because they'd
 		// be of the form `/Users/savil/...`, which are not generalized and cannot be checked in.
-		box.configDir, err = filepath.Rel(currentDir, box.configDir)
-		assert.NoErrorf(err, "expect to construct relative path from %s relative to base %s", box.configDir, currentDir)
+		box.projectDir, err = filepath.Rel(currentDir, box.projectDir)
+		assert.NoErrorf(err, "expect to construct relative path from %s relative to base %s", box.projectDir, currentDir)
 
 		shellPlan, err := box.ShellPlan()
 		assert.NoError(err, "devbox shell plan should not fail")

--- a/internal/impl/flake.go
+++ b/internal/impl/flake.go
@@ -14,7 +14,7 @@ func (d *Devbox) installNixProfileFlakeCommand(profileDir string) *exec.Cmd {
 		"nix", "profile", "install",
 		"--profile", profileDir,
 		"--extra-experimental-features", "nix-command flakes",
-		filepath.Join(d.configDir, ".devbox/gen/flake/"), // installables
+		filepath.Join(d.projectDir, ".devbox/gen/flake/"), // installables
 	)
 	if d.hasDevboxLockFile() {
 		_ = d.copyDevboxLockToFlakeLock()
@@ -70,9 +70,9 @@ func (d *Devbox) hasDevboxLockFile() bool {
 }
 
 func (d *Devbox) devboxLockPath() string {
-	return filepath.Join(d.configDir, "devbox.lock")
+	return filepath.Join(d.projectDir, "devbox.lock")
 }
 
 func (d *Devbox) flakeLockPath() string {
-	return filepath.Join(d.configDir, ".devbox/gen/flake/flake.lock")
+	return filepath.Join(d.projectDir, ".devbox/gen/flake/flake.lock")
 }


### PR DESCRIPTION
## Summary

`configDir` is used to mean the directory-path corresponding to the `--config`
flag in the `devbox` commands. Unfortunately, this can be conflated with the 
directory at `~/.config/devbox`, and so we can choose to rename it to `projectDir`.

Future PRs will address:
1. changes in `cloud.go` and other `devbox cloud` code.
2. changes in plugin framework, where this is referred to `rootDir`.

## How was it tested?

tests pass
could open `devbox shell` in a golang example project.
