### PR TITLE
[easy][plugins] User init hooks should run after plugins

### DIFF
--- a/internal/nix/shellrc.tmpl
+++ b/internal/nix/shellrc.tmpl
@@ -58,6 +58,16 @@ devbox log shell-ready {{ .ShellStartTime }}
 
 # End Devbox Post-init Hook
 
+# Begin Plugin Init Hook
+
+{{- if .PluginInitHook }}
+
+{{ .PluginInitHook }}
+
+{{- end }}
+
+# End Plugin Init Hook
+
 {{- if .UserHook }}
 
 # Begin Devbox User Hook
@@ -73,16 +83,6 @@ cd $workingDir
 # End Devbox User Hook
 
 {{- end }}
-
-# Begin Plugin Init Hook
-
-{{- if .PluginInitHook }}
-
-{{ .PluginInitHook }}
-
-{{- end }}
-
-# End Plugin Init Hook
 
 {{- if .ShellStartTime }}
 # log that the shell is interactive now!

--- a/internal/nix/shellrc.tmpl
+++ b/internal/nix/shellrc.tmpl
@@ -58,31 +58,31 @@ devbox log shell-ready {{ .ShellStartTime }}
 
 # End Devbox Post-init Hook
 
-# Begin Plugin Init Hook
+# Switch to the directory where devbox.json config is
+workingDir=$(pwd)
+cd {{ .ProjectDir }}
 
 {{- if .PluginInitHook }}
 
+# Begin Plugin Init Hook
+
 {{ .PluginInitHook }}
 
-{{- end }}
-
 # End Plugin Init Hook
+
+{{- end }}
 
 {{- if .UserHook }}
 
 # Begin Devbox User Hook
 
-# Switch to the directory where devbox.json config is
-workingDir=$(pwd)
-cd {{ .ProjectDir }}
-
 {{ .UserHook }}
-
-cd $workingDir
 
 # End Devbox User Hook
 
 {{- end }}
+
+cd $workingDir
 
 {{- if .ShellStartTime }}
 # log that the shell is interactive now!

--- a/internal/nix/testdata/shellrc/basic/shellrc.golden
+++ b/internal/nix/testdata/shellrc/basic/shellrc.golden
@@ -52,23 +52,23 @@ export PS1="(devbox) $PS1"
 
 # End Devbox Post-init Hook
 
-# Begin Devbox User Hook
-
 # Switch to the directory where devbox.json config is
 workingDir=$(pwd)
 cd path/to/projectDir
-
-echo "Hello from a devbox shell hook!"
-
-cd $workingDir
-
-# End Devbox User Hook
 
 # Begin Plugin Init Hook
 
 echo "Welcome to the devbox!"
 
 # End Plugin Init Hook
+
+# Begin Devbox User Hook
+
+echo "Hello from a devbox shell hook!"
+
+# End Devbox User Hook
+
+cd $workingDir
 
 # Begin Script command
 

--- a/internal/nix/testdata/shellrc/nohook/shellrc.golden
+++ b/internal/nix/testdata/shellrc/nohook/shellrc.golden
@@ -52,11 +52,17 @@ export PS1="(devbox) $PS1"
 
 # End Devbox Post-init Hook
 
+# Switch to the directory where devbox.json config is
+workingDir=$(pwd)
+cd path/to/projectDir
+
 # Begin Plugin Init Hook
 
 echo "Welcome to the devbox!"
 
 # End Plugin Init Hook
+
+cd $workingDir
 
 # Begin Script command
 

--- a/internal/nix/testdata/shellrc/noshellrc/shellrc.golden
+++ b/internal/nix/testdata/shellrc/noshellrc/shellrc.golden
@@ -10,23 +10,23 @@ export PS1="(devbox) $PS1"
 
 # End Devbox Post-init Hook
 
-# Begin Devbox User Hook
-
 # Switch to the directory where devbox.json config is
 workingDir=$(pwd)
 cd path/to/projectDir
-
-echo "Hello from a devbox shell hook!"
-
-cd $workingDir
-
-# End Devbox User Hook
 
 # Begin Plugin Init Hook
 
 echo "Welcome to the devbox!"
 
 # End Plugin Init Hook
+
+# Begin Devbox User Hook
+
+echo "Hello from a devbox shell hook!"
+
+# End Devbox User Hook
+
+cd $workingDir
 
 # Begin Script command
 


### PR DESCRIPTION
## Summary

Change the order of init hooks to ensure user hooks are run last. Also ensure plugin hooks are run from the same directory as user hooks (the project dir)

## How was it tested?

```
devbox add ruby
# modified devbox.json to echo $PATH in init hook
devbox shell
# inspected PATH and saw GEM_HOME was in it.
```
