### PR TITLE
[gha] Run tests on main

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -9,6 +9,9 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
+  push:
+    branches:
+      - main
   workflow_call:
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

Currently tests are only run on pull requests (and prior to https://github.com/jetpack-io/devbox/pull/556 on non-main branches).

We do want to run them on main pushes for 2 reasons:

1. Ensure main is not broken (e.g. in case of a bad merge)
2. Create GHA caches that can be used by all branches (GHA cache looks for cache keys in own branch and also in main)

## How was it tested?

Untested
