### PR TITLE
[port forward] terminate port-fwd sessions if VM is not active

### DIFF
--- a/internal/cloud/openssh/sshshim/mutagen.go
+++ b/internal/cloud/openssh/sshshim/mutagen.go
@@ -47,7 +47,11 @@ func terminateMutagenSessions(vmAddr string) error {
 				"For completeness, VmAddr is %s", hostname, vmAddr)
 	}
 
-	return mutagenbox.TerminateSessionsForMachine(machineID, nil /*env*/)
+	if err := mutagenbox.TerminateSessionsForMachine(machineID, nil /*env*/); err != nil {
+		return err
+	}
+
+	return mutagenbox.ForwardTerminateAll()
 }
 
 func checkActiveVM(vmAddr string) (bool, error) {


### PR DESCRIPTION
## Summary

This PR should stop port-forward sessions once the user's VM is found to be inactive
and we are terminating the sync sessions as well.

## How was it tested?


- `devbox cloud shell`
   - `devbox add apacheHttpd` (Make sure to run the source line after installing)
   - `devbox services start apache`
- locally port forward: `devbox cloud port-forward :8080` (test localhost on printed url)
  - Test port forward is active: devbox cloud port-forward ls
- Stop cloud shell, and wait (30 seconds) for the scale-to-zero logic to stop the VM.
   - edit some file in the directory (triggers a mutagen sync ssh operation)
- Test port forward is no longer exists: devbox cloud port-forward ls
