### PR TITLE
[flakes] enable native nixpkgs download progress output

### DIFF
--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -96,6 +96,7 @@ func (d *Devbox) addPackagesToProfile(mode installMode) error {
 				"--extra-experimental-features", "nix-command flakes",
 				nix.FlakeNixpkgs(d.cfg.Nixpkgs.Commit),
 			)
+			cmd.Stdout = d.writer
 		} else {
 			cmd = exec.Command(
 				"nix", "profile", "install",
@@ -103,10 +104,10 @@ func (d *Devbox) addPackagesToProfile(mode installMode) error {
 				"--extra-experimental-features", "nix-command flakes",
 				nix.FlakeNixpkgs(d.cfg.Nixpkgs.Commit)+"#"+pkg,
 			)
+			cmd.Stdout = &nixPackageInstallWriter{d.writer}
 		}
 
 		cmd.Env = nix.DefaultEnv()
-		cmd.Stdout = &nixPackageInstallWriter{d.writer}
 		cmd.Stderr = cmd.Stdout
 		err = cmd.Run()
 


### PR DESCRIPTION
## Summary

`nix flakes prefetch` has a native progress indicator in its output. However,
it seems that using the `nixPackagesInstallWriter` would result in it not displaying.
Perhaps because of the tab indentation? Not entirely sure.

This PR uses the regular `io.writer` instead of the custom `nixPackagesInstallWriter`
for the nixpkgs prefetch

## How was it tested?

- set a new commit hash in devbox.json
- ran `devbox shell`
observed the progess indicator
