### PR TITLE
[direnv] Fix a bug with devbox shell enabled & direnv

### DIFF
--- a/internal/impl/tmpl/envrc.tmpl
+++ b/internal/impl/tmpl/envrc.tmpl
@@ -4,13 +4,15 @@
 use_devbox() {
     watch_file devbox.json
     if [ -f .devbox/gen/shell.nix ]; then
+        DEVBOX_SHELL_ENABLED_BACKUP=$DEVBOX_SHELL_ENABLED
         use nix .devbox/gen/shell.nix
         eval $(devbox shell --print-env)
+        export DEVBOX_SHELL_ENABLED=$DEVBOX_SHELL_ENABLED_BACKUP
     fi
 }
 use devbox
 
 
 
-# check out https://www.jetpack.io/devbox/docs/ide_configuration/direnv/ 
+# check out https://www.jetpack.io/devbox/docs/ide_configuration/direnv/
 # for more details

--- a/internal/impl/tmpl/envrc.tmpl
+++ b/internal/impl/tmpl/envrc.tmpl
@@ -12,7 +12,5 @@ use_devbox() {
 }
 use devbox
 
-
-
 # check out https://www.jetpack.io/devbox/docs/ide_configuration/direnv/
 # for more details


### PR DESCRIPTION
## Summary
With recent changes to direnv integration. cd-ing into a direnv integration devbox project would prevent the user to run `devbox shell`. That is because the env variable `DEVBOX_SHELL_ENABLED` gets set alongside others with direnv integration even though the user may not be inside a devbox shell. 

This change keeps a back up of the value of `DEVBOX_SHELL_ENABLED` before letting direnv make any changes to env variables. Then puts the backed up value back for `DEVBOX_SHELL_ENABLED`.

## How was it tested?
- cd into a direnv directory
- confirm direnv has set devbox's env variables
- run `./devbox shell`
- confirm it goes into the shell successfully
- while in shell run `cd ..` and then `cd` back into the directory
- confirm `DEVBOX_SHELL_ENABLED` is still set to 1
- exit from devbox shell
- confirm `DEVBOX_SHELL_ENABLED` is either 0 or none
