### PR TITLE
[bug fix] re-create nix-profile on each install of packages (workaround fix)

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -555,6 +555,12 @@ func (d *Devbox) generateShellFiles() error {
 	return generateForShell(d.projectDir, plan, d.pluginManager)
 }
 
+func (d *Devbox) recreateProfileDir() (string, error) {
+	absPath := filepath.Join(d.projectDir, nix.ProfilePath)
+	_ = os.Remove(absPath)
+	return d.profileDir()
+}
+
 func (d *Devbox) profileDir() (string, error) {
 	absPath := filepath.Join(d.projectDir, nix.ProfilePath)
 	if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
@@ -656,7 +662,10 @@ func (d *Devbox) printPackageUpdateMessage(
 // installNixProfile installs or uninstalls packages to or from this
 // devbox's Nix profile so that it matches what's in development.nix or flake.nix
 func (d *Devbox) installNixProfile() (err error) {
-	profileDir, err := d.profileDir()
+	// Re-create the profile dir to avoid conflicts with previous versions
+	// of the profile that may have the same binary installed under a different
+	// `/nix/store` path
+	profileDir, err := d.recreateProfileDir()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Problem:
- Prior to #491: 
  - we'd install packages in the nix-profile using `nix-env --install development.nix`.
This was subsequently changed to install each package individually as in `nix-env --install --attr <package>`.
  - the nix-profile would have the package under `/nix/store/<hash>-devbox-development/path/to/binary`
which is now `/nix/store/<hash>-<package>/path/to/binary`.
- So, nix will complain about this conflict in the nix-profile.

Fix #1:
A brute-force fix is to `rm -rf .devbox` directory but this is bad UX

This PR's Fix:
The fix for now is to always re-create the profile. This is not great but tolerable
since we are not currently using the profile's generations. (We rely on the nix-profile
to enable us to install the package upon `devbox add` so it is present right away and when the
user next does `devbox shell`).

## How was it tested?

Step 1: built `devbox` from a commit prior to #491 to build the "old style" nix profile
Step 2: go to `main` and run `devbox shell` in the `go-1.19` example project. This fails.
Step 3: go to this branch, and run `devbox shell` again. This works.
