### PR TITLE
[cloud] add shell time-to-interactive segment event

### DIFF
--- a/examples/testdata/go/go-1.19/devbox.json
+++ b/examples/testdata/go/go-1.19/devbox.json
@@ -3,7 +3,10 @@
     "go_1_19"
   ],
   "shell": {
-    "init_hook": null
+    "init_hook": null,
+    "scripts": {
+      "go-version": "go version"
+    }
   },
   "nixpkgs": {
     "commit": "af9e00071d0971eb292fd5abef334e66eda3cb69"

--- a/internal/boxcli/log.go
+++ b/internal/boxcli/log.go
@@ -24,11 +24,11 @@ func doLogCommand(cmd *cobra.Command, args []string) error {
 		return usererr.New("expect an <event-name> arg for command: %s", cmd.CommandPath())
 	}
 
-	if args[0] == "shell-tti" {
+	if args[0] == "shell-ready" || args[0] == "shell-interactive" {
 		if len(args) < 2 {
 			return usererr.New("expected a start-time argument for logging the shell-ready event")
 		}
-		return telemetry.LogShellTimeToInteractiveEvent(args[1] /*startTime*/)
+		return telemetry.LogShellDurationEvent(args[0] /*event name*/, args[1] /*startTime*/)
 	}
 	return usererr.New("unrecognized event-name %s for command: %s", args[0], cmd.CommandPath())
 }

--- a/internal/boxcli/log.go
+++ b/internal/boxcli/log.go
@@ -1,0 +1,34 @@
+package boxcli
+
+import (
+	"github.com/spf13/cobra"
+	"go.jetpack.io/devbox/internal/boxcli/usererr"
+	"go.jetpack.io/devbox/internal/telemetry"
+)
+
+func LogCmd() *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:    "log <event-name> [<event-specific-args>]",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return doLogCommand(cmd, args)
+		},
+	}
+
+	return cmd
+}
+
+func doLogCommand(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return usererr.New("expect an <event-name> arg for command: %s", cmd.CommandPath())
+	}
+
+	if args[0] == "shell-tti" {
+		if len(args) < 2 {
+			return usererr.New("expected a start-time argument for logging the shell-ready event")
+		}
+		return telemetry.LogShellTimeToInteractiveEvent(args[1] /*startTime*/)
+	}
+	return usererr.New("unrecognized event-name %s for command: %s", args[0], cmd.CommandPath())
+}

--- a/internal/boxcli/midcobra/telemetry.go
+++ b/internal/boxcli/midcobra/telemetry.go
@@ -4,12 +4,7 @@
 package midcobra
 
 import (
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"io"
-	"log"
 	"os"
 	"time"
 
@@ -17,7 +12,6 @@ import (
 	segment "github.com/segmentio/analytics-go"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
-	"go.jetpack.io/devbox/internal/cloud/openssh"
 	"go.jetpack.io/devbox/internal/telemetry"
 )
 
@@ -57,7 +51,7 @@ type telemetryMiddleware struct {
 var _ Middleware = (*telemetryMiddleware)(nil)
 
 func (m *telemetryMiddleware) preRun(cmd *cobra.Command, args []string) {
-	m.startTime = time.Now()
+	m.startTime = telemetry.CommandStartTime()
 	if !m.disabled {
 		sentry := telemetry.NewSentry(m.opts.SentryDSN)
 		sentry.Init(m.opts.AppName, m.opts.AppVersion, m.executionID)
@@ -130,11 +124,10 @@ func (m *telemetryMiddleware) trackError(evt *event) {
 	sentry.CaptureException(evt.CommandError)
 }
 
+// Consider renaming this to commandEvent
+// since it has info about the specific command run.
 type event struct {
-	AnonymousID   string
-	AppName       string
-	AppVersion    string
-	CloudRegion   string
+	telemetry.Event
 	Command       string
 	CommandArgs   []string
 	CommandError  error
@@ -159,13 +152,17 @@ func (m *telemetryMiddleware) newEventIfValid(cmd *cobra.Command, args []string,
 	pkgs := getPackages(cmd)
 
 	// an empty userID means that we do not have a github username saved
-	userID := userIDFromGithubUsername()
+	userID := telemetry.UserIDFromGithubUsername()
 
 	return &event{
-		AnonymousID:  telemetry.DeviceID(),
-		AppName:      m.opts.AppName,
-		AppVersion:   m.opts.AppVersion,
-		CloudRegion:  os.Getenv("DEVBOX_REGION"),
+		Event: telemetry.Event{
+			AnonymousID: telemetry.DeviceID(),
+			AppName:     m.opts.AppName,
+			AppVersion:  m.opts.AppVersion,
+			CloudRegion: os.Getenv("DEVBOX_REGION"),
+			OsName:      telemetry.OS(),
+			UserID:      userID,
+		},
 		Command:      subcmd.CommandPath(),
 		CommandArgs:  subargs,
 		CommandError: runErr,
@@ -173,7 +170,6 @@ func (m *telemetryMiddleware) newEventIfValid(cmd *cobra.Command, args []string,
 		Failed:       runErr != nil,
 		Packages:     pkgs,
 		Shell:        os.Getenv("SHELL"),
-		UserID:       userID,
 	}
 }
 
@@ -188,13 +184,7 @@ func (m *telemetryMiddleware) trackEvent(evt *event) {
 		evt.SentryEventID = m.executionID
 	}
 
-	segmentClient, _ := segment.NewWithConfig(m.opts.TelemetryKey, segment.Config{
-		BatchSize: 1, /* no batching */
-		// Discard logs:
-		Logger:  segment.StdLogger(log.New(io.Discard, "" /* prefix */, 0)),
-		Verbose: false,
-	})
-
+	segmentClient := telemetry.NewSegmentClient(m.opts.TelemetryKey)
 	defer func() {
 		_ = segmentClient.Close()
 	}()
@@ -217,7 +207,7 @@ func (m *telemetryMiddleware) trackEvent(evt *event) {
 				Version: evt.AppVersion,
 			},
 			OS: segment.OSInfo{
-				Name: telemetry.OS(),
+				Name: evt.OsName,
 			},
 		},
 		Properties: segment.NewProperties().
@@ -231,21 +221,4 @@ func (m *telemetryMiddleware) trackEvent(evt *event) {
 			Set("shell", evt.Shell),
 		UserId: evt.UserID,
 	})
-}
-
-// userIDFromGithubUsername hashes the github username and produces a 64-char string as userId.
-// Returns an empty string if no github username is found.
-func userIDFromGithubUsername() string {
-	username, err := openssh.GithubUsernameFromLocalFile()
-	if err != nil || username == "" {
-		return ""
-	}
-
-	const salt = "d6134cd5-347d-4b7c-a2d0-295c0f677948"
-	mac := hmac.New(sha256.New, []byte(salt))
-
-	const githubPrefix = "github:"
-	mac.Write([]byte(githubPrefix + username))
-
-	return hex.EncodeToString(mac.Sum(nil))
 }

--- a/internal/boxcli/midcobra/telemetry.go
+++ b/internal/boxcli/midcobra/telemetry.go
@@ -126,7 +126,6 @@ type event struct {
 	Command       string
 	CommandArgs   []string
 	CommandError  error
-	Duration      time.Duration
 	Failed        bool
 	Packages      []string
 	SentryEventID string
@@ -155,13 +154,13 @@ func (m *telemetryMiddleware) newEventIfValid(cmd *cobra.Command, args []string,
 			AppName:     m.opts.AppName,
 			AppVersion:  m.opts.AppVersion,
 			CloudRegion: os.Getenv("DEVBOX_REGION"),
+			Duration:    time.Since(m.startTime),
 			OsName:      telemetry.OS(),
 			UserID:      userID,
 		},
 		Command:      subcmd.CommandPath(),
 		CommandArgs:  subargs,
 		CommandError: runErr,
-		Duration:     time.Since(m.startTime),
 		Failed:       runErr != nil,
 		Packages:     pkgs,
 		Shell:        os.Getenv("SHELL"),

--- a/internal/boxcli/midcobra/telemetry.go
+++ b/internal/boxcli/midcobra/telemetry.go
@@ -21,24 +21,19 @@ import (
 // 1. We only collect anonymized data – nothing that is personally identifiable
 // 2. Data is only stored in SOC 2 compliant systems, and we are SOC 2 compliant ourselves.
 // 3. Users should always have the ability to opt-out.
-func Telemetry(opts *TelemetryOpts) Middleware {
+func Telemetry() Middleware {
+
+	opts := telemetry.InitOpts()
 
 	return &telemetryMiddleware{
 		opts:     *opts,
-		disabled: telemetry.DoNotTrack() || opts.TelemetryKey == "" || opts.SentryDSN == "",
+		disabled: !telemetry.IsEnabled(opts),
 	}
-}
-
-type TelemetryOpts struct {
-	AppName      string
-	AppVersion   string
-	SentryDSN    string // used by error reporting
-	TelemetryKey string
 }
 
 type telemetryMiddleware struct {
 	// Setup:
-	opts     TelemetryOpts
+	opts     telemetry.Opts
 	disabled bool
 
 	// Used during execution:

--- a/internal/boxcli/midcobra/telemetry.go
+++ b/internal/boxcli/midcobra/telemetry.go
@@ -27,7 +27,7 @@ func Telemetry() Middleware {
 
 	return &telemetryMiddleware{
 		opts:     *opts,
-		disabled: !telemetry.IsEnabled(opts),
+		disabled: telemetry.IsDisabled(opts),
 	}
 }
 

--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox/internal/boxcli/midcobra"
-	"go.jetpack.io/devbox/internal/build"
 	"go.jetpack.io/devbox/internal/cloud/openssh/sshshim"
 	"go.jetpack.io/devbox/internal/debug"
 )
@@ -64,12 +63,7 @@ func RootCmd() *cobra.Command {
 func Execute(ctx context.Context, args []string) int {
 	defer debug.Recover()
 	exe := midcobra.New(RootCmd())
-	exe.AddMiddleware(midcobra.Telemetry(&midcobra.TelemetryOpts{
-		AppName:      "devbox",
-		AppVersion:   build.Version,
-		SentryDSN:    build.SentryDSN,
-		TelemetryKey: build.TelemetryKey,
-	}))
+	exe.AddMiddleware(midcobra.Telemetry())
 	exe.AddMiddleware(debugMiddleware)
 	return exe.Execute(ctx, args)
 }

--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -44,6 +44,7 @@ func RootCmd() *cobra.Command {
 	command.AddCommand(GenerateCmd())
 	command.AddCommand(InfoCmd())
 	command.AddCommand(InitCmd())
+	command.AddCommand(LogCmd())
 	command.AddCommand(PlanCmd())
 	command.AddCommand(RemoveCmd())
 	command.AddCommand(RunCmd())

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -36,6 +36,7 @@ func ShellCmd() *cobra.Command {
 
 	command.Flags().BoolVar(
 		&flags.PrintEnv, "print-env", false, "print script to setup shell environment")
+
 	flags.config.register(command)
 	return command
 }

--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 	"go.jetpack.io/devbox/internal/cloud/openssh/sshshim"
 	"go.jetpack.io/devbox/internal/cloud/stepper"
 	"go.jetpack.io/devbox/internal/debug"
+	"go.jetpack.io/devbox/internal/telemetry"
 )
 
 func Shell(w io.Writer, projectDir string, githubUsername string) error {
@@ -347,9 +349,10 @@ func shell(username, hostname, projectDir string) error {
 	}
 
 	client := &openssh.Client{
-		Username: username,
-		Addr:     hostname,
-		PathInVM: absoluteProjectPathInVM(username, projectPath),
+		Addr:             hostname,
+		CommandStartTime: strconv.FormatInt(telemetry.CommandStartTime().Unix(), 10),
+		PathInVM:         absoluteProjectPathInVM(username, projectPath),
+		Username:         username,
 	}
 	return client.Shell()
 }

--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -48,6 +47,10 @@ func Shell(w io.Writer, projectDir string, githubUsername string) error {
 		}
 	}
 	debug.Log("username: %s", username)
+
+	// Record the start time for telemetry, now that we are done with prompting
+	// for github username.
+	telemetryShellStartTime := time.Now()
 
 	sshClient := openssh.Client{
 		Username: username,
@@ -108,7 +111,7 @@ func Shell(w io.Writer, projectDir string, githubUsername string) error {
 	s3.Stop("Connecting to virtual machine")
 	fmt.Fprint(w, "\n")
 
-	return shell(username, vmHostname, projectDir)
+	return shell(username, vmHostname, projectDir, telemetryShellStartTime)
 }
 
 func PortForward(local, remote string) (string, error) {
@@ -342,17 +345,17 @@ func copyConfigFileToVM(hostname, username, projectDir, pathInVM string) error {
 	return errors.WithStack(err)
 }
 
-func shell(username, hostname, projectDir string) error {
+func shell(username, hostname, projectDir string, shellStartTime time.Time) error {
 	projectPath, err := relativeProjectPathInVM(projectDir)
 	if err != nil {
 		return err
 	}
 
 	client := &openssh.Client{
-		Addr:             hostname,
-		CommandStartTime: strconv.FormatInt(telemetry.CommandStartTime().Unix(), 10),
-		PathInVM:         absoluteProjectPathInVM(username, projectPath),
-		Username:         username,
+		Addr:           hostname,
+		PathInVM:       absoluteProjectPathInVM(username, projectPath),
+		ShellStartTime: telemetry.UnixTimestampFromTime(shellStartTime),
+		Username:       username,
 	}
 	return client.Shell()
 }

--- a/internal/cloud/openssh/client.go
+++ b/internal/cloud/openssh/client.go
@@ -17,14 +17,15 @@ import (
 )
 
 type Client struct {
-	Username string
-	Addr     string
-	PathInVM string
+	Addr             string
+	CommandStartTime string
+	PathInVM         string
+	Username         string
 }
 
 func (c *Client) Shell() error {
 	cmd := c.cmd("-t")
-	remoteCmd := fmt.Sprintf(`bash -l -c "start_devbox_shell.sh \"%s\""`, c.PathInVM)
+	remoteCmd := fmt.Sprintf(`bash -l -c "start_devbox_shell.sh \"%s\" %s"`, c.PathInVM, c.CommandStartTime)
 	cmd.Args = append(cmd.Args, remoteCmd)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/internal/cloud/openssh/client.go
+++ b/internal/cloud/openssh/client.go
@@ -17,15 +17,20 @@ import (
 )
 
 type Client struct {
-	Addr             string
-	CommandStartTime string
-	PathInVM         string
-	Username         string
+	Addr           string
+	PathInVM       string
+	ShellStartTime string // unix timestamp
+	Username       string
 }
 
 func (c *Client) Shell() error {
+
 	cmd := c.cmd("-t")
-	remoteCmd := fmt.Sprintf(`bash -l -c "start_devbox_shell.sh \"%s\" %s"`, c.PathInVM, c.CommandStartTime)
+	remoteCmd := fmt.Sprintf(
+		`bash -l -c "start_devbox_shell.sh \"%s\" %s"`,
+		c.PathInVM,
+		c.ShellStartTime,
+	)
 	cmd.Args = append(cmd.Args, remoteCmd)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -28,6 +28,7 @@ import (
 	"go.jetpack.io/devbox/internal/planner"
 	"go.jetpack.io/devbox/internal/planner/plansdk"
 	"go.jetpack.io/devbox/internal/plugin"
+	"go.jetpack.io/devbox/internal/telemetry"
 	"golang.org/x/exp/slices"
 )
 
@@ -220,6 +221,11 @@ func (d *Devbox) Shell() error {
 		return err
 	}
 
+	shellStartTime := os.Getenv("DEVBOX_SHELL_START_TIME")
+	if shellStartTime == "" {
+		shellStartTime = strconv.FormatInt(telemetry.CommandStartTime().Unix(), 10)
+	}
+
 	opts := []nix.ShellOption{
 		nix.WithPluginInitHook(strings.Join(pluginHooks, "\n")),
 		nix.WithProfile(profileDir),
@@ -227,6 +233,7 @@ func (d *Devbox) Shell() error {
 		nix.WithProjectDir(d.projectDir),
 		nix.WithEnvVariables(env),
 		nix.WithPKGConfigDir(filepath.Join(d.projectDir, plugin.VirtenvBinPath)),
+		nix.WithShellStartTime(shellStartTime),
 	}
 
 	shell, err := nix.DetectShell(opts...)

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -223,7 +223,7 @@ func (d *Devbox) Shell() error {
 
 	shellStartTime := os.Getenv("DEVBOX_SHELL_START_TIME")
 	if shellStartTime == "" {
-		shellStartTime = strconv.FormatInt(telemetry.CommandStartTime().Unix(), 10)
+		shellStartTime = telemetry.UnixTimestampFromTime(telemetry.CommandStartTime())
 	}
 
 	opts := []nix.ShellOption{

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -56,6 +56,9 @@ type Shell struct {
 	// profileDir is the absolute path to the directory storing the nix-profile
 	profileDir  string
 	historyFile string
+
+	// shellStartTime is the unix timestamp for when the command was invoked
+	shellStartTime string
 }
 
 type ShellOption func(*Shell)
@@ -149,6 +152,12 @@ func WithPKGConfigDir(pkgConfigDir string) ShellOption {
 func WithProjectDir(projectDir string) ShellOption {
 	return func(s *Shell) {
 		s.projectDir = projectDir
+	}
+}
+
+func WithShellStartTime(time string) ShellOption {
+	return func(s *Shell) {
+		s.shellStartTime = time
 	}
 }
 
@@ -465,6 +474,7 @@ func (s *Shell) writeDevboxShellrc(vars map[string]string) (path string, err err
 		PluginInitHook   string
 		PathPrepend      string
 		ScriptCommand    string
+		ShellStartTime   string
 		ProfileBinDir    string
 		HistoryFile      string
 		NixEnv           map[string]string
@@ -477,6 +487,7 @@ func (s *Shell) writeDevboxShellrc(vars map[string]string) (path string, err err
 		PluginInitHook:   strings.TrimSpace(s.pluginInitHook),
 		PathPrepend:      pathPrepend,
 		ScriptCommand:    strings.TrimSpace(s.ScriptCommand),
+		ShellStartTime:   s.shellStartTime,
 		ProfileBinDir:    s.profileDir + "/bin",
 		HistoryFile:      strings.TrimSpace(s.historyFile),
 		NixEnv:           vars,

--- a/internal/nix/shellrc.tmpl
+++ b/internal/nix/shellrc.tmpl
@@ -51,6 +51,11 @@ export {{ $name }}={{ $value }}
 # Prepend to the prompt to make it clear we're in a devbox shell.
 export PS1="(devbox) $PS1"
 
+# log that the shell is ready now!
+{{- if .ShellStartTime }}
+devbox log shell-tti {{ .ShellStartTime }}
+{{ end }}
+
 # End Devbox Post-init Hook
 
 {{- if .UserHook }}

--- a/internal/nix/shellrc.tmpl
+++ b/internal/nix/shellrc.tmpl
@@ -51,9 +51,9 @@ export {{ $name }}={{ $value }}
 # Prepend to the prompt to make it clear we're in a devbox shell.
 export PS1="(devbox) $PS1"
 
-# log that the shell is ready now!
 {{- if .ShellStartTime }}
-devbox log shell-tti {{ .ShellStartTime }}
+# log that the shell is ready now!
+devbox log shell-ready {{ .ShellStartTime }}
 {{ end }}
 
 # End Devbox Post-init Hook
@@ -83,6 +83,11 @@ cd $workingDir
 {{- end }}
 
 # End Plugin Init Hook
+
+{{- if .ShellStartTime }}
+# log that the shell is interactive now!
+devbox log shell-interactive {{ .ShellStartTime }}
+{{ end }}
 
 # Begin Script command
 

--- a/internal/telemetry/segment.go
+++ b/internal/telemetry/segment.go
@@ -138,7 +138,9 @@ func UserIDFromGithubUsername() string {
 }
 
 // timeFromUnixTimestamp is a helper utility that converts the timestamp string
-// into a golang time.Time struct
+// into a golang time.Time struct.
+//
+// See UnixTimestampFromTime for the inverse function.
 func timeFromUnixTimestamp(timestamp string) (time.Time, error) {
 
 	i, err := strconv.ParseInt(timestamp, 10, 64)
@@ -146,4 +148,12 @@ func timeFromUnixTimestamp(timestamp string) (time.Time, error) {
 		return time.Time{}, errors.WithStack(err)
 	}
 	return time.Unix(i, 0), nil
+}
+
+// UnixTimestampFromTime is a helper utility that converts a golang time.Time struct
+// to a timestamp string.
+//
+// See timeFromUnixTimestamp for the inverse function.
+func UnixTimestampFromTime(t time.Time) string {
+	return strconv.FormatInt(t.Unix(), 10)
 }

--- a/internal/telemetry/segment.go
+++ b/internal/telemetry/segment.go
@@ -67,6 +67,12 @@ func CommandStartTime() time.Time {
 // LogShellDurationEvent logs the duration from start of the command
 // till the shell was ready to be interactive.
 func LogShellDurationEvent(eventName string, startTime string) error {
+	opts := InitOpts()
+	if !IsEnabled(opts) {
+		// disabled
+		return nil
+	}
+
 	start, err := timeFromUnixTimestamp(startTime)
 	if err != nil {
 		return errors.WithStack(err)
@@ -75,8 +81,8 @@ func LogShellDurationEvent(eventName string, startTime string) error {
 	evt := ttiEvent{
 		Event: Event{
 			AnonymousID: DeviceID(),
-			AppName:     "",
-			AppVersion:  "",
+			AppName:     opts.AppName,
+			AppVersion:  opts.AppVersion,
 			CloudRegion: os.Getenv("DEVBOX_REGION"),
 			OsName:      OS(),
 			UserID:      UserIDFromGithubUsername(),
@@ -86,10 +92,6 @@ func LogShellDurationEvent(eventName string, startTime string) error {
 	}
 
 	fmt.Printf("DEBUG: logging with duration %d\n", evt.durationSeconds)
-	if build.TelemetryKey == "" {
-		// disabled
-		return nil
-	}
 
 	segmentClient := NewSegmentClient(build.TelemetryKey)
 	defer func() {

--- a/internal/telemetry/segment.go
+++ b/internal/telemetry/segment.go
@@ -4,7 +4,6 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"io"
 	"log"
 	"math"
@@ -68,7 +67,7 @@ func CommandStartTime() time.Time {
 // till the shell was ready to be interactive.
 func LogShellDurationEvent(eventName string, startTime string) error {
 	opts := InitOpts()
-	if !IsEnabled(opts) {
+	if IsDisabled(opts) {
 		// disabled
 		return nil
 	}
@@ -90,8 +89,6 @@ func LogShellDurationEvent(eventName string, startTime string) error {
 		eventName:       eventName,
 		durationSeconds: int(math.Round(time.Since(start).Seconds())),
 	}
-
-	fmt.Printf("DEBUG: logging with duration %d\n", evt.durationSeconds)
 
 	segmentClient := NewSegmentClient(build.TelemetryKey)
 	defer func() {

--- a/internal/telemetry/segment.go
+++ b/internal/telemetry/segment.go
@@ -36,6 +36,7 @@ type Event struct {
 // this is used for devbox shell (local and cloud).
 type ttiEvent struct {
 	Event
+	eventName string
 	// TODO savil. Can this be time.Duration as done in midcobra.telemetry?
 	durationSeconds int
 }
@@ -63,9 +64,9 @@ func CommandStartTime() time.Time {
 	return cmdStartTime
 }
 
-// LogShellTimeToInteractiveEvent logs the duration from start of the command
+// LogShellDurationEvent logs the duration from start of the command
 // till the shell was ready to be interactive.
-func LogShellTimeToInteractiveEvent(startTime string) error {
+func LogShellDurationEvent(eventName string, startTime string) error {
 	start, err := timeFromUnixTimestamp(startTime)
 	if err != nil {
 		return errors.WithStack(err)
@@ -80,6 +81,7 @@ func LogShellTimeToInteractiveEvent(startTime string) error {
 			OsName:      OS(),
 			UserID:      UserIDFromGithubUsername(),
 		},
+		eventName:       eventName,
 		durationSeconds: int(math.Round(time.Since(start).Seconds())),
 	}
 
@@ -97,7 +99,7 @@ func LogShellTimeToInteractiveEvent(startTime string) error {
 	// Ignore errors, telemetry is best effort
 	_ = segmentClient.Enqueue(segment.Track{
 		AnonymousId: evt.AnonymousID,
-		Event:       "shell-time-to-interactive",
+		Event:       evt.eventName,
 		Context: &segment.Context{
 			Device: segment.DeviceInfo{
 				Id: evt.AnonymousID,

--- a/internal/telemetry/segment.go
+++ b/internal/telemetry/segment.go
@@ -1,0 +1,137 @@
+package telemetry
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/samber/lo"
+	segment "github.com/segmentio/analytics-go"
+	"go.jetpack.io/devbox/internal/build"
+	"go.jetpack.io/devbox/internal/cloud/openssh"
+)
+
+func NewSegmentClient(telemetryKey string) segment.Client {
+	segmentClient, _ := segment.NewWithConfig(telemetryKey, segment.Config{
+		BatchSize: 1, /* no batching */
+		// Discard logs:
+		Logger:  segment.StdLogger(log.New(io.Discard, "" /* prefix */, 0)),
+		Verbose: false,
+	})
+
+	return segmentClient
+}
+
+var cmdStartTime time.Time
+
+func CommandStartTime() time.Time {
+	if cmdStartTime.IsZero() {
+		cmdStartTime = time.Now()
+	}
+	return cmdStartTime
+}
+
+type Event struct {
+	AnonymousID string
+	AppName     string
+	AppVersion  string
+	CloudRegion string
+	OsName      string
+	UserID      string
+}
+
+type ttiEvent struct {
+	Event
+	durationSeconds int
+}
+
+func LogShellTimeToInteractiveEvent(startTime string) error {
+	start, err := timeFromUnixTimestamp(startTime)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	evt := ttiEvent{
+		Event: Event{
+			AnonymousID: DeviceID(),
+			AppName:     "",
+			AppVersion:  "",
+			CloudRegion: os.Getenv("DEVBOX_REGION"),
+			OsName:      OS(),
+			UserID:      UserIDFromGithubUsername(),
+		},
+		durationSeconds: int(math.Round(time.Since(start).Seconds())),
+	}
+
+	return logShellTimeToInteractiveEvent(evt)
+}
+
+func logShellTimeToInteractiveEvent(evt ttiEvent) error {
+	fmt.Printf("DEBUG: logging with duration %d\n", evt.durationSeconds)
+	if build.TelemetryKey == "" {
+		// disabled
+		return nil
+	}
+
+	segmentClient := NewSegmentClient(build.TelemetryKey)
+	defer func() {
+		_ = segmentClient.Close()
+	}()
+
+	// Ignore errors, telemetry is best effort
+	_ = segmentClient.Enqueue(segment.Track{
+		AnonymousId: evt.AnonymousID,
+		Event:       "shell-time-to-interactive",
+		Context: &segment.Context{
+			Device: segment.DeviceInfo{
+				Id: evt.AnonymousID,
+			},
+			App: segment.AppInfo{
+				Name:    evt.AppName,
+				Version: evt.AppVersion,
+			},
+			OS: segment.OSInfo{
+				Name: evt.OsName,
+			},
+		},
+		Properties: segment.NewProperties().
+			Set("is_cloud", lo.Ternary(evt.CloudRegion != "", "true", "false")).
+			Set("duration_seconds", evt.durationSeconds),
+		UserId: evt.UserID,
+	})
+	return nil
+}
+
+// UserIDFromGithubUsername hashes the github username and produces a 64-char string as userID.
+// Returns an empty string if no github username is found.
+func UserIDFromGithubUsername() string {
+	username, err := openssh.GithubUsernameFromLocalFile()
+	if err != nil || username == "" {
+		return ""
+	}
+
+	const salt = "d6134cd5-347d-4b7c-a2d0-295c0f677948"
+	mac := hmac.New(sha256.New, []byte(salt))
+
+	const githubPrefix = "github:"
+	mac.Write([]byte(githubPrefix + username))
+
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func timeFromUnixTimestamp(timestamp string) (time.Time, error) {
+
+	i, err := strconv.ParseInt(timestamp, 10, 64)
+	if err != nil {
+		return time.Time{}, errors.WithStack(err)
+	}
+	return time.Unix(i, 0), nil
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -27,7 +27,7 @@ func InitOpts() *Opts {
 	}
 }
 
-func IsEnabled(opts *Opts) bool {
+func IsDisabled(opts *Opts) bool {
 	return DoNotTrack() || opts.TelemetryKey == "" || opts.SentryDSN == ""
 }
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -6,8 +6,30 @@ import (
 	"strconv"
 
 	"github.com/denisbrodbeck/machineid"
+	"go.jetpack.io/devbox/internal/build"
 	"go.jetpack.io/devbox/internal/fileutil"
 )
+
+// Opts are global values that apply to the entire devbox binary
+type Opts struct {
+	AppName      string
+	AppVersion   string
+	SentryDSN    string // used by error reporting
+	TelemetryKey string
+}
+
+func InitOpts() *Opts {
+	return &Opts{
+		AppName:      "devbox",
+		AppVersion:   build.Version,
+		SentryDSN:    build.SentryDSN,
+		TelemetryKey: build.TelemetryKey,
+	}
+}
+
+func IsEnabled(opts *Opts) bool {
+	return DoNotTrack() || opts.TelemetryKey == "" || opts.SentryDSN == ""
+}
 
 func DoNotTrack() bool {
 	// https://consoledonottrack.com/


### PR DESCRIPTION
## Summary

This PR logs a `shell-time-to-interactive` segment event.

`devbox shell` approach:
1. Upon starting a command, we capture the `telemetry.CommandStartTime()`.
2. When `devbox shell` runs, in the custom shellrc we have a "Devbox Post Init Hooks" section. Here, we call `devbox log shell-tti <command-start-time>`.
3. `devbox log shell-tti <command-start-time>` logs to segment TrackEvent with the elapsed time.

`devbox cloud shell` approach:
1. invoke `ssh <username>@<vm-address> start_devbox_shell.sh project-path <command-start-time>`.
2. (TODO in a separate axiom PR): we will invoke `DEVBOX_SHELL_START_TIME=<command-start-time> devbox shell`
3. `devbox shell` will use the `DEVBOX_SHELL_START_TIME` instead of the `telemetry.CommandStartTime()` in step (2) in the previous `devbox shell` approach.
4. Added an `is_cloud` property in segment.TrackEvent.

Limitation: the elapsed time logged's accuracy is vulnerable to clock skew if the local laptop's clock is not accurate.

Implementation Note:
1. I tried to share as much as I could between `telemetry/segment.go` and `midcobra/telemetry.go`.
2. We could consider refactoring the current segment code in `midcobra/telemetry.go` to be moved to `telemetry/segment.go` as well.

## How was it tested?

1. Tested the local `devbox shell` case by printing out the elapsed-time value just prior to logging to segment.
2. `DEVBOX_DEBUG=1 devbox cloud shell` showed that the correct unix time stamp.
3.  I can verify end-to-end that this works.

