### PR TITLE
Clean PATH of nix profile paths in print-dev-env shell/run

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -729,7 +729,7 @@ func (d *Devbox) computeNixEnv() ([]string, error) {
 		return nil, err
 	}
 	nixPath := env["PATH"]
-	hostPath := os.Getenv("PATH") // TODO: clean the nix paths, after confirming we actually need to do so.
+	hostPath := nix.CleanEnvPath(os.Getenv("PATH"), os.Getenv("NIX_PROFILES"))
 
 	env["PATH"] = fmt.Sprintf("%s:%s:%s:%s", pluginVirtenvPath, nixProfilePath, nixPath, hostPath)
 

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -173,7 +173,7 @@ func rcfilePath(basename string) string {
 func (s *Shell) Run(nixShellFilePath, nixFlakesFilePath string) error {
 	// Copy the current PATH into nix-shell, but clean and remove some
 	// directories that are incompatible.
-	parentPath := cleanEnvPath(os.Getenv("PATH"), os.Getenv("NIX_PROFILES"))
+	parentPath := CleanEnvPath(os.Getenv("PATH"), os.Getenv("NIX_PROFILES"))
 
 	env := append(s.env, os.Environ()...)
 	env = append(
@@ -572,14 +572,14 @@ func splitNixList(s string) []string {
 	return split
 }
 
-// cleanEnvPath takes a string formatted as a shell PATH and cleans it for
+// CleanEnvPath takes a string formatted as a shell PATH and cleans it for
 // passing to nix-shell. It does the following rules for each entry:
 //
 //  1. Applies filepath.Clean.
 //  2. Removes the path if it's relative (must begin with '/' and not be '.').
 //  3. Removes the path if it's a descendant of a user Nix profile directory
 //     (the default Nix profile is kept).
-func cleanEnvPath(pathEnv string, nixProfilesEnv string) string {
+func CleanEnvPath(pathEnv string, nixProfilesEnv string) string {
 	// Just to be safe, we need to guarantee that the NIX_PROFILES paths
 	// have been filepath.Clean'ed. The shellrc.tmpl has some commands that
 	// assume they are.

--- a/internal/nix/shell_test.go
+++ b/internal/nix/shell_test.go
@@ -125,7 +125,7 @@ func TestCleanEnvPath(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := cleanEnvPath(test.inPath, test.nixProfiles)
+			got := CleanEnvPath(test.inPath, test.nixProfiles)
 			if got != test.outPath {
 				t.Errorf("Got incorrect cleaned PATH.\ngot:  %s\nwant: %s", got, test.outPath)
 			}

--- a/internal/nix/shell_test.go
+++ b/internal/nix/shell_test.go
@@ -94,31 +94,31 @@ If the new shellrc is correct, you can update the golden file with:
 func TestCleanEnvPath(t *testing.T) {
 	tests := []struct {
 		name        string
-		nixProfiles []string
+		nixProfiles string
 		inPath      string
 		outPath     string
 	}{
 		{
 			name:        "RemoveUserNixProfileDarwin",
-			nixProfiles: []string{"/nix/var/nix/profiles/default", "/Users/test/.nix-profile"},
+			nixProfiles: "/nix/var/nix/profiles/default /Users/test/.nix-profile",
 			inPath:      "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/test/.nix-profile/bin:/nix/var/nix/profiles/default/bin",
 			outPath:     "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/nix/var/nix/profiles/default/bin",
 		},
 		{
 			name:        "RemoveUserNixProfileLinux",
-			nixProfiles: []string{"/nix/var/nix/profiles/default", "/home/test/.nix-profile"},
+			nixProfiles: "nix/var/nix/profiles/default /home/test/.nix-profile",
 			inPath:      "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/home/test/.nix-profile/bin:/nix/var/nix/profiles/default/bin",
 			outPath:     "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/nix/var/nix/profiles/default/bin",
 		},
 		{
 			name:        "NoNixProfiles",
-			nixProfiles: []string{},
+			nixProfiles: "",
 			inPath:      "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/home/test/.nix-profile/bin:/nix/var/nix/profiles/default/bin",
 			outPath:     "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/home/test/.nix-profile/bin:/nix/var/nix/profiles/default/bin",
 		},
 		{
 			name:        "NoRelativePaths",
-			nixProfiles: []string{},
+			nixProfiles: "",
 			inPath:      "/usr/local/bin:/usr/bin:../test:/bin:/usr/sbin:/sbin:.:..",
 			outPath:     "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
 		},


### PR DESCRIPTION
## Summary
TSIA

## How was it tested?
Verified that the following did _NOT_ include the nix profile path to `/Users/<user>/.nix-profile/bin`
```
DEVBOX_FEATURE_STRICT_RUN=1 ./devbox run -- echo '$PATH'
```