### PR TITLE
[shell] do not return error if it was a user shell command or script

### DIFF
--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -282,10 +282,25 @@ func (s *Shell) Run(nixShellFilePath string) error {
 	cmd.Stderr = os.Stderr
 
 	err := cmd.Run()
-	if err != nil && s.ScriptCommand != "" {
-		// Report error as exec error when executing shell -- <cmd> script.
-		err = usererr.NewExecError(err)
+
+	// If the error is an ExitError, this means the shell started up fine but there was
+	// an error from executing a shell command or script.
+	//
+	// This could be from one of the generated shellrc commands, but more likely is from
+	// a user's command or script. So, we want to return nil for this.
+	if exitErr := (&exec.ExitError{}); errors.As(err, &exitErr) {
+
+		// The exception to the previous comment is if we are executing a shell script
+		// via `devbox run` or the deprecated `devbox shell -- <command>`. In this case,
+		// we do want to return the exit code of the script that was run.
+		if s.ScriptCommand != "" {
+			err = usererr.NewExecError(err)
+		}
+		return nil
 	}
+
+	// This means that there was a error from devbox's code or nix's code. Not a user
+	// error and so we do return it.
 	return errors.WithStack(err)
 }
 

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -294,7 +294,7 @@ func (s *Shell) Run(nixShellFilePath string) error {
 		// via `devbox run` or the deprecated `devbox shell -- <command>`. In this case,
 		// we do want to return the exit code of the script that was run.
 		if s.ScriptCommand != "" {
-			err = usererr.NewExecError(err)
+			return usererr.NewExecError(err)
 		}
 		return nil
 	}


### PR DESCRIPTION
## Summary

For `devbox shell`, we do NOT return an exit error if a user's shell command had 
returned a non-zero exit code. `devbox cloud shell` inherits this behavior.

For `devbox run`, we do return an error for the above scenario (as before).


## How was it tested?

scenarios:
- verified local `devbox shell`
- cloud: custom built a binary and deployed a machine. Observed that we no longer
  return an error if the user's last command was errant:

cloud shell output:
```
(cloud) ❯ which foobar

(cloud) ❯ exit
exit
Shared connection to 9080557a662987.vm.devbox-vms.internal closed.

❯ echo "$?"
0
```
