### PR TITLE
[Plugin] Add a plugin for `python3xxPackage.pip`

### DIFF
--- a/plugins/pip.json
+++ b/plugins/pip.json
@@ -1,0 +1,17 @@
+{
+    "name": "pip",
+    "version": "0.0.1",
+    "match": "^python3[0-9]{1,2}Packages.pip",
+    "readme": "This plugin adds a script for automatically creating a virtual environment using `venv` for python3 projects, so you can install packages with pip as normal.\nTo activate the environment, run `source $VENV_DIR/bin/activate` or add it to the init_hook of your devbox.json\nTo change where your virtual environment is created, modify the $VENV_DIR environment variable in your init_hook",
+    "env": {
+        "VENV_DIR": "{{ .Virtenv }}/pip/.venv"
+    },
+    "create_files": {
+        "{{ .DevboxDir }}/venvShellHook.sh": "pip/venvShellHook.sh"
+    },
+    "shell": {
+        "init_hook": [
+            "sh {{ .DevboxDir }}/venvShellHook.sh"
+        ]
+    }
+}

--- a/plugins/pip.json
+++ b/plugins/pip.json
@@ -4,14 +4,14 @@
     "match": "^python3[0-9]{1,2}Packages.pip",
     "readme": "This plugin adds a script for automatically creating a virtual environment using `venv` for python3 projects, so you can install packages with pip as normal.\nTo activate the environment, run `source $VENV_DIR/bin/activate` or add it to the init_hook of your devbox.json\nTo change where your virtual environment is created, modify the $VENV_DIR environment variable in your init_hook",
     "env": {
-        "VENV_DIR": "{{ .Virtenv }}/pip/.venv"
+        "VENV_DIR": "{{ .Virtenv }}/.venv"
     },
     "create_files": {
-        "{{ .DevboxDir }}/venvShellHook.sh": "pip/venvShellHook.sh"
+        "{{ .Virtenv }}/bin/venvShellHook.sh": "pip/venvShellHook.sh"
     },
     "shell": {
         "init_hook": [
-            "sh {{ .DevboxDir }}/venvShellHook.sh"
+            "{{ .Virtenv }}/bin/venvShellHook.sh"
         ]
     }
 }

--- a/plugins/pip/venvShellHook.sh
+++ b/plugins/pip/venvShellHook.sh
@@ -1,0 +1,11 @@
+SOURCE_DATE_EPOCH=$(date +%s)
+
+if [ -d "$VENV_DIR" ]; then
+    echo "Skipping venv creation, '${VENV_DIR}' already exists"
+else
+    echo "Creating new venv environment in path: '${VENV_DIR}'"
+    # Note that the module venv was only introduced in python 3, so for 2.7
+    # this needs to be replaced with a call to virtualenv
+    which python3
+    python3 -m venv "$VENV_DIR"
+fi

--- a/plugins/pip/venvShellHook.sh
+++ b/plugins/pip/venvShellHook.sh
@@ -6,6 +6,6 @@ else
     echo "Creating new venv environment in path: '${VENV_DIR}'"
     # Note that the module venv was only introduced in python 3, so for 2.7
     # this needs to be replaced with a call to virtualenv
-    which python3
     python3 -m venv "$VENV_DIR"
 fi
+echo "You an activate the virtual environment by running 'source $VENV_DIR/bin/activate'"

--- a/plugins/pip/venvShellHook.sh
+++ b/plugins/pip/venvShellHook.sh
@@ -4,8 +4,6 @@ if [ -d "$VENV_DIR" ]; then
     echo "Skipping venv creation, '${VENV_DIR}' already exists"
 else
     echo "Creating new venv environment in path: '${VENV_DIR}'"
-    # Note that the module venv was only introduced in python 3, so for 2.7
-    # this needs to be replaced with a call to virtualenv
     python3 -m venv "$VENV_DIR"
 fi
 echo "You an activate the virtual environment by running 'source $VENV_DIR/bin/activate'"

--- a/plugins/pip/venvShellHook.sh
+++ b/plugins/pip/venvShellHook.sh
@@ -1,4 +1,4 @@
-SOURCE_DATE_EPOCH=$(date +%s)
+#!/bin/sh
 
 if [ -d "$VENV_DIR" ]; then
     echo "Skipping venv creation, '${VENV_DIR}' already exists"
@@ -6,4 +6,4 @@ else
     echo "Creating new venv environment in path: '${VENV_DIR}'"
     python3 -m venv "$VENV_DIR"
 fi
-echo "You an activate the virtual environment by running 'source $VENV_DIR/bin/activate'"
+echo "You an activate the virtual environment by running 'source \$VENV_DIR/bin/activate'"


### PR DESCRIPTION
## Summary

This plugin automatically sets up a virtual environment for python packages whenever a python3 version of `pip` is added.

- Sets a `VENV_DIR` environment variable that determines where the virtualenv is
- A `venvShellHook.sh` file is added in `devbox.d` which creates the venv directory at $VENV_DIR if it doesn't already exist
- The plugin's init hook runs the `venvShellHook.sh` script

I've left it so the user still needs to source the virtualenv manually, so they can choose whether or not to activate on starting devbox shell

## How was it tested?

Tested in devbox-examples, create a simple requirements.txt and ran it with the plugin
