### PR TITLE
[global] Turn on feature, keep command hidden

### DIFF
--- a/internal/boxcli/featureflag/home.go
+++ b/internal/boxcli/featureflag/home.go
@@ -1,3 +1,0 @@
-package featureflag
-
-var Home = disabled("HOME")

--- a/internal/impl/config.go
+++ b/internal/impl/config.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
-	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/cuecfg"
 	"go.jetpack.io/devbox/internal/debug"
@@ -51,9 +50,6 @@ type Stage struct {
 var commitMismatchWarningShown = false
 
 func (c *Config) Packages(w io.Writer) []string {
-	if featureflag.Home.Disabled() {
-		return c.RawPackages
-	}
 	path, err := GlobalConfigPath()
 	if err != nil {
 		return c.RawPackages


### PR DESCRIPTION
## Summary

Turns feature on. Adds warning if profile/bin path is not in $PATH

## How was it tested?

`devbox global add hello` 

<img width="1082" alt="image" src="https://user-images.githubusercontent.com/544948/218209148-a168ac25-08f3-4e9a-ae36-a98508b062e8.png">

