### PR TITLE
[flakes] remove special-case env-var TERM

### DIFF
--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -406,20 +406,8 @@ func (s *Shell) writeDevboxShellrc() (path string, err error) {
 		pathPrepend = s.pkgConfigDir + ":" + pathPrepend
 	}
 
-	envToKeepFlakes := map[string]string{}
-	// TODO savil: 80% confidence this can be removed
-	if featureflag.Flakes.Enabled() {
-		// `nix develop` has a list of ignoreVars, which we may want to not-ignore.
-		// For now, including just TERM since it affects shell cursor movement UX.
-		// https://github.com/NixOS/nix/blob/master/src/nix/develop.cc#L241-L259
-		envToKeepFlakes = map[string]string{
-			"TERM": os.Getenv("TERM"),
-		}
-	}
-
 	err = shellrcTmpl.Execute(shellrcf, struct {
 		ProjectDir       string
-		EnvToKeep        map[string]string
 		OriginalInit     string
 		OriginalInitPath string
 		UserHook         string
@@ -431,7 +419,6 @@ func (s *Shell) writeDevboxShellrc() (path string, err error) {
 		RunNixShellHook  bool
 	}{
 		ProjectDir:       s.projectDir,
-		EnvToKeep:        envToKeepFlakes,
 		OriginalInit:     string(bytes.TrimSpace(userShellrc)),
 		OriginalInitPath: filepath.Clean(s.userShellrcPath),
 		UserHook:         strings.TrimSpace(s.UserInitHook),

--- a/internal/nix/shellrc.tmpl
+++ b/internal/nix/shellrc.tmpl
@@ -17,7 +17,7 @@ content readable.
 */ -}}
 
 {{- if .RunNixShellHook -}}
-# Run the shell hook defined in shell.nix.
+# Run the shell hook defined in shell.nix or flake.nix
 eval $shellHook
 
 {{ end -}}
@@ -38,11 +38,6 @@ PATH="{{ .PathPrepend }}:$PATH"
 {{- if .HistoryFile }}
 HISTFILE={{.HistoryFile}}
 {{- end }}
-
-# Export env-vars which nix may remove by default, but are needed for shell UX
-{{ range $name, $value := .EnvToKeep }}
-export {{ $name }}={{ $value }}
-{{ end }}
 
 # Prepend to the prompt to make it clear we're in a devbox shell.
 export PS1="(devbox) $PS1"

--- a/internal/nix/testdata/shellrc/basic/shellrc.golden
+++ b/internal/nix/testdata/shellrc/basic/shellrc.golden
@@ -44,9 +44,6 @@ zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
 
 PATH="./.devbox/profile/bin:$PATH"
 
-# Export env-vars which nix may remove by default, but are needed for shell UX
-
-
 # Prepend to the prompt to make it clear we're in a devbox shell.
 export PS1="(devbox) $PS1"
 

--- a/internal/nix/testdata/shellrc/nohook/shellrc.golden
+++ b/internal/nix/testdata/shellrc/nohook/shellrc.golden
@@ -44,9 +44,6 @@ zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
 
 PATH="./.devbox/profile/bin:$PATH"
 
-# Export env-vars which nix may remove by default, but are needed for shell UX
-
-
 # Prepend to the prompt to make it clear we're in a devbox shell.
 export PS1="(devbox) $PS1"
 

--- a/internal/nix/testdata/shellrc/noshellrc/shellrc.golden
+++ b/internal/nix/testdata/shellrc/noshellrc/shellrc.golden
@@ -2,9 +2,6 @@
 
 PATH="./.devbox/profile/bin:$PATH"
 
-# Export env-vars which nix may remove by default, but are needed for shell UX
-
-
 # Prepend to the prompt to make it clear we're in a devbox shell.
 export PS1="(devbox) $PS1"
 


### PR DESCRIPTION
## Summary

This is being included by print-dev-env work, so no need to special case now.

## How was it tested?

```
> DEVBOX_FEATURE_FLAKES=1 devbox shell
(devbox)> env | grep TERM
TERM=xterm-256color
```
