### PR TITLE
tmpl: run nixpkgs-fmt on nix files

### DIFF
--- a/internal/impl/tmpl/development.nix.tmpl
+++ b/internal/impl/tmpl/development.nix.tmpl
@@ -1,22 +1,24 @@
 let
-  pkgs = import (fetchTarball {
-    url = "{{ .NixpkgsInfo.URL }}";
-    {{- if .NixpkgsInfo.Sha256 }}
-    sha256 = "{{ .NixpkgsInfo.Sha256 }}";
-    {{- end }}
-  }) {
-  };
+  pkgs = import
+    (fetchTarball {
+      url = "{{ .NixpkgsInfo.URL }}";
+      {{- if .NixpkgsInfo.Sha256 }}
+      sha256 = "{{ .NixpkgsInfo.Sha256 }}";
+      {{- end }}
+    })
+    { };
   {{- range .Definitions}}
     {{.}}
   {{ end }}
-in with pkgs;
+in
+with pkgs;
 buildEnv {
   ignoreCollisions = true;
   name = "devbox-development";
   paths = [
-  {{- range .DevPackages}}
-    {{.}}
-  {{- end }}
+    {{- range .DevPackages}}
+      {{.}}
+    {{- end }}
   ];
-  pathsToLink = [ "/bin" "/share" "/lib"];
+  pathsToLink = [ "/bin" "/share" "/lib" ];
 }

--- a/internal/impl/tmpl/flake.nix.tmpl
+++ b/internal/impl/tmpl/flake.nix.tmpl
@@ -1,49 +1,49 @@
 {
-    description = "A devbox shell";
+  description = "A devbox shell";
 
-    inputs = {
-        nixpkgs.url = "{{ .NixpkgsInfo.URL }}";
+  inputs = {
+    nixpkgs.url = "{{ .NixpkgsInfo.URL }}";
 
-        flake-utils.url = "github:numtide/flake-utils";
-    };
+    flake-utils.url = "github:numtide/flake-utils";
+  };
 
-    outputs = { self, nixpkgs, flake-utils }:
-        flake-utils.lib.eachDefaultSystem (system:
-        let pkgs = nixpkgs.legacyPackages.${system};
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system};
 
-        in {
-            devShell = pkgs.mkShell {
-              shellHook =
-                ''
-                  # We're technically no longer in a Nix shell after this hook because we
-                  # exec a devbox shell.
-                  export IN_NIX_SHELL=0
-                  export DEVBOX_SHELL_ENABLED=1
+      in {
+        devShell = pkgs.mkShell {
+          shellHook =
+            ''
+              # We're technically no longer in a Nix shell after this hook because we
+              # exec a devbox shell.
+              export IN_NIX_SHELL=0
+              export DEVBOX_SHELL_ENABLED=1
 
-                  # Undo the effects of `nix-shell --pure` on SSL certs.
-                  # See https://github.com/NixOS/nixpkgs/blob/dae204faa0243b4d0c0234a5f5f83a2549ecb5b7/pkgs/stdenv/generic/setup.sh#L677-L685
-                  if [ "$NIX_SSL_CERT_FILE" = "/no-cert-file.crt" ]; then
-                     unset NIX_SSL_CERT_FILE
-                  fi
-                  if [ "$SSL_CERT_FILE" = "/no-cert-file.crt" ]; then
-                     unset SSL_CERT_FILE
-                  fi
+              # Undo the effects of `nix-shell --pure` on SSL certs.
+              # See https://github.com/NixOS/nixpkgs/blob/dae204faa0243b4d0c0234a5f5f83a2549ecb5b7/pkgs/stdenv/generic/setup.sh#L677-L685
+              if [ "$NIX_SSL_CERT_FILE" = "/no-cert-file.crt" ]; then
+                 unset NIX_SSL_CERT_FILE
+              fi
+              if [ "$SSL_CERT_FILE" = "/no-cert-file.crt" ]; then
+                 unset SSL_CERT_FILE
+              fi
 
-                  # Append the parent shell's PATH so that we retain access to
-                  # non-Nix programs, while still preferring the Nix ones.
-                  export "PATH=$PATH:$PARENT_PATH"
+              # Append the parent shell's PATH so that we retain access to
+              # non-Nix programs, while still preferring the Nix ones.
+              export "PATH=$PATH:$PARENT_PATH"
 
-                  {{ if debug }}
-                  echo "PATH=$PATH"
-                  {{- end }}
-                '';
+              {{ if debug }}
+              echo "PATH=$PATH"
+              {{- end }}
+            '';
 
-              buildInputs = [
-                  {{- range .DevPackages}}
-                    pkgs.{{.}}
-                  {{end -}}
-              ];
-            };
-        }
-        );
+          buildInputs = [
+            {{- range .DevPackages}}
+              pkgs.{{.}}
+            {{end -}}
+          ];
+        };
+      }
+    );
 }

--- a/internal/impl/tmpl/shell.nix.tmpl
+++ b/internal/impl/tmpl/shell.nix.tmpl
@@ -1,15 +1,17 @@
 let
-  pkgs = import (fetchTarball {
-    url = "{{ .NixpkgsInfo.URL }}";
-    {{- if .NixpkgsInfo.Sha256 }}
-    sha256 = "{{ .NixpkgsInfo.Sha256 }}";
-    {{- end }}
-  }) {
-  };
+  pkgs = import
+    (fetchTarball {
+      url = "{{ .NixpkgsInfo.URL }}";
+      {{- if .NixpkgsInfo.Sha256 }}
+      sha256 = "{{ .NixpkgsInfo.Sha256 }}";
+      {{- end }}
+    })
+    { };
   {{- range .Definitions}}
     {{.}}
   {{ end }}
-in with pkgs;
+in
+with pkgs;
 mkShell {
   shellHook =
     ''
@@ -35,9 +37,9 @@ mkShell {
       echo "PATH=$PATH"
       {{- end }}
     '';
-     packages = [
-      {{- range .DevPackages}}
-        {{.}}
-      {{- end }}
-    ];
+  packages = [
+    {{- range .DevPackages}}
+      {{.}}
+    {{- end }}
+  ];
 }


### PR DESCRIPTION
Run `nixpkgs-fmt *.nix.tmpl` to make everything follow common formatting/style conventions.