### PR TITLE
Adds code to call nix print-dev-env

### DIFF
--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -91,3 +91,34 @@ func parseInfo(pkg string, data []byte) *Info {
 func DefaultEnv() []string {
 	return append(os.Environ(), "NIXPKGS_ALLOW_UNFREE=1")
 }
+
+type varsAndFuncs struct {
+	Functions map[string]string   // the key is the name, the value is the body.
+	Variables map[string]variable // the key is the name.
+}
+type variable struct {
+	Type  string // valid types are var, exported, and array.
+	Value any    // can be a string or an array of strings (iff type is array).
+}
+
+// printDevEnv calls `nix print-dev-env -f <path>` and returns its output. The output contains
+// all the environment variables and bash functions required to create a nix shell.
+func printDevEnv(nixShellFilePath string) (*varsAndFuncs, error) {
+	cmd := exec.Command("nix", "print-dev-env",
+		"-f", nixShellFilePath,
+		"--extra-experimental-features", "nix-command",
+		"--extra-experimental-features", "ca-derivations",
+		"--option", "experimental-features", "nix-command flakes",
+		"--json")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	var vaf varsAndFuncs
+	err = json.Unmarshal(out, &vaf)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return &vaf, nil
+}

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -101,11 +101,11 @@ type variable struct {
 	Value any    // can be a string or an array of strings (iff type is array).
 }
 
-// printDevEnv calls `nix print-dev-env -f <path>` and returns its output. The output contains
+// PrintDevEnv calls `nix print-dev-env -f <path>` and returns its output. The output contains
 // all the environment variables and bash functions required to create a nix shell.
-func printDevEnv(nixShellFilePath string) (*varsAndFuncs, error) {
+func PrintDevEnv(nixFilePath string) (*varsAndFuncs, error) {
 	cmd := exec.Command("nix", "print-dev-env",
-		"-f", nixShellFilePath,
+		"-f", nixFilePath,
 		"--extra-experimental-features", "nix-command",
 		"--extra-experimental-features", "ca-derivations",
 		"--option", "experimental-features", "nix-command flakes",


### PR DESCRIPTION
## Summary
This simply adds the ability to call `nix print-dev-env -f <file>`, parses the result and returns it. The idea is to then use the output of this to implement a better (read faster and more isolated) version of `devbox run` and eventually `devbox shell`. The output can also be used for a more correct implementation of `devbox shell --print-env` (albeit slower).

## How was it tested?
Used it for experimental implementation of `devbox shell` that relies on it. Will send that on a separate PR.