### PR TITLE
[direnv] Added env variables from plugins to direnv

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -29,7 +29,7 @@ type Devbox interface {
 	GenerateEnvrc(force bool) error
 	Info(pkg string, markdown bool) error
 	ListScripts() []string
-	PrintShellEnv() error
+	AddPluginEnv() error
 	// Remove removes Nix packages from the config so that it no longer exists in
 	// the devbox environment.
 	Remove(pkgs ...string) error

--- a/devbox.go
+++ b/devbox.go
@@ -29,7 +29,7 @@ type Devbox interface {
 	GenerateEnvrc(force bool) error
 	Info(pkg string, markdown bool) error
 	ListScripts() []string
-	AddPluginEnv() error
+	PluginEnv() (string, error)
 	// Remove removes Nix packages from the config so that it no longer exists in
 	// the devbox environment.
 	Remove(pkgs ...string) error

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -52,7 +52,7 @@ func runShellCmd(cmd *cobra.Command, args []string, flags shellCmdFlags) error {
 
 	if flags.PrintEnv {
 		// return here to prevent opening a devbox shell
-		return box.PrintShellEnv()
+		return box.AddPluginEnv()
 	}
 
 	if devbox.IsDevboxShellEnabled() {

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -51,8 +51,14 @@ func runShellCmd(cmd *cobra.Command, args []string, flags shellCmdFlags) error {
 	}
 
 	if flags.PrintEnv {
+		script, err := box.PluginEnv()
+		if err != nil {
+			return err
+		}
+		// print to stdout instead of stderr so that direnv can read the output
+		cmd.Print(script)
 		// return here to prevent opening a devbox shell
-		return box.AddPluginEnv()
+		return nil
 	}
 
 	if devbox.IsDevboxShellEnabled() {

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -215,6 +215,7 @@ func (d *Devbox) Shell() error {
 		return err
 	}
 
+	// tes
 	env, err := plugin.Env(d.cfg.Packages, d.projectDir)
 	if err != nil {
 		return err
@@ -348,14 +349,18 @@ func (d *Devbox) Exec(cmds ...string) error {
 	return nix.Exec(nixDir, cmds, env)
 }
 
-func (d *Devbox) PrintShellEnv() error {
-	profileBinDir, err := d.profileBinDir()
+func (d *Devbox) AddPluginEnv() error {
+	pluginEnvs, err := plugin.Env(d.cfg.Packages, d.projectDir)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
-	// TODO: For now we just updated the PATH but this may need to evolve
-	// to essentially a parsed shellrc.tmpl
-	fmt.Fprintf(d.writer, "export PATH=\"%s:$PATH\"", profileBinDir)
+	script := ""
+	for _, pluginEnv := range pluginEnvs {
+		script += fmt.Sprintf("export %s\n", pluginEnv)
+	}
+	// we have to use stdout here because d.writer is set to output to stderr
+	// which makes direnv unable to read the output
+	fmt.Fprintln(os.Stdout, script)
 	return nil
 }
 

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -215,7 +215,6 @@ func (d *Devbox) Shell() error {
 		return err
 	}
 
-	// tes
 	env, err := plugin.Env(d.cfg.Packages, d.projectDir)
 	if err != nil {
 		return err

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -349,19 +349,16 @@ func (d *Devbox) Exec(cmds ...string) error {
 	return nix.Exec(nixDir, cmds, env)
 }
 
-func (d *Devbox) AddPluginEnv() error {
+func (d *Devbox) PluginEnv() (string, error) {
 	pluginEnvs, err := plugin.Env(d.cfg.Packages, d.projectDir)
 	if err != nil {
-		return err
+		return "", err
 	}
 	script := ""
 	for _, pluginEnv := range pluginEnvs {
 		script += fmt.Sprintf("export %s\n", pluginEnv)
 	}
-	// we have to use stdout here because d.writer is set to output to stderr
-	// which makes direnv unable to read the output
-	fmt.Fprintln(os.Stdout, script)
-	return nil
+	return script, nil
 }
 
 func (d *Devbox) Info(pkg string, markdown bool) error {

--- a/internal/impl/tmpl/envrc.tmpl
+++ b/internal/impl/tmpl/envrc.tmpl
@@ -5,6 +5,7 @@ use_devbox() {
     watch_file devbox.json
     if [ -f .devbox/gen/shell.nix ]; then
         use nix .devbox/gen/shell.nix
+        eval $(devbox shell --print-env)
     fi
 }
 use devbox


### PR DESCRIPTION
## Summary
Transformed `devbox shell --print-env` command to add env variables from plugins when cd-ing into a direnv directory.

## How was it tested?
- compile
- run `./devbox init` (requires direnv)
- respond yes to prompt for direnv integration
- Using nginx as an example for a package with plugin, run `./devbox add nginx`
- confirm nginx plugin's env vars are set 
- `echo $NGINX_CONFDIR `, `echo $NGINX_PATH_PREFIX`, and `echo $NGINX_TMPDIR`