### PR TITLE
[devbox.json] Added env in config

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -28,7 +28,7 @@ type Devbox interface {
 	Generate() error
 	GenerateDevcontainer(force bool) error
 	GenerateDockerfile(force bool) error
-	GenerateEnvrc(force bool) error
+	GenerateEnvrc(force bool, source string) error
 	Info(pkg string, markdown bool) error
 	ListScripts() []string
 	PluginEnv() (string, error)

--- a/internal/boxcli/featureflag/env_config.go
+++ b/internal/boxcli/featureflag/env_config.go
@@ -1,0 +1,4 @@
+package featureflag
+
+// EnvConfig allows declaring env variables in Config(devbox.json)
+var EnvConfig = disabled("ENV_CONFIG")

--- a/internal/boxcli/generate.go
+++ b/internal/boxcli/generate.go
@@ -114,7 +114,7 @@ func runGenerateCmd(cmd *cobra.Command, args []string, flags *generateCmdFlags) 
 	case "dockerfile":
 		return box.GenerateDockerfile(flags.force)
 	case "direnv":
-		return box.GenerateEnvrc(flags.force)
+		return box.GenerateEnvrc(flags.force, "generate")
 	}
 	return nil
 }

--- a/internal/boxcli/init.go
+++ b/internal/boxcli/init.go
@@ -34,7 +34,7 @@ func runInitCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	err = box.GenerateEnvrc(false)
+	err = box.GenerateEnvrc(false, "init")
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/internal/impl/config.go
+++ b/internal/impl/config.go
@@ -29,6 +29,7 @@ type Config struct {
 
 	// Shell configures the devbox shell environment.
 	Shell struct {
+		Env map[string]string `json:"env,omitempty"`
 		// InitHook contains commands that will run at shell startup.
 		InitHook shellcmd.Commands             `json:"init_hook,omitempty"`
 		Scripts  map[string]*shellcmd.Commands `json:"scripts,omitempty"`

--- a/internal/impl/config.go
+++ b/internal/impl/config.go
@@ -27,9 +27,10 @@ type Config struct {
 	// It's differentiated from Packages() which also includes global packages.
 	RawPackages []string `cue:"[...string]" json:"packages"`
 
+	// Env allows specifying env variables
+	Env map[string]string `json:"env,omitempty"`
 	// Shell configures the devbox shell environment.
 	Shell struct {
-		Env map[string]string `json:"env,omitempty"`
 		// InitHook contains commands that will run at shell startup.
 		InitHook shellcmd.Commands             `json:"init_hook,omitempty"`
 		Scripts  map[string]*shellcmd.Commands `json:"scripts,omitempty"`

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -254,14 +254,6 @@ func (d *Devbox) Shell() error {
 		if err != nil {
 			return err
 		}
-	} else if featureflag.EnvConfig.Enabled() {
-		// TODO: this else-if can be removed when UnifiedEnv featureflag is
-		// removed. Since this logic already exists in computeNixEnv()
-
-		// Add env variables from config
-		for k, v := range d.configEnvs(env) {
-			env[k] = v
-		}
 	}
 
 	shellStartTime := os.Getenv("DEVBOX_SHELL_START_TIME")

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -249,6 +249,8 @@ func (d *Devbox) Shell() error {
 		if err != nil {
 			return err
 		}
+	} else {
+		env = append(env, d.getConfigEnvs(env)...)
 	}
 
 	shellStartTime := os.Getenv("DEVBOX_SHELL_START_TIME")
@@ -746,6 +748,13 @@ func (d *Devbox) computeNixEnv() (map[string]string, error) {
 	hostPath := nix.CleanEnvPath(os.Getenv("PATH"), os.Getenv("NIX_PROFILES"))
 
 	env["PATH"] = fmt.Sprintf("%s:%s:%s:%s", pluginVirtenvPath, nixProfilePath, nixPath, hostPath)
+
+	if featureflag.EnvConfig.Enabled() {
+		// Include env variables in config
+		for key, value := range d.cfg.Shell.Env {
+			env[key] = value
+		}
+	}
 
 	return env, nil
 }

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -888,6 +888,12 @@ func (d *Devbox) pluginVirtenvPath() string {
 	return filepath.Join(d.projectDir, plugin.VirtenvBinPath)
 }
 
+// Takes the computed env variables (nix + plugin) and adds env
+// variables defined in Config. It also parses variables in config
+// that are referenced by $VAR or ${VAR} and replaces them with
+// their value in the computed env variables. Note, this doesn't
+// allow env variables from outside the shell to be referenced so
+// no leaked variables are caused by this function.
 func (d *Devbox) getConfigEnvs(computedEnv []string) []string {
 	// convert key=value strings to map of {key: value}
 	computedEnvMap := map[string]string{}
@@ -909,7 +915,7 @@ func (d *Devbox) getConfigEnvs(computedEnv []string) []string {
 	}
 	var configEnvs []string
 	// Include env variables in config
-	for key, value := range d.cfg.Shell.Env {
+	for key, value := range d.cfg.Env {
 		// parse values for "$VAR" or "${VAR}"
 		parsedValue := os.Expand(value, mapperfunc)
 		configEnvs = append(configEnvs, fmt.Sprintf("%s=%s", key, parsedValue))


### PR DESCRIPTION
## Summary
Added ability to add env variables in devbox.json
Current implementation only supports literal string values as well as `$PATH` and `$PWD` variables.

## How was it tested?
1. Create a devbox.json similar to below:
```json
"shell": {
    "env": {
      "my_wd": "$PWD/test",
      "my_path": "$PATH:my_stuff/bin",
      "my_key": "string value"
    },
```
2. Run `DEVBOX_FEATURE_NIXLESS_SHELL=1 DEVBOX_FEATURE_ENV_CONFIG=1 ./devbox shell`

3. Inside devbox shell `echo $my_wd`, `echo $my_path` and `echo $my_key` and confirm values are correctly setup.