### PR TITLE
Do not shell quote environment variables

### DIFF
--- a/internal/nix/run.go
+++ b/internal/nix/run.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/alessio/shellescape"
 	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/debug"
@@ -24,7 +23,7 @@ func RunScript(nixShellFilePath string, projectDir string, cmdWithArgs string, a
 	nixEnv := []string{}
 	for k, v := range vaf.Variables {
 		if v.Type == "exported" {
-			nixEnv = append(nixEnv, fmt.Sprintf("%s=%s", k, shellescape.Quote(v.Value.(string))))
+			nixEnv = append(nixEnv, fmt.Sprintf("%s=%s", k, v.Value.(string)))
 		}
 	}
 


### PR DESCRIPTION
## Summary

This was causing problems with variable substitution. For example, `clang` would try to compile `'`

## How was it tested?
`devbox run clang` returns "no files" instead of `clang-11: error: no such file or directory: '''`