### PR TITLE
[install UX] use --remove-all flag to avoid profile package collisions

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -715,6 +715,7 @@ func (d *Devbox) installNixProfile() (err error) {
 				"--profile", profileDir,
 				"-f", nixPkgsURL,
 				"--install",
+				"--remove-all",
 				"--attr", pkg,
 			)
 		} else {


### PR DESCRIPTION
## Summary

This avoids the issue in #508
but without manually re-creating the profile directory.

## How was it tested?

repeated the test plan of #508

- [x] I'll do a timing run to ensure it doesn't regress the timings too much