### PR TITLE
[devbox cloud] require git in home and fs-root dirs to use as devbox project dir

### DIFF
--- a/internal/impl/config.go
+++ b/internal/impl/config.go
@@ -138,7 +138,6 @@ func findProjectDirFromParentDirSearch(root string, absPath string) (string, err
 		cur = filepath.Dir(cur)
 	}
 	if plansdk.FileExists(filepath.Join(cur, configFilename)) {
-
 		return cur, nil
 	}
 	return "", missingConfigError(absPath, true /*didCheckParents*/)

--- a/internal/impl/config.go
+++ b/internal/impl/config.go
@@ -138,6 +138,7 @@ func findProjectDirFromParentDirSearch(root string, absPath string) (string, err
 		cur = filepath.Dir(cur)
 	}
 	if plansdk.FileExists(filepath.Join(cur, configFilename)) {
+
 		return cur, nil
 	}
 	return "", missingConfigError(absPath, true /*didCheckParents*/)


### PR DESCRIPTION
## Summary

Problem:
When running `devbox cloud shell` (and other commands) if we don't find 
a `devbox.json` in the current directory and no `--config` flag is specified,
then we walk up the directory tree to find a `devbox.json` file. If we do find one,
we use that directory as the `projectDir`.

This has the danger that we may sync a sensitive directory like a user's homedir
or the filesystem-root dir (i.e. `/`). The syncing may inadvertently delete something in the directories
under this sensitive dir. 

@Lagoja ran into this since he has a devbox.json in his homedir.

Solution:
This PR protects against this by requiring a `.git` repository to be present in 
the same dir. We presume this would protect against data loss. Without a `.git`
we display a user error.


## How was it tested?


```
❯ devbox cloud shell
Devbox Cloud
Remote development environments powered by Nix


Error: Found a config (devbox.json) file at /Users/savil, but since it is a sensitive directory we require it to be part of a git repository before we sync it to devbox cloud
```
