### PR TITLE
Add Docsearch

### DIFF
--- a/docs/app/docusaurus.config.js
+++ b/docs/app/docusaurus.config.js
@@ -137,6 +137,13 @@ const config = {
         colorMode: {
             respectPrefersColorScheme: true
         },
+        algolia: {
+            appId: 'J1RTMNIB0R',
+            apiKey: 'b1bcbf465b384ccd6d986e85d6a62c28',
+            indexName: 'jetpack',
+            searchParameters: {},
+
+        },
         prism: {
             theme: lightCodeTheme,
             darkTheme: darkCodeTheme,

--- a/docs/app/src/css/custom.css
+++ b/docs/app/src/css/custom.css
@@ -120,6 +120,17 @@ aside>div {
     }
 }
 
+[data-theme='dark'] .DocSearch {
+    --docsearch-highlight-color: var(--cosmos);
+    --docsearch-searchbox-shadow: inset 0 0 0 2px var(--cosmos);
+    --docsearch-logo-color: var(--moon) !important;
+}
+
+.cls-1,
+.cls-2 {
+    fill: var(--moon) !important;
+}
+
 h1,
 h2,
 h3,


### PR DESCRIPTION
## Summary

Add Algolia Docsearch to our documentation

## How was it tested?

https://devbox-web-john-lago-jetpack-io.cloud.jetpack.dev/devbox/docs/

<img width="1354" alt="Screenshot 2023-02-10 at 1 02 49 PM" src="https://user-images.githubusercontent.com/750845/218197656-01b566ff-8c43-4d46-8812-91a7b0ab157b.png">

(note, the Logo uses the moon color in the actual preview).

