### PR TITLE
[generate] Fixed permission issue for generated dockerfile

### DIFF
--- a/internal/impl/tmpl/devcontainerDockerfile.tmpl
+++ b/internal/impl/tmpl/devcontainerDockerfile.tmpl
@@ -26,6 +26,5 @@ WORKDIR /code
 RUN sudo chown $DEVBOX_USER:root /code
 COPY devbox.json devbox.json
 RUN devbox shell -- echo "Installing packages"
-ENTRYPOINT ["devbox"]
-CMD ['shell']
+CMD ["devbox", "shell"]
 

--- a/internal/impl/tmpl/devcontainerDockerfile.tmpl
+++ b/internal/impl/tmpl/devcontainerDockerfile.tmpl
@@ -23,6 +23,7 @@ RUN . ~/.nix-profile/etc/profile.d/nix.sh
 ENV PATH="/home/${DEVBOX_USER}/.nix-profile/bin:/home/${DEVBOX_USER}/.devbox/nix/profile/default/bin:${PATH}"
 
 WORKDIR /code
+RUN sudo chown $DEVBOX_USER:root /code
 COPY devbox.json devbox.json
 RUN devbox shell -- echo "Installing packages"
 ENTRYPOINT ["devbox"]


### PR DESCRIPTION
## Summary
- Fixed permission issue with generated dockerfile for `devebox generate devcontainer` and `devbox generate dockerfile` addressing issue #627 
- Fixed issue with entrypoint command for generated dockerfile. The old format was causing the built image to have `devbox /bin/sh -c ["shell"]` as entrypoint instead of the intended `devbox shell`. So running `docker run image_name` would result in `Error: unknown command "/bin/sh" for "devbox"`

## How was it tested?
compile
run `devbox generate dockerfile`
run `docker built devboximage .`
run `docker run -it devboximage`
confirm docker image is built successfully
confirm docker image runs successfully
