### PR TITLE
Add virtenv path and nix profile path to computed nix path

### DIFF
--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -67,7 +67,7 @@ func (d *Devbox) addPackagesToProfile(mode installMode) error {
 	}
 	color.New(color.FgGreen).Fprintf(d.writer, msg)
 
-	profileDir, err := d.profileDir()
+	profileDir, err := d.profilePath()
 	if err != nil {
 		return err
 	}
@@ -143,7 +143,7 @@ func (d *Devbox) removePackagesFromProfile(pkgs []string) error {
 		return nil
 	}
 
-	profileDir, err := d.profileDir()
+	profileDir, err := d.profilePath()
 	if err != nil {
 		return err
 	}
@@ -192,7 +192,7 @@ func (d *Devbox) pendingPackagesForInstallation() ([]string, error) {
 		return nil, errors.New("Not implemented for legacy non-flakes devbox")
 	}
 
-	profileDir, err := d.profileDir()
+	profileDir, err := d.profilePath()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -17,7 +17,7 @@ import (
 
 // packages.go has functions for adding, removing and getting info about nix packages
 
-func (d *Devbox) profileDir() (string, error) {
+func (d *Devbox) profilePath() (string, error) {
 	absPath := filepath.Join(d.projectDir, nix.ProfilePath)
 
 	if err := resetProfileDirForFlakes(absPath); err != nil {
@@ -31,8 +31,8 @@ func (d *Devbox) profileDir() (string, error) {
 	return absPath, nil
 }
 
-func (d *Devbox) profileBinDir() (string, error) {
-	profileDir, err := d.profileDir()
+func (d *Devbox) profileBinPath() (string, error) {
+	profileDir, err := d.profilePath()
 	if err != nil {
 		return "", err
 	}

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -400,10 +400,12 @@ func (s *Shell) writeDevboxShellrc() (path string, err error) {
 		}
 	}()
 
-	// TODO: probably need to change this.
-	pathPrepend := s.profileDir + "/bin"
-	if s.pkgConfigDir != "" {
-		pathPrepend = s.pkgConfigDir + ":" + pathPrepend
+	pathPrepend := ""
+	if featureflag.NixlessShell.Disabled() {
+		pathPrepend = s.profileDir + "/bin"
+		if s.pkgConfigDir != "" {
+			pathPrepend = s.pkgConfigDir + ":" + pathPrepend
+		}
 	}
 
 	err = shellrcTmpl.Execute(shellrcf, struct {

--- a/internal/nix/shellrc.tmpl
+++ b/internal/nix/shellrc.tmpl
@@ -33,7 +33,7 @@ eval $shellHook
 
 # Begin Devbox Post-init Hook
 
-{{- if .PathPrepend }}
+{{ if .PathPrepend -}}
 PATH="{{ .PathPrepend }}:$PATH"
 {{- end }}
 

--- a/internal/nix/shellrc.tmpl
+++ b/internal/nix/shellrc.tmpl
@@ -33,7 +33,9 @@ eval $shellHook
 
 # Begin Devbox Post-init Hook
 
+{{- if .PathPrepend }}
 PATH="{{ .PathPrepend }}:$PATH"
+{{- end }}
 
 {{- if .HistoryFile }}
 HISTFILE={{.HistoryFile}}


### PR DESCRIPTION
## Summary

This brings the `computeNixEnv` PATH handling to (almost) parity with `devbox shell`. I might remove the virtenv path after confirming we don't need it.

## How was it tested?
Compared `devbox shell` PATH with the PATH I get in `devbox shell` or `devbox run` when I have `NIXLESS_SHELL` or `STRICT_RUN` enabled, respectively.