### PR TITLE
[flake] Add plan definitions to flake

### DIFF
--- a/internal/impl/tmpl/flake.nix.tmpl
+++ b/internal/impl/tmpl/flake.nix.tmpl
@@ -9,9 +9,13 @@
 
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
-      let pkgs = nixpkgs.legacyPackages.${system};
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        {{- range .Definitions}}
+        {{.}}
+        {{ end }}
 
-      in {
+      in with pkgs; {
         devShell = pkgs.mkShell {
           shellHook =
             ''
@@ -40,7 +44,7 @@
 
           buildInputs = [
             {{- range .DevPackages}}
-              pkgs.{{.}}
+              {{.}}
             {{end -}}
           ];
         };


### PR DESCRIPTION
## Summary

This ports over the definitions functionality from `shell.nix`. It's an alternative to https://github.com/jetpack-io/devbox/pull/639

Caveats: 

* Our current flake implementation is not using the `flake.nix` file at all, so I had to test using develop.
* I also tested using `DEVBOX_FEATURE_UNIFIED_ENV=1` but this doesn't work either because we prepend the profile path. Since the profile binaries don't reflect the `flake.nix` file definitions, the php binary does not have the extension. Please note that this is a bug that affects much more than PHP extensions and planner definitions. Basically any binary in the profile will not match binaries after running setup hooks. So while the environment variables may be correct, it's possible the binaries in PATH are wrong.

## How was it tested?

```bash
➜ devbox add php php81 php81Extensions.memcached
➜ nix develop .devbox/gen/flake/ 
➜ php -m | grep memcached
memcached
```

I also tested by sourcing `nix print-dev-env` with the generated flake file.