### PR TITLE
sentry trace for devbox shell

### DIFF
--- a/internal/boxcli/log.go
+++ b/internal/boxcli/log.go
@@ -28,7 +28,7 @@ func doLogCommand(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
 			return usererr.New("expected a start-time argument for logging the shell-ready event")
 		}
-		return telemetry.LogShellDurationEvent(args[0] /*event name*/, args[1] /*startTime*/)
+		return telemetry.LogShellDurationEvent(args[0] /*event name*/, args[1] /*startTime*/, args[2] /*sentry span*/)
 	}
 	return usererr.New("unrecognized event-name %s for command: %s", args[0], cmd.CommandPath())
 }

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -42,6 +42,7 @@ func ShellCmd() *cobra.Command {
 }
 
 func runShellCmd(cmd *cobra.Command, args []string, flags shellCmdFlags) error {
+
 	path, cmds, err := parseShellArgs(cmd, args, flags)
 	if err != nil {
 		return err

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -5,6 +5,7 @@
 package impl
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/fatih/color"
+	"github.com/getsentry/sentry-go"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
@@ -199,6 +201,8 @@ func (d *Devbox) Generate() error {
 }
 
 func (d *Devbox) Shell() error {
+	span := sentry.StartSpan(context.Background(), "local shell", sentry.TransactionName("local shell"))
+
 	if err := d.ensurePackagesAreInstalled(install); err != nil {
 		return err
 	}
@@ -234,6 +238,7 @@ func (d *Devbox) Shell() error {
 		nix.WithEnvVariables(env),
 		nix.WithPKGConfigDir(filepath.Join(d.projectDir, plugin.VirtenvBinPath)),
 		nix.WithShellStartTime(shellStartTime),
+		nix.WithSentrySpan(span),
 	}
 
 	shell, err := nix.DetectShell(opts...)

--- a/internal/nix/shellrc.tmpl
+++ b/internal/nix/shellrc.tmpl
@@ -86,7 +86,7 @@ cd $workingDir
 
 {{- if .ShellStartTime }}
 # log that the shell is interactive now!
-devbox log shell-interactive {{ .ShellStartTime }}
+devbox log shell-interactive {{ .ShellStartTime }} {{ .SentrySpan }}
 {{ end }}
 
 # Begin Script command

--- a/internal/telemetry/sentry.go
+++ b/internal/telemetry/sentry.go
@@ -34,6 +34,7 @@ func (s *Sentry) Init(appName, appVersion, executionID string) {
 
 	_ = sentry.Init(sentry.ClientOptions{
 		AttachStacktrace: true,
+		EnableTracing:    true,
 		Dsn:              s.dsn,
 		Environment:      environment,
 		Release:          release,


### PR DESCRIPTION
## Summary

capturing my failed attempt at using sentry tracing.

It fails when I try to unmarshal the sentry-span inside `devbox log <event>`.

## How was it tested?

ran `devbox shell`, whose shellrc calls `devbox log shell-ready <marshalled-sentry-span>`.
