### PR TITLE
[install UX] show incremental progress

### DIFF
--- a/examples/testdata/go/go-1.19/devbox.json
+++ b/examples/testdata/go/go-1.19/devbox.json
@@ -1,8 +1,6 @@
 {
   "packages": [
-    "go_1_19",
-    "bazel",
-    "vim"
+    "go_1_19"
   ],
   "shell": {
     "init_hook": null,

--- a/examples/testdata/go/go-1.19/devbox.json
+++ b/examples/testdata/go/go-1.19/devbox.json
@@ -1,6 +1,7 @@
 {
   "packages": [
-    "go_1_19"
+    "go_1_19",
+    "bazel"
   ],
   "shell": {
     "init_hook": null,
@@ -9,6 +10,6 @@
     }
   },
   "nixpkgs": {
-    "commit": "af9e00071d0971eb292fd5abef334e66eda3cb69"
+    "commit": "52e3e80afff4b16ccb7c52e9f0f5220552f03d04"
   }
 }

--- a/examples/testdata/go/go-1.19/devbox.json
+++ b/examples/testdata/go/go-1.19/devbox.json
@@ -1,7 +1,8 @@
 {
   "packages": [
     "go_1_19",
-    "bazel"
+    "bazel",
+    "vim"
   ],
   "shell": {
     "init_hook": null,

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -20,7 +20,6 @@ import (
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/boxcli/generate"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
-	"go.jetpack.io/devbox/internal/cloud/stepper"
 	"go.jetpack.io/devbox/internal/cuecfg"
 	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/fileutil"
@@ -30,6 +29,7 @@ import (
 	"go.jetpack.io/devbox/internal/planner/plansdk"
 	"go.jetpack.io/devbox/internal/plugin"
 	"go.jetpack.io/devbox/internal/telemetry"
+	"go.jetpack.io/devbox/internal/ux/stepper"
 	"golang.org/x/exp/slices"
 )
 
@@ -687,6 +687,8 @@ func (d *Devbox) installNixProfile() (err error) {
 	}
 
 	// Non flakes below:
+
+	// Append an empty string to warm the nixpkgs cache
 	packages := append([]string{""}, d.cfg.Packages...)
 
 	total := len(packages)
@@ -715,9 +717,9 @@ func (d *Devbox) installNixProfile() (err error) {
 		if pkg != "" {
 			cmd.Args = append(cmd.Args, "--attr", pkg)
 		} else {
-			// TODO savil. Figure out how to pre-install just the nixpkgs
-			step.Fail(msg)
-			continue
+			// Warm the nixpkgs cache.
+			// TODO savil. Find a way without installing the hello-world program.
+			cmd.Args = append(cmd.Args, "--attr", "hello")
 		}
 
 		cmd.Env = nix.DefaultEnv()

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -695,25 +695,24 @@ func (d *Devbox) installNixProfile() (err error) {
 	for idx, pkg := range packages {
 		stepNum := idx + 1
 
-		info, infoFound := nix.PkgInfo(d.cfg.Nixpkgs.Commit, pkg)
 		var msg string
 		if pkg == "" {
 			msg = fmt.Sprintf("[%d/%d] nixpkgs", stepNum, total)
-		} else if infoFound {
-			msg = fmt.Sprintf("[%d/%d] %s (%s)", stepNum, total, pkg, info.Version)
 		} else {
 			msg = fmt.Sprintf("[%d/%d] %s", stepNum, total, pkg)
 		}
 
 		step := stepper.Start(msg)
 
+		// TODO savil. hook this up to gcurtis's mirrorURL
+		nixPkgsURL := fmt.Sprintf("https://github.com/nixos/nixpkgs/archive/%s.tar.gz", d.cfg.Nixpkgs.Commit)
+
 		var cmd *exec.Cmd
 		if pkg != "" {
 			cmd = exec.Command(
 				"nix-env",
 				"--profile", profileDir,
-				// TODO savil. hook this up to gcurtis's mirrorURL
-				"-f", fmt.Sprintf("https://github.com/nixos/nixpkgs/archive/%s.tar.gz", d.cfg.Nixpkgs.Commit),
+				"-f", nixPkgsURL,
 				"--install",
 				"--attr", pkg,
 			)
@@ -722,7 +721,7 @@ func (d *Devbox) installNixProfile() (err error) {
 				"nix-instantiate",
 				"--eval",
 				"--attr", "path",
-				fmt.Sprintf("https://github.com/nixos/nixpkgs/archive/%s.tar.gz", d.cfg.Nixpkgs.Commit),
+				nixPkgsURL,
 			)
 		}
 

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -707,19 +707,23 @@ func (d *Devbox) installNixProfile() (err error) {
 
 		step := stepper.Start(msg)
 
-		cmd := exec.Command(
-			"nix-env",
-			"--profile", profileDir,
-			// TODO savil. hook this up to gcurtis's mirrorURL
-			"-f", fmt.Sprintf("https://github.com/nixos/nixpkgs/archive/%s.tar.gz", d.cfg.Nixpkgs.Commit),
-			"--install",
-		)
+		var cmd *exec.Cmd
 		if pkg != "" {
-			cmd.Args = append(cmd.Args, "--attr", pkg)
+			cmd = exec.Command(
+				"nix-env",
+				"--profile", profileDir,
+				// TODO savil. hook this up to gcurtis's mirrorURL
+				"-f", fmt.Sprintf("https://github.com/nixos/nixpkgs/archive/%s.tar.gz", d.cfg.Nixpkgs.Commit),
+				"--install",
+				"--attr", pkg,
+			)
 		} else {
-			// Warm the nixpkgs cache.
-			// TODO savil. Find a way without installing the hello-world program.
-			cmd.Args = append(cmd.Args, "--attr", "hello")
+			cmd = exec.Command(
+				"nix-instantiate",
+				"--eval",
+				"--attr", "path",
+				fmt.Sprintf("https://github.com/nixos/nixpkgs/archive/%s.tar.gz", d.cfg.Nixpkgs.Commit),
+			)
 		}
 
 		cmd.Env = nix.DefaultEnv()


### PR DESCRIPTION
## Summary

I was playing around with making the install step show more incremental progress.

This PR explores it by doing `nix-env --install` for just the nixpkgs and then
each package individually. This lets us print installation output as we go along.

The implementation is rather hacky. I override `devbox.cfg.Packages` to re-generate
the `development.nix`. There's more likely a more direct `nix-env --install` 
command invocation we can use but I was failing to figure it out this evening. I don't think 
we should commit this code as-is, but sharing for product oriented feedback and suggestions
on the right `nix-env --install` command to use so we can improve the hacky code.

## How was it tested?

deployed a custom binary to a custom VM:
```
Devbox Cloud
Remote development environments powered by Nix

✓ File syncing started
→ Connecting to virtual machine


Installing nix packages. This may take a while...
Ensure nixpkgs is downloaded, extracted and evaluated.
Ensure package installed: go_1_19
Ensure package installed: bazel
Done.
Starting a devbox shell...

(devbox ☁️ ) testdata/go/go-1.19 via 🐹 💫 watching for changes
```
