### PR TITLE
Put call to run_script at the end, to unbreak bash

### DIFF
--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -291,11 +291,11 @@ func (s *Shell) execCommand() string {
 	extraEnv, extraArgs := s.shellRCOverrides(shellrc)
 	args = append(args, extraEnv...)
 	args = append(args, s.binPath)
+	args = append(args, extraArgs...)
 	if s.ScriptCommand != "" {
 		args = append(args, "-ic")
 		args = append(args, "run_script")
 	}
-	args = append(args, extraArgs...)
 	return strings.Join(args, " ")
 }
 


### PR DESCRIPTION
## Summary
TSIA

Fixes #402 

## How was it tested?
```
SHELL=bash ./devbox run <script>
```