### PR TITLE
Fix cicd release version to read directly from github context

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -102,5 +102,5 @@ jobs:
       - name: Update latest version in s3
         run: |
           tmp_file=$(mktemp)
-          echo "${{ env.release_tag }}" > $tmp_file
+          echo "${{ github.ref_name }}" > $tmp_file
           aws s3 cp $tmp_file s3://releases.jetpack.io/devbox/latest/version


### PR DESCRIPTION
## Summary
Fix cicd release version to read directly from github context.

## How was it tested?
I'm pretty confident this will work, but it is hard to test. Will wait till the next release cycle.