### PR TITLE
Implement stricter "devbox run" using "nix print-dev-env"

### DIFF
--- a/internal/boxcli/featureflag/nix_dev_env_run.go
+++ b/internal/boxcli/featureflag/nix_dev_env_run.go
@@ -1,0 +1,7 @@
+package featureflag
+
+// NixDevEnvRun controls the implementation of `devbox run`. When enabled, `devbox run`
+// runs the script in the environment returned by `nix print-dev-env`. This means the
+// environment is much more "strict" or "pure", since it will _not_ include parts of
+// the host's environment like `devbox shell` does.
+var NixDevEnvRun = disabled("NIX_DEV_ENV_RUN")

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -38,6 +38,9 @@ const (
 
 	// shellHistoryFile keeps the history of commands invoked inside devbox shell
 	shellHistoryFile = ".devbox/shell_history"
+
+	scriptsDir    = ".devbox/gen/scripts"
+	hooksFilename = ".hooks"
 )
 
 func InitConfig(dir string, writer io.Writer) (created bool, err error) {
@@ -246,10 +249,9 @@ func (d *Devbox) Shell() error {
 	return shell.Run(nixShellFilePath)
 }
 
-func (d *Devbox) RunScriptInShell(scriptName string) error {
-	profileDir, err := d.profileDir()
-	if err != nil {
-		return err
+func (d *Devbox) RunScript(scriptName string) error {
+	if featureflag.NixDevEnvRun.Disabled() {
+		return d.RunScriptInNewNixShell(scriptName)
 	}
 
 	script := d.cfg.Shell.Scripts[scriptName]
@@ -257,23 +259,26 @@ func (d *Devbox) RunScriptInShell(scriptName string) error {
 		return errors.Errorf("unable to find a script with name %s", scriptName)
 	}
 
-	shell, err := nix.DetectShell(
-		nix.WithProfile(profileDir),
-		nix.WithHistoryFile(filepath.Join(d.projectDir, shellHistoryFile)),
-		nix.WithUserScript(scriptName, script.String()),
-		nix.WithProjectDir(d.projectDir),
-	)
-
-	if err != nil {
-		fmt.Fprint(d.writer, err)
-		shell = &nix.Shell{}
+	if err := d.ensurePackagesAreInstalled(install); err != nil {
+		return err
 	}
 
-	return shell.RunInShell()
+	if err := d.writeScriptsToFiles(); err != nil {
+		return err
+	}
+
+	pluginEnv, err := plugin.Env(d.cfg.Packages, d.projectDir)
+	if err != nil {
+		return err
+	}
+
+	nixShellFilePath := filepath.Join(d.projectDir, ".devbox/gen/shell.nix")
+	return nix.RunScript(nixShellFilePath, d.projectDir, d.scriptPath(scriptName), pluginEnv)
 }
 
-// TODO: consider unifying the implementations of RunScript and Shell.
-func (d *Devbox) RunScript(scriptName string) error {
+// RunScriptInNewNixShell implements `devbox run` (from outside a devbox shell) using a nix shell.
+// Deprecated: RunScript should be used instead.
+func (d *Devbox) RunScriptInNewNixShell(scriptName string) error {
 	if err := d.ensurePackagesAreInstalled(install); err != nil {
 		return err
 	}
@@ -319,6 +324,33 @@ func (d *Devbox) RunScript(scriptName string) error {
 
 	shell.UserInitHook = d.cfg.Shell.InitHook.String()
 	return shell.Run(nixShellFilePath)
+}
+
+// TODO: deprecate in favor of RunScript().
+func (d *Devbox) RunScriptInShell(scriptName string) error {
+	profileDir, err := d.profileDir()
+	if err != nil {
+		return err
+	}
+
+	script := d.cfg.Shell.Scripts[scriptName]
+	if script == nil {
+		return errors.Errorf("unable to find a script with name %s", scriptName)
+	}
+
+	shell, err := nix.DetectShell(
+		nix.WithProfile(profileDir),
+		nix.WithHistoryFile(filepath.Join(d.projectDir, shellHistoryFile)),
+		nix.WithUserScript(scriptName, script.String()),
+		nix.WithProjectDir(d.projectDir),
+	)
+
+	if err != nil {
+		fmt.Fprint(d.writer, err)
+		shell = &nix.Shell{}
+	}
+
+	return shell.RunInShell()
 }
 
 func (d *Devbox) ListScripts() []string {
@@ -658,6 +690,63 @@ func (d *Devbox) installNixProfile() (err error) {
 	}
 
 	return
+}
+
+// writeScriptsToFiles writes scripts defined in devbox.json into files inside .devbox/gen/scripts.
+// Scripts (and hooks) are persisted so that we can easily call them from devbox run (inside or outside shell).
+func (d *Devbox) writeScriptsToFiles() error {
+	err := os.MkdirAll(filepath.Join(d.projectDir, scriptsDir), 0755) // Ensure directory exists.
+	if err != nil {
+		return err
+	}
+	// TODO: Clean up any old files from previous runs.
+
+	// Write all hooks to a file.
+	pluginHooks, err := plugin.InitHooks(d.cfg.Packages, d.projectDir)
+	if err != nil {
+		return err
+	}
+	hooks := strings.Join(append([]string{d.cfg.Shell.InitHook.String()}, pluginHooks...), "\n\n")
+	// always write it, even if there are no hooks, because scripts will source it.
+	err = d.writeScriptFile(hooksFilename, hooks)
+	if err != nil {
+		return err
+	}
+
+	// Write scripts to files.
+	for name, body := range d.cfg.Shell.Scripts {
+		err = d.writeScriptFile(
+			name,
+			fmt.Sprintf(". %s\n\n%s", d.scriptPath(hooksFilename), body))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *Devbox) writeScriptFile(name string, body string) (err error) {
+	script, err := os.Create(d.scriptPath(name))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		cerr := script.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+	err = script.Chmod(0755)
+	if err != nil {
+		return err
+	}
+	_, err = script.WriteString(body)
+	return err
+}
+
+func (d *Devbox) scriptPath(scriptName string) string {
+	return filepath.Join(d.projectDir, scriptsDir, scriptName+".sh")
 }
 
 // Move to a utility package?

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -697,20 +697,20 @@ func (d *Devbox) installNixProfile() (err error) {
 func (d *Devbox) writeScriptsToFiles() error {
 	err := os.MkdirAll(filepath.Join(d.projectDir, scriptsDir), 0755) // Ensure directory exists.
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	// TODO: Clean up any old files from previous runs.
 
 	// Write all hooks to a file.
 	pluginHooks, err := plugin.InitHooks(d.cfg.Packages, d.projectDir)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	hooks := strings.Join(append([]string{d.cfg.Shell.InitHook.String()}, pluginHooks...), "\n\n")
 	// always write it, even if there are no hooks, because scripts will source it.
 	err = d.writeScriptFile(hooksFilename, hooks)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	// Write scripts to files.
@@ -719,7 +719,7 @@ func (d *Devbox) writeScriptsToFiles() error {
 			name,
 			fmt.Sprintf(". %s\n\n%s", d.scriptPath(hooksFilename), body))
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 	}
 
@@ -729,7 +729,7 @@ func (d *Devbox) writeScriptsToFiles() error {
 func (d *Devbox) writeScriptFile(name string, body string) (err error) {
 	script, err := os.Create(d.scriptPath(name))
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	defer func() {
 		cerr := script.Close()
@@ -739,10 +739,10 @@ func (d *Devbox) writeScriptFile(name string, body string) (err error) {
 	}()
 	err = script.Chmod(0755)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 	_, err = script.WriteString(body)
-	return err
+	return errors.WithStack(err)
 }
 
 func (d *Devbox) scriptPath(scriptName string) string {

--- a/internal/nix/run.go
+++ b/internal/nix/run.go
@@ -1,0 +1,45 @@
+package nix
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/alessio/shellescape"
+	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/internal/boxcli/usererr"
+	"go.jetpack.io/devbox/internal/debug"
+)
+
+func RunScript(nixShellFilePath string, projectDir string, scriptPath string, additionalEnv []string) error {
+	if scriptPath == "" {
+		return errors.New("attempted to run script but did not specify script name")
+	}
+
+	vaf, err := PrintDevEnv(nixShellFilePath)
+	if err != nil {
+		return err
+	}
+
+	nixEnv := []string{}
+	for k, v := range vaf.Variables {
+		if v.Type == "exported" {
+			nixEnv = append(nixEnv, fmt.Sprintf("%s=%s", k, shellescape.Quote(v.Value.(string))))
+		}
+	}
+
+	cmd := exec.Command("sh", "-c", scriptPath)
+	cmd.Env = append(nixEnv, additionalEnv...)
+	cmd.Dir = projectDir
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	debug.Log("Executing: %v", cmd.Args)
+	err = cmd.Run()
+	if err != nil {
+		// Report error as exec error when executing scripts.
+		err = usererr.NewExecError(err)
+	}
+	return errors.WithStack(err)
+}


### PR DESCRIPTION
## Summary

This is part of unifying everything (devbox run/shell) to use nix print-dev-env.

This implementation of `devbox run` is pretty simple:
* Write all the init hooks into a file named `.devbox/gen/scripts/.hooks.sh`. This includes plugin hooks.
* Write all the scripts into files named `.devbox/gen/scripts/<name>.sh.` The scripts have a call to source the hooks in the beginning.
* When calling `devbox run`: (1) compute the environment with `nix print-dev-env`, (2) merge any plugin environment vars, and (3) call `sh -c <script>` with the computed environment.

## How was it tested?
Tested by running all the scripts in this `devbox.json` and confirming their results as expected:
```
{
  "packages": [
    "go_1_19",
    "golangci-lint",
    "hello",
    "ps",
    "redis",
    "ruby"
  ],
  "shell": {
    "init_hook": [
      "export \"GOROOT=$(go env GOROOT)\"",
      "echo \"im the init hook and i ran\""
    ],
    "scripts": {
      "test_exit_code": "exit 1",
      "test_external_script": "./external.sh",
      "test_init_hook": [
        "echo \"inside script\"",
        "echo $GOROOT"
      ],
      "test_multi": [
        "go version",
        "hello"
      ],
      "test_pkg": [
        "echo $PATH",
        "hello"
      ],
      "test_plugin_env": "echo \"if plugin env works, you should see a port here (for redis): $REDIS_PORT\"",
      "test_plugin_hook": "echo \"if plugin hook works, you should see the ruby virt env here: $PATH\"",
      "test_single": "echo \"hello there\"",
      "test_touch": "which touch && touch test_touch",
      "test_vars": [
        "FOO=\"bar\"",
        "echo $FOO"
      ]
    }
  },
  "nixpkgs": {
    "commit": "aa7e3b940ad90ba58a5d8c0a2269ec557c9ecc70"
  }
}
```
as well as testing that `devbox run` works from a different directory, as well as a case with no hooks or plugins.