### PR TITLE
[flake] php extensions example project

### DIFF
--- a/examples/testdata/php/php-extensions/devbox.d/php81/php-fpm.conf
+++ b/examples/testdata/php/php-extensions/devbox.d/php81/php-fpm.conf
@@ -1,0 +1,17 @@
+[global]
+pid = ${PHPFPM_PID_FILE}
+error_log = ${PHPFPM_ERROR_LOG_FILE}
+daemonize = yes
+
+[www]
+; user = www-data
+; group = www-data
+listen = 127.0.0.1:${PHPFPM_PORT}
+; listen.owner = www-data
+; listen.group = www-data
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+chdir = /

--- a/examples/testdata/php/php-extensions/devbox.json
+++ b/examples/testdata/php/php-extensions/devbox.json
@@ -1,0 +1,13 @@
+{
+  "packages": [
+    "php81",
+    "php81Packages.composer",
+    "php81Extensions.ds"
+  ],
+  "shell": {
+    "init_hook": null
+  },
+  "nixpkgs": {
+    "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
+  }
+}

--- a/examples/testdata/php/php-extensions/index.php
+++ b/examples/testdata/php/php-extensions/index.php
@@ -1,0 +1,15 @@
+<?php
+
+// Check that the extension is loaded.
+if (!extension_loaded('ds')) {
+    echo("ds extension is not enabled\n");
+    exit(1);
+}
+
+$vec = new \Ds\Vector(["hello", "world"]);
+  
+echo("Original vector elements\n");
+foreach ($vec as $idx => $elem) {
+  echo("idx: $idx and elem: $elem\n");
+}
+echo("done\n");


### PR DESCRIPTION
## Summary

Added an example devbox-project that has a php extension package. This has been useful for doing adhoc testing when developing the feature of "flakes with php extensions". In a future PR, I'll add a testscript (and possibly remove this one).

## How was it tested?

```
> devbox shell

# with package `php81Extensions.ds`
> php index.php
Original vector elements
idx: 0 and elem: hello
idx: 1 and elem: world
done

# without package `php81Extensions.ds` 
> php index.php
ds extension is not enabled
```