### PR TITLE
[GHA] Bump versions, create daily golangci-lint cache

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -7,6 +7,8 @@ concurrency:
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -7,11 +7,6 @@ concurrency:
 
 on:
   pull_request:
-  push:
-    branches-ignore:
-      - main
-    paths-ignore:
-      - 'docs/**'
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -49,9 +49,9 @@ jobs:
             ~/.cache/golangci-lint
             ~/.cache/go-build
             ~/go/pkg
-          key: golangci-lint-cache-${{ steps.current-time.outputs.day }}
+          key: golangci-lint-cache-${{ runner.os }}-${{ steps.current-time.outputs.day }}
           restore-keys: |
-            golangci-lint-cache-
+            golangci-lint-cache-${{ runner.os }}-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.4.0
         with:

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -36,14 +36,27 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v3.5.0
         with:
           go-version-file: ./go.mod
-          cache: false # use golangci cache instead
+      - name: Get current time
+        uses: josStorer/get-current-time@v2.0.2
+        id: current-time
+      - name: Mount golangci-lint cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/golangci-lint
+            ~/.cache/go-build
+            ~/go/pkg
+          key: golangci-lint-cache-${{ steps.current-time.outputs.day }}
+          restore-keys: |
+            golangci-lint-cache-
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.2.0
+        uses: golangci/golangci-lint-action@v3.4.0
         with:
           args: "--out-${NO_FUTURE}format colored-line-number --timeout=10m"
+          skip-cache: true
 
   test:
     strategy:
@@ -53,7 +66,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v3.5.0
         with:
           go-version-file: ./go.mod
           cache: true
@@ -84,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v3.5.0
         with:
           go-version-file: ./go.mod
           cache: true


### PR DESCRIPTION
## Summary

We're going way above our GHA cache limits because every branch creates new cache keys for golangci-lint and our go builds. This means we rarely get cache hits.

This bumps GHA versions and changes golangci-lint to use daily cache (instead of creating a new unique cache key on every branch)

This also fixes a an issue where we're doing tests twice (once on push and once on pull request)

## How was it tested?

CICD
