### PR TITLE
[cloud] Implement port forwarding using mutagen

### DIFF
--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -108,15 +108,15 @@ func PortForward(local, remote string) (string, error) {
 	if vmHostname == "" {
 		return "", usererr.New("No VM found. Please run `devbox cloud shell` first.")
 	}
-	return mutagen.ForwardCreate(vmHostname, local, remote)
+	return mutagenbox.ForwardCreate(vmHostname, local, remote)
 }
 
 func PortForwardTerminateAll() error {
-	return mutagen.ForwardTerminateAll()
+	return mutagenbox.ForwardTerminateAll()
 }
 
 func PortForwardList() ([]string, error) {
-	return mutagen.ForwardList()
+	return mutagenbox.ForwardList()
 }
 
 func getGithubUsername() string {

--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -103,13 +103,20 @@ func Shell(w io.Writer, projectDir string, githubUsername string) error {
 	return shell(username, vmHostname, projectDir)
 }
 
-func PortForward(local, remote string) error {
+func PortForward(local, remote string) (string, error) {
 	vmHostname := vmHostnameFromSSHControlPath()
 	if vmHostname == "" {
-		return usererr.New("No VM found. Please run `devbox cloud shell` first.")
+		return "", usererr.New("No VM found. Please run `devbox cloud shell` first.")
 	}
-	portMap := fmt.Sprintf("%s:%s:%s", local, vmHostname, remote)
-	return exec.Command("ssh", "-N", vmHostname, "-L", portMap).Run()
+	return mutagen.ForwardCreate(vmHostname, local, remote)
+}
+
+func PortForwardTerminateAll() error {
+	return mutagen.ForwardTerminateAll()
+}
+
+func PortForwardList() ([]string, error) {
+	return mutagen.ForwardList()
 }
 
 func getGithubUsername() string {

--- a/internal/cloud/mutagen/forward.go
+++ b/internal/cloud/mutagen/forward.go
@@ -1,0 +1,98 @@
+package mutagen
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/samber/lo"
+	"go.jetpack.io/devbox/internal/boxcli/usererr"
+)
+
+func ForwardCreate(host, localPort, remotePort string) (string, error) {
+	var err error
+	if localPort == "" {
+		localPort, err = getFreePort()
+		if err != nil {
+			return "", err
+		}
+	}
+
+	if !isPortAvailable(localPort) {
+		return "", usererr.New("Port %s is not available", localPort)
+	}
+
+	local := "tcp:127.0.0.1:" + localPort
+	remote := host + ":22:tcp::" + remotePort
+	args := []string{"forward", "create", local, remote, "--label", "devbox=true"}
+	return localPort, execMutagen(args)
+}
+
+func ForwardTerminateAll() error {
+	args := []string{"forward", "terminate", "--label-selector", "devbox=true"}
+	return execMutagen(args)
+}
+
+func ForwardList() ([]string, error) {
+	args := []string{"forward", "list", "--label-selector", "devbox=true", "--template", "{{json .}}"}
+	out, err := execMutagenOut(args, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	list := []struct {
+		Source struct {
+			Connected bool   `json:"connected"`
+			Endpoint  string `json:"endpoint"`
+		} `json:"source"`
+		Destination struct {
+			Endpoint string `json:"endpoint"`
+		} `json:"destination"`
+		LastError string `json:"lastError"`
+	}{}
+
+	if err := json.Unmarshal(out, &list); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	result := []string{}
+	for _, item := range list {
+		srcParts := strings.Split(item.Source.Endpoint, ":")
+		destParts := strings.Split(item.Destination.Endpoint, ":")
+		result = append(result, fmt.Sprintf(
+			"%s:%s connected: %t %s",
+			srcParts[len(srcParts)-1],
+			destParts[len(destParts)-1],
+			item.Source.Connected,
+			lo.Ternary(item.LastError != "", "Error: "+item.LastError, ""),
+		))
+	}
+
+	return result, nil
+
+}
+
+func isPortAvailable(port string) bool {
+	ln, err := net.Listen("tcp", net.JoinHostPort("localhost", port))
+	if err != nil {
+		return false
+	}
+	_ = ln.Close()
+	return true
+}
+
+func getFreePort() (string, error) {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	defer l.Close()
+	return fmt.Sprintf("%d", l.Addr().(*net.TCPAddr).Port), nil
+}

--- a/internal/cloud/mutagen/forward.go
+++ b/internal/cloud/mutagen/forward.go
@@ -2,97 +2,46 @@ package mutagen
 
 import (
 	"encoding/json"
-	"fmt"
-	"net"
-	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/samber/lo"
-	"go.jetpack.io/devbox/internal/boxcli/usererr"
 )
 
-func ForwardCreate(host, localPort, remotePort string) (string, error) {
-	var err error
-	if localPort == "" {
-		localPort, err = getFreePort()
-		if err != nil {
-			return "", err
-		}
-	}
-
-	if !isPortAvailable(localPort) {
-		return "", usererr.New("Port %s is not available", localPort)
-	}
-
-	local := "tcp:127.0.0.1:" + localPort
-	remote := host + ":22:tcp::" + remotePort
-	args := []string{"forward", "create", local, remote, "--label", "devbox=true"}
-	return localPort, execMutagen(args)
+type Forward struct {
+	Source struct {
+		Connected bool   `json:"connected"`
+		Endpoint  string `json:"endpoint"`
+	} `json:"source"`
+	Destination struct {
+		Endpoint string `json:"endpoint"`
+	} `json:"destination"`
+	LastError string `json:"lastError"`
 }
 
-func ForwardTerminateAll() error {
-	args := []string{"forward", "terminate", "--label-selector", "devbox=true"}
-	return execMutagen(args)
+// ForwardCreate creates a new port forward using mutagen.
+// local looks like tcp:127.0.0.1:<port>
+// remote looks like <host>:<ssh-port>:tcp::<port> (ssh-port is usually 22)
+func ForwardCreate(env map[string]string, local, remote string, labels map[string]string) error {
+	args := []string{"forward", "create", local, remote}
+	return execMutagenEnv(append(args, labelFlag(labels)...), env)
 }
 
-func ForwardList() ([]string, error) {
-	args := []string{"forward", "list", "--label-selector", "devbox=true", "--template", "{{json .}}"}
-	out, err := execMutagenOut(args, nil)
+func ForwardTerminate(env map[string]string, labels map[string]string) error {
+	args := []string{"forward", "terminate"}
+	return execMutagenEnv(append(args, labelSelectorFlag(labels)...), env)
+}
+
+func ForwardList(env map[string]string, labels map[string]string) ([]Forward, error) {
+	args := []string{"forward", "list", "--template", "{{json .}}"}
+	out, err := execMutagenOut(append(args, labelSelectorFlag(labels)...), env)
 	if err != nil {
 		return nil, err
 	}
 
-	list := []struct {
-		Source struct {
-			Connected bool   `json:"connected"`
-			Endpoint  string `json:"endpoint"`
-		} `json:"source"`
-		Destination struct {
-			Endpoint string `json:"endpoint"`
-		} `json:"destination"`
-		LastError string `json:"lastError"`
-	}{}
+	list := []Forward{}
 
 	if err := json.Unmarshal(out, &list); err != nil {
 		return nil, errors.WithStack(err)
 	}
 
-	result := []string{}
-	for _, item := range list {
-		srcParts := strings.Split(item.Source.Endpoint, ":")
-		destParts := strings.Split(item.Destination.Endpoint, ":")
-		result = append(result, fmt.Sprintf(
-			"%s:%s connected: %t %s",
-			srcParts[len(srcParts)-1],
-			destParts[len(destParts)-1],
-			item.Source.Connected,
-			lo.Ternary(item.LastError != "", "Error: "+item.LastError, ""),
-		))
-	}
-
-	return result, nil
-
-}
-
-func isPortAvailable(port string) bool {
-	ln, err := net.Listen("tcp", net.JoinHostPort("localhost", port))
-	if err != nil {
-		return false
-	}
-	_ = ln.Close()
-	return true
-}
-
-func getFreePort() (string, error) {
-	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
-	if err != nil {
-		return "", errors.WithStack(err)
-	}
-
-	l, err := net.ListenTCP("tcp", addr)
-	if err != nil {
-		return "", errors.WithStack(err)
-	}
-	defer l.Close()
-	return fmt.Sprintf("%d", l.Addr().(*net.TCPAddr).Port), nil
+	return list, errors.WithStack(json.Unmarshal(out, &list))
 }

--- a/internal/cloud/mutagen/wrapper.go
+++ b/internal/cloud/mutagen/wrapper.go
@@ -1,12 +1,14 @@
 package mutagen
 
 import (
+	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"go.jetpack.io/devbox/internal/debug"
 )
@@ -55,7 +57,7 @@ func Create(spec *SessionSpec) error {
 		}
 	}
 
-	return execMutagen(args, spec.EnvVars)
+	return execMutagenEnv(args, spec.EnvVars)
 }
 
 func List(envVars map[string]string, names ...string) ([]Session, error) {
@@ -92,25 +94,25 @@ func List(envVars map[string]string, names ...string) ([]Session, error) {
 func Pause(names ...string) error {
 	args := []string{"sync", "pause"}
 	args = append(args, names...)
-	return execMutagen(args, nil /*envVars*/)
+	return execMutagen(args)
 }
 
 func Resume(envVars map[string]string, names ...string) error {
 	args := []string{"sync", "resume"}
 	args = append(args, names...)
-	return execMutagen(args, envVars)
+	return execMutagenEnv(args, envVars)
 }
 
 func Flush(names ...string) error {
 	args := []string{"sync", "flush"}
 	args = append(args, names...)
-	return execMutagen(args, nil /*envVars*/)
+	return execMutagen(args)
 }
 
 func Reset(envVars map[string]string, names ...string) error {
 	args := []string{"sync", "reset"}
 	args = append(args, names...)
-	return execMutagen(args, envVars)
+	return execMutagenEnv(args, envVars)
 }
 
 func Terminate(env map[string]string, labels map[string]string, names ...string) error {
@@ -121,27 +123,45 @@ func Terminate(env map[string]string, labels map[string]string, names ...string)
 	}
 
 	args = append(args, names...)
-	return execMutagen(args, env)
+	return execMutagenEnv(args, env)
 }
 
-func execMutagen(args []string, envVars map[string]string) error {
+func execMutagen(args []string) error {
+	return execMutagenEnv(args, nil)
+}
+
+func execMutagenEnv(args []string, envVars map[string]string) error {
+	_, err := execMutagenOut(args, envVars)
+	return err
+}
+
+func execMutagenOut(args []string, envVars map[string]string) ([]byte, error) {
 	binPath := ensureMutagen()
 	cmd := exec.Command(binPath, args...)
 	cmd.Env = envAsKeyValueStrings(envVars)
 
-	debugPrintExecCmd(cmd)
-	out, err := cmd.CombinedOutput()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 
-	if err != nil {
-		debug.Log("execMutagen error: %s, out: %s", err, string(out))
+	debugPrintExecCmd(cmd)
+
+	if err := cmd.Run(); err != nil {
+		debug.Log(
+			"execMutagen error: %s, stdout: %s, stderr: %s",
+			err,
+			stdout.String(),
+			stderr.String(),
+		)
 		if e := (&exec.ExitError{}); errors.As(err, &e) {
-			return errors.New(strings.TrimSpace(string(out)))
+			return nil, errors.New(strings.TrimSpace(stderr.String()))
 		}
-		return err
+		return nil, err
 	}
 
 	debug.Log("execMutagen worked for cmd: %s", cmd)
-	return nil
+	return stdout.Bytes(), nil
 }
 
 // debugPrintExecCmd prints the command to be run, along with MUTAGEN env-vars

--- a/internal/cloud/mutagen/wrapper.go
+++ b/internal/cloud/mutagen/wrapper.go
@@ -221,3 +221,25 @@ func ensureMutagen() string {
 	}
 	return installPath
 }
+
+func labelFlag(labels map[string]string) []string {
+	if len(labels) == 0 {
+		return []string{}
+	}
+	labelSlice := []string{}
+	for k, v := range labels {
+		labelSlice = append(labelSlice, fmt.Sprintf("%s=%s", k, v))
+	}
+	return []string{"--label", strings.Join(labelSlice, ",")}
+}
+
+func labelSelectorFlag(labels map[string]string) []string {
+	if len(labels) == 0 {
+		return []string{}
+	}
+	labelSlice := []string{}
+	for k, v := range labels {
+		labelSlice = append(labelSlice, fmt.Sprintf("%s=%s", k, v))
+	}
+	return []string{"--label-selector", strings.Join(labelSlice, ",")}
+}

--- a/internal/cloud/mutagenbox/forward.go
+++ b/internal/cloud/mutagenbox/forward.go
@@ -1,0 +1,93 @@
+package mutagenbox
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/samber/lo"
+	"go.jetpack.io/devbox/internal/boxcli/usererr"
+	"go.jetpack.io/devbox/internal/cloud/mutagen"
+)
+
+func ForwardCreate(host, localPort, remotePort string) (string, error) {
+	var err error
+	if localPort == "" {
+		localPort, err = getFreePort()
+		if err != nil {
+			return "", err
+		}
+	}
+
+	if !isPortAvailable(localPort) {
+		return "", usererr.New("Port %s is not available", localPort)
+	}
+
+	local := "tcp:127.0.0.1:" + localPort
+	remote := host + ":22:tcp::" + remotePort
+	labels := map[string]string{"devbox": "true"}
+	env, err := DefaultEnv()
+	if err != nil {
+		return "", err
+	}
+	return localPort, mutagen.ForwardCreate(env, local, remote, labels)
+}
+
+func ForwardTerminateAll() error {
+	env, err := DefaultEnv()
+	if err != nil {
+		return err
+	}
+	return mutagen.ForwardTerminate(env, map[string]string{"devbox": "true"})
+}
+
+func ForwardList() ([]string, error) {
+	env, err := DefaultEnv()
+	if err != nil {
+		return nil, err
+	}
+	forwards, err := mutagen.ForwardList(env, map[string]string{"devbox": "true"})
+	if err != nil {
+		return nil, err
+	}
+
+	result := []string{}
+	for _, item := range forwards {
+		srcParts := strings.Split(item.Source.Endpoint, ":")
+		destParts := strings.Split(item.Destination.Endpoint, ":")
+		result = append(result, fmt.Sprintf(
+			"%s:%s connected: %t %s",
+			srcParts[len(srcParts)-1],
+			destParts[len(destParts)-1],
+			item.Source.Connected,
+			lo.Ternary(item.LastError != "", "Error: "+item.LastError, ""),
+		))
+	}
+
+	return result, nil
+
+}
+
+func isPortAvailable(port string) bool {
+	ln, err := net.Listen("tcp", net.JoinHostPort("localhost", port))
+	if err != nil {
+		return false
+	}
+	_ = ln.Close()
+	return true
+}
+
+func getFreePort() (string, error) {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	defer l.Close()
+	return fmt.Sprintf("%d", l.Addr().(*net.TCPAddr).Port), nil
+}


### PR DESCRIPTION
## Summary

Implement port forwarding using mutagen. 

This implements the following:

* `devbox cloud port-forward <port> | :<port> | <port1>:<port2>`
* `devbox cloud port-forward list`
* `devbox cloud port-forward terminate` 

Improvements:

* port forward fails if port is in use
* Automatically find a port if user uses ":<port>" argument
* Better output after forwarding

## How was it tested?

* Started cloud vm, installed and started apache
* Started a few port forwards
* Went to browser and confirmed it was working.
* Tested `list` command, `terminate` command and `list` again.
