### PR TITLE
Avoid reinstalling pkgs if config has not changed

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -612,10 +612,8 @@ func (d *Devbox) ensurePackagesAreInstalled(mode installMode) error {
 		return err
 	}
 
-	err = os.WriteFile(hashFile, hash, 0644)
-	if err != nil {
+	if err := os.WriteFile(hashFile, hash, 0644); err != nil {
 		debug.Log("error writing hash file: %s", err)
-		err = nil
 	}
 
 	return nil
@@ -626,7 +624,7 @@ func (d *Devbox) configHash() []byte {
 	config, err := os.ReadFile(filepath.Join(d.projectDir, configFilename))
 	if err != nil {
 		debug.Log("error reading config: %s", err)
-		err = nil
+		return nil
 	}
 	checksum := sha256.Sum256(config)
 	return checksum[:]
@@ -646,7 +644,7 @@ func (d *Devbox) hashesMatch(hashFile string, hash []byte) bool {
 				debug.Log("error reading hash file: %s", err)
 				return false
 			} else {
-				return bytes.Compare(savedHash, hash) == 0
+				return bytes.Equal(savedHash, hash)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

The main time sink when doing `devbox shell` or `devbox run` is installing the nix packages. Most of the time, the packages actually haven't changed and there's really no need to "reinstall" anything (reinstall is in quotes because we're not reinstalling anything, just checking the packages are actually installed).

This PR writes a SHA256 sum of `config.json` into a file. At install time, we check the file and see if it matches the checksum, and if so, we skip the install altogether.  Reduces latency from ~12 seconds to ~1 second on my devbox.json with 8 packages.

Of course, this comes at a cost: we don't always want to skip the install. Maybe the user mucked around the Nix store without modifying `devbox.json`, or maybe I don't know, something else happened that breaks the assumption that no changes in `devbox.json` means that our nix packages are gucci. So (1) the cache only works within a 1 hour timeframe, which should help developers who don't change their config but who run `devbox run` often while develping, and (2) we should build an escape hatch. (2) is _not_ in this PR. Of course, the user can just manually delete the hash file, or make a change to the config in order to force the install, but that's not very user-friendly.

## How was it tested?
```
> ./devbox run -- echo "hi"
Installing nix packages. This may take a while...
✓ [1/8] nixpkgs
✓ [2/8] go_1_19
✓ [3/8] golangci-lint
✓ [4/8] hello
✓ [5/8] redis
✓ [6/8] ruby
✓ [7/8] cowsay
✓ [8/8] curl
Done.
hi

> ls -la .devbox/gen/hash.txt   # look at time
-rw-r--r--  1 rodrigo.ipince  staff  32 Jan 25 00:45 .devbox/gen/hash.txt

> ./devbox run -- echo "hi"   # after a couple mins
hi

> ls -la .devbox/gen/hash.txt   # check mod time was not changed, so we eventually expire cache (also verified by changing expiry time to 1 minute)
-rw-r--r--  1 rodrigo.ipince  staff  32 Jan 25 00:45 .devbox/gen/hash.txt

> echo "" >> devbox.json   # invalidate checksum
> ./devbox run -- echo "hi"
Installing nix packages. This may take a while...
✓ [1/8] nixpkgs
✓ [2/8] go_1_19
✓ [3/8] golangci-lint
✓ [4/8] hello
✓ [5/8] redis
✓ [6/8] ruby
✓ [7/8] cowsay
✓ [8/8] curl
Done.
hi

> ./devbox rm curl   # uninstalls are not cached
Uninstalling nix packages. This may take a while...
✓ [1/7] nixpkgs
✓ [2/7] go_1_19
✓ [3/7] golangci-lint
✓ [4/7] hello
✓ [5/7] redis
✓ [6/7] ruby
✓ [7/7] cowsay
Done.
curl (curl-7.87.0) is now removed.
```