### PR TITLE
[telemetry] do not log hidden commands to segment Command Events

### DIFF
--- a/internal/boxcli/midcobra/telemetry.go
+++ b/internal/boxcli/midcobra/telemetry.go
@@ -127,6 +127,7 @@ type event struct {
 	Command       string
 	CommandArgs   []string
 	CommandError  error
+	CommandHidden bool
 	Failed        bool
 	Packages      []string
 	SentryEventID string
@@ -161,14 +162,17 @@ func (m *telemetryMiddleware) newEventIfValid(cmd *cobra.Command, args []string,
 		Command:      subcmd.CommandPath(),
 		CommandArgs:  subargs,
 		CommandError: runErr,
-		Failed:       runErr != nil,
-		Packages:     pkgs,
-		Shell:        os.Getenv("SHELL"),
+		// The command is hidden if either the top-level command is hidden or
+		// the specific sub-command that was executed is hidden.
+		CommandHidden: cmd.Hidden || subcmd.Hidden,
+		Failed:        runErr != nil,
+		Packages:      pkgs,
+		Shell:         os.Getenv("SHELL"),
 	}
 }
 
 func (m *telemetryMiddleware) trackEvent(evt *event) {
-	if evt == nil {
+	if evt == nil || evt.CommandHidden {
 		return
 	}
 


### PR DESCRIPTION
## Summary

We do not want to log hidden commands (like `devbox log`) to segment Command Events.

We continue logging them to sentry to track any errors therein.

## How was it tested?

Ran `devbox shell` whose shellrc will invoke `devbox log shell-interactive`.
Opened Segment Dashboard > Source > Development Project > Debugger, and:
1. saw Command Events for "devbox shell" and Shell Events for interactive and ready durations.
2. did not see any Command Events for "devbox log" (which did show up previously)
