### PR TITLE
Prevent shell inception when using print-dev-env

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -763,6 +763,7 @@ func (d *Devbox) computeNixEnv(setFullPath bool) (map[string]string, error) {
 	// for both shell and run in order to be as identical as possible.
 	env["NIX_PKGS_ALLOW_UNFREE"] = "1"     // Only for shell because we don't expect nix calls within run
 	env["__ETC_PROFILE_NIX_SOURCED"] = "1" // Prevent user init file from loading nix profiles
+	env["DEVBOX_SHELL_ENABLED"] = "1"      // Used to determine whether we're inside a shell (e.g. to prevent shell inception)
 
 	// Add any vars defined in plugins.
 	pluginEnv, err := plugin.Env(d.packages(), d.projectDir)

--- a/testscripts/run/shellception.test.txt
+++ b/testscripts/run/shellception.test.txt
@@ -1,0 +1,4 @@
+# Do not support shell inception
+exec devbox init
+! exec devbox run devbox shell
+stdout 'Error: You are already in an active devbox shell.'


### PR DESCRIPTION
## Summary

I inadvertently removed this when cleaning up `shell.nix.tmpl` for unified env. I prefer to set this var in Go-code, as opposed to a nix shell hook.

## How was it tested?
```
> devbox shell
(devbox) > devbox shell
Error: You are already in an active devbox shell.
Run `exit` before calling `devbox shell` again. Shell inception is not supported.
```

```
devbox run devbox shell
Error: You are already in an active devbox shell.
Run `exit` before calling `devbox shell` again. Shell inception is not supported.
```

