### PR TITLE
[github merge queue] enable Github Workflows for merge-queue

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -10,6 +10,9 @@ on:
   push:
     branches:
       - main
+  merge_group:
+    branches:
+      - main
   workflow_call:
     inputs:
       run-mac-tests:

--- a/.github/workflows/docs-deploy-prod.yaml
+++ b/.github/workflows/docs-deploy-prod.yaml
@@ -8,6 +8,9 @@ on:
   push:
     branches:
       - main
+  merge_group:
+    branches:
+      - main
 
 env:
   JETPACK_SECRET_KEY: ${{ secrets.JETPACK_SECRET_KEY }}


### PR DESCRIPTION
## Summary

Github Workflows for the merge-queue need to be explicitly opted-in.
I inspected the existing workflows which were opted in for `push` events on `main` branch,
and enabled those for `merge_queue` events as well.

Relevant help article:
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

## How was it tested?

haven't tested
