### PR TITLE
Prevent shell inception in cloud shell

### DIFF
--- a/internal/boxcli/cloud.go
+++ b/internal/boxcli/cloud.go
@@ -75,6 +75,10 @@ func cloudPortForwardCmd() *cobra.Command {
 }
 
 func runCloudShellCmd(cmd *cobra.Command, flags *cloudShellCmdFlags) error {
+	if devbox.IsDevboxShellEnabled() {
+		return shellInceptionErrorMsg("devbox cloud shell")
+	}
+
 	box, err := devbox.Open(flags.config.path, cmd.ErrOrStderr())
 	if err != nil {
 		return errors.WithStack(err)

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
+	"go.jetpack.io/devbox/internal/boxcli/usererr"
 )
 
 type shellCmdFlags struct {
@@ -62,7 +63,7 @@ func runShellCmd(cmd *cobra.Command, args []string, flags shellCmdFlags) error {
 	}
 
 	if devbox.IsDevboxShellEnabled() {
-		return errors.New("You are already in an active devbox shell.\nRun 'exit' before calling devbox shell again. Shell inception is not supported.")
+		return shellInceptionErrorMsg("devbox shell")
 	}
 
 	if len(cmds) > 0 {
@@ -98,4 +99,9 @@ func parseShellArgs(cmd *cobra.Command, args []string, flags shellCmdFlags) (str
 	cmds := args[index:]
 
 	return path, cmds, nil
+}
+
+func shellInceptionErrorMsg(cmdPath string) error {
+	return usererr.New("You are already in an active devbox shell.\nRun `exit` before calling `%s` again."+
+		" Shell inception is not supported.", cmdPath)
 }


### PR DESCRIPTION
## Summary

We want to prevent shell inception in both `devbox shell` and `devbox cloud shell`.

Specifically, within regular shell and cloud shell we want to prevent another
regular shell or cloud shell from starting.

- refactor into a common utility function, and parameterize by the attempted 
- change from vanilla golang error to `usererr`

## How was it tested?

tested in `devbox shell`:
```
(devbox)
❯ devbox shell

Error: You are already in an active devbox shell.
Run `exit` before calling `devbox shell` again. Shell inception is not supported.

(devbox)
❯ devbox cloud shell

Error: You are already in an active devbox shell.
Run `exit` before calling `devbox cloud shell` again. Shell inception is not supported.
```

I didn't test within a `devbox cloud shell`, but conceptually it should work the
same because in the VM the user will be within a `devbox shell` again.
