### PR TITLE
Deprecate shell -- <cmd> in favor of run <cmd>

### DIFF
--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -6,6 +6,7 @@ package boxcli
 import (
 	"fmt"
 
+	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
@@ -21,12 +22,12 @@ func ShellCmd() *cobra.Command {
 	flags := shellCmdFlags{}
 	command := &cobra.Command{
 		Use:   "shell -- [<cmd>]",
-		Short: "Start a new shell or run a command with access to your packages",
-		Long: "Start a new shell or run a command with access to your packages.\n\n" +
-			"If invoked without `cmd`, devbox will start an interactive shell.\n" +
-			"If invoked with a `cmd`, devbox will run the command in a shell and then exit.\n" +
-			"In both cases, the shell will be started using the devbox.json found in the --config flag directory. " +
-			"If --config isn't set, then devbox recursively searches the current directory and its parents.",
+		Short: "Start a new shell with access to your packages",
+		Long: "Start a new shell with access to your packages.\n\n" +
+			"The shell will be started using the devbox.json found in the --config flag directory. " +
+			"If --config isn't set, then devbox recursively searches the current directory and its parents.\n\n" +
+			"[Deprecated] If invoked as devbox shell -- <cmd>, devbox will run the command in a shell and then exit. " +
+			"This behavior is deprecated and will be removed. Please use devbox run -- <cmd> instead.",
 		Args:    validateShellArgs,
 		PreRunE: ensureNixInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -68,6 +69,9 @@ func runShellCmd(cmd *cobra.Command, args []string, flags shellCmdFlags) error {
 	}
 
 	if len(cmds) > 0 {
+		fmt.Fprint(cmd.ErrOrStderr(),
+			color.HiYellowString("[Warning] \"devbox shell -- <cmd>\" is deprecated and will disappear "+
+				"in a future version. Use \"devbox run -- <cmd>\" instead\n"))
 		err = box.Exec(cmds...)
 	} else {
 		err = box.Shell()

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
+	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 )
 
@@ -19,15 +20,25 @@ type shellCmdFlags struct {
 }
 
 func ShellCmd() *cobra.Command {
-	flags := shellCmdFlags{}
-	command := &cobra.Command{
-		Use:   "shell -- [<cmd>]",
-		Short: "Start a new shell with access to your packages",
-		Long: "Start a new shell with access to your packages.\n\n" +
+	var longHelp string
+	if featureflag.UnifiedEnv.Enabled() {
+		longHelp = "Start a new shell with access to your packages.\n\n" +
 			"The shell will be started using the devbox.json found in the --config flag directory. " +
 			"If --config isn't set, then devbox recursively searches the current directory and its parents.\n\n" +
 			"[Deprecated] If invoked as devbox shell -- <cmd>, devbox will run the command in a shell and then exit. " +
-			"This behavior is deprecated and will be removed. Please use devbox run -- <cmd> instead.",
+			"This behavior is deprecated and will be removed. Please use devbox run -- <cmd> instead."
+	} else {
+		longHelp = "Start a new shell or run a command with access to your packages.\n\n" +
+			"If invoked without `cmd`, devbox will start an interactive shell.\n" +
+			"If invoked with a `cmd`, devbox will run the command in a shell and then exit.\n" +
+			"In both cases, the shell will be started using the devbox.json found in the --config flag directory. " +
+			"If --config isn't set, then devbox recursively searches the current directory and its parents."
+	}
+	flags := shellCmdFlags{}
+	command := &cobra.Command{
+		Use:     "shell -- [<cmd>]",
+		Short:   "Start a new shell with access to your packages",
+		Long:    longHelp,
 		Args:    validateShellArgs,
 		PreRunE: ensureNixInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -69,9 +80,11 @@ func runShellCmd(cmd *cobra.Command, args []string, flags shellCmdFlags) error {
 	}
 
 	if len(cmds) > 0 {
-		fmt.Fprint(cmd.ErrOrStderr(),
-			color.HiYellowString("[Warning] \"devbox shell -- <cmd>\" is deprecated and will disappear "+
-				"in a future version. Use \"devbox run -- <cmd>\" instead\n"))
+		if featureflag.UnifiedEnv.Enabled() {
+			fmt.Fprint(cmd.ErrOrStderr(),
+				color.HiYellowString("[Warning] \"devbox shell -- <cmd>\" is deprecated and will disappear "+
+					"in a future version. Use \"devbox run -- <cmd>\" instead\n"))
+		}
 		err = box.Exec(cmds...)
 	} else {
 		err = box.Shell()

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -6,12 +6,12 @@ package boxcli
 import (
 	"fmt"
 
-	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
+	"go.jetpack.io/devbox/internal/ux"
 )
 
 type shellCmdFlags struct {
@@ -81,9 +81,8 @@ func runShellCmd(cmd *cobra.Command, args []string, flags shellCmdFlags) error {
 
 	if len(cmds) > 0 {
 		if featureflag.UnifiedEnv.Enabled() {
-			fmt.Fprint(cmd.ErrOrStderr(),
-				color.HiYellowString("[Warning] \"devbox shell -- <cmd>\" is deprecated and will disappear "+
-					"in a future version. Use \"devbox run -- <cmd>\" instead\n"))
+			ux.Fwarning(cmd.ErrOrStderr(), "\"devbox shell -- <cmd>\" is deprecated and will disappear "+
+				"in a future version. Use \"devbox run -- <cmd>\" instead\n")
 		}
 		err = box.Exec(cmds...)
 	} else {

--- a/testscripts/run/command.test.txt
+++ b/testscripts/run/command.test.txt
@@ -1,0 +1,13 @@
+exec devbox init
+
+# We can run an arbitrary command
+exec devbox run echo "foo"
+stdout 'foo'
+
+# devbox shell -- <cmd> prints warning and is implemented with devbox run.
+# NOTE that devbox run passes DEVBOX_* vars through, but devbox shell does not.
+env DEVBOX_FOO=bar
+exec devbox shell -- echo '$DEVBOX_FOO'
+stdout 'bar'
+stderr '[Warning]' # for some reason, putting these two assertions in a single line makes the test fail.
+stderr '"devbox shell -- <cmd>" is deprecated and will disappear in a future version.' # Use "devbox run -- <cmd>" instead'


### PR DESCRIPTION
## Summary
Makes `devbox shell -- <cmd>` print a Warning and recommend using `devbox run <cmd>` instead. This behavior is protected behind the UNIFIED_ENV feature flag.

Note that `devbox services` internally uses `devbox shell -- <cmd>`, so when UNIFIED_ENV is enabled, it'll use `devbox run` instead. But it's a bit circular... when outside of a shell, running `devbox services start` is exactly equivalent to running `devbox run devbox services start`.

## How was it tested?
```
DEVBOX_FEATURE_UNIFIED_ENV=0 ./devbox shell --help
DEVBOX_FEATURE_UNIFIED_ENV=1 ./devbox shell --help

DEVBOX_FEATURE_UNIFIED_ENV=0 ./devbox shell -- echo "foo" # no warning
DEVBOX_FEATURE_UNIFIED_ENV=1 ./devbox shell -- echo "foo" # see warning

DEVBOX_FEATURE_UNIFIED_ENV=1 ./devbox shell -- echo '$PATH' 
DEVBOX_FEATURE_UNIFIED_ENV=1 ./devbox run echo '$PATH' # same paths
```