### PR TITLE
[flakes] reset nix profile directory when Flakes feature is toggled

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -590,25 +590,6 @@ func (d *Devbox) generateShellFiles() error {
 	return generateForShell(d.projectDir, plan, d.pluginManager)
 }
 
-// TODO savil. move to packages.go
-func (d *Devbox) profileDir() (string, error) {
-	absPath := filepath.Join(d.projectDir, nix.ProfilePath)
-	if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
-		return "", errors.WithStack(err)
-	}
-
-	return absPath, nil
-}
-
-// TODO savil. move to packages.go
-func (d *Devbox) profileBinDir() (string, error) {
-	profileDir, err := d.profileDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(profileDir, "bin"), nil
-}
-
 // installMode is an enum for helping with ensurePackagesAreInstalled implementation
 type installMode string
 

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -20,7 +20,6 @@ import (
 func (d *Devbox) profileDir() (string, error) {
 	absPath := filepath.Join(d.projectDir, nix.ProfilePath)
 
-	// Ensure the directory is cleared of old state if the Flakes feature has been turned on (or off)
 	if err := resetProfileDirForFlakes(absPath); err != nil {
 		debug.Log("ERROR: resetProfileDirForFlakes error: %v\n", err)
 	}
@@ -223,6 +222,8 @@ func (d *Devbox) pendingPackagesForInstallation() ([]string, error) {
 
 var resetCheckDone = false
 
+// resetProfileDirForFlakes ensures the profileDir directory is cleared of old
+// state if the Flakes feature has been changed, from the previous execution of a devbox command.
 func resetProfileDirForFlakes(profileDir string) (err error) {
 	if resetCheckDone {
 		return nil

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -2,16 +2,40 @@ package impl
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
+	"go.jetpack.io/devbox/internal/fileutil"
 	"go.jetpack.io/devbox/internal/nix"
 )
 
 // packages.go has functions for adding, removing and getting info about nix packages
+
+func (d *Devbox) profileDir() (string, error) {
+	absPath := filepath.Join(d.projectDir, nix.ProfilePath)
+
+	// Ensure the directory is cleared of old state if the Flakes feature has been turned on (or off)
+	_ = resetProfileDirForFlakes(absPath)
+
+	if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	return absPath, nil
+}
+
+func (d *Devbox) profileBinDir() (string, error) {
+	profileDir, err := d.profileDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(profileDir, "bin"), nil
+}
 
 // addPackagesToProfile inspects the packages in devbox.json, checks which of them
 // are missing from the nix profile, and then installs each package individually into the
@@ -192,4 +216,37 @@ func (d *Devbox) pendingPackagesForInstallation() ([]string, error) {
 		}
 	}
 	return pending, nil
+}
+
+var resetCheckDone = false
+
+func resetProfileDirForFlakes(profileDir string) (err error) {
+	if resetCheckDone {
+		return nil
+	}
+	defer func() {
+		if err == nil {
+			resetCheckDone = true
+		}
+	}()
+
+	dir, err := filepath.EvalSymlinks(profileDir)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	needsReset := false
+	if featureflag.Flakes.Enabled() {
+		// older nix profiles have a manifest.nix file present
+		needsReset = fileutil.Exists(filepath.Join(dir, "manifest.nix"))
+	} else {
+		// newer flake nix profiles have a manifest.json file present
+		needsReset = fileutil.Exists(filepath.Join(dir, "manifest.json"))
+	}
+
+	if !needsReset {
+		return nil
+	}
+
+	return errors.WithStack(os.Remove(profileDir))
 }

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
+	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/fileutil"
 	"go.jetpack.io/devbox/internal/nix"
 )
@@ -20,7 +21,9 @@ func (d *Devbox) profileDir() (string, error) {
 	absPath := filepath.Join(d.projectDir, nix.ProfilePath)
 
 	// Ensure the directory is cleared of old state if the Flakes feature has been turned on (or off)
-	_ = resetProfileDirForFlakes(absPath)
+	if err := resetProfileDirForFlakes(absPath); err != nil {
+		debug.Log("ERROR: resetProfileDirForFlakes error: %v\n", err)
+	}
 
 	if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
 		return "", errors.WithStack(err)

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -19,7 +19,8 @@ import (
 )
 
 // ProfilePath contains the contents of the profile generated via `nix-env --profile ProfilePath <command>`
-// Instead of using directory, prefer using the devbox.ProfilePath() function that ensures the directory exists.
+// or `nix profile install --profile ProfilePath <package...>`
+// Instead of using directory, prefer using the devbox.ProfileDir() function that ensures the directory exists.
 const ProfilePath = ".devbox/nix/profile/default"
 
 var ErrPackageNotFound = errors.New("package not found")


### PR DESCRIPTION
## Summary

If a nix-profile-directory was created for an old `nix-env` profile, then when
trying to use the new flake-y `nix profile` with the same directory, an error is 
reported.

This PR enables us to toggle `DEVBOX_FEATURE_FLAKES=` on and off for the same
devbox-projects by inspecting the contents of the profile:
1. a `manifest.nix` means that its an old style profile
2. a `manifest.json` means that its a new style profile (i.e. to be used with flakes feature)

The code will "reset" i.e. delete the directory and re-create it.

## How was it tested?

inserted a print statement prior to `os.Remove(dir)` in the reset function
```
> DEVBOX_FEATURE_FLAKES=0 devbox shell

> DEVBOX_FEATURE_FLAKES=1 devbox shell
reset = true

> DEVBOX_FEATURE_FLAKES=0 devbox shell
reset = true
```

Observe:
1. no error, we can toggle seamlessly
2. only one `reset = true` printed despite multiple calls to `devbox.profileDir()`
