### PR TITLE
[install UX] incrementally show the output in-line

### DIFF
--- a/internal/ux/stepper/stepper.go
+++ b/internal/ux/stepper/stepper.go
@@ -45,3 +45,8 @@ func (s *Stepper) Success(format string, a ...any) {
 	s.spinner.FinalMSG = fmt.Sprintf("%s %s\n", color.GreenString("✓"), msg)
 	s.spinner.Stop()
 }
+
+func (s *Stepper) Display(format string, a ...any) {
+	msg := fmt.Sprintf(format, a...)
+	s.spinner.Suffix = fmt.Sprintf(" %s %s", color.YellowString("→"), msg)
+}

--- a/internal/ux/stepper/stepper.go
+++ b/internal/ux/stepper/stepper.go
@@ -48,5 +48,6 @@ func (s *Stepper) Success(format string, a ...any) {
 
 func (s *Stepper) Display(format string, a ...any) {
 	msg := fmt.Sprintf(format, a...)
-	s.spinner.Suffix = fmt.Sprintf(" %s %s", color.YellowString("→"), msg)
+	// we need to add a space prefix to give a small gap between the spinner animation and the msg
+	s.spinner.Suffix = fmt.Sprintf(" %s", msg)
 }


### PR DESCRIPTION
## Summary

Thanks to @mikeland86's suggestion we can have snappy incremental in-line updates
of what the `nix-env --install` is doing.

## How was it tested?

added `buf` to a devbox.json and did `devbox shell`
