### PR TITLE
[flake] add and remove php-related packages

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -196,7 +196,7 @@ func (d *Devbox) Remove(pkgs ...string) error {
 		return err
 	}
 
-	if err := d.removePackagesFromProfile(uninstalledPackages); err != nil {
+	if err := d.removePackagesFromProfile(uninstalledPackages, uninstall); err != nil {
 		return err
 	}
 
@@ -630,9 +630,10 @@ func (d *Devbox) generateShellFiles() error {
 type installMode string
 
 const (
-	install   installMode = "install"
-	uninstall installMode = "uninstall"
-	ensure    installMode = "ensure"
+	install      installMode = "install"
+	uninstall    installMode = "uninstall"
+	ensure       installMode = "ensure"
+	phpReinstall installMode = "phpReinstall"
 )
 
 // TODO savil. move to packages.go

--- a/internal/nix/profile.go
+++ b/internal/nix/profile.go
@@ -173,6 +173,10 @@ func (item *NixProfileListItem) PackageName() (string, error) {
 	return packageName, nil
 }
 
+func (item *NixProfileListItem) StorePath() string {
+	return item.nixStorePath
+}
+
 // String serializes the NixProfileListItem back into the format printed by `nix profile list`
 func (item *NixProfileListItem) String() string {
 	return fmt.Sprintf("%d %s %s %s",

--- a/internal/nix/profile_test.go
+++ b/internal/nix/profile_test.go
@@ -9,6 +9,7 @@ type expectedTestData struct {
 	item        *NixProfileListItem
 	attrPath    string
 	packageName string
+	storePath   string
 }
 
 func TestNixProfileListItem(t *testing.T) {
@@ -33,6 +34,7 @@ func TestNixProfileListItem(t *testing.T) {
 				},
 				attrPath:    "legacyPackages.x86_64-darwin.go_1_19",
 				packageName: "go_1_19",
+				storePath:   "/nix/store/w0lyimyyxxfl3gw40n46rpn1yjrl3q85-go-1.19.3",
 			},
 		},
 		"numpy": {
@@ -52,6 +54,27 @@ func TestNixProfileListItem(t *testing.T) {
 				},
 				attrPath:    "legacyPackages.x86_64-darwin.python39Packages.numpy",
 				packageName: "python39Packages.numpy",
+				storePath:   "/nix/store/qly36iy1p4q1h5p4rcbvsn3ll0zsd9pd-python3.9-numpy-1.23.3",
+			},
+		},
+		"php-flake": {
+			line: fmt.Sprintf(
+				"%d %s %s %s",
+				0,
+				"git+file:///Users/savil/code/jetpack/devbox/examples/testdata/php/php-extensions/.devbox/gen/flake?dir=php#packages.x86_64-darwin.phpPackages",
+				"git+file:///Users/savil/code/jetpack/devbox/examples/testdata/php/php-extensions/.devbox/gen/flake?dir=php#packages.x86_64-darwin.phpPackages",
+				"/nix/store/sgj8amkpmwchq7s9523jrnvvinfkzcg8-php-packages",
+			),
+			expected: expectedTestData{
+				item: &NixProfileListItem{
+					0,
+					"git+file:///Users/savil/code/jetpack/devbox/examples/testdata/php/php-extensions/.devbox/gen/flake?dir=php#packages.x86_64-darwin.phpPackages",
+					"git+file:///Users/savil/code/jetpack/devbox/examples/testdata/php/php-extensions/.devbox/gen/flake?dir=php#packages.x86_64-darwin.phpPackages",
+					"/nix/store/sgj8amkpmwchq7s9523jrnvvinfkzcg8-php-packages",
+				},
+				attrPath:    "packages.x86_64-darwin.phpPackages",
+				packageName: "phpPackages",
+				storePath:   "/nix/store/sgj8amkpmwchq7s9523jrnvvinfkzcg8-php-packages",
 			},
 		},
 	}
@@ -95,5 +118,10 @@ func testItem(t *testing.T, line string, expected expectedTestData) {
 	}
 	if gotPackageName != expected.packageName {
 		t.Errorf("expected package name %s but got %s", expected.packageName, gotPackageName)
+	}
+
+	gotStorePath := item.StorePath()
+	if gotStorePath != expected.storePath {
+		t.Errorf("expected nix store path %s but got %s", expected.storePath, gotStorePath)
 	}
 }


### PR DESCRIPTION
## Summary

This PR enables adding and removing php-related packages, when the flakes feature is enabled.

The challenge here is that the `php` binary and the `composer` package need to be recompiled, when a php-extension package is added to devbox. When adding or removing these php-extension packages, this implies that we must re-install _all_ php related packages to ensure they are properly compiled. 

Re-installing requires us to remove the php packages, re-generate the php `flake.nix`,  and then add the packages.



NOTE: these changes are restricted to Flakes-gated code.

**Implementation notes**
in `impl/packages.go`:

- in `addPackagesToProfile`, we now do `nix profile install --profile <profile path> .devbox/gen/flake/php/flake.nix#PhpPackageName` for php packages.
   - this function calls `pendingPackagesForInstallation` (see below notes)
- in `removePackagesFromProfile`, if a php package was uninstalled, then we need to re-install all remaining php packages. This is because we may need to re-compile php. 
   - to do this, we introduce a new `installMode` called `reinstallPhp` which forces all php packages to be removed and re-added.
- in `pendingPackagesForInstallation`, we add some special-case logic for php packages.
   - if _any php package_ is pending installation, then we must remove _all_ installed php packages. And then re-install them together.


Other changes:
- in `removePackagesFromProfile`, I change from selecting by `attributePath` to `storePath` because `storePath` is unambiguous.

## How was it tested?

```
❯ DEVBOX_FEATURE_FLAKES=1 DEVBOX_FEATURE_UNIFIED_ENV=1 DEVBOX_DEBUG=0 devbox shell
Ensuring packages are installed.
Ensuring nixpkgs registry is downloaded.
Downloaded 'github:NixOS/nixpkgs/f80ac848e3d6f0c12c52758c0f25c10c97ca3b62' to '/nix/store/7g5pkgfwfa6yskp45c8g9i4dnlpmbrf0-source' (hash 'sha256-zOLE1YXf2RhYhtNv4n8C0xPaSjduchLlCxZaAeoAvxU=').
Ensuring nixpkgs registry is downloaded: Success

Installing 3 packages: php81, php81Packages.composer, php81Extensions.ds.

[1/3] php81
	path '/Users/savil/code/jetpack/devbox/examples/testdata/php/php-extensions/.devbox/gen/flake/php/flake.nix' does not contain a 'flake.nix', searching up
	warning: Git tree '/Users/savil/code/jetpack/devbox/examples/testdata/php/php-extensions/.devbox/gen/flake' is dirty
	warning: creating lock file '/Users/savil/code/jetpack/devbox/examples/testdata/php/php-extensions/.devbox/gen/flake/php/flake.lock'
	warning: Git tree '/Users/savil/code/jetpack/devbox/examples/testdata/php/php-extensions/.devbox/gen/flake' is dirty
[1/3] php81: Success
[2/3] php81Packages.composer
	path '/Users/savil/code/jetpack/devbox/examples/testdata/php/php-extensions/.devbox/gen/flake/php/flake.nix' does not contain a 'flake.nix', searching up
	warning: Git tree '/Users/savil/code/jetpack/devbox/examples/testdata/php/php-extensions/.devbox/gen/flake' is dirty
[2/3] php81Packages.composer: Success
[3/3] php81Extensions.ds
	path '/Users/savil/code/jetpack/devbox/examples/testdata/php/php-extensions/.devbox/gen/flake/php/flake.nix' does not contain a 'flake.nix', searching up
	warning: Git tree '/Users/savil/code/jetpack/devbox/examples/testdata/php/php-extensions/.devbox/gen/flake' is dirty
[3/3] php81Extensions.ds: Success
Starting a devbox shell...
(devbox)


# verify that the ds extension is installed:
❯ php index.php
Original vector elements
idx: 0 and elem: hello
idx: 1 and elem: world
done
(devbox)
```


Removing php extension package, and verifying the php extension no longer works:
<img width="1426" alt="Screenshot 2023-02-16 at 4 55 31 PM" src="https://user-images.githubusercontent.com/676452/219521981-a7403712-32f1-4ac6-930d-c9f8a044ed3f.png">


Adding php extension back, and verifying the php extension works again:
<img width="1414" alt="Screenshot 2023-02-16 at 4 56 05 PM" src="https://user-images.githubusercontent.com/676452/219522051-3b1298a4-c7d0-4a20-b141-de3f8ee7037e.png">


NOTE: that the redundant lines for:
```
Ensuring nixpkgs registry is downloaded.
Downloaded 'github:NixOS/nixpkgs/f80ac848e3d6f0c12c52758c0f25c10c97ca3b62' to '/nix/store/7g5pkgfwfa6yskp45c8g9i4dnlpmbrf0-source' (hash 'sha256-zOLE1YXf2RhYhtNv4n8C0xPaSjduchLlCxZaAeoAvxU=').
Ensuring nixpkgs registry is downloaded: Success
```
will be removed once we cache the information about the nixpkgs that have been downloaded.