### PR TITLE
[telemetry] update event name and change is_cloud to shell_access kind

### DIFF
--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -588,6 +588,9 @@ var envToKeep = map[string]bool{
 	"SHELL_SESSIONS_DISABLE": true, // Respect session save/resume setting (see /etc/zshrc_Apple_Terminal).
 	"SECURITYSESSIONID":      true,
 
+	// SSH variables
+	"SSH_TTY": true, // Used by devbox telemetry logging
+
 	// Nix + Devbox
 	//
 	// Variables specific to running in a Nix shell and devbox shell.

--- a/internal/telemetry/segment.go
+++ b/internal/telemetry/segment.go
@@ -156,14 +156,13 @@ func UnixTimestampFromTime(t time.Time) string {
 }
 
 func shellAccess() shellAccessKind {
-	// START_WEB_TERMINAL is used to ensure a VM is started for a browser shell.
-	// In the future, we may change our model to reuse VMs for either browser or ssh shells
-	// and so should update this logic accordingly.
-	if os.Getenv("START_WEB_TERMINAL") == "1" {
+	// Check if running in devbox cloud
+	if os.Getenv("DEVBOX_REGION") != "" {
+		// Check if running via ssh tty (i.e. ssh shell)
+		if os.Getenv("SSH_TTY") != "" {
+			return ssh
+		}
 		return browser
-	} else if os.Getenv("DEVBOX_REGION") != "" {
-		return ssh
-	} else {
-		return local
 	}
+	return local
 }

--- a/internal/telemetry/segment.go
+++ b/internal/telemetry/segment.go
@@ -4,14 +4,15 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"log"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/samber/lo"
 	segment "github.com/segmentio/analytics-go"
 	"go.jetpack.io/devbox/internal/build"
 	"go.jetpack.io/devbox/internal/cloud/openssh"
@@ -31,12 +32,13 @@ type Event struct {
 	UserID      string
 }
 
-// ttiEvent contains fields used to log the time-to-interactive event. For now,
-// this is used for devbox shell (local and cloud).
-type ttiEvent struct {
-	Event
-	eventName string
-}
+type shellAccessKind string
+
+const (
+	local   shellAccessKind = "local"
+	ssh     shellAccessKind = "ssh"
+	browser shellAccessKind = "browser"
+)
 
 // NewSegmentClient returns a client object to use for segment logging.
 // Callers are responsible for calling client.Close().
@@ -75,17 +77,14 @@ func LogShellDurationEvent(eventName string, startTime string) error {
 		return errors.WithStack(err)
 	}
 
-	evt := ttiEvent{
-		Event: Event{
-			AnonymousID: DeviceID(),
-			AppName:     opts.AppName,
-			AppVersion:  opts.AppVersion,
-			CloudRegion: os.Getenv("DEVBOX_REGION"),
-			Duration:    time.Since(start),
-			OsName:      OS(),
-			UserID:      UserIDFromGithubUsername(),
-		},
-		eventName: eventName,
+	evt := Event{
+		AnonymousID: DeviceID(),
+		AppName:     opts.AppName,
+		AppVersion:  opts.AppVersion,
+		CloudRegion: os.Getenv("DEVBOX_REGION"),
+		Duration:    time.Since(start),
+		OsName:      OS(),
+		UserID:      UserIDFromGithubUsername(),
 	}
 
 	segmentClient := NewSegmentClient(build.TelemetryKey)
@@ -96,7 +95,8 @@ func LogShellDurationEvent(eventName string, startTime string) error {
 	// Ignore errors, telemetry is best effort
 	_ = segmentClient.Enqueue(segment.Track{
 		AnonymousId: evt.AnonymousID,
-		Event:       evt.eventName,
+		// Event name. We trim the prefix from shell-interactive/shell-ready to avoid redundancy.
+		Event: fmt.Sprintf("[%s] Shell Event: %s", evt.AppName, strings.TrimPrefix(eventName, "shell-")),
 		Context: &segment.Context{
 			Device: segment.DeviceInfo{
 				Id: evt.AnonymousID,
@@ -110,7 +110,7 @@ func LogShellDurationEvent(eventName string, startTime string) error {
 			},
 		},
 		Properties: segment.NewProperties().
-			Set("is_cloud", lo.Ternary(evt.CloudRegion != "", "true", "false")).
+			Set("shell_access", shellAccess()).
 			Set("duration", evt.Duration.Milliseconds()),
 		UserId: evt.UserID,
 	})
@@ -153,4 +153,17 @@ func timeFromUnixTimestamp(timestamp string) (time.Time, error) {
 // See timeFromUnixTimestamp for the inverse function.
 func UnixTimestampFromTime(t time.Time) string {
 	return strconv.FormatInt(t.Unix(), 10)
+}
+
+func shellAccess() shellAccessKind {
+	// START_WEB_TERMINAL is used to ensure a VM is started for a browser shell.
+	// In the future, we may change our model to reuse VMs for either browser or ssh shells
+	// and so should update this logic accordingly.
+	if os.Getenv("START_WEB_TERMINAL") == "1" {
+		return browser
+	} else if os.Getenv("DEVBOX_REGION") != "" {
+		return ssh
+	} else {
+		return local
+	}
 }


### PR DESCRIPTION
## Summary

Updating:
1. Event name to be of the form: `[devbox] Shell event: interactive` which is consistent with the command event names.
2. Changing is_cloud to shell_access with values `local | ssh | browser`

## How was it tested?

- [x] Need to test

1. apply development keys for segment and sentry
2. `local`: run local `devbox shell` and verify event logged in segment dashboard.
3. `ssh`: deploy custom VM with custom devbox binary. verify event logged in segment dashboard.
4. `browser`: Follow devbox-cloud README for http-gateway, but how do I test the custom devbox binary?
