### PR TITLE
[cloud shell] prevent cloud-shell-inception

### DIFF
--- a/internal/boxcli/cloud.go
+++ b/internal/boxcli/cloud.go
@@ -4,6 +4,7 @@
 package boxcli
 
 import (
+	"os"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -113,7 +114,8 @@ func cloudPortForwardList() *cobra.Command {
 }
 
 func runCloudShellCmd(cmd *cobra.Command, flags *cloudShellCmdFlags) error {
-	if devbox.IsDevboxShellEnabled() {
+	// calling `devbox cloud shell` when already in the VM is not allowed.
+	if region := os.Getenv("DEVBOX_REGION"); region != "" {
 		return shellInceptionErrorMsg("devbox cloud shell")
 	}
 

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -107,6 +107,6 @@ func parseShellArgs(cmd *cobra.Command, args []string, flags shellCmdFlags) (str
 }
 
 func shellInceptionErrorMsg(cmdPath string) error {
-	return usererr.New("You are already in an active devbox shell.\nRun `exit` before calling `%s` again."+
+	return usererr.New("You are already in an active %[1]s.\nRun `exit` before calling `%[1]s` again."+
 		" Shell inception is not supported.", cmdPath)
 }


### PR DESCRIPTION
## Summary

Allow `devbox shell` calling `devbox cloud shell`

Prevent:
1. `devbox shell` calling `devbox shell`
2. `devbox shell` in a cloud VM calling `devbox cloud shell`.

## How was it tested?

called `devbox cloud shell` from a `devbox shell`.

These operations were stopped
```
(devbox)
❯ DEVBOX_REGION=savil devbox cloud shell

Error: You are already in an active devbox cloud shell.
Run `exit` before calling `devbox cloud shell` again. Shell inception is not supported.

(devbox)
❯ devbox shell

Error: You are already in an active devbox shell.
Run `exit` before calling `devbox shell` again. Shell inception is not supported.

```
