### PR TITLE
[flakes] respect nixpkgs commit hash

### DIFF
--- a/internal/impl/tmpl/flake.nix.tmpl
+++ b/internal/impl/tmpl/flake.nix.tmpl
@@ -2,10 +2,7 @@
     description = "A devbox shell";
 
     inputs = {
-        # master branch can be slow because not all binaries are built and populated in the cache.
-        # using the nixpkgs-unstable tag ensures everything has been built and populated in the cache.
-        # https://www.reddit.com/r/NixOS/comments/ydr4po/comment/itv6oqo/?utm_source=reddit&utm_medium=web2x&context=3
-        nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+        nixpkgs.url = "{{ .NixpkgsInfo.URL }}";
 
         flake-utils.url = "github:numtide/flake-utils";
     };

--- a/internal/impl/tmpl/shell.nix.tmpl
+++ b/internal/impl/tmpl/shell.nix.tmpl
@@ -1,7 +1,5 @@
 let
   pkgs = import (fetchTarball {
-    # Commit hash as of 2022-08-16
-    # `git ls-remote https://github.com/nixos/nixpkgs nixos-unstable`
     url = "{{ .NixpkgsInfo.URL }}";
     {{- if .NixpkgsInfo.Sha256 }}
     sha256 = "{{ .NixpkgsInfo.Sha256 }}";


### PR DESCRIPTION
## Summary

The `nixpkgs` URL in the flakes template was using the latest nixpkgs
and not respecting the version in `devbox.json`

## How was it tested?

ran `DEVBOX_FEATURE_FLAKES=1 devbox shell` in go1.19 example project.
inspected `devbox.lock` and verified that the nixpkgs version matches that
of `devbox.json` (and confirmed that with `main` branch's devbox binary these would not match)
