### PR TITLE
Unflip strict run feature flag

### DIFF
--- a/internal/boxcli/featureflag/strict_run.go
+++ b/internal/boxcli/featureflag/strict_run.go
@@ -4,4 +4,4 @@ package featureflag
 // runs the script in the environment returned by `nix print-dev-env`. This means the
 // environment is much more "strict" or "pure", since it will _not_ include parts of
 // the host's environment like `devbox shell` does.
-var StrictRun = enabled("STRICT_RUN")
+var StrictRun = disabled("STRICT_RUN")


### PR DESCRIPTION
## Summary

Turning the feature off after finding some issues when running against `devbox-examples`.