### PR TITLE
[nix] Filter out 'devbox-development' messages

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -29,6 +29,7 @@ import (
 	"go.jetpack.io/devbox/internal/planner/plansdk"
 	"go.jetpack.io/devbox/internal/plugin"
 	"go.jetpack.io/devbox/internal/telemetry"
+	"go.jetpack.io/devbox/internal/ux"
 	"golang.org/x/exp/slices"
 )
 
@@ -677,8 +678,9 @@ func (d *Devbox) installNixProfile() (err error) {
 	}
 
 	cmd.Env = nix.DefaultEnv()
-	cmd.Stdout = d.writer
-	cmd.Stderr = d.writer
+	cmd.Stdout = ux.NewFilterWriter(d.writer, "devbox-development")
+	cmd.Stderr = cmd.Stdout
+
 	err = cmd.Run()
 
 	var exitErr *exec.ExitError

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -678,7 +678,10 @@ func (d *Devbox) installNixProfile() (err error) {
 	}
 
 	cmd.Env = nix.DefaultEnv()
-	cmd.Stdout = ux.NewFilterWriter(d.writer, "devbox-development")
+	cmd.Stdout = ux.NewFilterWriter(d.writer,
+		`replacing old 'devbox-development'`,
+		`installing 'devbox-development'`,
+	)
 	cmd.Stderr = cmd.Stdout
 
 	err = cmd.Run()

--- a/internal/ux/filterwriter.go
+++ b/internal/ux/filterwriter.go
@@ -1,0 +1,24 @@
+package ux
+
+import (
+	"bytes"
+	"io"
+)
+
+type filterWriter struct {
+	w        io.Writer
+	filtered []byte
+}
+
+func (fw *filterWriter) Write(p []byte) (n int, err error) {
+	if bytes.Contains(p, fw.filtered) {
+		return len(p), nil
+	}
+	return fw.w.Write(p)
+}
+
+// NewFilterWriter returns a writer that filters out all writes that contain the
+// given string.
+func NewFilterWriter(w io.Writer, f string) io.Writer {
+	return &filterWriter{w: w, filtered: []byte(f)}
+}

--- a/internal/ux/filterwriter.go
+++ b/internal/ux/filterwriter.go
@@ -3,22 +3,29 @@ package ux
 import (
 	"bytes"
 	"io"
+
+	"github.com/samber/lo"
 )
 
 type filterWriter struct {
 	w        io.Writer
-	filtered []byte
+	filtered [][]byte
 }
 
 func (fw *filterWriter) Write(p []byte) (n int, err error) {
-	if bytes.Contains(p, fw.filtered) {
-		return len(p), nil
+	for _, filter := range fw.filtered {
+		if bytes.Contains(p, filter) {
+			return len(p), nil
+		}
 	}
 	return fw.w.Write(p)
 }
 
 // NewFilterWriter returns a writer that filters out all writes that contain the
-// given string.
-func NewFilterWriter(w io.Writer, f string) io.Writer {
-	return &filterWriter{w: w, filtered: []byte(f)}
+// given string(s).
+func NewFilterWriter(w io.Writer, f ...string) io.Writer {
+	return &filterWriter{
+		w:        w,
+		filtered: lo.Map(f, func(s string, _ int) []byte { return []byte(s) }),
+	}
 }


### PR DESCRIPTION
## Summary

Filters out

```bash
replacing old 'devbox-development'
installing 'devbox-development'
```

from every command that runs `ensurePackagesAreInstalled`

## How was it tested?

```bash
> devbox run echo hello
Installing nix packages. This may take a while...
Done.
hello
```
