### PR TITLE
Set PATH prepend after user init file runs

### DIFF
--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -396,12 +396,9 @@ func (s *Shell) writeDevboxShellrc() (path string, err error) {
 		}
 	}()
 
-	pathPrepend := ""
-	if featureflag.UnifiedEnv.Disabled() {
-		pathPrepend = s.profileDir + "/bin"
-		if s.pkgConfigDir != "" {
-			pathPrepend = s.pkgConfigDir + ":" + pathPrepend
-		}
+	pathPrepend := s.profileDir + "/bin"
+	if s.pkgConfigDir != "" {
+		pathPrepend = s.pkgConfigDir + ":" + pathPrepend
 	}
 
 	err = shellrcTmpl.Execute(shellrcf, struct {
@@ -414,7 +411,7 @@ func (s *Shell) writeDevboxShellrc() (path string, err error) {
 		ScriptCommand    string
 		ShellStartTime   string
 		HistoryFile      string
-		RunNixShellHook  bool
+		UnifiedEnv       bool
 	}{
 		ProjectDir:       s.projectDir,
 		OriginalInit:     string(bytes.TrimSpace(userShellrc)),
@@ -425,7 +422,7 @@ func (s *Shell) writeDevboxShellrc() (path string, err error) {
 		ScriptCommand:    strings.TrimSpace(s.ScriptCommand),
 		ShellStartTime:   s.shellStartTime,
 		HistoryFile:      strings.TrimSpace(s.historyFile),
-		RunNixShellHook:  featureflag.UnifiedEnv.Enabled(),
+		UnifiedEnv:       featureflag.UnifiedEnv.Enabled(),
 	})
 	if err != nil {
 		return "", fmt.Errorf("execute shellrc template: %v", err)

--- a/internal/nix/shellrc.tmpl
+++ b/internal/nix/shellrc.tmpl
@@ -16,7 +16,7 @@ content readable.
 
 */ -}}
 
-{{- if .RunNixShellHook -}}
+{{- if .UnifiedEnv -}}
 # Run the shell hook defined in shell.nix or flake.nix
 eval $shellHook
 
@@ -33,10 +33,16 @@ eval $shellHook
 
 # Begin Devbox Post-init Hook
 
-{{ if .PathPrepend -}}
+{{ if .UnifiedEnv -}}
+PATH="$DEVBOX_PATH_PREPEND:$PATH"
+{{ else }}
 PATH="{{ .PathPrepend }}:$PATH"
 {{- end }}
 
+{{- /*
+We need to set HISTFILE here because when starting a new shell, the shell will ignore the
+existing value of HISTFILE.
+*/ -}}
 {{- if .HistoryFile }}
 HISTFILE={{.HistoryFile}}
 {{- end }}


### PR DESCRIPTION
## Summary
This applies to `devbox shell` only. We defer the path prepending until _after_ any user init file is run. For `devbox run`, we set the path before creating the new shell.

## How was it tested?
```
DEVBOX_FEATURE_UNIFIED_ENV=1 devbox shell
echo $PATH
# inspect that .zshrc path prepends appear AFTER the nix paths
```