### PR TITLE
[cloud telemetry] part 2: add 'cloud_region' property to segment

### DIFF
--- a/internal/boxcli/midcobra/telemetry.go
+++ b/internal/boxcli/midcobra/telemetry.go
@@ -203,6 +203,22 @@ func (m *telemetryMiddleware) trackEvent(evt *event) {
 		UserId:      evt.UserID,
 	})
 
+	cloudRegion := os.Getenv("DEVBOX_REGION")
+	isInDevboxCloud := cloudRegion != ""
+	properties := segment.NewProperties().
+		Set("command", evt.Command).
+		Set("command_args", evt.CommandArgs).
+		Set("failed", evt.Failed).
+		Set("duration", evt.Duration.Milliseconds()).
+		Set("packages", evt.Packages).
+		Set("sentry_event_id", evt.SentryEventID).
+		Set("shell", evt.Shell).
+		Set("cloud", isInDevboxCloud)
+
+	if isInDevboxCloud {
+		properties.Set("cloud.region", cloudRegion)
+	}
+
 	_ = segmentClient.Enqueue(segment.Track{ // Ignore errors, telemetry is best effort
 		AnonymousId: evt.AnonymousID, // Use device id instead
 		Event:       fmt.Sprintf("[%s] Command: %s", evt.AppName, evt.Command),
@@ -218,15 +234,8 @@ func (m *telemetryMiddleware) trackEvent(evt *event) {
 				Name: telemetry.OS(),
 			},
 		},
-		Properties: segment.NewProperties().
-			Set("command", evt.Command).
-			Set("command_args", evt.CommandArgs).
-			Set("failed", evt.Failed).
-			Set("duration", evt.Duration.Milliseconds()).
-			Set("packages", evt.Packages).
-			Set("sentry_event_id", evt.SentryEventID).
-			Set("shell", evt.Shell),
-		UserId: evt.UserID,
+		Properties: properties,
+		UserId:     evt.UserID,
 	})
 }
 

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -577,6 +577,7 @@ var envToKeep = map[string]bool{
 	//
 	// Variables specific to devbox configuration.
 	"DEVBOX_USE_VERSION": true, // Version of devbox used upon invoking `devbox shell`.
+	"DEVBOX_REGION":      true, // Region of the Devbox cloud
 }
 
 func buildAllowList(allowList []string) map[string]bool {


### PR DESCRIPTION
## Summary

This PR adds two properties to each segment event from midcobra:
1. `cloud: bool`
2. if cloud is true, then `cloud.region: string`

## How was it tested?

- [x] opened a cloud shell and verified that `DEVBOX_REGION` env var is populated.
- [x] do an end to end test once the gateway change in https://github.com/jetpack-io/axiom/pull/2940 is deployed
