### PR TITLE
Add a default stale issue workflow

### DIFF
--- a/.github/workflows/stale-issue-cleanup.yml
+++ b/.github/workflows/stale-issue-cleanup.yml
@@ -10,8 +10,9 @@ jobs:
     steps:
       - uses: actions/stale@v7
         with:
-          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
-          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove the `stale` label or add a comment, otherwise this issue will be closed in 5 days.'
+          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove the `stale` label or add a comment, otherwise this PR will be closed in 5 days.'
+          exempt-issue-labels: 'future'
           exempt-pr-labels: 'awaiting-approval, work-in-progress'
           days-before-stale: 30
           days-before-close: 5

--- a/.github/workflows/stale-issue-cleanup.yml
+++ b/.github/workflows/stale-issue-cleanup.yml
@@ -1,0 +1,18 @@
+name: 'Close stale issues and PRs'
+# Marks issues and PRs as stale after 30 days, then closes them if marked stale for 5 days
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v7
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          exempt-pr-labels: 'awaiting-approval, work-in-progress'
+          days-before-stale: 30
+          days-before-close: 5
+          debug-only: true


### PR DESCRIPTION
## Summary

Adds a stale issue workflow that will close issues and PRs after 30 days of inactivity. 

This will exempt issues and prs with certain labels, so long drafts or issues that are marked for the future can be preserved

## How was it tested?

Untested, but marking this `debug-only` so we can try it as a dry run
