### PR TITLE
[devbox.json] Added env field in devbox.json

### DIFF
--- a/internal/impl/config.go
+++ b/internal/impl/config.go
@@ -25,7 +25,10 @@ type Config struct {
 
 	// Shell configures the devbox shell environment.
 	Shell struct {
+		// Env contains environment variables that will be set in shell
 		// InitHook contains commands that will run at shell startup.
+		// Scripts contain commands that can be executed via devbox run
+		Env      map[string]string             `json:"env,omitempty"`
 		InitHook shellcmd.Commands             `json:"init_hook,omitempty"`
 		Scripts  map[string]*shellcmd.Commands `json:"scripts,omitempty"`
 	} `json:"shell,omitempty"`

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -238,12 +238,10 @@ func (d *Devbox) Shell() error {
 	if err != nil {
 		return err
 	}
-	fmt.Println(env)
 	env, err = d.appendConfigEnv(env)
 	if err != nil {
 		return err
 	}
-	fmt.Println(env)
 
 	shellStartTime := os.Getenv("DEVBOX_SHELL_START_TIME")
 	if shellStartTime == "" {

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -238,10 +238,7 @@ func (d *Devbox) Shell() error {
 	if err != nil {
 		return err
 	}
-	env, err = d.appendConfigEnv(env)
-	if err != nil {
-		return err
-	}
+	env = d.appendConfigEnv(env)
 
 	shellStartTime := os.Getenv("DEVBOX_SHELL_START_TIME")
 	if shellStartTime == "" {
@@ -285,10 +282,7 @@ func (d *Devbox) RunScript(cmdName string, cmdArgs []string) error {
 	if err != nil {
 		return err
 	}
-	env, err = d.appendConfigEnv(env)
-	if err != nil {
-		return err
-	}
+	env = d.appendConfigEnv(env)
 
 	var cmdWithArgs []string
 	if _, ok := d.cfg.Shell.Scripts[cmdName]; ok {
@@ -340,11 +334,7 @@ func (d *Devbox) RunScriptInNewNixShell(scriptName string) error {
 	if err != nil {
 		return err
 	}
-	env, err = d.appendConfigEnv(env)
-
-	if err != nil {
-		return err
-	}
+	env = d.appendConfigEnv(env)
 
 	opts := []nix.ShellOption{
 		nix.WithPluginInitHook(strings.Join(pluginHooks, "\n")),
@@ -737,11 +727,11 @@ func (d *Devbox) computeNixEnv() ([]string, error) {
 
 // addConfigEnv takes env variables that are to be set (plugin Env vars)
 // and appends env variables defined in devbox.json to it.
-func (d *Devbox) appendConfigEnv(env []string) ([]string, error) {
+func (d *Devbox) appendConfigEnv(env []string) []string {
 	for key, value := range d.cfg.Shell.Env {
 		env = append(env, fmt.Sprintf("%s=%s", key, value))
 	}
-	return env, nil
+	return env
 }
 
 // installNixProfile installs or uninstalls packages to or from this

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -277,7 +277,7 @@ func (d *Devbox) RunScript(cmdName string, cmdArgs []string) error {
 		return err
 	}
 
-	pluginEnv, err := plugin.Env(d.cfg.Packages, d.projectDir)
+	env, err := d.computeNixEnv()
 	if err != nil {
 		return err
 	}
@@ -297,12 +297,11 @@ func (d *Devbox) RunScript(cmdName string, cmdArgs []string) error {
 			return err
 		}
 		cmdWithArgs = []string{d.scriptPath(d.scriptFilename(arbitraryCmdFilename))}
-		// TODO: move this env var elsewhere. I will move all the env stuff into a single ComputeEnv() function.
-		pluginEnv = append(pluginEnv, fmt.Sprintf("DEVBOX_RUN_CMD=%s", strings.Join(append([]string{cmdName}, cmdArgs...), " ")))
+		env = append(env, fmt.Sprintf("DEVBOX_RUN_CMD=%s", strings.Join(append([]string{cmdName}, cmdArgs...), " ")))
 	}
 
 	nixShellFilePath := filepath.Join(d.projectDir, ".devbox/gen/shell.nix")
-	return nix.RunScript(nixShellFilePath, d.projectDir, strings.Join(cmdWithArgs, " "), pluginEnv)
+	return nix.RunScript(nixShellFilePath, d.projectDir, strings.Join(cmdWithArgs, " "), env)
 }
 
 // RunScriptInNewNixShell implements `devbox run` (from outside a devbox shell) using a nix shell.
@@ -682,6 +681,47 @@ func (d *Devbox) printPackageUpdateMessage(
 	return nil
 }
 
+func (d *Devbox) computeNixEnv() ([]string, error) {
+	nixShellFilePath := filepath.Join(d.projectDir, ".devbox/gen/shell.nix")
+	vaf, err := nix.PrintDevEnv(nixShellFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	env := map[string]string{}
+	for k, v := range vaf.Variables {
+		if v.Type == "exported" {
+			env[k] = v.Value.(string)
+		}
+	}
+
+	// Overwrite/leak whitelisted vars into nixEnv:
+	for name, leak := range leakVarsForRun {
+		if leak {
+			env[name] = os.Getenv(name)
+		}
+	}
+
+	// Include the host PATH at the end.
+	env["PATH"] = fmt.Sprintf("%s:%s", env["PATH"], os.Getenv("PATH"))
+
+	// TODO: prepend the nix profile path
+	// TODO: prepend package config dir
+
+	envPairs := []string{}
+	for k, v := range env {
+		envPairs = append(envPairs, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	pluginEnv, err := plugin.Env(d.cfg.Packages, d.projectDir)
+	if err != nil {
+		return nil, err
+	}
+	envPairs = append(envPairs, pluginEnv...)
+
+	return envPairs, nil
+}
+
 // installNixProfile installs or uninstalls packages to or from this
 // devbox's Nix profile so that it matches what's in development.nix or flake.nix
 func (d *Devbox) installNixProfile() (err error) {
@@ -818,4 +858,24 @@ func IsDevboxShellEnabled() bool {
 func commandExists(command string) bool {
 	_, err := exec.LookPath(command)
 	return err == nil
+}
+
+// leakVarsForRun contains a list of variables that, if set in the host, will be copied
+// to the environment of devbox run. If they're NOT set in the host, they will be set
+// to an empty value for devbox run. NOTE: we want to keep this list AS SMALL AS POSSIBLE.
+// The longer this list, the less "pure" devbox run becomes.
+//
+// In particular, this list should be much smaller than that of devbox shell, since we
+// do want to allow more parts of the host environment to leak into a shell session, so
+// that the shell session is easy to use for our users. However, in devbox run, we value
+// reproducibility above interactive ease-of-use.
+var leakVarsForRun = map[string]bool{
+	"HOME": true, // Without this, HOME is set to /homeless-shelter and most programs fail.
+
+	// Where to write temporary files. nix print-dev-env sets these to an unwriteable path,
+	// so we override that here with whatever the host has set.
+	"TMP":     true,
+	"TEMP":    true,
+	"TMPDIR":  true,
+	"TEMPDIR": true,
 }

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -238,6 +238,12 @@ func (d *Devbox) Shell() error {
 	if err != nil {
 		return err
 	}
+	fmt.Println(env)
+	env, err = d.appendConfigEnv(env)
+	if err != nil {
+		return err
+	}
+	fmt.Println(env)
 
 	shellStartTime := os.Getenv("DEVBOX_SHELL_START_TIME")
 	if shellStartTime == "" {
@@ -278,6 +284,10 @@ func (d *Devbox) RunScript(cmdName string, cmdArgs []string) error {
 	}
 
 	env, err := d.computeNixEnv()
+	if err != nil {
+		return err
+	}
+	env, err = d.appendConfigEnv(env)
 	if err != nil {
 		return err
 	}
@@ -329,6 +339,11 @@ func (d *Devbox) RunScriptInNewNixShell(scriptName string) error {
 	}
 
 	env, err := plugin.Env(d.cfg.Packages, d.projectDir)
+	if err != nil {
+		return err
+	}
+	env, err = d.appendConfigEnv(env)
+
 	if err != nil {
 		return err
 	}
@@ -720,6 +735,15 @@ func (d *Devbox) computeNixEnv() ([]string, error) {
 	envPairs = append(envPairs, pluginEnv...)
 
 	return envPairs, nil
+}
+
+// addConfigEnv takes env variables that are to be set (plugin Env vars)
+// and appends env variables defined in devbox.json to it.
+func (d *Devbox) appendConfigEnv(env []string) ([]string, error) {
+	for key, value := range d.cfg.Shell.Env {
+		env = append(env, fmt.Sprintf("%s=%s", key, value))
+	}
+	return env, nil
 }
 
 // installNixProfile installs or uninstalls packages to or from this

--- a/internal/nix/run.go
+++ b/internal/nix/run.go
@@ -1,7 +1,6 @@
 package nix
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 
@@ -10,28 +9,9 @@ import (
 	"go.jetpack.io/devbox/internal/debug"
 )
 
-func RunScript(nixShellFilePath string, projectDir string, cmdWithArgs string, additionalEnv []string) error {
+func RunScript(nixShellFilePath string, projectDir string, cmdWithArgs string, env []string) error {
 	if cmdWithArgs == "" {
 		return errors.New("attempted to run an empty command or script")
-	}
-
-	vaf, err := PrintDevEnv(nixShellFilePath)
-	if err != nil {
-		return err
-	}
-
-	nixEnv := []string{}
-	for k, v := range vaf.Variables {
-		if v.Type == "exported" {
-			nixEnv = append(nixEnv, fmt.Sprintf("%s=%s", k, v.Value.(string)))
-		}
-	}
-
-	// Overwrite/leak whitelisted vars into nixEnv:
-	for name, leak := range leakVarsForRun {
-		if leak {
-			nixEnv = append(nixEnv, fmt.Sprintf("%s=%s", name, os.Getenv(name)))
-		}
 	}
 
 	// Try to find sh in the PATH, if not, default to a well known absolute path.
@@ -40,7 +20,7 @@ func RunScript(nixShellFilePath string, projectDir string, cmdWithArgs string, a
 		shPath = "/bin/sh"
 	}
 	cmd := exec.Command(shPath, "-c", cmdWithArgs)
-	cmd.Env = append(nixEnv, additionalEnv...)
+	cmd.Env = env
 	cmd.Dir = projectDir
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
@@ -53,24 +33,4 @@ func RunScript(nixShellFilePath string, projectDir string, cmdWithArgs string, a
 		err = usererr.NewExecError(err)
 	}
 	return errors.WithStack(err)
-}
-
-// leakVarsForRun contains a list of variables that, if set in the host, will be copied
-// to the environment of devbox run. If they're NOT set in the host, they will be set
-// to an empty value for devbox run. NOTE: we want to keep this list AS SMALL AS POSSIBLE.
-// The longer this list, the less "pure" devbox run becomes.
-//
-// In particular, this list should be much smaller than that of devbox shell, since we
-// do want to allow more parts of the host environment to leak into a shell session, so
-// that the shell session is easy to use for our users. However, in devbox run, we value
-// reproducibility above interactive ease-of-use.
-var leakVarsForRun = map[string]bool{
-	"HOME": true, // Without this, HOME is set to /homeless-shelter and most programs fail.
-
-	// Where to write temporary files. nix print-dev-env sets these to an unwriteable path,
-	// so we override that here with whatever the host has set.
-	"TMP":     true,
-	"TEMP":    true,
-	"TMPDIR":  true,
-	"TEMPDIR": true,
 }


### PR DESCRIPTION
## Summary
Added an `env` field in devbox.json inside shell object since it's related to shell environment.
Right now the env field only supports literal values (e.g., `"key"="value"`) and doesn't process shell commands (e.g., `"key"="$(ls -a)"`). This feature will be added in a future PR.

Also adding the empty `env` field in `devbox init` will be added in future PR.

## How was it tested?
add the `devbox.json` below in an empty directory.
run `devbox shell` from inside shell `echo $FOO` and confirm the env variable's value is set
or 
run `devbox run test`

```json
{
  "packages": [],
  "shell": {
    "env": {
      "FOO": "BAR"
    },
    "init_hook": [],
    "scripts": {
      "test": "echo $FOO"
    }
  },
  "nixpkgs": {
    "commit": "52e3e80afff4b16ccb7c52e9f0f5220552f03d04"
  }
}
```
