### PR TITLE
[devbox cloud] remove sshshim gate

### DIFF
--- a/internal/boxcli/featureflag/sshshim.go
+++ b/internal/boxcli/featureflag/sshshim.go
@@ -1,3 +1,0 @@
-package featureflag
-
-var SSHShim = enabled("SSH_SHIM")

--- a/internal/cloud/mutagenbox/mutagenbox.go
+++ b/internal/cloud/mutagenbox/mutagenbox.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
-	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/cloud/mutagen"
 )
 
@@ -39,10 +38,6 @@ func DefaultSyncLabels(machineID string) map[string]string {
 }
 
 func DefaultEnv() (map[string]string, error) {
-	if featureflag.SSHShim.Disabled() {
-		return map[string]string{}, nil
-	}
-
 	shimDir, err := ShimDir()
 	if err != nil {
 		return nil, err

--- a/internal/cloud/openssh/sshshim/generate.go
+++ b/internal/cloud/openssh/sshshim/generate.go
@@ -5,16 +5,12 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
-	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/cloud/mutagenbox"
 	"go.jetpack.io/devbox/internal/cloud/openssh"
 )
 
 // Setup creates the ssh and scp symlinks
 func Setup() error {
-	if featureflag.SSHShim.Disabled() {
-		return nil
-	}
 	shimDir, err := mutagenbox.ShimDir()
 	if err != nil {
 		return errors.WithStack(err)


### PR DESCRIPTION
## Summary

This code has been active for quite a while now. So we can remove the gate.

## How was it tested?

- [x] did `devbox cloud shell`. and synced a file change.
