### PR TITLE
[bug fix] update Env caller to use map instead of key=val array

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -431,8 +431,8 @@ func (d *Devbox) PluginEnv() (string, error) {
 		return "", err
 	}
 	script := ""
-	for _, pluginEnv := range pluginEnvs {
-		script += fmt.Sprintf("export %s\n", pluginEnv)
+	for k, v := range pluginEnvs {
+		script += fmt.Sprintf("export %s=%s\n", k, v)
 	}
 	return script, nil
 }

--- a/internal/plugin/pkgcfg.go
+++ b/internal/plugin/pkgcfg.go
@@ -138,13 +138,12 @@ func createEnvFile(pkg, projectDir string) error {
 		return err
 	}
 	env := ""
-	for _, val := range envVars {
-		parts := strings.SplitN(val, "=", 2)
-		escaped, err := cuecfg.MarshalJSON(parts[1])
+	for key, val := range envVars {
+		escaped, err := cuecfg.MarshalJSON(val)
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		env += fmt.Sprintf("export %s=%s\n", parts[0], escaped)
+		env += fmt.Sprintf("export %s=%s\n", key, escaped)
 	}
 	filePath := filepath.Join(projectDir, VirtenvPath, pkg, "/env")
 	if err = createDir(filepath.Dir(filePath)); err != nil {


### PR DESCRIPTION
## Summary

I think this callsite was missed in #621

## How was it tested?

```
> cd devbox/examples/php
> devbox shell
```
previously this would fail with `runtime error: index out of range [1] with length 1`
