### PR TITLE
Allow limited set of vars to leak into devbox run env

### DIFF
--- a/internal/nix/run.go
+++ b/internal/nix/run.go
@@ -35,7 +35,7 @@ func RunScript(nixShellFilePath string, projectDir string, cmdWithArgs string, a
 		}
 	}
 
-	cmd := exec.Command("sh", "-c", scriptPath)
+	cmd := exec.Command("sh", "-c", cmdWithArgs)
 	cmd.Env = append(nixEnv, additionalEnv...)
 	cmd.Dir = projectDir
 	cmd.Stdin = os.Stdin

--- a/internal/nix/run.go
+++ b/internal/nix/run.go
@@ -28,7 +28,14 @@ func RunScript(nixShellFilePath string, projectDir string, cmdWithArgs string, a
 		}
 	}
 
-	cmd := exec.Command("sh", "-c", cmdWithArgs)
+	// Overwrite/leak whitelisted vars into nixEnv:
+	for name, leak := range leakVarsForRun {
+		if leak {
+			nixEnv = append(nixEnv, fmt.Sprintf("%s=%s", name, os.Getenv(name)))
+		}
+	}
+
+	cmd := exec.Command("sh", "-c", scriptPath)
 	cmd.Env = append(nixEnv, additionalEnv...)
 	cmd.Dir = projectDir
 	cmd.Stdin = os.Stdin
@@ -42,4 +49,24 @@ func RunScript(nixShellFilePath string, projectDir string, cmdWithArgs string, a
 		err = usererr.NewExecError(err)
 	}
 	return errors.WithStack(err)
+}
+
+// leakVarsForRun contains a list of variables that, if set in the host, will be copied
+// to the environment of devbox run. If they're NOT set in the host, they will be set
+// to an empty value for devbox run. NOTE: we want to keep this list AS SMALL AS POSSIBLE.
+// The longer this list, the less "pure" devbox run becomes.
+//
+// In particular, this list should be much smaller than that of devbox shell, since we
+// do want to allow more parts of the host environment to leak into a shell session, so
+// that the shell session is easy to use for our users. However, in devbox run, we value
+// reproducibility above interactive ease-of-use.
+var leakVarsForRun = map[string]bool{
+	"HOME": true, // Without this, HOME is set to /homeless-shelter and most programs fail.
+
+	// Where to write temporary files. nix print-dev-env sets these to an unwriteable path,
+	// so we override that here with whatever the host has set.
+	"TMP":     true,
+	"TEMP":    true,
+	"TMPDIR":  true,
+	"TEMPDIR": true,
 }


### PR DESCRIPTION
## Summary
TSIA

Study on how these vars were chosen:
https://www.notion.so/jetpackio/Env-audit-nix-shell-vs-print-dev-env-bebe176d2a2b4796967df92f58201fef

## How was it tested?
```
DEVBOX_FEATURE_NIX_DEV_ENV_RUN=1 ./devbox run -- echo '$HOME' # my home, instead of /homeless-shelter
DEVBOX_FEATURE_NIX_DEV_ENV_RUN=1 ./devbox run -- echo '$TMP' # not set in host, not set here
DEVBOX_FEATURE_NIX_DEV_ENV_RUN=1 ./devbox run -- echo '$TMPDIR' # set in host, set here

DEVBOX_FEATURE_NIX_DEV_ENV_RUN=1 ./devbox run lint # works without complaining about lockfile
DEVBOX_FEATURE_NIX_DEV_ENV_RUN=1 ./devbox run build # works as well

DEVBOX_FEATURE_NIX_DEV_ENV_RUN=1 ./devbox run curl https://www.google.com # works without ssl failure
```