### PR TITLE
Mark some more errors as user errors

### DIFF
--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
+	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/debug"
 )
 
@@ -73,7 +74,7 @@ func parseScriptArgs(args []string, flags runCmdFlags) (string, string, []string
 		scriptArgs = args[1:]
 	} else {
 		// this should never happen because cobra should prevent it, but it's better to be defensive.
-		return "", "", nil, errors.New("no command or script provided")
+		return "", "", nil, usererr.New("no command or script provided")
 	}
 
 	return path, script, scriptArgs, nil

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -306,7 +306,7 @@ func (d *Devbox) RunScriptInNewNixShell(scriptName string) error {
 	nixShellFilePath := filepath.Join(d.projectDir, ".devbox/gen/shell.nix")
 	script := d.cfg.Shell.Scripts[scriptName]
 	if script == nil {
-		return errors.Errorf("unable to find a script with name %s", scriptName)
+		return usererr.New("unable to find a script with name %s", scriptName)
 	}
 
 	pluginHooks, err := plugin.InitHooks(d.cfg.Packages, d.projectDir)
@@ -349,7 +349,7 @@ func (d *Devbox) RunScriptInShell(scriptName string) error {
 
 	script := d.cfg.Shell.Scripts[scriptName]
 	if script == nil {
-		return errors.Errorf("unable to find a script with name %s", scriptName)
+		return usererr.New("unable to find a script with name %s", scriptName)
 	}
 
 	shell, err := nix.DetectShell(


### PR DESCRIPTION
## Summary

So that they're not reported to Sentry.

## How was it tested?
```
DO_NOT_TRACK=0 devbox run invalid-script
```