### PR TITLE
[flakes | print-dev-env] enable flakes to work with print-dev-env

### DIFF
--- a/internal/impl/tmpl/flake.nix.tmpl
+++ b/internal/impl/tmpl/flake.nix.tmpl
@@ -12,17 +12,16 @@
         let pkgs = nixpkgs.legacyPackages.${system};
 
         in {
+            # TODO savil. Revisit. Can we replace devshell with just buildEnv?
+            # since we use print-dev-env to start the shell manually.
             defaultPackage = pkgs.buildEnv {
-                ignoreCollisions = true;
                 name="devbox-shell-env";
                 paths = [
                   {{- range .DevPackages}}
                     pkgs.{{.}}
                   {{end -}}
                 ];
-                pathsToLink = [ "/bin" "/share" "/lib"];
             };
-            # TODO savil. Revisit. I think we may not need the devshell at all since we use print-dev-env to start the shell manually.
             devShell = pkgs.mkShell {
               shellHook =
                 ''

--- a/internal/impl/tmpl/flake.nix.tmpl
+++ b/internal/impl/tmpl/flake.nix.tmpl
@@ -12,15 +12,16 @@
         let pkgs = nixpkgs.legacyPackages.${system};
 
         in {
-            # TODO savil. Revisit. Can we replace devshell with just buildEnv?
-            # since we use print-dev-env to start the shell manually.
+            # defaultPackage is used by the `nix profile --install`
             defaultPackage = pkgs.buildEnv {
+                ignoreCollisions = true;
                 name="devbox-shell-env";
                 paths = [
                   {{- range .DevPackages}}
                     pkgs.{{.}}
                   {{end -}}
                 ];
+                pathsToLink = [ "/bin" "/share" "/lib" ];
             };
             devShell = pkgs.mkShell {
               shellHook =

--- a/internal/impl/tmpl/flake.nix.tmpl
+++ b/internal/impl/tmpl/flake.nix.tmpl
@@ -34,10 +34,10 @@
 
                   # Undo the effects of `nix-shell --pure` on SSL certs.
                   # See https://github.com/NixOS/nixpkgs/blob/dae204faa0243b4d0c0234a5f5f83a2549ecb5b7/pkgs/stdenv/generic/setup.sh#L677-L685
-                  if [ "$NIX_SSL_CERT_FILE" == "/no-cert-file.crt" ]; then
+                  if [ "$NIX_SSL_CERT_FILE" = "/no-cert-file.crt" ]; then
                      unset NIX_SSL_CERT_FILE
                   fi
-                  if [ "$SSL_CERT_FILE" == "/no-cert-file.crt" ]; then
+                  if [ "$SSL_CERT_FILE" = "/no-cert-file.crt" ]; then
                      unset SSL_CERT_FILE
                   fi
 
@@ -46,12 +46,8 @@
                   export "PATH=$PATH:$PARENT_PATH"
 
                   {{ if debug }}
-                  echo "pwd is: $(pwd)"
-                  echo "PARENT_PATH=$PARENT_PATH"
                   echo "PATH=$PATH"
                   {{- end }}
-
-                  # exec env "SHELL=/bin/zsh" "ZDOTDIR=/var/folders/zv/r3sx92_94gq86_rq3yn1ky2h0000gn/T/devbox3840985630" /bin/zsh
                 '';
 
               buildInputs = [

--- a/internal/impl/tmpl/flake.nix.tmpl
+++ b/internal/impl/tmpl/flake.nix.tmpl
@@ -13,13 +13,16 @@
 
         in {
             defaultPackage = pkgs.buildEnv {
+                ignoreCollisions = true;
                 name="devbox-shell-env";
                 paths = [
                   {{- range .DevPackages}}
                     pkgs.{{.}}
                   {{end -}}
                 ];
+                pathsToLink = [ "/bin" "/share" "/lib"];
             };
+            # TODO savil. Revisit. I think we may not need the devshell at all since we use print-dev-env to start the shell manually.
             devShell = pkgs.mkShell {
               shellHook =
                 ''
@@ -52,13 +55,9 @@
                   # exec env "SHELL=/bin/zsh" "ZDOTDIR=/var/folders/zv/r3sx92_94gq86_rq3yn1ky2h0000gn/T/devbox3840985630" /bin/zsh
                 '';
 
-              # We do not need to install these because we do `nix profile install`
-              # using the defaultPackages above.
-              # BUT leaving this comment in place to revisit once I understand the environment implications more.
-              # TODO savil. Revisit.
               buildInputs = [
                   {{- range .DevPackages}}
-                    # pkgs.{{.}}
+                    pkgs.{{.}}
                   {{end -}}
               ];
             };

--- a/internal/nix/run.go
+++ b/internal/nix/run.go
@@ -10,12 +10,17 @@ import (
 	"go.jetpack.io/devbox/internal/debug"
 )
 
-func RunScript(nixShellFilePath string, projectDir string, cmdWithArgs string, additionalEnv []string) error {
+func RunScript(
+	nixShellFilePath, nixFlakesFilePath string,
+	projectDir string,
+	cmdWithArgs string,
+	additionalEnv []string,
+) error {
 	if cmdWithArgs == "" {
 		return errors.New("attempted to run an empty command or script")
 	}
 
-	vaf, err := PrintDevEnv(nixShellFilePath)
+	vaf, err := PrintDevEnv(nixShellFilePath, nixFlakesFilePath)
 	if err != nil {
 		return err
 	}

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -453,7 +453,6 @@ func (s *Shell) writeDevboxShellrc(vars map[string]string) (path string, err err
 	err = shellrcTmpl.Execute(shellrcf, struct {
 		ProjectDir       string
 		EnvToKeep        map[string]string
-		IsFlakesDisabled bool
 		OriginalInit     string
 		OriginalInitPath string
 		UserHook         string
@@ -466,7 +465,6 @@ func (s *Shell) writeDevboxShellrc(vars map[string]string) (path string, err err
 	}{
 		ProjectDir:       s.projectDir,
 		EnvToKeep:        envToKeepFlakes,
-		IsFlakesDisabled: featureflag.Flakes.Disabled(),
 		OriginalInit:     string(bytes.TrimSpace(userShellrc)),
 		OriginalInitPath: filepath.Clean(s.userShellrcPath),
 		UserHook:         strings.TrimSpace(s.UserInitHook),

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -171,7 +171,7 @@ func rcfilePath(basename string) string {
 	return filepath.Join(home, basename)
 }
 
-func (s *Shell) Run(nixShellFilePath string) error {
+func (s *Shell) Run(nixShellFilePath, nixFlakesFilePath string) error {
 	// Just to be safe, we need to guarantee that the NIX_PROFILES paths
 	// have been filepath.Clean'ed. The shellrc.tmpl has some commands that
 	// assume they are.
@@ -194,44 +194,12 @@ func (s *Shell) Run(nixShellFilePath string) error {
 		"NIXPKGS_ALLOW_UNFREE=1",
 	)
 
-	if featureflag.Flakes.Enabled() {
-		if s.binPath == "" {
-			return errors.New("Unsupported for flakes: shell having no binPath")
-		}
-		cmd := exec.Command("nix", "develop", ".devbox/gen/flake",
-			"--extra-experimental-features", "nix-command flakes",
-			"--verbose",
-			"--ignore-environment",
-			"--command", "/bin/bash", "-c", s.execCommand(),
-			"--keep", "PARENT_PATH", // TODO savil. Why does it not show up inside devbox shell?
-		)
-
-		for _, keyVal := range env {
-			if strings.HasPrefix(keyVal, "PARENT_PATH") {
-				debug.Log("PARENT_PATH in env is %s\n", keyVal)
-			}
-		}
-
-		cmd.Args = append(cmd.Args, toKeepArgs(env, buildAllowList(s.env))...)
-		cmd.Env = env
-		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-
-		debug.Log("Executing nix develop command: %v", cmd.Args)
-		debug.Log("Executing nix develop command with env: %v", cmd.Environ())
-
-		err := cmd.Run()
-		if err != nil && s.ScriptCommand != "" {
-			// Report error as exec error when executing shell -- <cmd> script.
-			err = usererr.NewExecError(err)
-		}
-		return errors.WithStack(err)
-	}
-
 	// Launch a fallback shell if we couldn't find the path to the user's
 	// default shell.
 	if s.binPath == "" {
+		if featureflag.Flakes.Enabled() {
+			return errors.New("No default shell not supported in Flakes mode")
+		}
 		cmd := exec.Command("nix-shell", "--pure")
 		cmd.Args = append(cmd.Args, toKeepArgs(env, buildAllowList(s.env))...)
 		cmd.Args = append(cmd.Args, nixShellFilePath)
@@ -247,7 +215,7 @@ func (s *Shell) Run(nixShellFilePath string) error {
 	var cmd *exec.Cmd
 	if featureflag.NixlessShell.Enabled() {
 		// Get the required env vars from nix, and then spawn a shell directly.
-		vars, err := s.computeNixShellEnv(nixShellFilePath)
+		vars, err := s.computeNixShellEnv(nixShellFilePath, nixFlakesFilePath)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -304,12 +272,13 @@ func (s *Shell) Run(nixShellFilePath string) error {
 	return errors.WithStack(err)
 }
 
-func (s *Shell) computeNixShellEnv(nixShellFilePath string) (map[string]string, error) {
-	vaf, err := PrintDevEnv(nixShellFilePath)
+func (s *Shell) computeNixShellEnv(nixShellFilePath, nixFlakesFilePath string) (map[string]string, error) {
+	vaf, err := PrintDevEnv(nixShellFilePath, nixFlakesFilePath)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	ignoreList := []string{"HOME"} // do not overwrite the user's HOME.
+	// TODO remove TMPDIR for shell purity? But maybe it is okay, since each system will have a different TMPDIR.
+	ignoreList := []string{"HOME", "TMPDIR"} // do not overwrite the user's HOME.
 
 	vars := map[string]string{}
 	for name, vrb := range vaf.Variables {
@@ -471,6 +440,7 @@ func (s *Shell) writeDevboxShellrc(vars map[string]string) (path string, err err
 	}
 
 	envToKeepFlakes := map[string]string{}
+	// TODO savil: 80% confidence this can be removed
 	if featureflag.Flakes.Enabled() {
 		// `nix develop` has a list of ignoreVars, which we may want to not-ignore.
 		// For now, including just TERM since it affects shell cursor movement UX.
@@ -483,6 +453,7 @@ func (s *Shell) writeDevboxShellrc(vars map[string]string) (path string, err err
 	err = shellrcTmpl.Execute(shellrcf, struct {
 		ProjectDir       string
 		EnvToKeep        map[string]string
+		IsFlakesDisabled bool
 		OriginalInit     string
 		OriginalInitPath string
 		UserHook         string
@@ -495,6 +466,7 @@ func (s *Shell) writeDevboxShellrc(vars map[string]string) (path string, err err
 	}{
 		ProjectDir:       s.projectDir,
 		EnvToKeep:        envToKeepFlakes,
+		IsFlakesDisabled: featureflag.Flakes.Disabled(),
 		OriginalInit:     string(bytes.TrimSpace(userShellrc)),
 		OriginalInitPath: filepath.Clean(s.userShellrcPath),
 		UserHook:         strings.TrimSpace(s.UserInitHook),

--- a/internal/nix/shellrc.tmpl
+++ b/internal/nix/shellrc.tmpl
@@ -20,7 +20,7 @@ content readable.
 export {{ $name }}={{ $value }}
 {{ end -}}
 
-{{- if .NixEnv }}
+{{- if .IsFlakesDisabled }}
 # Run the shell hook defined in shell.nix.
 eval $shellHook
 

--- a/internal/nix/shellrc.tmpl
+++ b/internal/nix/shellrc.tmpl
@@ -20,10 +20,9 @@ content readable.
 export {{ $name }}={{ $value }}
 {{ end -}}
 
-{{- if and .IsFlakesDisabled .NixEnv }}
+{{- if .NixEnv }}
 # Run the shell hook defined in shell.nix.
 eval $shellHook
-
 {{ end -}}
 
 {{- if .OriginalInit -}}

--- a/internal/nix/shellrc.tmpl
+++ b/internal/nix/shellrc.tmpl
@@ -20,7 +20,7 @@ content readable.
 export {{ $name }}={{ $value }}
 {{ end -}}
 
-{{- if .IsFlakesDisabled }}
+{{- if and .IsFlakesDisabled .NixEnv }}
 # Run the shell hook defined in shell.nix.
 eval $shellHook
 


### PR DESCRIPTION
## Summary

This PR is a step towards enabling `devbox shell` to work with both Flakes and NixlessShell featureflags enabled.

Future PR TODOs: refer to notion doc on Post Devbox Cloud Clean up Tasks.

## How was it tested?

in `examples/testdata/go/go-1.19`:
```
> DEVBOX_FEATURE_FLAKES=1 DEVBOX_FEATURE_NIXLESS_SHELL=1 DEVBOX_DEBUG=1 devbox shell
(devbox) > go run main.go
Go version: go1.19.3

```

Also started shells with the following control cases:
1. `DEVBOX_FEATURE_FLAKES=0 DEVBOX_FEATURE_NIXLESS_SHELL=0 DEVBOX_DEBUG=1 devbox shell`
2. `DEVBOX_FEATURE_FLAKES=0 DEVBOX_FEATURE_NIXLESS_SHELL=1 DEVBOX_DEBUG=1 devbox shell`

For the control cases, did:
```
> devbox add vim
> which vim
> devbox rm vim
```
to verify that the package was added and removed