### PR TITLE
[plugins] Change default nginx port to a non-privileged port

### DIFF
--- a/plugins/nginx/nginx.conf
+++ b/plugins/nginx/nginx.conf
@@ -1,8 +1,8 @@
 events {}
 http{
 server {
-         listen       80;
-         listen       [::]:80;
+         listen       8081;
+         listen       [::]:8081;
          server_name  localhost;
          root         ../../../devbox.d/web;
 


### PR DESCRIPTION
## Summary

Port 80 requires root. Use 8081 instead. (Avoided 8080 because apache plugin has that as default)

## How was it tested?

```bash
devbox add nginx
devbox services start
curl localhost:8081
```
