### PR TITLE
Add deprecation warning on shell -- cmd

### DIFF
--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -6,6 +6,7 @@ package boxcli
 import (
 	"fmt"
 
+	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
@@ -21,12 +22,12 @@ func ShellCmd() *cobra.Command {
 	flags := shellCmdFlags{}
 	command := &cobra.Command{
 		Use:   "shell -- [<cmd>]",
-		Short: "Start a new shell or run a command with access to your packages",
-		Long: "Start a new shell or run a command with access to your packages.\n\n" +
-			"If invoked without `cmd`, devbox will start an interactive shell.\n" +
-			"If invoked with a `cmd`, devbox will run the command in a shell and then exit.\n" +
-			"In both cases, the shell will be started using the devbox.json found in the --config flag directory. " +
-			"If --config isn't set, then devbox recursively searches the current directory and its parents.",
+		Short: "Start a new shell with access to your packages",
+		Long: "Start a new shell with access to your packages.\n\n" +
+			"The shell will be started using the devbox.json found in the --config flag directory. " +
+			"If --config isn't set, then devbox recursively searches the current directory and its parents.\n\n" +
+			"[Deprecated] If invoked as devbox shell -- <cmd>, devbox will run the command in a shell and then exit. " +
+			"This behavior is deprecated and will be removed. Please use devbox run -- <cmd> instead.",
 		Args:    validateShellArgs,
 		PreRunE: ensureNixInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -68,6 +69,9 @@ func runShellCmd(cmd *cobra.Command, args []string, flags shellCmdFlags) error {
 	}
 
 	if len(cmds) > 0 {
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			color.HiYellowString("[Warning] \"devbox shell -- <cmd>\" is deprecated and will disappear "+
+				"in a future version. Use \"devbox run -- <cmd>\" instead\n"))
 		err = box.Exec(cmds...)
 	} else {
 		err = box.Shell()

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -69,7 +69,7 @@ func runShellCmd(cmd *cobra.Command, args []string, flags shellCmdFlags) error {
 	}
 
 	if len(cmds) > 0 {
-		fmt.Fprintf(cmd.ErrOrStderr(),
+		fmt.Fprint(cmd.ErrOrStderr(),
 			color.HiYellowString("[Warning] \"devbox shell -- <cmd>\" is deprecated and will disappear "+
 				"in a future version. Use \"devbox run -- <cmd>\" instead\n"))
 		err = box.Exec(cmds...)


### PR DESCRIPTION
## Summary
TSIA

To be merged after #503.

## How was it tested?
```
> ./devbox shell -- hello
[Warning] "devbox shell -- <cmd>" is deprecated and will disappear in a future version. Use "devbox run -- <cmd>" instead
Installing nix packages. This may take a while... done.
Hello, world!
```

```
> ./devbox shell -q -- hello
Hello, world!
```

```
> ./devbox shell --help
Start a new shell with access to your packages.

The shell will be started using the devbox.json found in the --config flag directory. If --config isn't set, then devbox recursively searches the current directory and its parents.

[Deprecated] If invoked as devbox shell -- <cmd>, devbox will run the command in a shell and then exit. This behavior is deprecated and will be removed. Please use devbox run -- <cmd> instead.

Usage:
  devbox shell -- [<cmd>] [flags]

Flags:
  -c, --config string   path to directory containing a devbox.json config file
  -h, --help            help for shell
      --print-env       print script to setup shell environment

Global Flags:
  -q, --quiet   suppresses logs.
```