### PR TITLE
Include some more shell-specific vars, remove nix shell hook

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -742,19 +742,19 @@ func (d *Devbox) computeNixEnv(setFullPath bool) (map[string]string, error) {
 	// Copy over (and overwrite) vars that we explicitly "leak", as well as DEVBOX_ vars.
 	for _, kv := range os.Environ() {
 		parts := strings.SplitN(kv, "=", 2)
-		k := parts[0]
-		v := parts[1]
+		key := parts[0]
+		val := parts[1]
 
 		if strings.HasPrefix(parts[0], "DEVBOX_") {
-			env[k] = v
+			env[key] = val
 		}
 
-		if _, ok := leakedVars[k]; ok {
-			env[k] = v
+		if _, ok := leakedVars[key]; ok {
+			env[key] = val
 		}
 
-		if _, ok := leakedVarsForShell[k]; ok {
-			env[k] = v
+		if _, ok := leakedVarsForShell[key]; ok {
+			env[key] = val
 		}
 	}
 

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -741,11 +741,12 @@ func (d *Devbox) computeNixEnv(setFullPath bool) (map[string]string, error) {
 
 	// Copy over (and overwrite) vars that we explicitly "leak", as well as DEVBOX_ vars.
 	for _, kv := range os.Environ() {
-		parts := strings.SplitN(kv, "=", 2)
-		key := parts[0]
-		val := parts[1]
+		key, val, found := strings.Cut(kv, "=")
+		if !found {
+			return nil, errors.Errorf("expected \"=\" in keyval: %s", kv)
+		}
 
-		if strings.HasPrefix(parts[0], "DEVBOX_") {
+		if strings.HasPrefix(key, "DEVBOX_") {
 			env[key] = val
 		}
 

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -710,8 +710,9 @@ func (d *Devbox) printPackageUpdateMessage(
 // devbox execution commands (i.e. devbox run, shell). In short, the environment is
 // calculated as follows:
 // 1. Start with the output of nix print-dev-env
-// 2. Allow a limited set of variables (leakedVars) in the host machine to "leak" in (e.g. HOME).
+// 2. Allow a limited set of variables (e.g. leakedVars) in the host machine to "leak" in (e.g. HOME).
 // 3. Include any plugin env vars.
+// 4. Include any user-defined env vars from devbox.json.
 //
 // The PATH variable has some special handling. In short:
 // 1. Start with the PATH as defined by nix (through nix print-dev-env).
@@ -738,13 +739,31 @@ func (d *Devbox) computeNixEnv(setFullPath bool) (map[string]string, error) {
 		}
 	}
 
-	// Overwrite/leak whitelisted vars into nixEnv:
-	for name, leak := range leakedVars {
-		if leak {
-			env[name] = os.Getenv(name)
+	// Copy over (and overwrite) vars that we explicitly "leak", as well as DEVBOX_ vars.
+	for _, kv := range os.Environ() {
+		parts := strings.SplitN(kv, "=", 2)
+		k := parts[0]
+		v := parts[1]
+
+		if strings.HasPrefix(parts[0], "DEVBOX_") {
+			env[k] = v
+		}
+
+		if _, ok := leakedVars[k]; ok {
+			env[k] = v
+		}
+
+		if _, ok := leakedVarsForShell[k]; ok {
+			env[k] = v
 		}
 	}
 
+	// These variables are only needed for shell, but we include them here in the computed env
+	// for both shell and run in order to be as identical as possible.
+	env["NIX_PKGS_ALLOW_UNFREE"] = "1"     // Only for shell because we don't expect nix calls within run
+	env["__ETC_PROFILE_NIX_SOURCED"] = "1" // Prevent user init file from loading nix profiles
+
+	// Add any vars defined in plugins.
 	pluginEnv, err := plugin.Env(d.packages(), d.projectDir)
 	if err != nil {
 		return nil, err
@@ -753,11 +772,13 @@ func (d *Devbox) computeNixEnv(setFullPath bool) (map[string]string, error) {
 		env[k] = v
 	}
 
-	// TODO: add shell-specific vars, including:
-	// - NIXPKGS_ALLOW_UNFREE=1 (not needed in run because we don't expect nix calls there)
-	// - __ETC_PROFILE_NIX_SOURCED=1 (not needed in run because we don't expect rc files to try to load nix profiles)
-	// - HISTFILE (not needed in run because it's non-interactive)
-	// - (some of) nix.envToKeep.
+	// Include env variables in devbox.json
+	if featureflag.EnvConfig.Enabled() {
+		// TODO: if the uer defines PATH here, how should it be handled?
+		for k, v := range d.configEnvs(env) {
+			env[k] = v
+		}
+	}
 
 	// PATH handling.
 	pluginVirtenvPath := d.pluginVirtenvPath() // TODO: consider removing this; not being used?
@@ -778,13 +799,6 @@ func (d *Devbox) computeNixEnv(setFullPath bool) (map[string]string, error) {
 	} else {
 		env["PATH"] = hostPath
 		env["DEVBOX_PATH_PREPEND"] = pathPrepend
-	}
-
-	if featureflag.EnvConfig.Enabled() {
-		// Include env variables in config
-		for k, v := range d.configEnvs(env) {
-			env[k] = v
-		}
 	}
 
 	return env, nil
@@ -979,4 +993,48 @@ var leakedVars = map[string]bool{
 	"TEMP":    true,
 	"TMPDIR":  true,
 	"TEMPDIR": true,
+}
+
+var leakedVarsForShell = map[string]bool{
+	// POSIX
+	//
+	// Variables that are part of the POSIX standard.
+	"OLDPWD": true,
+	"PWD":    true,
+	"TERM":   true,
+	"TZ":     true,
+	"USER":   true,
+
+	// POSIX Locale
+	//
+	// Variables that are part of the POSIX standard which define
+	// the shell's locale.
+	"LC_ALL":      true, // Sets and overrides all of the variables below.
+	"LANG":        true, // Default to use for any of the variables below that are unset or null.
+	"LC_COLLATE":  true, // Collation order.
+	"LC_CTYPE":    true, // Character classification and case conversion.
+	"LC_MESSAGES": true, // Formats of informative and diagnostic messages and interactive responses.
+	"LC_MONETARY": true, // Monetary formatting.
+	"LC_NUMERIC":  true, // Numeric, non-monetary formatting.
+	"LC_TIME":     true, // Date and time formats.
+
+	// Common
+	//
+	// Variables that most programs agree on, but aren't strictly
+	// part of POSIX.
+	"TERM_PROGRAM":         true, // Name of the terminal the shell is running in.
+	"TERM_PROGRAM_VERSION": true, // The version of TERM_PROGRAM.
+	"SHLVL":                true, // The number of nested shells.
+
+	// Apple Terminal
+	//
+	// Special-cased variables that macOS's Terminal.app sets before
+	// launching the shell. It's not clear what exactly all of these do,
+	// but it seems like omitting them can cause problems.
+	"TERM_SESSION_ID":        true,
+	"SHELL_SESSIONS_DISABLE": true, // Respect session save/resume setting (see /etc/zshrc_Apple_Terminal).
+	"SECURITYSESSIONID":      true,
+
+	// SSH variables
+	"SSH_TTY": true, // Used by devbox telemetry logging
 }

--- a/internal/impl/generate.go
+++ b/internal/impl/generate.go
@@ -93,9 +93,10 @@ func toJSON(a any) string {
 }
 
 var templateFuncs = template.FuncMap{
-	"json":     toJSON,
-	"contains": strings.Contains,
-	"debug":    debug.IsEnabled,
+	"json":       toJSON,
+	"contains":   strings.Contains,
+	"debug":      debug.IsEnabled,
+	"unifiedEnv": featureflag.UnifiedEnv.Enabled,
 }
 
 func makeFlakeFile(outPath string, plan *plansdk.ShellPlan) error {

--- a/internal/impl/tmpl/shell.nix.tmpl
+++ b/internal/impl/tmpl/shell.nix.tmpl
@@ -15,6 +15,7 @@ with pkgs;
 mkShell {
   shellHook =
     ''
+      {{ if not unifiedEnv }}
       # We're technically no longer in a Nix shell after this hook because we
       # exec a devbox shell.
       export IN_NIX_SHELL=0
@@ -35,6 +36,8 @@ mkShell {
 
       {{ if debug }}
       echo "PATH=$PATH"
+      {{- end }}
+
       {{- end }}
     '';
   packages = [

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -223,7 +223,7 @@ func (s *Shell) Run(nixShellFilePath, nixFlakesFilePath string) error {
 		extraEnv, extraArgs := s.shellRCOverrides(shellrc)
 
 		cmd = exec.Command(s.binPath)
-		cmd.Env = append(filterVars(s.env, buildAllowList(s.env)), extraEnv...)
+		cmd.Env = append(s.env, extraEnv...)
 		cmd.Args = append(cmd.Args, extraArgs...)
 		debug.Log("Executing shell %s with args: %v", s.binPath, cmd.Args)
 	} else {

--- a/testscripts/run/env.test.txt
+++ b/testscripts/run/env.test.txt
@@ -7,5 +7,21 @@ exec devbox run echo '$FOO'
 
 # Some vars (like HOME) should leak into the run environment
 env HOME=/home/test
+env USER=test-user
 exec devbox run echo '$HOME'
 stdout '/home/test'
+exec devbox run echo '$USER'
+stdout 'test-user'
+
+# Fixed/hard-coded vars are set
+exec devbox run echo '$NIX_PKGS_ALLOW_UNFREE'
+stdout '1'
+exec devbox run echo '$__ETC_PROFILE_NIX_SOURCED'
+stdout '1'
+
+# DEVBOX_* vars are passed through
+env DEVBOX_FOO=baz
+exec devbox run echo '$DEVBOX_FOO'
+stdout 'baz'
+
+# TODO: test order/overwriting of variables


### PR DESCRIPTION
## Summary
Add some more variables that are required for shell: DEVBOX_ vars, a couple hard-coded nix vars, and a few more vars to leak.

Also removes the `shell.nix` hook, which we no longer need if we're using unified env.

## How was it tested?
go tests