### PR TITLE
[cleanup] plugin framework: rename rootDir to projectDir

### DIFF
--- a/internal/plugin/files.go
+++ b/internal/plugin/files.go
@@ -8,7 +8,7 @@ import (
 	"go.jetpack.io/devbox/plugins"
 )
 
-func getConfigIfAny(pkg, rootDir string) (*config, error) {
+func getConfigIfAny(pkg, projectDir string) (*config, error) {
 	configFiles, err := plugins.BuiltIn.ReadDir(".")
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -24,7 +24,7 @@ func getConfigIfAny(pkg, rootDir string) (*config, error) {
 			return nil, errors.WithStack(err)
 		}
 
-		cfg, err := buildConfig(pkg, rootDir, string(content))
+		cfg, err := buildConfig(pkg, projectDir, string(content))
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}

--- a/internal/plugin/hooks.go
+++ b/internal/plugin/hooks.go
@@ -1,9 +1,9 @@
 package plugin
 
-func InitHooks(pkgs []string, rootDir string) ([]string, error) {
+func InitHooks(pkgs []string, projectDir string) ([]string, error) {
 	hooks := []string{}
 	for _, pkg := range pkgs {
-		c, err := getConfigIfAny(pkg, rootDir)
+		c, err := getConfigIfAny(pkg, projectDir)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/plugin/info.go
+++ b/internal/plugin/info.go
@@ -9,11 +9,11 @@ import (
 )
 
 func PrintReadme(
-	pkg, rootDir string,
+	pkg, projectDir string,
 	w io.Writer,
 	showSourceEnv, markdown bool,
 ) error {
-	cfg, err := getConfigIfAny(pkg, rootDir)
+	cfg, err := getConfigIfAny(pkg, projectDir)
 
 	if err != nil {
 		return err
@@ -46,7 +46,7 @@ func PrintReadme(
 	}
 
 	if showSourceEnv {
-		err = printSourceEnvMessage(pkg, rootDir, w)
+		err = printSourceEnvMessage(pkg, projectDir, w)
 	}
 	return err
 }
@@ -132,8 +132,8 @@ func printInfoInstructions(pkg string, w io.Writer) error {
 	return errors.WithStack(err)
 }
 
-func printSourceEnvMessage(pkg, rootDir string, w io.Writer) error {
-	env, err := Env([]string{pkg}, rootDir)
+func printSourceEnvMessage(pkg, projectDir string, w io.Writer) error {
+	env, err := Env([]string{pkg}, projectDir)
 	if err != nil {
 		return err
 	}

--- a/internal/plugin/rm.go
+++ b/internal/plugin/rm.go
@@ -7,17 +7,17 @@ import (
 	"github.com/pkg/errors"
 )
 
-func Remove(rootDir string, pkgs []string) error {
+func Remove(projectDir string, pkgs []string) error {
 	for _, pkg := range pkgs {
-		if err := os.RemoveAll(filepath.Join(rootDir, VirtenvPath, pkg)); err != nil {
+		if err := os.RemoveAll(filepath.Join(projectDir, VirtenvPath, pkg)); err != nil {
 			return errors.WithStack(err)
 		}
 	}
 	return nil
 }
 
-func RemoveInvalidSymlinks(rootDir string) error {
-	binPath := filepath.Join(rootDir, VirtenvBinPath)
+func RemoveInvalidSymlinks(projectDir string) error {
+	binPath := filepath.Join(projectDir, VirtenvBinPath)
 	if _, err := os.Stat(binPath); errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
@@ -26,9 +26,9 @@ func RemoveInvalidSymlinks(rootDir string) error {
 		return errors.WithStack(err)
 	}
 	for _, entry := range dirEntry {
-		_, err := os.Stat(filepath.Join(rootDir, VirtenvPath, "bin", entry.Name()))
+		_, err := os.Stat(filepath.Join(projectDir, VirtenvPath, "bin", entry.Name()))
 		if errors.Is(err, os.ErrNotExist) {
-			os.Remove(filepath.Join(rootDir, VirtenvPath, "bin", entry.Name()))
+			os.Remove(filepath.Join(projectDir, VirtenvPath, "bin", entry.Name()))
 		}
 	}
 	return nil

--- a/internal/plugin/services.go
+++ b/internal/plugin/services.go
@@ -17,10 +17,10 @@ type service struct {
 	Stop  string `json:"stop"`
 }
 
-func GetServices(pkgs []string, rootDir string) (Services, error) {
+func GetServices(pkgs []string, projectDir string) (Services, error) {
 	services := map[string]service{}
 	for _, pkg := range pkgs {
-		c, err := getConfigIfAny(pkg, rootDir)
+		c, err := getConfigIfAny(pkg, projectDir)
 		if err != nil {
 			return nil, err
 		}

--- a/plugins/apacheHttpd.json
+++ b/plugins/apacheHttpd.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "readme": "If you with to edit the config file, please copy it out of the .devbox directory.",
   "env": {
-    "HTTPD_DEVBOX_CONFIG_DIR": "{{ .DevboxConfigDir }}",
+    "HTTPD_DEVBOX_CONFIG_DIR": "{{ .DevboxProjectDir }}",
     "HTTPD_CONFDIR": "{{ .DevboxDir }}",
     "HTTPD_ERROR_LOG_FILE": "{{ .Virtenv }}/error.log",
     "HTTPD_PORT": "8080"


### PR DESCRIPTION
## Summary

For the plugin framework, this renames rootDir to projectDir. This change
makes it consistent with the rest of the devbox codebase.

did not change this one, because it may break users. Or are we early enough that 
we can change it?
```
docs/app/docs/devbox_examples/servers/apache.md:HTTPD_DEVBOX_CONFIG_DIR={PROJECT_DIR}
```

## How was it tested?

automated tests
