### PR TITLE
Unify print-dev-env feature flags

### DIFF
--- a/internal/boxcli/featureflag/nixless_shell.go
+++ b/internal/boxcli/featureflag/nixless_shell.go
@@ -1,6 +1,0 @@
-package featureflag
-
-// NixlessShell controls the nixless shell feature. When enabled, `devbox shell`
-// creates a shell without relying on `nix-shell`, but by setting the required environment
-// variables and spawning a shell directly.
-var NixlessShell = disabled("NIXLESS_SHELL")

--- a/internal/boxcli/featureflag/strict_run.go
+++ b/internal/boxcli/featureflag/strict_run.go
@@ -1,7 +1,0 @@
-package featureflag
-
-// StrictRun controls the implementation of `devbox run`. When enabled, `devbox run`
-// runs the script in the environment returned by `nix print-dev-env`. This means the
-// environment is much more "strict" or "pure", since it will _not_ include parts of
-// the host's environment like `devbox shell` does.
-var StrictRun = disabled("STRICT_RUN")

--- a/internal/boxcli/featureflag/unified_env.go
+++ b/internal/boxcli/featureflag/unified_env.go
@@ -1,0 +1,10 @@
+package featureflag
+
+// UnifiedEnv controls the implementation of `devbox run` and `devbox shell`.
+// When enabled, these commands are executed by spawning a shell and passing it
+// an environment that was computed primarily based on `nix print-dev-env`. The
+// modifications that we make to the output of `nix print-dev-env` are documented
+// in impl.computeNixEnv().
+// The feature is called UnifiedEnv because we use the exact same environment for
+// both devbox shell and devbox run.
+var UnifiedEnv = disabled("UNIFIED_ENV")

--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -49,7 +49,7 @@ func runScriptCmd(cmd *cobra.Command, args []string, flags runCmdFlags) error {
 		return errors.WithStack(err)
 	}
 
-	if featureflag.StrictRun.Enabled() {
+	if featureflag.UnifiedEnv.Enabled() {
 		err = box.RunScript(script, scriptArgs)
 	} else {
 		if devbox.IsDevboxShellEnabled() {

--- a/internal/boxcli/run_test.go
+++ b/internal/boxcli/run_test.go
@@ -49,7 +49,7 @@ func TestRunCommand(t *testing.T) {
 	defer td.Close()
 	err := td.SetDevboxJSON(devboxJSON)
 	assert.NoError(t, err)
-	err = td.SetEnv("DEVBOX_FEATURE_STRICT_RUN", "1")
+	err = td.SetEnv("DEVBOX_FEATURE_UNIFIED_ENV", "1")
 	assert.NoError(t, err)
 	_, err = td.RunCommand(RunCmd(), "ls > test.txt")
 	assert.NoError(t, err)

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -244,7 +244,7 @@ func (d *Devbox) Shell() error {
 		return err
 	}
 
-	if featureflag.NixlessShell.Enabled() {
+	if featureflag.UnifiedEnv.Enabled() {
 		env, err = d.computeNixEnv()
 		if err != nil {
 			return err
@@ -277,7 +277,7 @@ func (d *Devbox) Shell() error {
 }
 
 func (d *Devbox) RunScript(cmdName string, cmdArgs []string) error {
-	if featureflag.StrictRun.Disabled() {
+	if featureflag.UnifiedEnv.Disabled() {
 		return d.RunScriptInNewNixShell(cmdName)
 	}
 

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -212,7 +212,7 @@ func (s *Shell) Run(nixShellFilePath, nixFlakesFilePath string) error {
 	}
 
 	var cmd *exec.Cmd
-	if featureflag.NixlessShell.Enabled() {
+	if featureflag.UnifiedEnv.Enabled() {
 		shellrc, err := s.writeDevboxShellrc()
 		if err != nil {
 			// We don't have a good fallback here, since all the variables we need for anything to work
@@ -401,7 +401,7 @@ func (s *Shell) writeDevboxShellrc() (path string, err error) {
 	}()
 
 	pathPrepend := ""
-	if featureflag.NixlessShell.Disabled() {
+	if featureflag.UnifiedEnv.Disabled() {
 		pathPrepend = s.profileDir + "/bin"
 		if s.pkgConfigDir != "" {
 			pathPrepend = s.pkgConfigDir + ":" + pathPrepend
@@ -429,7 +429,7 @@ func (s *Shell) writeDevboxShellrc() (path string, err error) {
 		ScriptCommand:    strings.TrimSpace(s.ScriptCommand),
 		ShellStartTime:   s.shellStartTime,
 		HistoryFile:      strings.TrimSpace(s.historyFile),
-		RunNixShellHook:  featureflag.NixlessShell.Enabled(),
+		RunNixShellHook:  featureflag.UnifiedEnv.Enabled(),
 	})
 	if err != nil {
 		return "", fmt.Errorf("execute shellrc template: %v", err)

--- a/testscripts/testrunner/setupenv.go
+++ b/testscripts/testrunner/setupenv.go
@@ -19,7 +19,7 @@ func setupTestEnv(env *testscript.Env) error {
 
 	// Enable new `devbox run` so we can use it in tests. This is temporary,
 	// and should be removed once we enable this feature flag.
-	env.Setenv("DEVBOX_FEATURE_STRICT_RUN", "1")
+	env.Setenv("DEVBOX_FEATURE_UNIFIED_ENV", "1")
 	return nil
 }
 


### PR DESCRIPTION
## Summary
TSIA. Lmk if you have a better name suggestion. I can't seem to be satisfied with any name I pick.

## How was it tested?
```
DEVBOX_FEATURE_UNIFIED_ENV=1 ./devbox run -- echo '$PATH'
```