### PR TITLE
Add testscript tests for PATH setting

### DIFF
--- a/testscripts/assert/assert.test.txt
+++ b/testscripts/assert/assert.test.txt
@@ -1,0 +1,7 @@
+# Tests assert functions (since some are relatively complex)
+
+exec print a:b:c:d:e:fg:h
+path.order 'a' 'c' 'e'
+! path.order 'a' 'b' 'a'
+path.order 'a' 'f'
+! path.order 'a' 'c' 'h' 'h'

--- a/testscripts/run/path.test.txt
+++ b/testscripts/run/path.test.txt
@@ -19,14 +19,16 @@ exec devbox run echo '$PATH'
 ! stdout '/some//dirty/../clean/path'
 stdout '/some/clean/path'
 
-# Path contains path to installed nix packages
-stdout '-which-'
-
 # Path contains plugin virtual env path
 stdout '.devbox/virtenv/bin'
 
-# Path contains devbox-managed nix profiel path
+# Path contains devbox-managed nix profile path
 stdout '.devbox/nix/profile/default/bin'
 
-# TODO: verify that paths appear in desired order.
+# Path contains path to installed nix packages
+stdout '-which-'
+
+# Verify PATH is set in correct order: virtual env path, nix profile, nix packages, host path.
+path.order '.devbox/virtenv/bin' '.devbox/nix/profile/default/bin' '-which-' 'some/clean/path'
+
 # TODO: verify that bashrc file prepends do not prepend before nix paths.

--- a/testscripts/testrunner/testrunner.go
+++ b/testscripts/testrunner/testrunner.go
@@ -2,8 +2,10 @@ package testrunner
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/bmatcuk/doublestar/v4"
@@ -17,6 +19,10 @@ func Main(m *testing.M) int {
 		"devbox": func() int {
 			// Call the devbox CLI directly:
 			return boxcli.Execute(context.Background(), os.Args[1:])
+		},
+		"print": func() int { // Not 'echo' because we don't expand variables
+			fmt.Println(strings.Join(os.Args[1:], " "))
+			return 0
 		},
 	}
 	return testscript.RunMain(m, commands)


### PR DESCRIPTION
## Summary
Tests that the PATH is built in the desired order. Had to add a `print` function and `path.order` assertion function. Let me know if you have any other ideas!

## How was it tested?
```
go test ./testscripts/testscripts_test.go
```