### PR TITLE
Persist devbox binary version in shell session if version is pinned

### DIFF
--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -511,6 +511,11 @@ var envToKeep = map[string]bool{
 	"NIX_SSL_CERT_FILE":         true, // The path to Nix-installed SSL certificates (used by some Nix programs).
 	"SSL_CERT_FILE":             true, // The path to non-Nix SSL certificates (used by some Nix and non-Nix programs).
 	"NIXPKGS_ALLOW_UNFREE":      true, // Whether to allow the use of unfree packages.
+
+	// Devbox
+	//
+	// Variables specific to devbox configuration.
+	"DEVBOX_USE_VERSION": true, // Version of devbox used upon invoking `devbox shell`.
 }
 
 func buildAllowList(allowList []string) map[string]bool {


### PR DESCRIPTION
## Summary
TLDR; Persist devbox binary version in shell session if version is pinned, by whitelisting `DEVBOX_USE_VERSION` as an env variable to keep in devbox shell.

Currently, if a user pin a devbox version to use via `DEVBOX_USE_VERSION=0.1.2 devbox shell`, inside the shell, any devbox command will use the latest version instead of the pinned `0.1.2` version.

This change makes sure that the devbox version inside a devbox shell is the same as the one outside, if pinned.

## How was it tested?
`DEVBOX_USE_VERSION=0.1.2 devbox shell`
in devbox shell
`devbox version` -> it should output `0.1.2` instead of `0.2.0`