### PR TITLE
[flake] remove buildEnv from flake.nix

### DIFF
--- a/internal/impl/tmpl/flake.nix.tmpl
+++ b/internal/impl/tmpl/flake.nix.tmpl
@@ -12,17 +12,6 @@
         let pkgs = nixpkgs.legacyPackages.${system};
 
         in {
-            # defaultPackage is used by the `nix profile --install`
-            defaultPackage = pkgs.buildEnv {
-                ignoreCollisions = true;
-                name="devbox-shell-env";
-                paths = [
-                  {{- range .DevPackages}}
-                    pkgs.{{.}}
-                  {{end -}}
-                ];
-                pathsToLink = [ "/bin" "/share" "/lib" ];
-            };
             devShell = pkgs.mkShell {
               shellHook =
                 ''


### PR DESCRIPTION
## Summary

Now that we are installing packages individually in `nix profile`, we no longer
need the `buildEnv` that is specified in the `flake.nix`.

## How was it tested?

Using `DEVBOX_FEATURE_FLAKES=1 DEVBOX_FEATURE_NIXLESS_SHELL=1`:

```
> devbox shell
(devbox) > devbox add vim emacs
(devbox) > which vim
# verify path in /nix/store not /usr/local/bin

(devbox) > devbox rm vim
(devbox) > which vim
# verify path in /usr/local/bin and not /nix/store 
```

