### PR TITLE
Move xdg functions into its own package

### DIFF
--- a/internal/cloud/mutagen/wrapper.go
+++ b/internal/cloud/mutagen/wrapper.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 
 	"go.jetpack.io/devbox/internal/debug"
+	"go.jetpack.io/devbox/internal/xdg"
 )
 
 func Create(spec *SessionSpec) error {
@@ -214,7 +215,7 @@ func envAsKeyValueStrings(userEnv map[string]string) []string {
 }
 
 func ensureMutagen() string {
-	installPath := CacheSubpath("mutagen/bin/mutagen")
+	installPath := xdg.CacheSubpath("mutagen/bin/mutagen")
 	err := InstallMutagenOnce(installPath)
 	if err != nil {
 		panic(err)

--- a/internal/xdg/xdg.go
+++ b/internal/xdg/xdg.go
@@ -1,7 +1,4 @@
-package mutagen
-
-// TODO: publish as it's own shared package that other binaries
-// can use.
+package xdg
 
 import (
 	"os"


### PR DESCRIPTION
## Summary
So that I can re-use it in other parts of the code not related to mutagen.

## How was it tested?
`go test -v ./...`