### PR TITLE
[global] Move global to XDG_DATA_HOME

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -67,6 +67,6 @@ func IsDevboxShellEnabled() bool {
 	return impl.IsDevboxShellEnabled()
 }
 
-func GlobalDataPath() string {
+func GlobalDataPath() (string, error) {
 	return impl.GlobalDataPath()
 }

--- a/devbox.go
+++ b/devbox.go
@@ -67,6 +67,6 @@ func IsDevboxShellEnabled() bool {
 	return impl.IsDevboxShellEnabled()
 }
 
-func GlobalConfigPath() (string, error) {
-	return impl.GlobalConfigPath()
+func GlobalDataPath() string {
+	return impl.GlobalDataPath()
 }

--- a/internal/boxcli/global.go
+++ b/internal/boxcli/global.go
@@ -91,6 +91,7 @@ func globalPullCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "pull <file> | <url>",
 		Short:   "Pulls a global config from a file or URL",
+		Long:    "Pulls a global config from a file or URL. URLs must be prefixed with 'http://' or 'https://'.",
 		PreRunE: ensureNixInstalled,
 		RunE:    pullGlobalCmdFunc,
 		Args:    cobra.ExactArgs(1),
@@ -98,7 +99,10 @@ func globalPullCmd() *cobra.Command {
 }
 
 func addGlobalCmdFunc(cmd *cobra.Command, args []string) error {
-	path := devbox.GlobalDataPath()
+	path, err := devbox.GlobalDataPath()
+	if err != nil {
+		return err
+	}
 	if _, err := devbox.InitConfig(path, cmd.ErrOrStderr()); err != nil {
 		return errors.WithStack(err)
 	}
@@ -111,7 +115,10 @@ func addGlobalCmdFunc(cmd *cobra.Command, args []string) error {
 }
 
 func removeGlobalCmdFunc(cmd *cobra.Command, args []string) error {
-	path := devbox.GlobalDataPath()
+	path, err := devbox.GlobalDataPath()
+	if err != nil {
+		return err
+	}
 	if _, err := devbox.InitConfig(path, cmd.ErrOrStderr()); err != nil {
 		return errors.WithStack(err)
 	}
@@ -124,7 +131,10 @@ func removeGlobalCmdFunc(cmd *cobra.Command, args []string) error {
 }
 
 func listGlobalCmdFunc(cmd *cobra.Command, args []string) error {
-	path := devbox.GlobalDataPath()
+	path, err := devbox.GlobalDataPath()
+	if err != nil {
+		return err
+	}
 	if _, err := devbox.InitConfig(path, cmd.ErrOrStderr()); err != nil {
 		return errors.WithStack(err)
 	}
@@ -136,7 +146,10 @@ func listGlobalCmdFunc(cmd *cobra.Command, args []string) error {
 }
 
 func pullGlobalCmdFunc(cmd *cobra.Command, args []string) error {
-	path := devbox.GlobalDataPath()
+	path, err := devbox.GlobalDataPath()
+	if err != nil {
+		return err
+	}
 	if _, err := devbox.InitConfig(path, cmd.ErrOrStderr()); err != nil {
 		return errors.WithStack(err)
 	}

--- a/internal/boxcli/global.go
+++ b/internal/boxcli/global.go
@@ -98,10 +98,7 @@ func globalPullCmd() *cobra.Command {
 }
 
 func addGlobalCmdFunc(cmd *cobra.Command, args []string) error {
-	path, err := devbox.GlobalConfigPath()
-	if err != nil {
-		return err
-	}
+	path := devbox.GlobalDataPath()
 	if _, err := devbox.InitConfig(path, cmd.ErrOrStderr()); err != nil {
 		return errors.WithStack(err)
 	}
@@ -114,10 +111,7 @@ func addGlobalCmdFunc(cmd *cobra.Command, args []string) error {
 }
 
 func removeGlobalCmdFunc(cmd *cobra.Command, args []string) error {
-	path, err := devbox.GlobalConfigPath()
-	if err != nil {
-		return err
-	}
+	path := devbox.GlobalDataPath()
 	if _, err := devbox.InitConfig(path, cmd.ErrOrStderr()); err != nil {
 		return errors.WithStack(err)
 	}
@@ -130,10 +124,7 @@ func removeGlobalCmdFunc(cmd *cobra.Command, args []string) error {
 }
 
 func listGlobalCmdFunc(cmd *cobra.Command, args []string) error {
-	path, err := devbox.GlobalConfigPath()
-	if err != nil {
-		return err
-	}
+	path := devbox.GlobalDataPath()
 	if _, err := devbox.InitConfig(path, cmd.ErrOrStderr()); err != nil {
 		return errors.WithStack(err)
 	}
@@ -145,10 +136,7 @@ func listGlobalCmdFunc(cmd *cobra.Command, args []string) error {
 }
 
 func pullGlobalCmdFunc(cmd *cobra.Command, args []string) error {
-	path, err := devbox.GlobalConfigPath()
-	if err != nil {
-		return err
-	}
+	path := devbox.GlobalDataPath()
 	if _, err := devbox.InitConfig(path, cmd.ErrOrStderr()); err != nil {
 		return errors.WithStack(err)
 	}

--- a/internal/boxcli/midcobra/debug.go
+++ b/internal/boxcli/midcobra/debug.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/pflag"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/debug"
+	"go.jetpack.io/devbox/internal/ux"
 )
 
 type DebugMiddleware struct {
@@ -54,7 +55,7 @@ func (d *DebugMiddleware) postRun(cmd *cobra.Command, args []string, runErr erro
 	}
 	if usererr.HasUserMessage(runErr) {
 		if usererr.IsWarning(runErr) {
-			color.Yellow("\nWarning: %s\n\n", runErr.Error())
+			ux.Fwarning(cmd.ErrOrStderr(), runErr.Error())
 		} else {
 			color.Red("\nError: " + runErr.Error() + "\n\n")
 		}

--- a/internal/impl/config.go
+++ b/internal/impl/config.go
@@ -53,7 +53,11 @@ type Stage struct {
 var commitMismatchWarningShown = false
 
 func (c *Config) Packages(w io.Writer) []string {
-	global, err := readConfig(filepath.Join(GlobalDataPath(), "devbox.json"))
+	dataPath, err := GlobalDataPath()
+	if err != nil {
+		ux.Ferror(w, "unable to get devbox global data path: %s", err)
+	}
+	global, err := readConfig(filepath.Join(dataPath, "devbox.json"))
 	if err != nil {
 		return c.RawPackages
 	}

--- a/internal/impl/config.go
+++ b/internal/impl/config.go
@@ -55,7 +55,7 @@ var commitMismatchWarningShown = false
 func (c *Config) Packages(w io.Writer) []string {
 	dataPath, err := GlobalDataPath()
 	if err != nil {
-		ux.Ferror(w, "unable to get devbox global data path: %s", err)
+		ux.Ferror(w, "unable to get devbox global data path: %s\n", err)
 	}
 	global, err := readConfig(filepath.Join(dataPath, "devbox.json"))
 	if err != nil {

--- a/internal/impl/config.go
+++ b/internal/impl/config.go
@@ -53,11 +53,7 @@ type Stage struct {
 var commitMismatchWarningShown = false
 
 func (c *Config) Packages(w io.Writer) []string {
-	path, err := GlobalConfigPath()
-	if err != nil {
-		return c.RawPackages
-	}
-	global, err := readConfig(filepath.Join(path, "devbox.json"))
+	global, err := readConfig(filepath.Join(GlobalDataPath(), "devbox.json"))
 	if err != nil {
 		return c.RawPackages
 	}

--- a/internal/impl/global.go
+++ b/internal/impl/global.go
@@ -128,7 +128,7 @@ func GlobalDataPath() string {
 }
 
 func GlobalNixProfilePath() string {
-	return filepath.Join(GlobalDataPath(), "nix-profile")
+	return filepath.Join(GlobalDataPath(), "profile")
 }
 
 // Checks if the global profile is in the path
@@ -136,10 +136,10 @@ func ensureGlobalProfileInPath() error {
 	currentPath := xdg.DataSubpath("devbox/global/current")
 	// For now default is always current. In the future we will support multiple
 	// and allow user to switch.
-	if err := os.Symlink(GlobalDataPath(), currentPath); err != nil && !os.IsExist(err) {
+	if err := os.Symlink(GlobalNixProfilePath(), currentPath); err != nil && !os.IsExist(err) {
 		return errors.WithStack(err)
 	}
-	binPath := filepath.Join(currentPath, "nix-profile", "bin")
+	binPath := filepath.Join(currentPath, "bin")
 	if !strings.Contains(os.Getenv("PATH"), binPath) {
 		return usererr.NewWarning(
 			"devbox global profile is not in your PATH. Add `export PATH=$PATH:%s` to your shell config to fix this.", binPath,

--- a/internal/impl/global.go
+++ b/internal/impl/global.go
@@ -16,13 +16,13 @@ import (
 	"go.jetpack.io/devbox/internal/nix"
 	"go.jetpack.io/devbox/internal/planner/plansdk"
 	"go.jetpack.io/devbox/internal/ux"
+	"go.jetpack.io/devbox/internal/xdg"
 )
 
+// In the future we will support multiple global profiles
+const currentGlobalProfile = "default"
+
 func (d *Devbox) AddGlobal(pkgs ...string) error {
-	profilePath, err := globalProfilePath()
-	if err != nil {
-		return err
-	}
 	// validate all packages exist. Don't install anything if any are missing
 	for _, pkg := range pkgs {
 		if !nix.FlakesPkgExists(plansdk.DefaultNixpkgsCommit, pkg) {
@@ -30,6 +30,7 @@ func (d *Devbox) AddGlobal(pkgs ...string) error {
 		}
 	}
 	var added []string
+	profilePath := GlobalNixProfilePath()
 	for _, pkg := range pkgs {
 		if err := nix.ProfileInstall(profilePath, plansdk.DefaultNixpkgsCommit, pkg); err != nil {
 			fmt.Fprintf(d.writer, "Error installing %s: %s", pkg, err)
@@ -46,10 +47,6 @@ func (d *Devbox) AddGlobal(pkgs ...string) error {
 }
 
 func (d *Devbox) RemoveGlobal(pkgs ...string) error {
-	profilePath, err := globalProfilePath()
-	if err != nil {
-		return err
-	}
 	if _, missing := lo.Difference(d.cfg.RawPackages, pkgs); len(missing) > 0 {
 		ux.Fwarning(
 			d.writer,
@@ -58,6 +55,7 @@ func (d *Devbox) RemoveGlobal(pkgs ...string) error {
 		)
 	}
 	var removed []string
+	profilePath := GlobalNixProfilePath()
 	for _, pkg := range lo.Intersect(d.cfg.RawPackages, pkgs) {
 		if err := nix.ProfileRemove(profilePath, plansdk.DefaultNixpkgsCommit, pkg); err != nil {
 			fmt.Fprintf(d.writer, "Error removing %s: %s", pkg, err)
@@ -123,31 +121,25 @@ func (d *Devbox) addFromPull(pullCfg *Config) error {
 	return d.AddGlobal(diff...)
 }
 
-func GlobalConfigPath() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", errors.WithStack(err)
-	}
-	return filepath.Join(home, "/.config/devbox/"), nil
+func GlobalDataPath() string {
+	path := xdg.DataSubpath(filepath.Join("devbox/global", currentGlobalProfile))
+	_ = os.MkdirAll(path, 0755)
+	return path
 }
 
-func globalProfilePath() (string, error) {
-	configPath, err := GlobalConfigPath()
-	if err != nil {
-		return "", err
-	}
-	nixDirPath := filepath.Join(configPath, "nix")
-	_ = os.MkdirAll(nixDirPath, 0755)
-	return filepath.Join(nixDirPath, "profile"), nil
+func GlobalNixProfilePath() string {
+	return filepath.Join(GlobalDataPath(), "nix-profile")
 }
 
 // Checks if the global profile is in the path
 func ensureGlobalProfileInPath() error {
-	profilePath, err := globalProfilePath()
-	if err != nil {
-		return err
+	currentPath := xdg.DataSubpath("devbox/global/current")
+	// For now default is always current. In the future we will support multiple
+	// and allow user to switch.
+	if err := os.Symlink(GlobalDataPath(), currentPath); err != nil && !os.IsExist(err) {
+		return errors.WithStack(err)
 	}
-	binPath := filepath.Join(profilePath, "bin")
+	binPath := filepath.Join(currentPath, "nix-profile", "bin")
 	if !strings.Contains(os.Getenv("PATH"), binPath) {
 		return usererr.NewWarning(
 			"devbox global profile is not in your PATH. Add `export PATH=$PATH:%s` to your shell config to fix this.", binPath,

--- a/internal/ux/messages.go
+++ b/internal/ux/messages.go
@@ -11,3 +11,8 @@ func Fwarning(w io.Writer, format string, a ...any) {
 	color.New(color.FgHiYellow).Fprint(w, "Warning: ")
 	fmt.Fprintf(w, format, a...)
 }
+
+func Ferror(w io.Writer, format string, a ...any) {
+	color.New(color.FgHiRed).Fprint(w, "Error: ")
+	fmt.Fprintf(w, format, a...)
+}


### PR DESCRIPTION
## Summary

This is stacked on https://github.com/jetpack-io/devbox/pull/630

This moves global data to XDG_DATA_HOME or `~/.local/share`

* The devbox.json is stored in `~/.local/share/devbox/global/default/devbox.json`
* The nix profile is in `~/.local/share/devbox/global/default/nix-profile`
* the bin path is `~/.local/share/devbox/global/current/nix-profile/bin`

## How was it tested?

`devbox global add hello`
