### PR TITLE
Update sentry to avoid logging errors from os exec commands

### DIFF
--- a/internal/boxcli/midcobra/midcobra.go
+++ b/internal/boxcli/midcobra/midcobra.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+	"go.jetpack.io/devbox/internal/boxcli/usererr"
 )
 
 type Executable interface {
@@ -62,17 +63,30 @@ func (ex *midcobraExecutable) Execute(ctx context.Context, args []string) int {
 	// Execute the cobra command:
 	err := ex.cmd.ExecuteContext(ctx)
 
+	var postRunErr error
+	var userExecErr *usererr.UserExecError
+	if err != nil {
+		// If the error is from a user exec call, exclude such error from postrun hooks.
+		if !errors.As(err, &userExecErr) {
+			postRunErr = err
+		}
+	}
+
 	// Run the 'post' hooks. Note that unlike the default PostRun cobra functionality these
 	// run even if the command resulted in an error. This is useful when we still want to clean up
 	// before the program exists or we want to log something. The error, if any, gets passed
 	// to the post hook.
 	for _, m := range ex.middlewares {
-		m.postRun(ex.cmd, args, err)
+		m.postRun(ex.cmd, args, postRunErr)
 	}
 
 	if err != nil {
 		// If the error is from the exec call, return the exit code of the exec call.
+		// Note: order matters! Check if it is a user exec error before a generic exit error.
 		var exitErr *exec.ExitError
+		if errors.As(err, &userExecErr) {
+			return userExecErr.ExitCode()
+		}
 		if errors.As(err, &exitErr) {
 			return exitErr.ExitCode()
 		}

--- a/internal/boxcli/midcobra/midcobra.go
+++ b/internal/boxcli/midcobra/midcobra.go
@@ -65,11 +65,9 @@ func (ex *midcobraExecutable) Execute(ctx context.Context, args []string) int {
 
 	var postRunErr error
 	var userExecErr *usererr.UserExecError
-	if err != nil {
-		// If the error is from a user exec call, exclude such error from postrun hooks.
-		if !errors.As(err, &userExecErr) {
-			postRunErr = err
-		}
+	// If the error is from a user exec call, exclude such error from postrun hooks.
+	if err != nil && !errors.As(err, &userExecErr) {
+		postRunErr = err
 	}
 
 	// Run the 'post' hooks. Note that unlike the default PostRun cobra functionality these
@@ -84,6 +82,7 @@ func (ex *midcobraExecutable) Execute(ctx context.Context, args []string) int {
 		// If the error is from the exec call, return the exit code of the exec call.
 		// Note: order matters! Check if it is a user exec error before a generic exit error.
 		var exitErr *exec.ExitError
+		var userExecErr *usererr.UserExecError
 		if errors.As(err, &userExecErr) {
 			return userExecErr.ExitCode()
 		}

--- a/internal/boxcli/midcobra/telemetry.go
+++ b/internal/boxcli/midcobra/telemetry.go
@@ -91,7 +91,6 @@ func (m *telemetryMiddleware) postRun(cmd *cobra.Command, args []string, runErr 
 			"packages":   pkgs,
 		})
 	})
-
 	// verified with manual testing that the sentryID returned by CaptureException
 	// is the same as m.ExecutionID, since we set EventID = m.ExecutionID in sentry.Init
 	sentry.CaptureException(runErr)

--- a/internal/boxcli/usererr/execerr.go
+++ b/internal/boxcli/usererr/execerr.go
@@ -1,0 +1,40 @@
+package usererr
+
+import (
+	"os/exec"
+
+	"errors"
+)
+
+type UserExecError struct {
+	err *exec.ExitError
+}
+
+func NewExecError(source error) error {
+	if source == nil {
+		return nil
+	}
+	var exitErr *exec.ExitError
+	// If the error is not from the exec call, return the original error.
+	if !errors.As(source, &exitErr) {
+		return source
+	}
+	return &UserExecError{
+		err: exitErr,
+	}
+}
+
+func (e *UserExecError) Error() string {
+	return e.err.Error()
+}
+
+func (e *UserExecError) Is(target error) bool {
+	return errors.Is(e.err, target)
+}
+
+func (e *UserExecError) ExitCode() int {
+	return e.err.ExitCode()
+}
+
+// Unwrap provides compatibility for Go 1.13 error chains.
+func (e *UserExecError) Unwrap() error { return e.err }

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/debug"
 )
 
@@ -42,7 +43,7 @@ func Exec(path string, command []string, env []string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Env = append(DefaultEnv(), env...)
-	return errors.WithStack(cmd.Run())
+	return errors.WithStack(usererr.NewExecError(cmd.Run()))
 }
 
 func PkgInfo(nixpkgsCommit, pkg string) (*Info, bool) {

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -17,6 +17,7 @@ import (
 	"github.com/alessio/shellescape"
 	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
+	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/debug"
 )
 
@@ -210,7 +211,7 @@ func (s *Shell) Run(nixShellFilePath string) error {
 
 		debug.Log("Executing nix develop command: %v", cmd.Args)
 		debug.Log("Executing nix develop command with env: %v", cmd.Environ())
-		return errors.WithStack(cmd.Run())
+		return errors.WithStack(usererr.NewExecError(cmd.Run()))
 	}
 
 	// Launch a fallback shell if we couldn't find the path to the user's
@@ -237,7 +238,7 @@ func (s *Shell) Run(nixShellFilePath string) error {
 	cmd.Stderr = os.Stderr
 
 	debug.Log("Executing nix-shell command: %v", cmd.Args)
-	return errors.WithStack(cmd.Run())
+	return errors.WithStack(usererr.NewExecError(cmd.Run()))
 }
 
 // execCommand is a command that replaces the current shell with s. This is what
@@ -302,7 +303,8 @@ func (s *Shell) RunInShell() error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	debug.Log("Executing command from inside devbox shell: %v", cmd.Args)
-	return errors.WithStack(cmd.Run())
+
+	return errors.WithStack(usererr.NewExecError(cmd.Run()))
 }
 
 func (s *Shell) shellRCOverrides(shellrc string) (extraEnv []string, extraArgs []string) {

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -211,7 +211,13 @@ func (s *Shell) Run(nixShellFilePath string) error {
 
 		debug.Log("Executing nix develop command: %v", cmd.Args)
 		debug.Log("Executing nix develop command with env: %v", cmd.Environ())
-		return errors.WithStack(usererr.NewExecError(cmd.Run()))
+
+		err := cmd.Run()
+		if err != nil && s.ScriptCommand != "" {
+			// Report error as exec error when executing shell -- <cmd> script.
+			err = usererr.NewExecError(err)
+		}
+		return errors.WithStack(err)
 	}
 
 	// Launch a fallback shell if we couldn't find the path to the user's
@@ -238,7 +244,12 @@ func (s *Shell) Run(nixShellFilePath string) error {
 	cmd.Stderr = os.Stderr
 
 	debug.Log("Executing nix-shell command: %v", cmd.Args)
-	return errors.WithStack(usererr.NewExecError(cmd.Run()))
+	err := cmd.Run()
+	if err != nil && s.ScriptCommand != "" {
+		// Report error as exec error when executing shell -- <cmd> script.
+		err = usererr.NewExecError(err)
+	}
+	return errors.WithStack(err)
 }
 
 // execCommand is a command that replaces the current shell with s. This is what


### PR DESCRIPTION
## Summary
Update sentry to avoid logging errors from os exec commands. After https://github.com/jetpack-io/devbox/pull/441 goes in, sentry starts to log user script errors which are not devbox errors. This is to exclude those errors. cc @devholic 

## How was it tested?
devbox run build
./dist/devbox shell -- exit 1
./dist/devbox run nonexistentcmd