### PR TITLE
plansdk: use nixpkgs mirror when in cloud VM 

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -12,6 +12,6 @@
     }
   },
   "nixpkgs": {
-    "commit": "aa7e3b940ad90ba58a5d8c0a2269ec557c9ecc70"
+    "commit": "3954218cf613eba8e0dcefa9abe337d26bc48fd0"
   }
 }

--- a/internal/impl/tmpl/development.nix.tmpl
+++ b/internal/impl/tmpl/development.nix.tmpl
@@ -1,7 +1,9 @@
 let
-  mirrorURL = builtins.getEnv "DEVBOX_NIXPKGS_URL";
   pkgs = import (fetchTarball {
-    url = if mirrorURL == "" then "{{ .NixpkgsInfo.URL }}" else mirrorURL;
+    url = "{{ .NixpkgsInfo.URL }}";
+    {{- if .NixpkgsInfo.Sha256 }}
+    sha256 = "{{ .NixpkgsInfo.Sha256 }}";
+    {{- end }}
   }) {
     {{- if .NixOverlays }}
       overlays = [

--- a/internal/impl/tmpl/runtime.nix.tmpl
+++ b/internal/impl/tmpl/runtime.nix.tmpl
@@ -1,7 +1,9 @@
 let
-  mirrorURL = builtins.getEnv "DEVBOX_NIXPKGS_URL";
   pkgs = import (fetchTarball {
-    url = if mirrorURL == "" then "{{ .NixpkgsInfo.URL }}" else mirrorURL;
+    url = "{{ .NixpkgsInfo.URL }}";
+    {{- if .NixpkgsInfo.Sha256 }}
+    sha256 = "{{ .NixpkgsInfo.Sha256 }}";
+    {{- end }}
   }) {
     {{- if .NixOverlays }}
       overlays = [

--- a/internal/impl/tmpl/shell.nix.tmpl
+++ b/internal/impl/tmpl/shell.nix.tmpl
@@ -1,7 +1,11 @@
 let
-  mirrorURL = builtins.getEnv "DEVBOX_NIXPKGS_URL";
   pkgs = import (fetchTarball {
-    url = if mirrorURL == "" then "{{ .NixpkgsInfo.URL }}" else mirrorURL;
+    # Commit hash as of 2022-08-16
+    # `git ls-remote https://github.com/nixos/nixpkgs nixos-unstable`
+    url = "{{ .NixpkgsInfo.URL }}";
+    {{- if .NixpkgsInfo.Sha256 }}
+    sha256 = "{{ .NixpkgsInfo.Sha256 }}";
+    {{- end }}
   }) {
     {{- if .NixOverlays }}
       overlays = [


### PR DESCRIPTION
This change is a bit hacky. I'd like to eventually clean this up to work better with the various nix commands. It also reverts the previous env var change since it's no longer needed.

When generating the various *.nix files, check to see if the cloud mirror is reachable. If it is, download nixpkgs archives from there instead of GitHub.

Also update the default commit hash to be the current nixpkgs unstable, which is also in the cache. This guarantees that any new devbox projects created after this release will hit the cache in the cloud.