### PR TITLE
cloud: clean up mutagen sync ssh commands

### DIFF
--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -55,15 +55,15 @@ func Shell(w io.Writer, projectDir string, githubUsername string) error {
 	// for github username.
 	telemetryShellStartTime := time.Now()
 
-	sshClient := openssh.Client{
-		Username: username,
-		Addr:     "gateway.devbox.sh",
+	sshCmd := &openssh.Cmd{
+		Username:        username,
+		DestinationAddr: "gateway.devbox.sh",
 	}
 	// When developing we can use this env variable to point
 	// to a different gateway
 	var err error
 	if envGateway := os.Getenv("DEVBOX_GATEWAY"); envGateway != "" {
-		sshClient.Addr = envGateway
+		sshCmd.DestinationAddr = envGateway
 		err = openssh.SetupInsecureDebug(envGateway)
 	} else {
 		err = openssh.SetupDevbox()
@@ -84,7 +84,7 @@ func Shell(w io.Writer, projectDir string, githubUsername string) error {
 			stepVM.Success("Detected existing virtual machine")
 		} else {
 			var region string
-			vmHostname, region, err = getVirtualMachine(sshClient)
+			vmHostname, region, err = getVirtualMachine(sshCmd)
 			if err != nil {
 				return err
 			}
@@ -187,8 +187,8 @@ func (vm vm) redact() *vm {
 	return &vm
 }
 
-func getVirtualMachine(client openssh.Client) (vmHost string, region string, err error) {
-	sshOut, err := client.Exec("auth")
+func getVirtualMachine(sshCmd *openssh.Cmd) (vmHost string, region string, err error) {
+	sshOut, err := sshCmd.ExecRemote("auth")
 	if err != nil {
 		return "", "", errors.Wrapf(err, "error requesting VM")
 	}
@@ -276,19 +276,20 @@ func updateSyncStatus(mutagenSessionName, username, hostname, relProjectPathInVM
 	status := "disconnected"
 
 	// Ensure the destination directory exists
-	destServer := fmt.Sprintf("%s@%s", username, hostname)
 	destDir := fmt.Sprintf("/home/%s/.config/devbox/starship/%s", username, hyphenatePath(filepath.Base(relProjectPathInVM)))
-	remoteCmd := fmt.Sprintf("mkdir -p %s", destDir)
-	cmd := exec.Command("ssh", destServer, remoteCmd)
-	err := cmd.Run()
-	debug.Log("mkdir starship mutagen_status command: %s with error: %s", cmd, err)
+	mkdirCmd := openssh.Command(username, hostname)
+	_, err := mkdirCmd.ExecRemote(fmt.Sprintf(`mkdir -p "%s"`, destDir))
+	if err != nil {
+		debug.Log("error setting initial starship mutagen status: %v", err)
+	}
 
 	// Set an initial status
 	displayableStatus := "initial sync"
-	remoteCmd = fmt.Sprintf("echo %s > %s/mutagen_status.txt", displayableStatus, destDir)
-	cmd = exec.Command("ssh", destServer, remoteCmd)
-	err = cmd.Run()
-	debug.Log("scp starship.toml with command: %s and error: %s", cmd, err)
+	statusCmd := openssh.Command(username, hostname)
+	_, err = statusCmd.ExecRemote(fmt.Sprintf(`echo "%s" > "%s/mutagen_status.txt"`, displayableStatus, destDir))
+	if err != nil {
+		debug.Log("error setting initial starship mutagen status: %v", err)
+	}
 	time.Sleep(5 * time.Second)
 
 	debug.Log("Starting check for file sync status")
@@ -305,10 +306,11 @@ func updateSyncStatus(mutagenSessionName, username, hostname, relProjectPathInVM
 			displayableStatus = "\"watching for changes\""
 		}
 
-		remoteCmd = fmt.Sprintf("echo %s > %s/mutagen_status.txt", displayableStatus, destDir)
-		cmd = exec.Command("ssh", destServer, remoteCmd)
-		err = cmd.Run()
-		debug.Log("scp starship.toml with command: %s and error: %s", cmd, err)
+		statusCmd := openssh.Command(username, hostname)
+		_, err = statusCmd.ExecRemote(fmt.Sprintf(`echo "%s" > "%s/mutagen_status.txt"`, displayableStatus, destDir))
+		if err != nil {
+			debug.Log("error setting initial starship mutagen status: %v", err)
+		}
 		time.Sleep(5 * time.Second)
 	}
 }
@@ -331,18 +333,18 @@ func getSyncStatus(mutagenSessionName string) (string, error) {
 func copyConfigFileToVM(hostname, username, projectDir, pathInVM string) error {
 
 	// Ensure the devbox-project's directory exists in the VM
-	destServer := fmt.Sprintf("%s@%s", username, hostname)
-	cmd := exec.Command("ssh", destServer, "--", "mkdir", "-p", pathInVM)
-	err := cmd.Run()
-	debug.Log("ssh mkdir command: %s with error: %s", cmd, err)
+	mkdirCmd := openssh.Command(username, hostname)
+	_, err := mkdirCmd.ExecRemote(fmt.Sprintf(`mkdir -p "%s"`, pathInVM))
 	if err != nil {
+		debug.Log("error copying config file to VM: %v", err)
 		return errors.WithStack(err)
 	}
 
 	// Copy the config file to the devbox-project directory in the VM
+	destServer := fmt.Sprintf("%s@%s", username, hostname)
 	configFilePath := filepath.Join(projectDir, "devbox.json")
 	destPath := fmt.Sprintf("%s:%s", destServer, pathInVM)
-	cmd = exec.Command("scp", configFilePath, destPath)
+	cmd := exec.Command("scp", configFilePath, destPath)
 	err = cmd.Run()
 	debug.Log("scp devbox.json command: %s with error: %s", cmd, err)
 	return errors.WithStack(err)
@@ -354,14 +356,14 @@ func shell(username, hostname, projectDir string, shellStartTime time.Time) erro
 		return err
 	}
 
-	client := &openssh.Client{
-		Addr:           hostname,
-		PathInVM:       absoluteProjectPathInVM(username, projectPath),
-		ShellStartTime: telemetry.UnixTimestampFromTime(shellStartTime),
-		Username:       username,
+	cmd := &openssh.Cmd{
+		DestinationAddr: hostname,
+		PathInVM:        absoluteProjectPathInVM(username, projectPath),
+		ShellStartTime:  telemetry.UnixTimestampFromTime(shellStartTime),
+		Username:        username,
 	}
 	sessionErrors := newSSHSessionErrors()
-	return cloudShellErrorHandler(client.Shell(sessionErrors), sessionErrors)
+	return cloudShellErrorHandler(cmd.Shell(sessionErrors), sessionErrors)
 }
 
 // relativeProjectPathInVM refers to the project path relative to the user's

--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -191,7 +191,7 @@ func (vm vm) redact() *vm {
 	return &vm
 }
 
-func getVirtualMachine(sshCmd *openssh.Cmd) (vmHost, vmHost, region string, err error) {
+func getVirtualMachine(sshCmd *openssh.Cmd) (vmUser, vmHost, region string, err error) {
 	sshOut, err := sshCmd.ExecRemote("auth")
 	if err != nil {
 		return "", "", "", errors.Wrapf(err, "error requesting VM")


### PR DESCRIPTION
Use the `openssh` package where possible when executing the SSH commands for setting the mutagen sync status. This provides better logging when commands fail.

Also rename `openssh.Client` to `Cmd` to better reflect that we're calling an external process.