### PR TITLE
[polish] capitalize the default answer in direnv integration question

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -503,7 +503,7 @@ func (d *Devbox) GenerateEnvrc(force bool) error {
 			// prompt for direnv allow
 			var result string
 			prompt := &survey.Input{
-				Message: "Do you want to enable direnv integration for this devbox project? [y/n]",
+				Message: "Do you want to enable direnv integration for this devbox project? [y/N]",
 			}
 			err := survey.AskOne(prompt, &result)
 			if err != nil {


### PR DESCRIPTION
## Summary

It is common convention to capitalize the default answer in linux CLI prompts.

## How was it tested?

the default behavior appears to be No
