### PR TITLE
[cloud] Add preview wording

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -4,7 +4,10 @@
     "golangci-lint"
   ],
   "shell": {
-    "init_hook": "export \"GOROOT=$(go env GOROOT)\"",
+    "init_hook": [
+      "export \"GOROOT=$(go env GOROOT)\"",
+      "export \"PATH=$(pwd)/dist:$PATH\""
+    ],
     "scripts": {
       "build": "go build -o dist/devbox cmd/devbox/main.go",
       "build-linux": "GOOS=linux go build -o dist/devbox-linux cmd/devbox/main.go",

--- a/internal/boxcli/cloud.go
+++ b/internal/boxcli/cloud.go
@@ -22,8 +22,11 @@ type cloudShellCmdFlags struct {
 
 func CloudCmd() *cobra.Command {
 	command := &cobra.Command{
-		Use:    "cloud",
-		Short:  "Remote development environments on the cloud",
+		Use:   "cloud",
+		Short: "[Preview] Remote development environments on the cloud",
+		Long: "Remote development environments on the cloud. All cloud commands " +
+			"are currently in developer preview and may have some rough edges. " +
+			"Please report any issues to https://github.com/jetpack-io/devbox/issues",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
@@ -39,7 +42,7 @@ func cloudShellCmd() *cobra.Command {
 
 	command := &cobra.Command{
 		Use:   "shell",
-		Short: "Shell into a cloud environment that matches your local devbox environment",
+		Short: "[Preview] Shell into a cloud environment that matches your local devbox environment",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCloudShellCmd(cmd, &flags)
 		},
@@ -55,7 +58,7 @@ func cloudShellCmd() *cobra.Command {
 func cloudPortForwardCmd() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "forward <local-port>:<remote-port> | :<remote-port> | stop | list",
-		Short: "Port forwards a local port to a remote devbox cloud port",
+		Short: "[Preview] Port forwards a local port to a remote devbox cloud port",
 		Long: "Port forwards a local port to a remote devbox cloud port. If 0 or " +
 			"no local port is specified, we find a suitable local port. Use 'stop' " +
 			"to stop all port forwards.",

--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -28,10 +28,9 @@ import (
 )
 
 func Shell(w io.Writer, projectDir string, githubUsername string) error {
-	c := color.New(color.FgMagenta).Add(color.Bold)
-	c.Fprintln(w, "Devbox Cloud")
-	fmt.Fprintln(w, "Remote development environments powered by Nix")
-	fmt.Fprint(w, "\n")
+	color.New(color.FgMagenta, color.Bold).Fprint(w, "Devbox Cloud\n")
+	fmt.Fprint(w, "Remote development environments powered by Nix\n\n")
+	fmt.Fprint(w, "This is an open developer preview and may have some rough edges. Please report any issues to https://github.com/jetpack-io/devbox/issues\n\n")
 
 	if err := ensureProjectDirIsNotSensitive(projectDir); err != nil {
 		return err


### PR DESCRIPTION
## Summary

Adds preview wording to cloud commands and to text that shows up when doing `devbox cloud shell`

## How was it tested?

<img width="964" alt="image" src="https://user-images.githubusercontent.com/544948/214978919-6942e071-fd72-47db-8007-c04f1fb4c1a1.png">

