### PR TITLE
Change README badge to use the Quickstart Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Devbox was originally developed by [jetpack.io](https://www.jetpack.io) and is i
 
 You can try out Devbox in your browser using the button below: 
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/new)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=tutorial)
 
 The example below creates a development environment with `python 2.7` and `go 1.18`, even though those packages are not installed in the underlying machine:
 


### PR DESCRIPTION
This changes the button to use the quickstart example in devbox examples.

Signed-off-by: John Lago <750845+Lagoja@users.noreply.github.com>

## Summary

## How was it tested?
