### PR TITLE
[RFC][install UX] support DEVBOX_MIRROR_URL

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -705,8 +705,10 @@ func (d *Devbox) installNixProfile() (err error) {
 
 		step := stepper.Start(d.writer, msg)
 
-		// TODO savil. hook this up to gcurtis's mirrorURL
 		nixPkgsURL := fmt.Sprintf("https://github.com/nixos/nixpkgs/archive/%s.tar.gz", d.cfg.Nixpkgs.Commit)
+		if mirrorURL := os.Getenv("DEVBOX_MIRROR_URL"); mirrorURL != "" {
+			nixPkgsURL = mirrorURL
+		}
 
 		var cmd *exec.Cmd
 		if pkg != "" {


### PR DESCRIPTION
## Summary

This seeks to do the same as how `development.nix` and `shell.nix` are using the mirror url.

@gcurtis I'm not sure if this is fully what works. Thoughts?

## How was it tested?

did `devbox shell` with and without setting the DEVBOX_MIRROR_URL
