### PR TITLE
Fix devbox run for fish and possibly other shells

### DIFF
--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -272,7 +272,11 @@ func (s *Shell) execCommand() string {
 	// override the shellrc file, so just launch the shell without any
 	// additional args.
 	if s.userShellrcPath == "" {
-		return strings.Join(append(args, s.binPath), " ")
+		args = append(args, s.binPath)
+		if s.ScriptCommand != "" {
+			args = append(args, "-ic", shellescape.Quote(s.ScriptCommand))
+		}
+		return strings.Join(args, " ")
 	}
 
 	// Create a devbox shellrc file that runs the user's shellrc + the shell


### PR DESCRIPTION
## Summary

For shells that aren't fully detected and for which we don't have custom logic (like fish), we fallback to just running the shell. `devbox run` was failing to attempt to run any command in this case. This PR makes it so that we at least attempt to run the command. It may or may not work, depending on the shell, but it does work with fish.

This is a bit of a hacky fix to get fish to work. Longer-term I want to re-implement devbox run so it doesn't depend on specific shells and rcfiles, so we can avoid these compatibility problems altogether.

## How was it tested?
```
SHELL=fish ./devbox run <script>
```
