### PR TITLE
Update devbox run help text

### DIFF
--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -5,6 +5,7 @@ package boxcli
 
 import (
 	"github.com/pkg/errors"
+	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
@@ -17,19 +18,27 @@ type runCmdFlags struct {
 }
 
 func RunCmd() *cobra.Command {
+	longHelp := "Starts a new shell and runs your script or command in it, exiting when done.\n\n" +
+		"The script must be defined in `devbox.json`, or else it will be interpreted as an " +
+		"arbitrary command. You can pass arguments to your script or command. Everything " +
+		"after `--` will be passed verbatim into your command (see examples).\n\n"
+	shortHelp := "Runs a script or command in a shell with access to your packages"
+	example := "\nRun a command directly:\n\n  devbox add cowsay\n  devbox run cowsay hello\n  " +
+		"devbox run -- cowsay -d hello\n\nRun a script (defined as `\"moo\": \"cowsay moo\"`) " +
+		"in your devbox.json:\n\n  devbox run moo"
+	if featureflag.UnifiedEnv.Disabled() {
+		shortHelp = "Starts a new devbox shell and runs the target script"
+		longHelp = "Starts a new interactive shell and runs your target script in it. The shell will " +
+			"exit once your target script is completed or when it is terminated via CTRL-C. " +
+			"Scripts can be defined in your `devbox.json`"
+		example = ""
+	}
 	flags := runCmdFlags{}
 	command := &cobra.Command{
-		Use:   "run [<script> | <cmd>]",
-		Short: "Runs a script or command in a shell with access to your packages",
-		Long: "Starts a new shell and runs your script or command in it, exiting when done.\n\n" +
-			"The script must be defined in `devbox.json`, or else it will be interpreted as an " +
-			"arbitrary command. You can pass arguments to your script or command. Everything " +
-			"after `--` will be passed verbatim into your command (see examples).\n\n" +
-			"Note that the environment used in `devbox run` is more restrictive than that of " +
-			"`devbox shell`. It includes your devbox packages and nothing else.",
-		Example: "\nRun a command directly:\n\n  devbox add cowsay\n  devbox run cowsay hello\n  " +
-			"devbox run -- cowsay -d hello\n\nRun a script (defined as `\"moo\": \"cowsay moo\"`) " +
-			"in your devbox.json:\n\n  devbox run moo",
+		Use:     lo.Ternary(featureflag.UnifiedEnv.Enabled(), "run [<script> | <cmd>]", "run <script>"),
+		Short:   shortHelp,
+		Long:    longHelp,
+		Example: example,
 		Args:    cobra.MinimumNArgs(1),
 		PreRunE: ensureNixInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -19,9 +19,17 @@ type runCmdFlags struct {
 func RunCmd() *cobra.Command {
 	flags := runCmdFlags{}
 	command := &cobra.Command{
-		Use:     "run <script>",
-		Short:   "Starts a new devbox shell and runs the target script",
-		Long:    "Starts a new interactive shell and runs your target script in it. The shell will exit once your target script is completed or when it is terminated via CTRL-C. Scripts can be defined in your `devbox.json`",
+		Use:   "run [<script> | <cmd>]",
+		Short: "Runs a script or command in a shell with access to your packages",
+		Long: "Starts a new shell and runs your script or command in it, exiting when done.\n\n" +
+			"The script must be defined in `devbox.json`, or else it will be interpreted as an " +
+			"arbitrary command. You can pass arguments to your script or command. Everything " +
+			"after `--` will be passed verbatim into your command (see examples).\n\n" +
+			"Note that the environment used in `devbox run` is more restrictive than that of " +
+			"`devbox shell`. It includes your devbox packages and nothing else.",
+		Example: "\nRun a command directly:\n\n  devbox add cowsay\n  devbox run cowsay hello\n  " +
+			"devbox run -- cowsay -d hello\n\nRun a script (defined as `\"moo\": \"cowsay moo\"`) " +
+			"in your devbox.json:\n\n  devbox run moo",
 		Args:    cobra.MinimumNArgs(1),
 		PreRunE: ensureNixInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary
Update help text when unified env feature is on. This feature also enables `run` to accept arbitrary commands, and to pass arguments to scripts.

## How was it tested?
```
> DEVBOX_FEATURE_UNIFIED_ENV=1 ./devbox run --help
Starts a new shell and runs your script or command in it, exiting when done.

The script must be defined in `devbox.json`, or else it will be interpreted as an arbitrary command. You can pass arguments to your script or command. Everything after `--` will be passed verbatim into your command (see examples).

Usage:
  devbox run [<script> | <cmd>] [flags]

Examples:

Run a command directly:

  devbox add cowsay
  devbox run cowsay hello
  devbox run -- cowsay -d hello

Run a script (defined as `"moo": "cowsay moo"`) in your devbox.json:

  devbox run moo

Flags:
  -c, --config string   path to directory containing a devbox.json config file
  -h, --help            help for run

Global Flags:
  -q, --quiet   suppresses logs.
```