### PR TITLE
fix golang testdata

### DIFF
--- a/examples/testdata/go/go-1.17/main.go
+++ b/examples/testdata/go/go-1.17/main.go
@@ -3,13 +3,14 @@ package main
 import (
 	"fmt"
 	"runtime"
+	"strings"
 )
 
 func main() {
 	expected := "go1.17"
 	goVersion := runtime.Version()
 	fmt.Printf("Go version: %s\n", goVersion)
-	if goVersion != expected {
+	if !strings.HasPrefix(goVersion, expected) {
 		panic(fmt.Errorf("expected version: %s, got: %s", expected, goVersion))
 	}
 }

--- a/examples/testdata/go/go-1.18/main.go
+++ b/examples/testdata/go/go-1.18/main.go
@@ -3,13 +3,14 @@ package main
 import (
 	"fmt"
 	"runtime"
+	"strings"
 )
 
 func main() {
 	expected := "go1.18"
 	goVersion := runtime.Version()
 	fmt.Printf("Go version: %s\n", goVersion)
-	if goVersion != expected {
+	if !strings.HasPrefix(goVersion, expected) {
 		panic(fmt.Errorf("expected version: %s, got: %s", expected, goVersion))
 	}
 }

--- a/examples/testdata/go/go-1.19/main.go
+++ b/examples/testdata/go/go-1.19/main.go
@@ -3,13 +3,14 @@ package main
 import (
 	"fmt"
 	"runtime"
+	"strings"
 )
 
 func main() {
 	expected := "go1.19"
 	goVersion := runtime.Version()
 	fmt.Printf("Go version: %s\n", goVersion)
-	if goVersion != expected {
+	if !strings.HasPrefix(goVersion, expected) {
 		panic(fmt.Errorf("expected version: %s, got: %s", expected, goVersion))
 	}
 }


### PR DESCRIPTION
## Summary

These gave errors like:
```
expected version: go1.17, got: go1.17.13
```
when doing `go run main.go` in their respective `devbox shell`

## How was it tested?

opened a `devbox shell` and did `go run main.go` and got the version printed out without any panic
