### PR TITLE
[tiny] Improve format of generated nix files

### DIFF
--- a/internal/impl/tmpl/development.nix.tmpl
+++ b/internal/impl/tmpl/development.nix.tmpl
@@ -15,7 +15,7 @@ let
   };
   {{- range .Definitions}}
     {{.}}
-  {{end -}}
+  {{ end }}
 in with pkgs;
 buildEnv {
   ignoreCollisions = true;
@@ -23,7 +23,7 @@ buildEnv {
   paths = [
   {{- range .DevPackages}}
     {{.}}
-  {{end -}}
+  {{- end }}
   ];
   pathsToLink = [ "/bin" "/share" "/lib"];
 }

--- a/internal/impl/tmpl/shell.nix.tmpl
+++ b/internal/impl/tmpl/shell.nix.tmpl
@@ -17,7 +17,7 @@ let
   };
   {{- range .Definitions}}
     {{.}}
-  {{end -}}
+  {{ end }}
 in with pkgs;
 mkShell {
   shellHook =
@@ -47,6 +47,6 @@ mkShell {
      packages = [
       {{- range .DevPackages}}
         {{.}}
-      {{end -}}
+      {{- end }}
     ];
 }


### PR DESCRIPTION
## Summary
This was just bugging me a bit.

## How was it tested?
They used to look like this:
```
let
  mirrorURL = builtins.getEnv "DEVBOX_NIXPKGS_URL";
  pkgs = import (fetchTarball {
    url = if mirrorURL == "" then "https://github.com/nixos/nixpkgs/archive/52e3e80afff4b16ccb7c52e9f0f5220552f03d04.tar.gz" else mirrorURL;
  }) {
  };in with pkgs;
mkShell {
  shellHook =
    ''
      # We're technically no longer in a Nix shell after this hook because we
      # exec a devbox shell.
      export IN_NIX_SHELL=0
      export DEVBOX_SHELL_ENABLED=1

      # Undo the effects of `nix-shell --pure` on SSL certs.
      # See https://github.com/NixOS/nixpkgs/blob/dae204faa0243b4d0c0234a5f5f83a2549ecb5b7/pkgs/stdenv/generic/setup.sh#L677-L685
      if [ "$NIX_SSL_CERT_FILE" = "/no-cert-file.crt" ]; then
      	unset NIX_SSL_CERT_FILE
      fi
      if [ "$SSL_CERT_FILE" = "/no-cert-file.crt" ]; then
      	unset SSL_CERT_FILE
      fi

      # Append the parent shell's PATH so that we retain access to
      # non-Nix programs, while still preferring the Nix ones.
      export "PATH=$PATH:$PARENT_PATH"


    '';
     packages = [
        mariadb

        git

        php81

        php81Packages.composer

        nginx
      ];
}
```

Now they look like this:
```
let
  mirrorURL = builtins.getEnv "DEVBOX_NIXPKGS_URL";
  pkgs = import (fetchTarball {
    url = if mirrorURL == "" then "https://github.com/nixos/nixpkgs/archive/52e3e80afff4b16ccb7c52e9f0f5220552f03d04.tar.gz" else mirrorURL;
  }) {
  };
in with pkgs;
mkShell {
  shellHook =
    ''
      # We're technically no longer in a Nix shell after this hook because we
      # exec a devbox shell.
      export IN_NIX_SHELL=0
      export DEVBOX_SHELL_ENABLED=1

      # Undo the effects of `nix-shell --pure` on SSL certs.
      # See https://github.com/NixOS/nixpkgs/blob/dae204faa0243b4d0c0234a5f5f83a2549ecb5b7/pkgs/stdenv/generic/setup.sh#L677-L685
      if [ "$NIX_SSL_CERT_FILE" = "/no-cert-file.crt" ]; then
      	unset NIX_SSL_CERT_FILE
      fi
      if [ "$SSL_CERT_FILE" = "/no-cert-file.crt" ]; then
      	unset SSL_CERT_FILE
      fi

      # Append the parent shell's PATH so that we retain access to
      # non-Nix programs, while still preferring the Nix ones.
      export "PATH=$PATH:$PARENT_PATH"


    '';
     packages = [
        mariadb
        git
        php81
        php81Packages.composer
        nginx
    ];
}
```