### PR TITLE
[forward] Rename port-forward to forward and simplify API

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -1,17 +1,17 @@
 {
-    "packages": [
-        "go_1_19",
-        "golangci-lint"
-    ],
-    "shell": {
-        "init_hook": "export \"GOROOT=$(go env GOROOT)\"",
-        "scripts": {
-            "build": "go build -o dist/devbox cmd/devbox/main.go",
-            "build-linux": "GOOS=linux go build -o dist/devbox-linux cmd/devbox/main.go",
-            "lint": "golangci-lint run"
-        }
-    },
-    "nixpkgs": {
-        "commit": "aa7e3b940ad90ba58a5d8c0a2269ec557c9ecc70"
+  "packages": [
+    "go_1_19",
+    "golangci-lint"
+  ],
+  "shell": {
+    "init_hook": "export \"GOROOT=$(go env GOROOT)\"",
+    "scripts": {
+      "build": "go build -o dist/devbox cmd/devbox/main.go",
+      "build-linux": "GOOS=linux go build -o dist/devbox-linux cmd/devbox/main.go",
+      "lint": "golangci-lint run"
     }
+  },
+  "nixpkgs": {
+    "commit": "aa7e3b940ad90ba58a5d8c0a2269ec557c9ecc70"
+  }
 }

--- a/internal/boxcli/cloud.go
+++ b/internal/boxcli/cloud.go
@@ -53,21 +53,15 @@ func cloudShellCmd() *cobra.Command {
 
 func cloudPortForwardCmd() *cobra.Command {
 	command := &cobra.Command{
-		Use:   "port-forward <local-port>:<remote-port> | <port> | :<remote-port> | terminate",
+		Use:   "forward <local-port>:<remote-port> | :<remote-port> | stop | list",
 		Short: "Port forwards a local port to a remote devbox cloud port",
-		Long: "Port forwards a local port to a remote devbox cloud port. If a " +
-			"single port is specified, it is used for local and remote. If no local" +
-			" port is specified, we find a suitable local port. Use 'terminate' to " +
-			"terminate all port forwards.",
+		Long: "Port forwards a local port to a remote devbox cloud port. If 0 or " +
+			"no local port is specified, we find a suitable local port. Use 'stop' " +
+			"to stop all port forwards.",
 		Hidden: true,
 		Args:   cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ports := []string{}
-			if strings.ContainsRune(args[0], ':') {
-				ports = strings.Split(args[0], ":")
-			} else {
-				ports = append(ports, args[0], args[0])
-			}
+			ports := strings.Split(args[0], ":")
 
 			if len(ports) != 2 {
 				return usererr.New("Invalid port format. Expected <local-port>:<remote-port>")
@@ -85,14 +79,14 @@ func cloudPortForwardCmd() *cobra.Command {
 		},
 	}
 	command.AddCommand(cloudPortForwardList())
-	command.AddCommand(cloudPortForwardTerminateAllCmd())
+	command.AddCommand(cloudPortForwardStopCmd())
 	return command
 }
 
-func cloudPortForwardTerminateAllCmd() *cobra.Command {
+func cloudPortForwardStopCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:    "terminate",
-		Short:  "Terminates all port forwards managed by devbox",
+		Use:    "stop",
+		Short:  "Stops all port forwards managed by devbox",
 		Hidden: true,
 		Args:   cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/boxcli/cloud.go
+++ b/internal/boxcli/cloud.go
@@ -58,8 +58,7 @@ func cloudPortForwardCmd() *cobra.Command {
 		Long: "Port forwards a local port to a remote devbox cloud port. If 0 or " +
 			"no local port is specified, we find a suitable local port. Use 'stop' " +
 			"to stop all port forwards.",
-		Hidden: true,
-		Args:   cobra.ExactArgs(1),
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ports := strings.Split(args[0], ":")
 
@@ -85,10 +84,9 @@ func cloudPortForwardCmd() *cobra.Command {
 
 func cloudPortForwardStopCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:    "stop",
-		Short:  "Stops all port forwards managed by devbox",
-		Hidden: true,
-		Args:   cobra.ExactArgs(0),
+		Use:   "stop",
+		Short: "Stops all port forwards managed by devbox",
+		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cloud.PortForwardTerminateAll()
 		},
@@ -100,7 +98,6 @@ func cloudPortForwardList() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "Lists all port forwards managed by devbox",
-		Hidden:  true,
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			l, err := cloud.PortForwardList()

--- a/internal/cloud/mutagenbox/forward.go
+++ b/internal/cloud/mutagenbox/forward.go
@@ -13,7 +13,7 @@ import (
 
 func ForwardCreate(host, localPort, remotePort string) (string, error) {
 	var err error
-	if localPort == "" {
+	if localPort == "" || localPort == "0" {
 		localPort, err = getFreePort()
 		if err != nil {
 			return "", err


### PR DESCRIPTION
## Summary

Renames:
* `port-forward` -> `forward`
* `terminate` -> `stop`

Simplifies:
* Removes single port option
* accepts 0 (zero) as a local port. If this is passed in, we determine the port.

## How was it tested?

```bash
devbox cloud forward :8080
devbox cloud forward list
devbox cloud forward stop
```