### PR TITLE
[direnv] Fixed .envrc file to emulate nix-shell env

### DIFF
--- a/internal/boxcli/init.go
+++ b/internal/boxcli/init.go
@@ -30,5 +30,13 @@ func runInitCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
+	box, err := devbox.Open(path, cmd.ErrOrStderr())
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	err = box.GenerateEnvrc(false)
+	if err != nil {
+		return errors.WithStack(err)
+	}
 	return nil
 }

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -60,34 +60,6 @@ func InitConfig(dir string, writer io.Writer) (created bool, err error) {
 			color.HiYellowString(s),
 		)
 	}
-	// .envrc file creation
-	if commandExists("direnv") {
-		// prompt for direnv allow
-		var result string
-		prompt := &survey.Input{
-			Message: "Do you want to enable direnv integration for this devbox project?[y/n]",
-		}
-		err = survey.AskOne(prompt, &result)
-		if err != nil {
-			return false, errors.WithStack(err)
-		}
-
-		if strings.ToLower(result) == "y" {
-			envrcfilePath := filepath.Join(dir, ".envrc")
-			filesExist := fileutil.Exists(envrcfilePath)
-			if !filesExist { // don't overwrite an existing .envrc
-				err := generate.CreateEnvrc(tmplFS, dir)
-				if err != nil {
-					return false, errors.WithStack(err)
-				}
-			}
-			cmd := exec.Command("direnv", "allow")
-			err = cmd.Run()
-			if err != nil {
-				return false, errors.WithStack(err)
-			}
-		}
-	}
 
 	return cuecfg.InitFile(cfgPath, config)
 }
@@ -491,9 +463,31 @@ func (d *Devbox) GenerateEnvrc(force bool) error {
 	filesExist := fileutil.Exists(envrcfilePath)
 	// confirm .envrc doesn't exist and don't overwrite an existing .envrc
 	if force || !filesExist {
-		err := generate.CreateEnvrc(tmplFS, d.projectDir)
-		if err != nil {
-			return errors.WithStack(err)
+		// .envrc file creation
+		if commandExists("direnv") {
+			// prompt for direnv allow
+			var result string
+			prompt := &survey.Input{
+				Message: "Do you want to enable direnv integration for this devbox project?[y/n]",
+			}
+			err := survey.AskOne(prompt, &result)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+
+			if strings.ToLower(result) == "y" {
+				if !filesExist { // don't overwrite an existing .envrc
+					err := generate.CreateEnvrc(tmplFS, d.projectDir)
+					if err != nil {
+						return errors.WithStack(err)
+					}
+				}
+				cmd := exec.Command("direnv", "allow")
+				err = cmd.Run()
+				if err != nil {
+					return errors.WithStack(err)
+				}
+			}
 		}
 	} else {
 		return usererr.New(

--- a/internal/impl/tmpl/envrc.tmpl
+++ b/internal/impl/tmpl/envrc.tmpl
@@ -3,9 +3,13 @@
 
 use_devbox() {
     watch_file devbox.json
-    eval $(devbox shell --print-env)
+    if [ -f .devbox/gen/shell.nix ]; then
+        use nix .devbox/gen/shell.nix
+    fi
 }
 use devbox
+
+
 
 # check out https://www.jetpack.io/devbox/docs/ide_configuration/direnv/ 
 # for more details


### PR DESCRIPTION
## Summary
Changed the generated `.envrc` file to this logic: 
if `.devbox/gen/shell.nix` exists -> use direnv's `use nix` function to set the environment. Otherwise just watch `devbox.json` and activate direnv.

## How was it tested?
- compile
- run `./devbox init` and answer "y" to the prompt (requires direnv to be installed)
- confirm there is no error and a `.envrc` file is created
- run `./devbox add go_1_18`
- run `which go` and confirm it points to nix store without any reload required
