### PR TITLE
[services] Ensure services have env vars + cleanup

### DIFF
--- a/internal/boxcli/featureflag/pkgconfig.go
+++ b/internal/boxcli/featureflag/pkgconfig.go
@@ -1,3 +1,0 @@
-package featureflag
-
-var PKGConfig = enabled("PKG_CONFIG") // DEVBOX_FEATURE_PKG_CONFIG

--- a/internal/boxcli/info.go
+++ b/internal/boxcli/info.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
-	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 )
 
 type infoCmdFlags struct {
@@ -19,7 +18,6 @@ func InfoCmd() *cobra.Command {
 	flags := infoCmdFlags{}
 	command := &cobra.Command{
 		Use:     "info <pkg>",
-		Hidden:  !featureflag.PKGConfig.Enabled(),
 		Short:   "Display package info",
 		Args:    cobra.ExactArgs(1),
 		PreRunE: ensureNixInstalled,

--- a/internal/boxcli/services.go
+++ b/internal/boxcli/services.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
-	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 )
 
 type servicesCmdFlags struct {
@@ -17,9 +16,8 @@ type servicesCmdFlags struct {
 func ServicesCmd() *cobra.Command {
 	flags := servicesCmdFlags{}
 	servicesCommand := &cobra.Command{
-		Use:    "services",
-		Hidden: !featureflag.PKGConfig.Enabled(),
-		Short:  "Interact with devbox services",
+		Use:   "services",
+		Short: "Interact with devbox services",
 	}
 
 	lsCommand := &cobra.Command{

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -158,19 +158,19 @@ func (d *Devbox) Add(pkgs ...string) error {
 	if err := d.ensurePackagesAreInstalled(install); err != nil {
 		return err
 	}
-	if featureflag.PKGConfig.Enabled() {
-		for _, pkg := range pkgs {
-			if err := plugin.PrintReadme(
-				pkg,
-				d.projectDir,
-				d.writer,
-				IsDevboxShellEnabled(),
-				false, /*markdown*/
-			); err != nil {
-				return err
-			}
+
+	for _, pkg := range pkgs {
+		if err := plugin.PrintReadme(
+			pkg,
+			d.projectDir,
+			d.writer,
+			IsDevboxShellEnabled(),
+			false, /*markdown*/
+		); err != nil {
+			return err
 		}
 	}
+
 	return d.printPackageUpdateMessage(install, pkgs)
 }
 
@@ -194,10 +194,8 @@ func (d *Devbox) Remove(pkgs ...string) error {
 		return err
 	}
 
-	if featureflag.PKGConfig.Enabled() {
-		if err := plugin.Remove(d.projectDir, uninstalledPackages); err != nil {
-			return err
-		}
+	if err := plugin.Remove(d.projectDir, uninstalledPackages); err != nil {
+		return err
 	}
 
 	if err := d.ensurePackagesAreInstalled(uninstall); err != nil {
@@ -246,23 +244,18 @@ func (d *Devbox) Shell() error {
 		return err
 	}
 
+	env, err := plugin.Env(d.cfg.Packages, d.projectDir)
+	if err != nil {
+		return err
+	}
+
 	opts := []nix.ShellOption{
 		nix.WithPluginInitHook(strings.Join(pluginHooks, "\n")),
 		nix.WithProfile(profileDir),
 		nix.WithHistoryFile(filepath.Join(d.projectDir, shellHistoryFile)),
 		nix.WithProjectDir(d.projectDir),
-	}
-	// TODO: separate package suggestions from shell planners
-	if featureflag.PKGConfig.Enabled() {
-		env, err := plugin.Env(d.cfg.Packages, d.projectDir)
-		if err != nil {
-			return err
-		}
-		opts = append(
-			opts,
-			nix.WithEnvVariables(env),
-			nix.WithPKGConfigDir(filepath.Join(d.projectDir, plugin.VirtenvBinPath)),
-		)
+		nix.WithEnvVariables(env),
+		nix.WithPKGConfigDir(filepath.Join(d.projectDir, plugin.VirtenvBinPath)),
 	}
 
 	shell, err := nix.DetectShell(opts...)
@@ -324,24 +317,19 @@ func (d *Devbox) RunScript(scriptName string) error {
 		return err
 	}
 
+	env, err := plugin.Env(d.cfg.Packages, d.projectDir)
+	if err != nil {
+		return err
+	}
+
 	opts := []nix.ShellOption{
 		nix.WithPluginInitHook(strings.Join(pluginHooks, "\n")),
 		nix.WithProfile(profileDir),
 		nix.WithHistoryFile(filepath.Join(d.projectDir, shellHistoryFile)),
 		nix.WithUserScript(scriptName, script.String()),
 		nix.WithProjectDir(d.projectDir),
-	}
-
-	if featureflag.PKGConfig.Enabled() {
-		env, err := plugin.Env(d.cfg.Packages, d.projectDir)
-		if err != nil {
-			return err
-		}
-		opts = append(
-			opts,
-			nix.WithEnvVariables(env),
-			nix.WithPKGConfigDir(filepath.Join(d.projectDir, plugin.VirtenvBinPath)),
-		)
+		nix.WithEnvVariables(env),
+		nix.WithPKGConfigDir(filepath.Join(d.projectDir, plugin.VirtenvBinPath)),
 	}
 
 	shell, err := nix.DetectShell(opts...)
@@ -375,18 +363,13 @@ func (d *Devbox) Exec(cmds ...string) error {
 		return err
 	}
 
-	env := []string{}
-	virtenvBinPath := ""
-	if featureflag.PKGConfig.Enabled() {
-		envMap, err := plugin.Env(d.cfg.Packages, d.projectDir)
-		if err != nil {
-			return err
-		}
-		for k, v := range envMap {
-			env = append(env, fmt.Sprintf("%s=%s", k, v))
-		}
-		virtenvBinPath = filepath.Join(d.projectDir, plugin.VirtenvBinPath) + ":"
+	env, err := plugin.Env(d.cfg.Packages, d.projectDir)
+	if err != nil {
+		return err
 	}
+
+	virtenvBinPath := filepath.Join(d.projectDir, plugin.VirtenvBinPath) + ":"
+
 	pathWithProfileBin := fmt.Sprintf("PATH=%s%s:$PATH", virtenvBinPath, profileBinDir)
 	cmds = append([]string{pathWithProfileBin}, cmds...)
 
@@ -580,13 +563,7 @@ func (d *Devbox) ensurePackagesAreInstalled(mode installMode) error {
 	}
 	fmt.Fprintln(d.writer, "done.")
 
-	if featureflag.PKGConfig.Enabled() {
-		if err := plugin.RemoveInvalidSymlinks(d.projectDir); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return plugin.RemoveInvalidSymlinks(d.projectDir)
 }
 
 func (d *Devbox) printPackageUpdateMessage(

--- a/internal/impl/generate.go
+++ b/internal/impl/generate.go
@@ -55,11 +55,9 @@ func generateForShell(rootPath string, plan *plansdk.ShellPlan, pluginManager *p
 		}
 	}
 
-	if featureflag.PKGConfig.Enabled() {
-		for _, pkg := range plan.DevPackages {
-			if err := pluginManager.CreateFilesAndShowReadme(pkg, rootPath); err != nil {
-				return err
-			}
+	for _, pkg := range plan.DevPackages {
+		if err := pluginManager.CreateFilesAndShowReadme(pkg, rootPath); err != nil {
+			return err
 		}
 	}
 

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -125,11 +125,9 @@ func WithHistoryFile(historyFile string) ShellOption {
 	}
 }
 
-func WithEnvVariables(envVariables map[string]string) ShellOption {
+func WithEnvVariables(envVariables []string) ShellOption {
 	return func(s *Shell) {
-		for k, v := range envVariables {
-			s.env = append(s.env, fmt.Sprintf("%s=%s", k, v))
-		}
+		s.env = append(s.env, envVariables...)
 	}
 }
 

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -125,6 +125,8 @@ func WithHistoryFile(historyFile string) ShellOption {
 	}
 }
 
+// TODO: Consider removing this once plugins add env vars directly to binaries
+// via wrapper scripts.
 func WithEnvVariables(envVariables []string) ShellOption {
 	return func(s *Shell) {
 		s.env = append(s.env, envVariables...)

--- a/internal/plugin/pkgcfg.go
+++ b/internal/plugin/pkgcfg.go
@@ -103,8 +103,8 @@ func (m *Manager) CreateFilesAndShowReadme(pkg, projectDir string) error {
 
 }
 
-func Env(pkgs []string, projectDir string) (map[string]string, error) {
-	env := map[string]string{}
+func Env(pkgs []string, projectDir string) ([]string, error) {
+	env := []string{}
 	for _, pkg := range pkgs {
 		cfg, err := getConfigIfAny(pkg, projectDir)
 		if err != nil {
@@ -114,7 +114,7 @@ func Env(pkgs []string, projectDir string) (map[string]string, error) {
 			continue
 		}
 		for k, v := range cfg.Env {
-			env[k] = v
+			env = append(env, fmt.Sprintf("%s=%s", k, v))
 		}
 	}
 	return env, nil
@@ -126,12 +126,13 @@ func createEnvFile(pkg, projectDir string) error {
 		return err
 	}
 	env := ""
-	for k, v := range envVars {
-		escaped, err := json.Marshal(v)
+	for _, val := range envVars {
+		parts := strings.SplitN(val, "=", 2)
+		escaped, err := json.Marshal(parts[1])
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		env += fmt.Sprintf("export %s=%s\n", k, escaped)
+		env += fmt.Sprintf("export %s=%s\n", parts[0], escaped)
 	}
 	filePath := filepath.Join(projectDir, VirtenvPath, pkg, "/env")
 	if err = createDir(filepath.Dir(filePath)); err != nil {

--- a/internal/plugin/pkgcfg.go
+++ b/internal/plugin/pkgcfg.go
@@ -103,6 +103,9 @@ func (m *Manager) CreateFilesAndShowReadme(pkg, projectDir string) error {
 
 }
 
+// Env returns the environment variables for the given plugins.
+// TODO: We should associate the env variables with the individual plugin
+// binaries via wrappers instead of adding to the environment everywhere.
 func Env(pkgs []string, projectDir string) ([]string, error) {
 	env := []string{}
 	for _, pkg := range pkgs {

--- a/internal/plugin/services.go
+++ b/internal/plugin/services.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/samber/lo"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 )
 
@@ -50,38 +51,27 @@ func (s *Services) UnmarshalJSON(b []byte) error {
 }
 
 func StartServices(pkgs, serviceNames []string, root string, w io.Writer) error {
-	services, err := GetServices(pkgs, root)
-	if err != nil {
-		return err
-	}
-	envVars, err := Env(pkgs, root)
-	if err != nil {
-		return err
-	}
-
-	for _, name := range serviceNames {
-		service, found := services[name]
-		if !found {
-			return usererr.New("Service not found")
-		}
-		cmd := exec.Command("sh", "-c", service.Start)
-		cmd.Stdout = w
-		cmd.Stderr = w
-		cmd.Env = envVars
-		cmd.Env = append(cmd.Env, os.Environ()...)
-		if err = cmd.Run(); err != nil {
-			if len(serviceNames) == 1 {
-				return usererr.WithUserMessage(err, "Service %q failed to start", name)
-			}
-			fmt.Fprintf(w, "Service %q failed to start. Error = %s\n", name, err)
-		} else {
-			fmt.Fprintf(w, "Service %q started\n", name)
-		}
-	}
-	return nil
+	return toggleServices(pkgs, serviceNames, root, w, startService)
 }
 
 func StopServices(pkgs, serviceNames []string, root string, w io.Writer) error {
+	return toggleServices(pkgs, serviceNames, root, w, stopService)
+}
+
+type serviceAction int
+
+const (
+	startService serviceAction = iota
+	stopService
+)
+
+func toggleServices(
+	pkgs,
+	serviceNames []string,
+	root string,
+	w io.Writer,
+	action serviceAction,
+) error {
 	services, err := GetServices(pkgs, root)
 	if err != nil {
 		return err
@@ -95,18 +85,24 @@ func StopServices(pkgs, serviceNames []string, root string, w io.Writer) error {
 		if !found {
 			return usererr.New("Service not found")
 		}
-		cmd := exec.Command("sh", "-c", service.Stop)
+		cmd := exec.Command(
+			"sh",
+			"-c",
+			lo.Ternary(action == startService, service.Start, service.Stop),
+		)
 		cmd.Stdout = w
 		cmd.Stderr = w
 		cmd.Env = envVars
 		cmd.Env = append(cmd.Env, os.Environ()...)
 		if err = cmd.Run(); err != nil {
+			actionString := lo.Ternary(action == startService, "start", "stop")
 			if len(serviceNames) == 1 {
-				return usererr.WithUserMessage(err, "Service %q failed to stop", name)
+				return usererr.WithUserMessage(err, "Service %q failed to %s", name, actionString)
 			}
-			fmt.Fprintf(w, "Service %q failed to stop. Error = %s\n", name, err)
+			fmt.Fprintf(w, "Service %q failed to %s. Error = %s\n", name, actionString, err)
 		} else {
-			fmt.Fprintf(w, "Service %q stopped\n", name)
+			actionStringPast := lo.Ternary(action == startService, "started", "stopped")
+			fmt.Fprintf(w, "Service %q %s\n", name, actionStringPast)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

Ensures services have correct environment when called in shell. This fixes a particular case where a plugin is installed and then a service is started without restarting the shell.

Cleanup:

* Removed feature flag
* Simplified code by having plugin.Env return a slice instead of a map
* Factored out service start/stop to make linter happy

## How was it tested?

* `devbox shell`
* `devbox add apacheHttpd && devbox service start apache`
