### PR TITLE
Remove obsolete var and simplify cleanEnvPath()

### DIFF
--- a/internal/nix/shell_test.go
+++ b/internal/nix/shell_test.go
@@ -94,31 +94,31 @@ If the new shellrc is correct, you can update the golden file with:
 func TestCleanEnvPath(t *testing.T) {
 	tests := []struct {
 		name        string
-		nixProfiles []string
+		nixProfiles string
 		inPath      string
 		outPath     string
 	}{
 		{
 			name:        "RemoveUserNixProfileDarwin",
-			nixProfiles: []string{"/nix/var/nix/profiles/default", "/Users/test/.nix-profile"},
+			nixProfiles: "/nix/var/nix/profiles/default /Users/test/.nix-profile",
 			inPath:      "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/test/.nix-profile/bin:/nix/var/nix/profiles/default/bin",
 			outPath:     "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/nix/var/nix/profiles/default/bin",
 		},
 		{
 			name:        "RemoveUserNixProfileLinux",
-			nixProfiles: []string{"/nix/var/nix/profiles/default", "/home/test/.nix-profile"},
+			nixProfiles: "nix/var/nix/profiles/default /home/test/.nix-profile",
 			inPath:      "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/home/test/.nix-profile/bin:/nix/var/nix/profiles/default/bin",
 			outPath:     "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/nix/var/nix/profiles/default/bin",
 		},
 		{
 			name:        "NoNixProfiles",
-			nixProfiles: []string{},
+			nixProfiles: "",
 			inPath:      "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/home/test/.nix-profile/bin:/nix/var/nix/profiles/default/bin",
 			outPath:     "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/home/test/.nix-profile/bin:/nix/var/nix/profiles/default/bin",
 		},
 		{
 			name:        "NoRelativePaths",
-			nixProfiles: []string{},
+			nixProfiles: "",
 			inPath:      "/usr/local/bin:/usr/bin:../test:/bin:/usr/sbin:/sbin:.:..",
 			outPath:     "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
 		},


### PR DESCRIPTION
## Summary

Removes obsolete setting of `NIX_PROFILES` var, which allows us to move the splitting of nix profiles paths inside the `cleanEnvPath` function (which I then plan to reuse elsewhere).

This change is a no-op.

## How was it tested?
Verified that `NIX_PROFILES` wasn't even making it through to `devbox shell`