### PR TITLE
[cloud] improve mutagen session name sanitization

### DIFF
--- a/internal/cloud/mutagen/type_test.go
+++ b/internal/cloud/mutagen/type_test.go
@@ -1,0 +1,30 @@
+package mutagen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeSessionName(t *testing.T) {
+
+	testCases := []struct {
+		input     string
+		sanitized string
+	}{
+		{"7foo", "a7foo"},
+		{"foo", "foo"},
+		{"foo/bar", "foo-bar"},
+		{"foo/bar/baz", "foo-bar-baz"},
+		{"foo.bar", "foo-bar"},
+		{"foo_bar", "foo-bar"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.input, func(t *testing.T) {
+			assert := assert.New(t)
+			result := SanitizeSessionName(testCase.input)
+			assert.Equal(testCase.sanitized, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Sanitizes the mutagen session name to match the validation done in mutagen's code.
Specifically:
1. ensure the first char is a letter
2. ensure only numbers, letters and dash characters are used

## How was it tested?

1. added test
2. copied `rust-stable` example project into folder: `/var/folders/79/1yc1ywp10w9f2xnr_rpp_ff00000gn/T/tmp.XshVTWYu`.Then started `devbox cloud shell` and saw it sync files successfully.
