### PR TITLE
[cleanup] devbox cloud: rename configDir to projectDir

### DIFF
--- a/internal/cloud/cloud_test.go
+++ b/internal/cloud/cloud_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestConfigDirName(t *testing.T) {
+func TestProjectDirName(t *testing.T) {
 
 	testCases := []struct {
-		configDir string
-		dirName   string
+		projectDir string
+		dirName    string
 	}{
 		{"/", defaultProjectDirName},
 		{".", defaultProjectDirName},
@@ -21,9 +21,9 @@ func TestConfigDirName(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		t.Run(testCase.configDir, func(t *testing.T) {
+		t.Run(testCase.projectDir, func(t *testing.T) {
 			assert := assert.New(t)
-			assert.Equal(testCase.dirName, projectDirName(testCase.configDir))
+			assert.Equal(testCase.dirName, projectDirName(testCase.projectDir))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

This PR renames configDir to projectDir for `devbox cloud` code.



## How was it tested?

After this PR, the following is what is left which correspond to `~/.config/devbox`
```
❯ git grep -in configDir | grep cloud
internal/cloud/mutagen/xdg.go:19:func ConfigDir() string {
internal/cloud/mutagen/xdg.go:24:	return filepath.Join(ConfigDir(), subpath)
internal/cloud/openssh/config.go:90:		ConfigDir     string
internal/cloud/openssh/config.go:97:		ConfigDir:     devboxSSHDir,
internal/cloud/openssh/config.go:240:	devboxConfigDir := filepath.Join(dotConfig, "devbox")
internal/cloud/openssh/config.go:241:	if err := EnsureDirExists(devboxConfigDir, 0755, true); err != nil {
internal/cloud/openssh/config.go:246:	devboxSSHDir := filepath.Join(devboxConfigDir, "ssh")
internal/cloud/openssh/sshconfig.tmpl:6:	UserKnownHostsFile "{{ .ConfigDir }}/known_hosts"
internal/cloud/openssh/sshconfig.tmpl:11:	UserKnownHostsFile "{{ .ConfigDir }}/known_hosts"
internal/cloud/openssh/sshconfig.tmpl:16:	IdentityFile "{{ .ConfigDir }}/keys/%h"
internal/cloud/openssh/sshconfig.tmpl:19:	UserKnownHostsFile "{{ .ConfigDir }}/known_hosts"
internal/cloud/openssh/sshconfig.tmpl:23:	ControlPath "{{ .ConfigDir }}/sockets/%h"
internal/cloud/openssh/sshconfig.tmpl:32:	UserKnownHostsFile "{{ .ConfigDir }}/known_hosts_debug"
```
