### PR TITLE
[cleanup] nix/shell: rename configDir to projectDir

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -230,7 +230,7 @@ func (d *Devbox) Shell() error {
 		nix.WithPluginInitHook(strings.Join(pluginHooks, "\n")),
 		nix.WithProfile(profileDir),
 		nix.WithHistoryFile(filepath.Join(d.projectDir, shellHistoryFile)),
-		nix.WithConfigDir(d.projectDir),
+		nix.WithProjectDir(d.projectDir),
 	}
 	// TODO: separate package suggestions from shell planners
 	if featureflag.PKGConfig.Enabled() {
@@ -270,7 +270,7 @@ func (d *Devbox) RunScriptInShell(scriptName string) error {
 		nix.WithProfile(profileDir),
 		nix.WithHistoryFile(filepath.Join(d.projectDir, shellHistoryFile)),
 		nix.WithUserScript(scriptName, script.String()),
-		nix.WithConfigDir(d.projectDir),
+		nix.WithProjectDir(d.projectDir),
 	)
 
 	if err != nil {
@@ -309,7 +309,7 @@ func (d *Devbox) RunScript(scriptName string) error {
 		nix.WithProfile(profileDir),
 		nix.WithHistoryFile(filepath.Join(d.projectDir, shellHistoryFile)),
 		nix.WithUserScript(scriptName, script.String()),
-		nix.WithConfigDir(d.projectDir),
+		nix.WithProjectDir(d.projectDir),
 	}
 
 	if featureflag.PKGConfig.Enabled() {

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -38,7 +38,7 @@ const (
 type Shell struct {
 	name            name
 	binPath         string
-	configDir       string // path to where devbox.json config resides
+	projectDir      string // path to where devbox.json config resides
 	pkgConfigDir    string
 	env             []string
 	userShellrcPath string
@@ -144,9 +144,9 @@ func WithPKGConfigDir(pkgConfigDir string) ShellOption {
 	}
 }
 
-func WithConfigDir(configDir string) ShellOption {
+func WithProjectDir(projectDir string) ShellOption {
 	return func(s *Shell) {
-		s.configDir = configDir
+		s.projectDir = projectDir
 	}
 }
 
@@ -383,7 +383,7 @@ func (s *Shell) writeDevboxShellrc() (path string, err error) {
 	}
 
 	err = shellrcTmpl.Execute(shellrcf, struct {
-		ConfigDir        string
+		ProjectDir       string
 		EnvToKeep        map[string]string
 		OriginalInit     string
 		OriginalInitPath string
@@ -394,7 +394,7 @@ func (s *Shell) writeDevboxShellrc() (path string, err error) {
 		ProfileBinDir    string
 		HistoryFile      string
 	}{
-		ConfigDir:        s.configDir,
+		ProjectDir:       s.projectDir,
 		EnvToKeep:        envToKeepFlakes,
 		OriginalInit:     string(bytes.TrimSpace(userShellrc)),
 		OriginalInitPath: filepath.Clean(s.userShellrcPath),

--- a/internal/nix/shell_test.go
+++ b/internal/nix/shell_test.go
@@ -49,7 +49,7 @@ func TestWriteDevboxShellrc(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			s := &Shell{
-				configDir:       "path/to/configDir",
+				projectDir:      "path/to/projectDir",
 				userShellrcPath: test.shellrcPath,
 				UserInitHook:    test.hook,
 				pluginInitHook:  `echo "Welcome to the devbox!"`,

--- a/internal/nix/shellrc.tmpl
+++ b/internal/nix/shellrc.tmpl
@@ -50,7 +50,7 @@ export PS1="(devbox) $PS1"
 
 # Switch to the directory where devbox.json config is
 workingDir=$(pwd)
-cd {{ .ConfigDir }}
+cd {{ .ProjectDir }}
 
 {{ .UserHook }}
 
@@ -76,7 +76,7 @@ cd $workingDir
 
 function run_script {
     workingDir=$(pwd)
-    cd {{ .ConfigDir }}
+    cd {{ .ProjectDir }}
 
     {{  .ScriptCommand }}
 

--- a/internal/nix/testdata/shellrc/basic/shellrc.golden
+++ b/internal/nix/testdata/shellrc/basic/shellrc.golden
@@ -56,7 +56,7 @@ export PS1="(devbox) $PS1"
 
 # Switch to the directory where devbox.json config is
 workingDir=$(pwd)
-cd path/to/configDir
+cd path/to/projectDir
 
 echo "Hello from a devbox shell hook!"
 

--- a/internal/nix/testdata/shellrc/noshellrc/shellrc.golden
+++ b/internal/nix/testdata/shellrc/noshellrc/shellrc.golden
@@ -14,7 +14,7 @@ export PS1="(devbox) $PS1"
 
 # Switch to the directory where devbox.json config is
 workingDir=$(pwd)
-cd path/to/configDir
+cd path/to/projectDir
 
 echo "Hello from a devbox shell hook!"
 


### PR DESCRIPTION
## Summary

Doing the rename for `nix/shell.go` code.

## How was it tested?

After this PR, the remaining references are to
(1) pkgConfigDir which is unrelated 
(2) DevboxConfigDir in pkgconfig code, which I'm addressing in its own PR.
```
❯ git grep -in configDir | grep -v cloud
internal/impl/devbox.go:244:			nix.WithPKGConfigDir(filepath.Join(d.projectDir, plugin.VirtenvBinPath)),
internal/impl/devbox.go:323:			nix.WithPKGConfigDir(filepath.Join(d.projectDir, plugin.VirtenvBinPath)),
internal/nix/shell.go:42:	pkgConfigDir    string
internal/nix/shell.go:141:func WithPKGConfigDir(pkgConfigDir string) ShellOption {
internal/nix/shell.go:143:		s.pkgConfigDir = pkgConfigDir
internal/nix/shell.go:371:	if s.pkgConfigDir != "" {
internal/nix/shell.go:372:		pathPrepend = s.pkgConfigDir + ":" + pathPrepend
internal/plugin/pkgcfg.go:80:			"DevboxConfigDir":      rootDir,
internal/plugin/pkgcfg.go:154:		"DevboxConfigDir":      rootDir,
plugins/apacheHttpd.json:6:    "HTTPD_DEVBOX_CONFIG_DIR": "{{ .DevboxConfigDir }}",

```
