### PR TITLE
Fixed plugin env not setting in direnv

### DIFF
--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -5,7 +5,6 @@ package boxcli
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -57,7 +56,7 @@ func runShellCmd(cmd *cobra.Command, args []string, flags shellCmdFlags) error {
 			return err
 		}
 		// explicitly print to stdout instead of stderr so that direnv can read the output
-		fmt.Fprint(os.Stdout, script)
+		fmt.Fprint(cmd.OutOrStdout(), script)
 		// return here to prevent opening a devbox shell
 		return nil
 	}

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -5,6 +5,7 @@ package boxcli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -55,8 +56,8 @@ func runShellCmd(cmd *cobra.Command, args []string, flags shellCmdFlags) error {
 		if err != nil {
 			return err
 		}
-		// print to stdout instead of stderr so that direnv can read the output
-		cmd.Print(script)
+		// explicitly print to stdout instead of stderr so that direnv can read the output
+		fmt.Fprint(os.Stdout, script)
 		// return here to prevent opening a devbox shell
 		return nil
 	}


### PR DESCRIPTION
## Summary
cmd.print() was not printing in stdout. Therefore the output was not being picked up by `eval` in `.envrc`
## How was it tested?
- `devbox init`
- `devbox add nginx`
- `echo $NGINX_CONFDIR`
