### PR TITLE
Experimental impl of nixless shell

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	cuelang.org/go v0.4.3
 	github.com/AlecAivazis/survey/v2 v2.3.6
+	github.com/alessio/shellescape v1.4.1
 	github.com/bmatcuk/doublestar/v4 v4.4.0
 	github.com/briandowns/spinner v1.19.0
 	github.com/cavaliergopher/grab/v3 v3.0.1
@@ -33,7 +34,6 @@ require (
 require golang.org/x/net v0.2.0 // indirect
 
 require (
-	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/cockroachdb/apd/v2 v2.0.2 // indirect

--- a/internal/boxcli/featureflag/nixless_shell.go
+++ b/internal/boxcli/featureflag/nixless_shell.go
@@ -1,0 +1,6 @@
+package featureflag
+
+// NixlessShell controls the nixless shell feature. When enabled, `devbox shell`
+// creates a shell without relying on `nix-shell`, but by setting the required environment
+// variables and spawning a shell directly.
+var NixlessShell = disabled("NIXLESS_SHELL")

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -290,7 +290,7 @@ func (s *Shell) computeNixShellEnv(nixShellFilePath string) (map[string]string, 
 	ignoreList := []string{"HOME"} // do not overwrite the user's HOME.
 
 	vars := map[string]string{}
-	for name, v := range vaf.Variables {
+	for name, vrb := range vaf.Variables {
 		if slices.Contains(ignoreList, name) {
 			continue
 		}
@@ -300,8 +300,8 @@ func (s *Shell) computeNixShellEnv(nixShellFilePath string) (map[string]string, 
 		// var: export VAR=VAL
 		// exported: export VAR=VAL
 		// array: declare -a VAR=('VAL1' 'VAL2' )
-		if v.Type == "exported" {
-			vars[name] = shellescape.Quote(v.Value.(string))
+		if vrb.Type == "exported" {
+			vars[name] = shellescape.Quote(vrb.Value.(string))
 		}
 	}
 

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -19,6 +19,7 @@ import (
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/debug"
+	"golang.org/x/exp/slices"
 )
 
 //go:embed shellrc.tmpl
@@ -235,21 +236,76 @@ func (s *Shell) Run(nixShellFilePath string) error {
 		return errors.WithStack(cmd.Run())
 	}
 
-	cmd := exec.Command("nix-shell", "--command", s.execCommand(), "--pure")
-	cmd.Args = append(cmd.Args, toKeepArgs(env, buildAllowList(s.env))...)
-	cmd.Args = append(cmd.Args, nixShellFilePath)
-	cmd.Env = env
+	var cmd *exec.Cmd
+	if featureflag.NixlessShell.Enabled() {
+		// Get the required env vars from nix, and then spawn a shell directly.
+		vars, err := s.computeNixShellEnv(nixShellFilePath)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		shellrc, err := s.writeDevboxShellrc(vars)
+		if err != nil {
+			// We don't have a good fallback here, since all the variables we need for anything to work
+			// are in the shellrc file. For now let's fail. Later on, we should remove the vars from the
+			// shellrc file. That said, one of the variables we have to evaluate ($shellHook), so we need
+			// the shellrc file anyway (unless we remove the hook somehow).
+			debug.Log("Failed to write devbox shellrc: %s", err)
+			return errors.WithStack(err)
+		}
+		// Link other files that affect the shell settings and environments.
+		s.linkShellStartupFiles(filepath.Dir(shellrc))
+		extraEnv, extraArgs := s.shellRCOverrides(shellrc)
+
+		cmd = exec.Command(s.binPath)
+		cmd.Env = append(filterVars(env, buildAllowList(s.env)), extraEnv...)
+		cmd.Args = append(cmd.Args, extraArgs...)
+		debug.Log("Executing shell %s with args: %v", s.binPath, cmd.Args)
+	} else {
+		// Use nix-shell
+		cmd = exec.Command("nix-shell", "--command", s.execCommand(), "--pure")
+		keepArgs := toKeepArgs(env, buildAllowList(s.env))
+		fmt.Printf("kept args: %+v\n", keepArgs)
+		cmd.Args = append(cmd.Args, keepArgs...)
+		cmd.Args = append(cmd.Args, nixShellFilePath)
+		cmd.Env = env
+		debug.Log("Executing nix-shell command: %v", cmd.Args)
+	}
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	debug.Log("Executing nix-shell command: %v", cmd.Args)
 	err := cmd.Run()
 	if err != nil && s.ScriptCommand != "" {
 		// Report error as exec error when executing shell -- <cmd> script.
 		err = usererr.NewExecError(err)
 	}
 	return errors.WithStack(err)
+}
+
+func (s *Shell) computeNixShellEnv(nixShellFilePath string) (map[string]string, error) {
+	vaf, err := PrintDevEnv(nixShellFilePath)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	ignoreList := []string{"HOME"} // do not overwrite the user's HOME.
+
+	vars := map[string]string{}
+	for name, v := range vaf.Variables {
+		if slices.Contains(ignoreList, name) {
+			continue
+		}
+
+		// We only care about "exported" because the var and array types seem to only be used by nix-defined
+		// functions that we don't need (like genericBuild). For reference, each type translates to bash as follows:
+		// var: export VAR=VAL
+		// exported: export VAR=VAL
+		// array: declare -a VAR=('VAL1' 'VAL2' )
+		if v.Type == "exported" {
+			vars[name] = shellescape.Quote(v.Value.(string))
+		}
+	}
+
+	return vars, nil
 }
 
 // execCommand is a command that replaces the current shell with s. This is what
@@ -281,7 +337,7 @@ func (s *Shell) execCommand() string {
 
 	// Create a devbox shellrc file that runs the user's shellrc + the shell
 	// hook in devbox.json.
-	shellrc, err := s.writeDevboxShellrc()
+	shellrc, err := s.writeDevboxShellrc(map[string]string{})
 	if err != nil {
 		// Fall back to just launching the shell without a custom
 		// shellrc.
@@ -345,7 +401,7 @@ func (s *Shell) execCommandInShell() (string, string, string) {
 	return s.binPath, strings.Join(args, " "), s.ScriptCommand
 }
 
-func (s *Shell) writeDevboxShellrc() (path string, err error) {
+func (s *Shell) writeDevboxShellrc(vars map[string]string) (path string, err error) {
 	if s.userShellrcPath == "" {
 		// If this happens, then there's a bug with how we detect shells
 		// and their shellrc paths. If the shell is unknown or we can't
@@ -386,6 +442,7 @@ func (s *Shell) writeDevboxShellrc() (path string, err error) {
 		}
 	}()
 
+	// TODO: probably need to change this.
 	pathPrepend := s.profileDir + "/bin"
 	if s.pkgConfigDir != "" {
 		pathPrepend = s.pkgConfigDir + ":" + pathPrepend
@@ -412,6 +469,7 @@ func (s *Shell) writeDevboxShellrc() (path string, err error) {
 		ScriptCommand    string
 		ProfileBinDir    string
 		HistoryFile      string
+		NixEnv           map[string]string
 	}{
 		ProjectDir:       s.projectDir,
 		EnvToKeep:        envToKeepFlakes,
@@ -423,6 +481,7 @@ func (s *Shell) writeDevboxShellrc() (path string, err error) {
 		ScriptCommand:    strings.TrimSpace(s.ScriptCommand),
 		ProfileBinDir:    s.profileDir + "/bin",
 		HistoryFile:      strings.TrimSpace(s.historyFile),
+		NixEnv:           vars,
 	})
 	if err != nil {
 		return "", fmt.Errorf("execute shellrc template: %v", err)

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -264,7 +264,6 @@ func (s *Shell) Run(nixShellFilePath string) error {
 		// Use nix-shell
 		cmd = exec.Command("nix-shell", "--command", s.execCommand(), "--pure")
 		keepArgs := toKeepArgs(env, buildAllowList(s.env))
-		fmt.Printf("kept args: %+v\n", keepArgs)
 		cmd.Args = append(cmd.Args, keepArgs...)
 		cmd.Args = append(cmd.Args, nixShellFilePath)
 		cmd.Env = env

--- a/internal/nix/shell_test.go
+++ b/internal/nix/shell_test.go
@@ -55,7 +55,7 @@ func TestWriteDevboxShellrc(t *testing.T) {
 				pluginInitHook:  `echo "Welcome to the devbox!"`,
 				profileDir:      "./.devbox/profile",
 			}
-			gotPath, err := s.writeDevboxShellrc()
+			gotPath, err := s.writeDevboxShellrc(map[string]string{})
 			if err != nil {
 				t.Fatal("Got writeDevboxShellrc error:", err)
 			}

--- a/internal/nix/shellrc.tmpl
+++ b/internal/nix/shellrc.tmpl
@@ -31,7 +31,7 @@ eval $shellHook
 {{ .OriginalInit }}
 
 # End {{ .OriginalInitPath }}
-{{ end }}
+{{ end -}}
 
 # Begin Devbox Post-init Hook
 

--- a/internal/nix/shellrc.tmpl
+++ b/internal/nix/shellrc.tmpl
@@ -18,14 +18,15 @@ content readable.
 
 {{- range $name, $value := .NixEnv -}}
 export {{ $name }}={{ $value }}
-{{ end }}
+{{ end -}}
 
 {{- if .NixEnv }}
 # Run the shell hook defined in shell.nix.
 eval $shellHook
+
 {{ end -}}
 
-{{ if .OriginalInit }}
+{{- if .OriginalInit -}}
 # Begin {{ .OriginalInitPath }}
 
 {{ .OriginalInit }}

--- a/internal/nix/shellrc.tmpl
+++ b/internal/nix/shellrc.tmpl
@@ -16,6 +16,13 @@ content readable.
 
 */ -}}
 
+{{ range $name, $value := .NixEnv }}
+export {{ $name }}={{ $value }}
+{{ end }}
+
+# The shell shellHook defined in shell.nix.
+eval $shellHook
+
 {{- if .OriginalInit -}}
 
 # Begin {{ .OriginalInitPath }}

--- a/internal/nix/shellrc.tmpl
+++ b/internal/nix/shellrc.tmpl
@@ -31,6 +31,7 @@ eval $shellHook
 {{ .OriginalInit }}
 
 # End {{ .OriginalInitPath }}
+
 {{ end -}}
 
 # Begin Devbox Post-init Hook

--- a/internal/nix/shellrc.tmpl
+++ b/internal/nix/shellrc.tmpl
@@ -16,22 +16,22 @@ content readable.
 
 */ -}}
 
-{{ range $name, $value := .NixEnv }}
+{{- range $name, $value := .NixEnv -}}
 export {{ $name }}={{ $value }}
 {{ end }}
 
-# The shell shellHook defined in shell.nix.
+{{- if .NixEnv }}
+# Run the shell hook defined in shell.nix.
 eval $shellHook
+{{ end -}}
 
-{{- if .OriginalInit -}}
-
+{{ if .OriginalInit }}
 # Begin {{ .OriginalInitPath }}
 
 {{ .OriginalInit }}
 
 # End {{ .OriginalInitPath }}
-
-{{ end -}}
+{{ end }}
 
 # Begin Devbox Post-init Hook
 


### PR DESCRIPTION
## Summary
This is a simplistic implementation of `devbox shell` that launches a shell directly, instead of calling `nix-shell`. Instead it uses `nix print-dev-env` to construct the environment needed to replicate a nix shell, and launches the shell directly. As with `devbox shell`, it lets some parts of the user's environment "leak" into the shell, in the same ways that the current implementation of `devbox shell` does. The behavior is behind a feature flag, so this PR should be a no-op for any user that doesn't explicitly enable the feature.

The current implementation relies on exporting the variables in the shellrc file, which I'd like to change in the future (will probably just change it on this PR itself).

## How was it tested?
Tried it with a few shells and verified that the PATH and other vars looked reasonable, and that calls to nix packages resolved to the packages in the nix store.
```
DEVBOX_FEATURE_NIXLESS_SHELL=1 SHELL=[zsh bash sh] ./devbox shell

DEVBOX_FEATURE_NIXLESS_SHELL=1 ./devbox shell -- hello
```