### PR TITLE
[direnv] Added featureflag for devbox generate direnv

### DIFF
--- a/internal/boxcli/generate/devcontainer_util.go
+++ b/internal/boxcli/generate/devcontainer_util.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 )
 
 type devcontainerObject struct {
@@ -78,11 +79,17 @@ func CreateEnvrc(tmplFS embed.FS, path string) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
+	// setup values to pass to template
+	tmplData := struct {
+		EnvConfigFlagDisabled bool
+	}{
+		EnvConfigFlagDisabled: featureflag.EnvConfig.Disabled(),
+	}
 	// get .envrc content
 	tmplName := "envrc.tmpl"
 	t := template.Must(template.ParseFS(tmplFS, "tmpl/"+tmplName))
 	// write content into file
-	err = t.Execute(file, nil)
+	err = t.Execute(file, tmplData)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/internal/impl/tmpl/envrc.tmpl
+++ b/internal/impl/tmpl/envrc.tmpl
@@ -5,7 +5,9 @@ use_devbox() {
     watch_file devbox.json
     if [ -f .devbox/gen/shell.nix ]; then
         DEVBOX_SHELL_ENABLED_BACKUP=$DEVBOX_SHELL_ENABLED
+        {{ if .EnvConfigFlagDisabled -}}
         use nix .devbox/gen/shell.nix
+        {{ end -}}
         eval $(devbox shell --print-env)
         export DEVBOX_SHELL_ENABLED=$DEVBOX_SHELL_ENABLED_BACKUP
     fi


### PR DESCRIPTION
## Summary
When print-dev-env and env variables in config features get out of feature flag, `devbox generate direnv` no longer needs to rely on `use nix` function of direnv to calculate the environment variables.
This PR puts the use nix line in generated `.envrc` template file, behind the same feature flag.

## How was it tested?
Compile.
Run `./devbox generate direnv && cat .envrc`
remove or rename `.envrc`
Run `DEVBOX_FEATURE_ENV_CONFIG=1 ./devbox generate direnv && cat .envrc` 
compare the content of 2 `.envrc` files
