### PR TITLE
[nix] Don't add bad package to devbox.json

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -111,6 +111,7 @@ func (d *Devbox) Config() *Config {
 }
 
 func (d *Devbox) Add(pkgs ...string) error {
+	original := d.cfg.Packages
 	// Check packages are valid before adding.
 	for _, pkg := range pkgs {
 		ok := nix.PkgExists(d.cfg.Nixpkgs.Commit, pkg)
@@ -142,7 +143,7 @@ func (d *Devbox) Add(pkgs ...string) error {
 				"Packages were not added to devbox.json\n",
 			strings.Join(pkgs, ", "),
 		)
-		d.cfg.Packages, _ = lo.Difference(d.cfg.Packages, pkgs)
+		d.cfg.Packages = original
 		_ = d.saveCfg() // ignore error to ensure we return the original error
 		return err
 	}


### PR DESCRIPTION
## Summary

If we get any error while trying to add packages we revert devbox.json and show error.

## How was it tested?

Tried to add a broken package and made sure it did not get added to devbox.json

```bash
devbox add php81Extensions.blackfire
Installing nix packages.
	error: attribute 'extensionName' missing
	       at /nix/store/j5a7i3dvxslg2ychfy53wdhg1m3xfrwm-source/pkgs/development/interpreters/php/generic.nix:94:29:
	           93|
	           94|           getExtName = ext: ext.extensionName;
	             |                             ^
	           95|
	(use '--show-trace' to show detailed location information)

There was an error installing nix packages: php81Extensions.blackfire. Packages were not added to devbox.json
Error: apply Nix derivation: running command /nix/var/nix/profiles/default/bin/nix-env --profile /Users/mike/dev/scratch/php/.devbox/nix/profile/default --install -f /Users/mike/dev/scratch/php/.devbox/gen/development.nix: exit status 1 with command stderr:
```