### PR TITLE
Add revive linter and enable indent-error-flow rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - misspell
     - nilerr
     - reassign
+    - revive
     - staticcheck
     - stylecheck
     - typecheck
@@ -32,6 +33,9 @@ linters:
 linters-settings:
   errorlint:
     errorf: false
+  revive:
+    rules:
+      - name: indent-error-flow
   varnamelen:
     max-distance: 10
     ignore-decls:

--- a/internal/boxcli/midcobra/debug.go
+++ b/internal/boxcli/midcobra/debug.go
@@ -58,9 +58,8 @@ func (d *DebugMiddleware) postRun(cmd *cobra.Command, args []string, runErr erro
 		if usererr.IsWarning(runErr) {
 			ux.Fwarning(cmd.ErrOrStderr(), runErr.Error())
 			return
-		} else {
-			color.New(color.FgRed).Fprintf(cmd.ErrOrStderr(), "\nError: %s\n\n", runErr.Error())
 		}
+		color.New(color.FgRed).Fprintf(cmd.ErrOrStderr(), "\nError: %s\n\n", runErr.Error())
 	} else {
 		color.New(color.FgRed).Fprintf(cmd.ErrOrStderr(), "Error: %v\n\n", runErr)
 	}

--- a/internal/boxcli/midcobra/midcobra.go
+++ b/internal/boxcli/midcobra/midcobra.go
@@ -97,9 +97,8 @@ func (ex *midcobraExecutable) Execute(ctx context.Context, args []string) int {
 			return exitErr.ExitCode()
 		}
 		return 1 // Error exit code
-	} else {
-		return 0
 	}
+	return 0
 }
 
 func ExecutionID() string {

--- a/internal/cloud/mutagen/sync.go
+++ b/internal/cloud/mutagen/sync.go
@@ -38,9 +38,8 @@ func Sync(spec *SessionSpec) (*Session, error) {
 	}
 	if len(sessions) > 0 {
 		return &sessions[0], nil
-	} else {
-		return nil, errors.New("failed to find session that was just created")
 	}
+	return nil, errors.New("failed to find session that was just created")
 	// TODO: starting the mutagen session currently fails if there's any error or
 	// interactivity required for the ssh connection.
 	// That includes:

--- a/internal/cloud/user.go
+++ b/internal/cloud/user.go
@@ -24,7 +24,6 @@ func queryGithubUsername() (string, error) {
 	err := cmd.Run()
 
 	if err != nil {
-
 		if e := (&exec.ExitError{}); errors.As(err, &e) && e.ExitCode() == 1 {
 			// This is the Happy case, and we can parse out the error message
 			debug.Log(
@@ -32,11 +31,10 @@ func queryGithubUsername() (string, error) {
 				bufErr.String(),
 			)
 			return parseUsernameFromErrorMessage(bufErr.String()), nil
-		} else {
-			// This is the sad case, and we should let the caller figure out how to proceed with the user
-			debug.Log("error from command `%s`: %v, out: %v, stderr: %v", cmd, err, bufOut.String(), bufErr.String())
-			return "", errors.WithStack(err)
 		}
+		// This is the sad case, and we should let the caller figure out how to proceed with the user
+		debug.Log("error from command `%s`: %v, out: %v, stderr: %v", cmd, err, bufOut.String(), bufErr.String())
+		return "", errors.WithStack(err)
 	}
 
 	return "", nil

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -212,11 +212,11 @@ func (d *Devbox) ShellPlan() (*plansdk.ShellPlan, error) {
 	shellPlan := planner.GetShellPlan(d.projectDir, userDefinedPkgs)
 	shellPlan.DevPackages = userDefinedPkgs
 
-	if nixpkgsInfo, err := plansdk.GetNixpkgsInfo(d.cfg.Nixpkgs.Commit); err != nil {
+	nixpkgsInfo, err := plansdk.GetNixpkgsInfo(d.cfg.Nixpkgs.Commit)
+	if err != nil {
 		return nil, err
-	} else {
-		shellPlan.NixpkgsInfo = nixpkgsInfo
 	}
+	shellPlan.NixpkgsInfo = nixpkgsInfo
 
 	return shellPlan, nil
 }
@@ -435,13 +435,11 @@ func (d *Devbox) ExecWithShell(cmds ...string) error {
 func (d *Devbox) Exec(cmds ...string) error {
 	if featureflag.UnifiedEnv.Disabled() {
 		return d.ExecWithShell(cmds...)
-	} else {
-		if len(cmds) > 0 {
-			return d.RunScript(cmds[0], cmds[1:])
-		} else {
-			return errors.Errorf("cannot execute empty command: %v", cmds)
-		}
 	}
+	if len(cmds) > 0 {
+		return d.RunScript(cmds[0], cmds[1:])
+	}
+	return errors.Errorf("cannot execute empty command: %v", cmds)
 }
 
 func (d *Devbox) PrintEnv() (string, error) {

--- a/internal/initrec/recommenders/golang/golang.go
+++ b/internal/initrec/recommenders/golang/golang.go
@@ -43,11 +43,10 @@ func getGoPackage(srcDir string) string {
 	v, ok := versionMap[goVersion]
 	if ok {
 		return v
-	} else {
-		// Should we be throwing an error instead, if we don't have a nix package
-		// for the specified version of go?
-		return defaultPkg
 	}
+	// Should we be throwing an error instead, if we don't have a nix package
+	// for the specified version of go?
+	return defaultPkg
 }
 
 func parseGoVersion(gomodPath string) string {

--- a/internal/initrec/recommenders/java/java.go
+++ b/internal/initrec/recommenders/java/java.go
@@ -109,9 +109,8 @@ func getJavaPackage(srcDir string, builderTool string) (string, error) {
 	v, ok := jVersionMap[javaVersion.Major()]
 	if ok {
 		return v, nil
-	} else {
-		return defaultJava, nil
 	}
+	return defaultJava, nil
 }
 
 func parseJavaVersion(srcDir string, builderTool string) (*plansdk.Version, error) {


### PR DESCRIPTION
## Summary

1. Add `revive` linter to `.golangci.yml`
2. Enable `indent-error-flow` rule only for `revive`
3. Address related issues.

## How was it tested?

Linter.