### PR TITLE
[stepper] respect the io.Writer used in impl/devbox.go

### DIFF
--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -73,7 +73,7 @@ func Shell(w io.Writer, projectDir string, githubUsername string) error {
 	}
 
 	if vmHostname == "" {
-		stepVM := stepper.Start("Creating a virtual machine on the cloud...")
+		stepVM := stepper.Start(w, "Creating a virtual machine on the cloud...")
 		// Inspect the ssh ControlPath to check for existing connections
 		vmHostname = vmHostnameFromSSHControlPath()
 		if vmHostname != "" {
@@ -98,7 +98,7 @@ func Shell(w io.Writer, projectDir string, githubUsername string) error {
 	}
 	debug.Log("vm_hostname: %s", vmHostname)
 
-	s2 := stepper.Start("Starting file syncing...")
+	s2 := stepper.Start(w, "Starting file syncing...")
 	err = syncFiles(username, vmHostname, projectDir)
 	if err != nil {
 		s2.Fail("Starting file syncing [FAILED]")
@@ -106,7 +106,7 @@ func Shell(w io.Writer, projectDir string, githubUsername string) error {
 	}
 	s2.Success("File syncing started")
 
-	s3 := stepper.Start("Connecting to virtual machine...")
+	s3 := stepper.Start(w, "Connecting to virtual machine...")
 	time.Sleep(1 * time.Second)
 	s3.Stop("Connecting to virtual machine")
 	fmt.Fprint(w, "\n")

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -703,7 +703,7 @@ func (d *Devbox) installNixProfile() (err error) {
 			msg = fmt.Sprintf("[%d/%d] %s", stepNum, total, pkg)
 		}
 
-		step := stepper.Start(msg)
+		step := stepper.Start(d.writer, msg)
 
 		// TODO savil. hook this up to gcurtis's mirrorURL
 		nixPkgsURL := fmt.Sprintf("https://github.com/nixos/nixpkgs/archive/%s.tar.gz", d.cfg.Nixpkgs.Commit)

--- a/internal/ux/stepper/stepper.go
+++ b/internal/ux/stepper/stepper.go
@@ -5,6 +5,7 @@ package stepper
 
 import (
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -15,8 +16,8 @@ type Stepper struct {
 	spinner *spinner.Spinner
 }
 
-func Start(format string, a ...any) *Stepper {
-	spinner := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
+func Start(w io.Writer, format string, a ...any) *Stepper {
+	spinner := spinner.New(spinner.CharSets[11], 100*time.Millisecond, spinner.WithWriter(w))
 	err := spinner.Color("magenta")
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
## Summary

I noticed the stepper wasn't respecting the `io.Writer` used in the `impl/devbox.go`
and `cloud/cloud.go` apis.

Hooked it up.

## How was it tested?

Ran `devbox shell` and `devbox cloud shell` and got expected output.
