### PR TITLE
[polish] Minor polish on help text

### DIFF
--- a/internal/boxcli/info.go
+++ b/internal/boxcli/info.go
@@ -27,7 +27,7 @@ func InfoCmd() *cobra.Command {
 	}
 
 	flags.config.register(command)
-	command.Flags().BoolVar(&flags.markdown, "markdown", false, "Output in markdown format")
+	command.Flags().BoolVar(&flags.markdown, "markdown", false, "output in markdown format")
 	return command
 }
 

--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -54,7 +54,7 @@ func RootCmd() *cobra.Command {
 	command.AddCommand(genDocsCmd())
 
 	command.PersistentFlags().BoolVarP(
-		&flags.quiet, "quiet", "q", false, "Quiet mode: Suppresses logs.")
+		&flags.quiet, "quiet", "q", false, "suppresses logs.")
 	debugMiddleware.AttachToFlag(command.PersistentFlags(), "debug")
 
 	return command

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -22,7 +22,7 @@ func ShellCmd() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "shell -- [<cmd>]",
 		Short: "Start a new shell or run a command with access to your packages",
-		Long: "Start a new shell or run a command with access to your packages. \n" +
+		Long: "Start a new shell or run a command with access to your packages.\n\n" +
 			"If invoked without `cmd`, devbox will start an interactive shell.\n" +
 			"If invoked with a `cmd`, devbox will run the command in a shell and then exit.\n" +
 			"In both cases, the shell will be started using the devbox.json found in the --config flag directory. " +
@@ -35,7 +35,7 @@ func ShellCmd() *cobra.Command {
 	}
 
 	command.Flags().BoolVar(
-		&flags.PrintEnv, "print-env", false, "Print script to setup shell environment")
+		&flags.PrintEnv, "print-env", false, "print script to setup shell environment")
 	flags.config.register(command)
 	return command
 }

--- a/internal/boxcli/version.go
+++ b/internal/boxcli/version.go
@@ -27,7 +27,7 @@ func VersionCmd() *cobra.Command {
 	}
 
 	command.Flags().BoolVarP(&flags.verbose, "verbose", "v", false, // value
-		"Verbose: displays additional version information",
+		"displays additional version information",
 	)
 	return command
 }


### PR DESCRIPTION
## Summary
To follow convention of (a) help for commands is capitalized, (b) help for flags isn't.

I also removed "quiet mode" and "verbose", because when you print the help, "quiet" and "verbose" is printed directly next to it, so it's kind of redundant.

## How was it tested?
Ran `./devbox` and `./devbox help <cmd>` for every command