### PR TITLE
[plugins] Join hash -r and source message and show in yellow

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -625,11 +625,13 @@ func (d *Devbox) printPackageUpdateMessage(
 		// (Only when in devbox shell) Prompt the user to run hash -r
 		// to ensure we refresh the shell hash and load the proper environment.
 		if IsDevboxShellEnabled() {
-			plugin.PrintEnvUpdateMessage(
+			if err := plugin.PrintEnvUpdateMessage(
 				lo.Ternary(mode == install, pkgs, []string{}),
 				d.projectDir,
 				d.writer,
-			)
+			); err != nil {
+				return err
+			}
 		}
 	} else {
 		fmt.Fprintf(d.writer, "No packages %s.\n", verb)

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -164,7 +164,6 @@ func (d *Devbox) Add(pkgs ...string) error {
 				pkg,
 				d.projectDir,
 				d.writer,
-				IsDevboxShellEnabled(),
 				false, /*markdown*/
 			); err != nil {
 				return err
@@ -423,7 +422,6 @@ func (d *Devbox) Info(pkg string, markdown bool) error {
 		pkg,
 		d.projectDir,
 		d.writer,
-		false, /*showSourceEnv*/
 		markdown,
 	)
 }
@@ -605,7 +603,7 @@ func (d *Devbox) printPackageUpdateMessage(
 
 	if len(pkgs) > 0 {
 
-		successMsg := fmt.Sprintf("%s (%s) is now %s.", pkgs[0], infos[0], verb)
+		successMsg := fmt.Sprintf("%s (%s) is now %s.\n", pkgs[0], infos[0], verb)
 		if len(pkgs) > 1 {
 			pkgsWithVersion := []string{}
 			for idx, pkg := range pkgs {
@@ -622,13 +620,16 @@ func (d *Devbox) printPackageUpdateMessage(
 		}
 		fmt.Fprint(d.writer, successMsg)
 
-		// (Only when in devbox shell) Prompt the user to run `hash -r` to ensure
-		// their shell can access the most recently installed binaries, or ensure
-		// their recently uninstalled binaries are not accidentally still available.
-		if !IsDevboxShellEnabled() {
-			fmt.Fprintln(d.writer)
-		} else {
-			fmt.Fprintln(d.writer, " Run `hash -r` to ensure your shell is updated.")
+		fmt.Fprintln(d.writer)
+
+		// (Only when in devbox shell) Prompt the user to run hash -r
+		// to ensure we refresh the shell hash and load the proper environment.
+		if IsDevboxShellEnabled() {
+			plugin.PrintEnvUpdateMessage(
+				lo.Ternary(mode == install, pkgs, []string{}),
+				d.projectDir,
+				d.writer,
+			)
 		}
 	} else {
 		fmt.Fprintf(d.writer, "No packages %s.\n", verb)

--- a/internal/plugin/info.go
+++ b/internal/plugin/info.go
@@ -139,11 +139,11 @@ func PrintEnvUpdateMessage(pkgs []string, projectDir string, w io.Writer) error 
 		if path := getEnvFilePathIfExist(pkg, projectDir); path != "" {
 			wd, err := os.Getwd()
 			if err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 			relPath, err := filepath.Rel(wd, path)
 			if err != nil {
-				return err
+				return errors.WithStack(err)
 			}
 			commands = append(commands, fmt.Sprintf("source %s", relPath))
 		}

--- a/internal/plugin/info.go
+++ b/internal/plugin/info.go
@@ -3,7 +3,11 @@ package plugin
 import (
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
+	"strings"
 
+	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
 )
@@ -11,7 +15,7 @@ import (
 func PrintReadme(
 	pkg, rootDir string,
 	w io.Writer,
-	showSourceEnv, markdown bool,
+	markdown bool,
 ) error {
 	cfg, err := getConfigIfAny(pkg, rootDir)
 
@@ -45,9 +49,6 @@ func PrintReadme(
 		return err
 	}
 
-	if showSourceEnv {
-		err = printSourceEnvMessage(pkg, rootDir, w)
-	}
 	return err
 }
 
@@ -132,18 +133,26 @@ func printInfoInstructions(pkg string, w io.Writer) error {
 	return errors.WithStack(err)
 }
 
-func printSourceEnvMessage(pkg, rootDir string, w io.Writer) error {
-	env, err := Env([]string{pkg}, rootDir)
-	if err != nil {
-		return err
+func PrintEnvUpdateMessage(pkgs []string, projectDir string, w io.Writer) error {
+	commands := []string{"hash -r"}
+	for _, pkg := range pkgs {
+		if path := getEnvFilePathIfExist(pkg, projectDir); path != "" {
+			wd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			relPath, err := filepath.Rel(wd, path)
+			if err != nil {
+				return err
+			}
+			commands = append(commands, fmt.Sprintf("source %s", relPath))
+		}
 	}
-	if len(env) > 0 {
-		_, err = fmt.Fprintf(
+	color.New(color.FgYellow).
+		Fprintf(
 			w,
-			"To ensure environment is set, run `source %s/%s/env`\n\n",
-			VirtenvPath,
-			pkg,
+			"Run `%s` to ensure your shell is updated.\n\n",
+			strings.Join(commands, " && "),
 		)
-	}
-	return errors.WithStack(err)
+	return nil
 }

--- a/internal/plugin/pkgcfg.go
+++ b/internal/plugin/pkgcfg.go
@@ -120,6 +120,14 @@ func Env(pkgs []string, rootDir string) (map[string]string, error) {
 	return env, nil
 }
 
+func getEnvFilePathIfExist(pkg, rootDir string) string {
+	filePath := filepath.Join(rootDir, VirtenvPath, pkg, "/env")
+	if _, err := os.Stat(filePath); err != nil {
+		return ""
+	}
+	return filePath
+}
+
 func createEnvFile(pkg, rootDir string) error {
 	envVars, err := Env([]string{pkg}, rootDir)
 	if err != nil {


### PR DESCRIPTION
## Summary

This improves the message we show when a package that has env vars is installed. It shows it in yellow at the very end always. It also joins the `hash -r` command so that it's a single command.

This is a stopgap until we have a better way to use update env variables while in shell. Once that is done, some of this change can be reverted. (we might also be able to remove the need for `hash -r` command by running it directly from devbox and/or only showing it when it actually needs to be run)

I also considered creating a global env file that sources all the env files but this would cause potential overwriting I didn't want. 

## How was it tested?

<img width="595" alt="image" src="https://user-images.githubusercontent.com/544948/211695932-63e628e4-3cb9-42a2-aab3-aed933930597.png">
