### PR TITLE
Flip swich on strict devbox run feature flag

### DIFF
--- a/internal/boxcli/featureflag/strict_run.go
+++ b/internal/boxcli/featureflag/strict_run.go
@@ -1,7 +1,7 @@
 package featureflag
 
-// NixDevEnvRun controls the implementation of `devbox run`. When enabled, `devbox run`
+// StrictRun controls the implementation of `devbox run`. When enabled, `devbox run`
 // runs the script in the environment returned by `nix print-dev-env`. This means the
 // environment is much more "strict" or "pure", since it will _not_ include parts of
 // the host's environment like `devbox shell` does.
-var NixDevEnvRun = disabled("NIX_DEV_ENV_RUN")
+var StrictRun = enabled("STRICT_RUN")

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -250,7 +250,7 @@ func (d *Devbox) Shell() error {
 }
 
 func (d *Devbox) RunScript(cmdName string, cmdArgs []string) error {
-	if featureflag.NixDevEnvRun.Disabled() {
+	if featureflag.StrictRun.Disabled() {
 		return d.RunScriptInNewNixShell(cmdName)
 	}
 


### PR DESCRIPTION
## Summary

Enable print-dev-env based devbox run by default. A user can always disable it by passing `DEVBOX_FEATURE_STRICT_RUN=0`. Note that I renamed the feature because the other name was a mouthful.

## How was it tested?
````
./devbox run test_single
./devbox run hello # success. would've failed otherwise
DEVBOX_FEATURE_STRICT_RUN=0 ./devbox run hello # fails