### PR TITLE
devbox shell uses computeNixEnv

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -685,6 +685,7 @@ func (d *Devbox) printPackageUpdateMessage(
 }
 
 func (d *Devbox) computeNixEnv() ([]string, error) {
+
 	vaf, err := nix.PrintDevEnv(d.nixShellFilePath(), d.nixFlakesFilePath())
 	if err != nil {
 		return nil, err
@@ -692,13 +693,18 @@ func (d *Devbox) computeNixEnv() ([]string, error) {
 
 	env := map[string]string{}
 	for k, v := range vaf.Variables {
+		// We only care about "exported" because the var and array types seem to only be used by nix-defined
+		// functions that we don't need (like genericBuild). For reference, each type translates to bash as follows:
+		// var: export VAR=VAL
+		// exported: export VAR=VAL
+		// array: declare -a VAR=('VAL1' 'VAL2' )
 		if v.Type == "exported" {
 			env[k] = v.Value.(string)
 		}
 	}
 
 	// Overwrite/leak whitelisted vars into nixEnv:
-	for name, leak := range leakVarsForRun {
+	for name, leak := range leakedVars {
 		if leak {
 			env[name] = os.Getenv(name)
 		}
@@ -860,16 +866,12 @@ func commandExists(command string) bool {
 	return err == nil
 }
 
-// leakVarsForRun contains a list of variables that, if set in the host, will be copied
-// to the environment of devbox run. If they're NOT set in the host, they will be set
-// to an empty value for devbox run. NOTE: we want to keep this list AS SMALL AS POSSIBLE.
-// The longer this list, the less "pure" devbox run becomes.
-//
-// In particular, this list should be much smaller than that of devbox shell, since we
-// do want to allow more parts of the host environment to leak into a shell session, so
-// that the shell session is easy to use for our users. However, in devbox run, we value
-// reproducibility above interactive ease-of-use.
-var leakVarsForRun = map[string]bool{
+// leakedVars contains a list of variables that, if set in the host, will be copied
+// to the environment of devbox run/shell. If they're NOT set in the host, they will be set
+// to an empty value.
+// NOTE: we want to keep this list AS SMALL AS POSSIBLE. The longer this list, the less "pure"
+// (and therefore, reproducible) devbox becomes.
+var leakedVars = map[string]bool{
 	"HOME": true, // Without this, HOME is set to /homeless-shelter and most programs fail.
 
 	// Where to write temporary files. nix print-dev-env sets these to an unwriteable path,

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -237,6 +237,13 @@ func (d *Devbox) Shell() error {
 		return err
 	}
 
+	if featureflag.NixlessShell.Enabled() {
+		env, err = d.computeNixEnv()
+		if err != nil {
+			return err
+		}
+	}
+
 	shellStartTime := os.Getenv("DEVBOX_SHELL_START_TIME")
 	if shellStartTime == "" {
 		shellStartTime = telemetry.UnixTimestampFromTime(telemetry.CommandStartTime())

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -214,12 +214,7 @@ func (s *Shell) Run(nixShellFilePath, nixFlakesFilePath string) error {
 
 	var cmd *exec.Cmd
 	if featureflag.NixlessShell.Enabled() {
-		// Get the required env vars from nix, and then spawn a shell directly.
-		vars, err := s.computeNixShellEnv(nixShellFilePath, nixFlakesFilePath)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-		shellrc, err := s.writeDevboxShellrc(vars)
+		shellrc, err := s.writeDevboxShellrc()
 		if err != nil {
 			// We don't have a good fallback here, since all the variables we need for anything to work
 			// are in the shellrc file. For now let's fail. Later on, we should remove the vars from the
@@ -233,7 +228,7 @@ func (s *Shell) Run(nixShellFilePath, nixFlakesFilePath string) error {
 		extraEnv, extraArgs := s.shellRCOverrides(shellrc)
 
 		cmd = exec.Command(s.binPath)
-		cmd.Env = append(filterVars(env, buildAllowList(s.env)), extraEnv...)
+		cmd.Env = append(filterVars(s.env, buildAllowList(s.env)), extraEnv...)
 		cmd.Args = append(cmd.Args, extraArgs...)
 		debug.Log("Executing shell %s with args: %v", s.binPath, cmd.Args)
 	} else {
@@ -328,7 +323,7 @@ func (s *Shell) execCommand() string {
 
 	// Create a devbox shellrc file that runs the user's shellrc + the shell
 	// hook in devbox.json.
-	shellrc, err := s.writeDevboxShellrc(map[string]string{})
+	shellrc, err := s.writeDevboxShellrc()
 	if err != nil {
 		// Fall back to just launching the shell without a custom
 		// shellrc.
@@ -392,7 +387,7 @@ func (s *Shell) execCommandInShell() (string, string, string) {
 	return s.binPath, strings.Join(args, " "), s.ScriptCommand
 }
 
-func (s *Shell) writeDevboxShellrc(vars map[string]string) (path string, err error) {
+func (s *Shell) writeDevboxShellrc() (path string, err error) {
 	if s.userShellrcPath == "" {
 		// If this happens, then there's a bug with how we detect shells
 		// and their shellrc paths. If the shell is unknown or we can't
@@ -461,7 +456,7 @@ func (s *Shell) writeDevboxShellrc(vars map[string]string) (path string, err err
 		ScriptCommand    string
 		ShellStartTime   string
 		HistoryFile      string
-		NixEnv           map[string]string
+		RunNixShellHook  bool
 	}{
 		ProjectDir:       s.projectDir,
 		EnvToKeep:        envToKeepFlakes,
@@ -473,7 +468,7 @@ func (s *Shell) writeDevboxShellrc(vars map[string]string) (path string, err err
 		ScriptCommand:    strings.TrimSpace(s.ScriptCommand),
 		ShellStartTime:   s.shellStartTime,
 		HistoryFile:      strings.TrimSpace(s.historyFile),
-		NixEnv:           vars,
+		RunNixShellHook:  featureflag.NixlessShell.Enabled(),
 	})
 	if err != nil {
 		return "", fmt.Errorf("execute shellrc template: %v", err)

--- a/internal/nix/shell_test.go
+++ b/internal/nix/shell_test.go
@@ -55,7 +55,7 @@ func TestWriteDevboxShellrc(t *testing.T) {
 				pluginInitHook:  `echo "Welcome to the devbox!"`,
 				profileDir:      "./.devbox/profile",
 			}
-			gotPath, err := s.writeDevboxShellrc(map[string]string{})
+			gotPath, err := s.writeDevboxShellrc()
 			if err != nil {
 				t.Fatal("Got writeDevboxShellrc error:", err)
 			}

--- a/internal/nix/shellrc.tmpl
+++ b/internal/nix/shellrc.tmpl
@@ -16,13 +16,14 @@ content readable.
 
 */ -}}
 
-{{- range $name, $value := .NixEnv -}}
-export {{ $name }}={{ $value }}
+{{- range .NixEnv -}}
+export {{ . }}
 {{ end -}}
 
-{{- if .NixEnv }}
+{{- if .RunNixShellHook -}}
 # Run the shell hook defined in shell.nix.
 eval $shellHook
+
 {{ end -}}
 
 {{- if .OriginalInit -}}

--- a/internal/nix/shellrc.tmpl
+++ b/internal/nix/shellrc.tmpl
@@ -16,10 +16,6 @@ content readable.
 
 */ -}}
 
-{{- range .NixEnv -}}
-export {{ . }}
-{{ end -}}
-
 {{- if .RunNixShellHook -}}
 # Run the shell hook defined in shell.nix.
 eval $shellHook


### PR DESCRIPTION
## Summary

This makes devbox shell (with "nixless shell" feature enabled) reuse the `computeNixEnv` function that devbox run uses (with strict run feature enabled).

Next I will rename and unify the feature flags so we just have 1 to control both behaviors, and also better separate the implementation of `shell`, which is a bit complex atm. But this should help unblock @mohsenari in his work to add env vars.

## How was it tested?
Ran `devbox shell` with/without "nixless shell" enabled and check environment vars looked as expected.