### PR TITLE
Remove dot from flag help text

### DIFF
--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -55,7 +55,7 @@ func RootCmd() *cobra.Command {
 	command.AddCommand(genDocsCmd())
 
 	command.PersistentFlags().BoolVarP(
-		&flags.quiet, "quiet", "q", false, "suppresses logs.")
+		&flags.quiet, "quiet", "q", false, "suppresses logs")
 	debugMiddleware.AttachToFlag(command.PersistentFlags(), "debug")
 
 	return command


### PR DESCRIPTION
## Summary
Since no other flag help text uses punctuation
