### PR TITLE
[nix] Fix ensure nix installed

### DIFF
--- a/internal/boxcli/setup.go
+++ b/internal/boxcli/setup.go
@@ -73,6 +73,12 @@ func ensureNixInstalled(cmd *cobra.Command, args []string) error {
 	if err := nix.Install(cmd.ErrOrStderr()); err != nil {
 		return err
 	}
+
+	// Source again
+	if err := nix.SourceNixEnv(); err != nil {
+		return err
+	}
+
 	cmd.PrintErrln("Nix installed successfully. Devbox is ready to use!.")
 	return nil
 }

--- a/internal/nix/source.go
+++ b/internal/nix/source.go
@@ -29,7 +29,7 @@ func SourceNixEnv() error {
 	cmd := exec.Command(
 		"/bin/sh",
 		"-c",
-		fmt.Sprintf("source %s ; echo '<<<ENVIRONMENT>>>' ; env", srcFile),
+		fmt.Sprintf(". %s ; echo '<<<ENVIRONMENT>>>' ; env", srcFile),
 	)
 
 	bs, err := cmd.CombinedOutput()


### PR DESCRIPTION
## Summary

Fixes bug in ensure nix installed.

@gcurtis was right. source does not work in sh. Changed with a `.`. My best guess is that I did not test the end-to-end installation when I switched this code from `bash` to `sh` in this [commit](https://github.com/jetpack-io/devbox/pull/426/commits/dd7287936f37b7ccc5ea7170e9b70a2896efaed3#diff-5012a4a5b4cd2f8957a7f9aebcb2cca11654b6f85d72800aa8be9c482a644535R30)

Also made a small fix to re-source after installation. This should prevent the user from having to re-run the command after nix is installed. (I thought this was working previously, but I'm not sure how)

Edit: This can be improved by properly handling stderr. But I want to get this out fast so we can patch it.

## How was it tested?

* Fresh ubuntu container, created user for single user install
* `devbox init` and `devbox shell`
