### PR TITLE
[cuecfg] Don't HTML escape json

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -12,6 +12,6 @@
     }
   },
   "nixpkgs": {
-    "commit": "d01cb18be494e3d860fcfe6be4ad63614360333c"
+    "commit": "aa7e3b940ad90ba58a5d8c0a2269ec557c9ecc70"
   }
 }

--- a/internal/cuecfg/cuecfg.go
+++ b/internal/cuecfg/cuecfg.go
@@ -21,7 +21,7 @@ func Marshal(valuePtr any, extension string) ([]byte, error) {
 
 	switch extension {
 	case ".json":
-		return marshalJSON(valuePtr)
+		return MarshalJSON(valuePtr)
 	case ".yml", ".yaml":
 		return marshalYaml(valuePtr)
 	case ".toml":

--- a/internal/cuecfg/json.go
+++ b/internal/cuecfg/json.go
@@ -24,7 +24,7 @@ func MarshalJSON(v interface{}) ([]byte, error) {
 	if err := e.Encode(v); err != nil {
 		return nil, errors.WithStack(err)
 	}
-	return buff.Bytes(), nil
+	return bytes.TrimRight(buff.Bytes(), "\n"), nil
 }
 
 func unmarshalJSON(data []byte, v interface{}) error {

--- a/internal/cuecfg/json.go
+++ b/internal/cuecfg/json.go
@@ -3,13 +3,28 @@
 
 package cuecfg
 
-import "encoding/json"
+import (
+	"bytes"
+	"encoding/json"
 
+	"github.com/pkg/errors"
+)
+
+// MarshalJSON marshals the given value to JSON. It does not HTML escape and
+// adds standard indentation.
+//
 // TODO: consider using cue's JSON marshaller instead of
 // "encoding/json" ... it might have extra functionality related
 // to the cue language.
-func marshalJSON(v interface{}) ([]byte, error) {
-	return json.MarshalIndent(v, "", "  ")
+func MarshalJSON(v interface{}) ([]byte, error) {
+	buff := &bytes.Buffer{}
+	e := json.NewEncoder(buff)
+	e.SetIndent("", "  ")
+	e.SetEscapeHTML(false)
+	if err := e.Encode(v); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return buff.Bytes(), nil
 }
 
 func unmarshalJSON(data []byte, v interface{}) error {

--- a/internal/impl/generate.go
+++ b/internal/impl/generate.go
@@ -5,7 +5,6 @@ package impl
 
 import (
 	"embed"
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
+	"go.jetpack.io/devbox/internal/cuecfg"
 	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/planner/plansdk"
 	"go.jetpack.io/devbox/internal/plugin"
@@ -87,7 +87,10 @@ func writeFromTemplate(path string, plan interface{}, tmplName string) error {
 }
 
 func toJSON(a any) string {
-	data, _ := json.Marshal(a)
+	data, err := cuecfg.MarshalJSON(a)
+	if err != nil {
+		panic(err)
+	}
 	return string(data)
 }
 

--- a/internal/impl/shellcmd/command.go
+++ b/internal/impl/shellcmd/command.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"unicode"
+
+	"go.jetpack.io/devbox/internal/cuecfg"
 )
 
 // Formats for marshalling and unmarshalling a series of shell commands in a
@@ -78,9 +80,9 @@ func (s *Commands) AppendScript(script string) {
 func (s Commands) MarshalJSON() ([]byte, error) {
 	switch s.MarshalAs {
 	case CmdArray:
-		return json.Marshal(s.Cmds)
+		return cuecfg.MarshalJSON(s.Cmds)
 	case CmdString:
-		return json.Marshal(s.String())
+		return cuecfg.MarshalJSON(s.String())
 	default:
 		panic(fmt.Sprintf("invalid command format: %s", s.MarshalAs))
 	}

--- a/internal/impl/shellcmd/command_test.go
+++ b/internal/impl/shellcmd/command_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"go.jetpack.io/devbox/internal/cuecfg"
 )
 
 func TestCommandsUnmarshalString(t *testing.T) {
@@ -84,7 +85,7 @@ func TestCommandsUnmarshalString(t *testing.T) {
 						i, got, want)
 				}
 			}
-			b, err := json.Marshal(got)
+			b, err := cuecfg.MarshalJSON(got)
 			if err != nil {
 				t.Fatal("Got error marshalling back to JSON:", err)
 			}
@@ -156,7 +157,7 @@ func ExampleCommands_AppendScript() {
 			echo "this is always printed"
 		fi`,
 	)
-	b, _ := json.MarshalIndent(&shCmds, "", "  ")
+	b, _ := cuecfg.MarshalJSON(&shCmds)
 	fmt.Println(string(b))
 
 	// Output:

--- a/internal/planner/plansdk/plansdk.go
+++ b/internal/planner/plansdk/plansdk.go
@@ -4,11 +4,11 @@
 package plansdk
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 
 	"github.com/imdario/mergo"
+	"go.jetpack.io/devbox/internal/cuecfg"
 	"go.jetpack.io/devbox/internal/pkgslice"
 )
 
@@ -72,7 +72,7 @@ func MergeShellPlans(plans ...*ShellPlan) (*ShellPlan, error) {
 }
 
 func (p PlanError) MarshalJSON() ([]byte, error) {
-	return json.Marshal(p.Error())
+	return cuecfg.MarshalJSON(p.Error())
 }
 
 func FileExists(path string) bool {

--- a/internal/plugin/pkgcfg.go
+++ b/internal/plugin/pkgcfg.go
@@ -11,6 +11,7 @@ import (
 	"text/template"
 
 	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/internal/cuecfg"
 	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/impl/shellcmd"
 	"go.jetpack.io/devbox/internal/nix"
@@ -139,7 +140,7 @@ func createEnvFile(pkg, projectDir string) error {
 	env := ""
 	for _, val := range envVars {
 		parts := strings.SplitN(val, "=", 2)
-		escaped, err := json.Marshal(parts[1])
+		escaped, err := cuecfg.MarshalJSON(parts[1])
 		if err != nil {
 			return errors.WithStack(err)
 		}


### PR DESCRIPTION
## Summary

This fixes issue reported by @Lagoja where we are HTML encoding the config.

Not sure if it makes sense to only expose `cuecfgMarshalJSON` but this was easiest/quickest fix.

## How was it tested?

* Added a script with "&&" and ">>" 
* Added a pkg to force a config write
* Inspected config.
