### PR TITLE
Use same impl for devbox run in shell or out

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -34,6 +34,7 @@ type Devbox interface {
 	// the devbox environment.
 	Remove(pkgs ...string) error
 	RunScript(scriptName string, scriptArgs []string) error
+	// TODO: Deprecate in favor of RunScript
 	RunScriptInShell(scriptName string) error
 	Services() (plugin.Services, error)
 	// Shell generates the devbox environment and launches nix-shell as a child

--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
+	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/debug"
 )
 
@@ -47,10 +48,14 @@ func runScriptCmd(cmd *cobra.Command, args []string, flags runCmdFlags) error {
 		return errors.WithStack(err)
 	}
 
-	if devbox.IsDevboxShellEnabled() {
-		err = box.RunScriptInShell(script)
-	} else {
+	if featureflag.StrictRun.Enabled() {
 		err = box.RunScript(script, scriptArgs)
+	} else {
+		if devbox.IsDevboxShellEnabled() {
+			err = box.RunScriptInShell(script)
+		} else {
+			err = box.RunScript(script, scriptArgs)
+		}
 	}
 	return err
 }


### PR DESCRIPTION
## Summary

The new devbox run implementation lets us reuse the exact same implementation, whether we're in or outside a devbox shell. I also behaves exactly the same way, yay!

## How was it tested?
```
./devbox shell
./devbox run hello
./devbox run echo '$HOME'
```
