### PR TITLE
impl: allow nixpkgs URL to be set with DEVBOX_NIXPKGS_URL

### DIFF
--- a/internal/impl/tmpl/development.nix.tmpl
+++ b/internal/impl/tmpl/development.nix.tmpl
@@ -1,9 +1,7 @@
 let
+  mirrorURL = builtins.getEnv "DEVBOX_NIXPKGS_URL";
   pkgs = import (fetchTarball {
-    url = "{{ .NixpkgsInfo.URL }}";
-    {{- if .NixpkgsInfo.Sha256 }}
-    sha256 = "{{ .NixpkgsInfo.Sha256 }}";
-    {{- end }}
+    url = if mirrorURL == "" then "{{ .NixpkgsInfo.URL }}" else mirrorURL;
   }) {
     {{- if .NixOverlays }}
       overlays = [

--- a/internal/impl/tmpl/runtime.nix.tmpl
+++ b/internal/impl/tmpl/runtime.nix.tmpl
@@ -1,9 +1,7 @@
 let
+  mirrorURL = builtins.getEnv "DEVBOX_NIXPKGS_URL";
   pkgs = import (fetchTarball {
-    url = "{{ .NixpkgsInfo.URL }}";
-    {{- if .NixpkgsInfo.Sha256 }}
-    sha256 = "{{ .NixpkgsInfo.Sha256 }}";
-    {{- end }}
+    url = if mirrorURL == "" then "{{ .NixpkgsInfo.URL }}" else mirrorURL;
   }) {
     {{- if .NixOverlays }}
       overlays = [

--- a/internal/impl/tmpl/shell.nix.tmpl
+++ b/internal/impl/tmpl/shell.nix.tmpl
@@ -1,11 +1,7 @@
 let
+  mirrorURL = builtins.getEnv "DEVBOX_NIXPKGS_URL";
   pkgs = import (fetchTarball {
-    # Commit hash as of 2022-08-16
-    # `git ls-remote https://github.com/nixos/nixpkgs nixos-unstable`
-    url = "{{ .NixpkgsInfo.URL }}";
-    {{- if .NixpkgsInfo.Sha256 }}
-    sha256 = "{{ .NixpkgsInfo.Sha256 }}";
-    {{- end }}
+    url = if mirrorURL == "" then "{{ .NixpkgsInfo.URL }}" else mirrorURL;
   }) {
     {{- if .NixOverlays }}
       overlays = [


### PR DESCRIPTION
## Summary

If the DEVBOX_NIXPKGS_URL environment variable is set, use it for the nixpkgs URL instead of the one baked into the nix file.

## How was it tested?

Ran `devbox shell` with it set and unset.