### PR TITLE
Fix URLs for badges in Quickstart

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -7,8 +7,6 @@ concurrency:
 
 on:
   pull_request:
-    paths-ignore:
-      - 'docs/**'
   push:
     branches:
       - main

--- a/docs/app/docs/quickstart.mdx
+++ b/docs/app/docs/quickstart.mdx
@@ -86,13 +86,13 @@ We’ll create a new development environment with the packages we need. These pa
 
 Once you publish your Devbox project to Github, you can help other developers get started by adding the Devbox Badge to your repo. Please copy the code snippets below and paste them into your README.md to add the badge
 
-![Devbox Dark Badge](../static/img/shield_galaxy.svg)
+[![Built with Devbox](https://jetpack.io/img/devbox/shield_galaxy.svg)](https://jetpack.io/devbox/docs/contributor-quickstart/)
 
 <Tabs>
 <TabItem value='md' label='Markdown'>
 
 ```md
-[![Built with Devbox](https://jetpack.io/devbox/img/shield_galaxy.svg)](https://jetpack.io/devbox/docs/contributor-quickstart/)
+[![Built with Devbox](https://jetpack.io/img/devbox/shield_galaxy.svg)](https://jetpack.io/devbox/docs/contributor-quickstart/)
 ```
 
 </TabItem>
@@ -101,7 +101,7 @@ Once you publish your Devbox project to Github, you can help other developers ge
 ```html
 <a href="https://jetpack.io/devbox/docs/contributor-quickstart/">
     <img
-        src="https://jetpack.io/devbox/img/shield_galaxy.svg" 
+        src="https://jetpack.io/img/devbox/shield_galaxy.svg" 
         alt="Built with Devbox"
     />
 </a>
@@ -110,13 +110,13 @@ Once you publish your Devbox project to Github, you can help other developers ge
 </TabItem>
 </Tabs>
 
-![Devbox Light Badge](../static/img/shield_moon.svg)
+[![Built with Devbox](https://jetpack.io/img/devbox/shield_moon.svg)](https://jetpack.io/devbox/docs/contributor-quickstart/)
 
 <Tabs>
 <TabItem value='md' label='Markdown'>
 
 ```md
-[![Built with Devbox](https://jetpack.io/devbox/img/shield_moon.svg)](https://jetpack.io/devbox/docs/contributor-quickstart/)
+[![Built with Devbox](https://jetpack.io/img/devbox/shield_moon.svg)](https://jetpack.io/devbox/docs/contributor-quickstart/)
 ```
 
 </TabItem>
@@ -125,7 +125,7 @@ Once you publish your Devbox project to Github, you can help other developers ge
 ```html
 <a href="https://jetpack.io/devbox/docs/contributor-quickstart/">
     <img 
-        src="https://jetpack.io/devbox/img/shield_moon.svg" 
+        src="https://jetpack.io/img/devbox/shield_moon.svg" 
         alt="Built with Devbox" 
     />
 </a>


### PR DESCRIPTION
## Summary

Fixes URLs for badges in Quickstart

## How was it tested?

Launchpad + Localhost