### PR TITLE
[telemetry] fix missing UserID for command events

### DIFF
--- a/internal/boxcli/midcobra/telemetry.go
+++ b/internal/boxcli/midcobra/telemetry.go
@@ -131,7 +131,6 @@ type event struct {
 	Packages      []string
 	SentryEventID string
 	Shell         string
-	UserID        string
 }
 
 // newEventIfValid creates a new telemetry event, but returns nil if we cannot construct


### PR DESCRIPTION
## Summary

Problem:
UserID field was missing for logs for Command events

Cause:
1. The `event` struct in `midcobra/telemetry` embeds the `telemetry.Event`.
2. Both structs had a `UserID` field
3. We were writing to the `telemetry.Event.UserID` field
4. But when reading the outer struct's `UserID` field would be read, masking the value in the embedded field.

Fix:
Remove the outer field definition

## How was it tested?

1. Added print statements prior to logging the Command and Shell events, and confirmed that UserID was present.
2. Verified in segment's development project Debugger events that UserID is present for both Command and Shell events.
