### PR TITLE
[CICD] Only run mac tests on main

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -27,6 +27,8 @@ permissions:
 jobs:
   tests:
     uses: ./.github/workflows/cli-tests.yaml
+    with:
+      run-mac-tests: true
 
   prerelease:
     runs-on: ubuntu-latest

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -11,6 +11,9 @@ on:
     branches:
       - main
   workflow_call:
+    inputs:
+      run-mac-tests:
+        type: boolean
   workflow_dispatch:
 
 permissions:
@@ -61,9 +64,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         exclude:
-          - os: ${{ github.ref == 'refs/heads/main' && 'dummy' || 'macos-latest' }}
+          # This expression basically says run mac tests if on main branch or
+          # if this job is triggered by another workflow with "with: run-mac-tests: true"
+          - os: ${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && 'dummy' || 'macos-latest' }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: ${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && '20' || '10' }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3.5.0

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -29,7 +29,7 @@ jobs:
   golangci-lint:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-12]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
@@ -59,7 +59,9 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-12]
+        os: [ubuntu-latest, macos-latest]
+        exclude:
+          - os: ${{ github.ref == 'refs/heads/main' && 'dummy' || 'macos-latest' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## Summary

mac tests are really slow (failing because they hit timeout). This increases the timeout to 20 minutes but only runs it on main.

## How was it tested?

CICD
