### PR TITLE
[service-manager] Add more process compose yamls

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -628,6 +628,7 @@ func (d *Devbox) StartProcessManager(ctx context.Context) error {
 	}
 	processComposePath, err := utilityLookPath("process-compose")
 	if err != nil {
+		fmt.Fprintln(d.writer, "Installing process-compose. This may take a minute but will only happen once.")
 		if err = addDevboxUtilityPackage("process-compose"); err != nil {
 			return err
 		}

--- a/internal/impl/util.go
+++ b/internal/impl/util.go
@@ -6,9 +6,12 @@ import (
 
 	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/internal/nix"
-	"go.jetpack.io/devbox/internal/planner/plansdk"
 	"go.jetpack.io/devbox/internal/xdg"
 )
+
+// we need a more modern commit to get version of process-compose we want
+// once the default nixpkgs commit is updated, we can remove this
+const nixpkgsUtilityCommit = "f7475ce8950b761d80a13f3f81d2c23fce60c1dd"
 
 // addDevboxUtilityPackage adds a package to the devbox utility profile.
 // It's used to install applications devbox might need, like process-compose
@@ -19,7 +22,7 @@ func addDevboxUtilityPackage(pkg string) error {
 	if err != nil {
 		return err
 	}
-	return nix.ProfileInstall(profilePath, plansdk.DefaultNixpkgsCommit, pkg)
+	return nix.ProfileInstall(profilePath, nixpkgsUtilityCommit, pkg)
 }
 
 func utilityLookPath(binName string) (string, error) {

--- a/plugins/apache/httpd.conf
+++ b/plugins/apache/httpd.conf
@@ -15,6 +15,7 @@ LoadModule proxy_module modules/mod_proxy.so
 LoadModule proxy_fcgi_module modules/mod_proxy_fcgi.so
 LoadModule dir_module modules/mod_dir.so
 LoadModule alias_module modules/mod_alias.so
+LoadModule log_config_module modules/mod_log_config.so
 
 <IfModule unixd_module>
     User daemon
@@ -37,6 +38,8 @@ DocumentRoot  "${HTTPD_CONFDIR}/../web"
     Require all denied
 </Files>
 ErrorLog "${HTTPD_ERROR_LOG_FILE}"
+LogFormat "%h %l %u %t \"%r\" %>s %b" access
+CustomLog "${HTTPD_ACCESS_LOG_FILE}" access
 <IfModule headers_module>
     RequestHeader unset Proxy early
 </IfModule>

--- a/plugins/apache/process-compose.yaml
+++ b/plugins/apache/process-compose.yaml
@@ -1,0 +1,15 @@
+version: "0.5"
+
+processes:
+  apache:
+    command: "echo \"Apache starting on port $HTTPD_PORT\ http://localhost:$HTTPD_PORT\" && apachectl start -f $HTTPD_CONFDIR/httpd.conf -D FOREGROUND"
+    availability:
+      restart: "always"
+  apache-error:
+    command: "tail -f $HTTPD_ERROR_LOG_FILE"
+    availability:
+      restart: "always"
+  apache-access:
+    command: "tail -f $HTTPD_ACCESS_LOG_FILE"
+    availability:
+      restart: "always"

--- a/plugins/apacheHttpd.json
+++ b/plugins/apacheHttpd.json
@@ -6,11 +6,13 @@
     "HTTPD_DEVBOX_CONFIG_DIR": "{{ .DevboxProjectDir }}",
     "HTTPD_CONFDIR": "{{ .DevboxDir }}",
     "HTTPD_ERROR_LOG_FILE": "{{ .Virtenv }}/error.log",
+    "HTTPD_ACCESS_LOG_FILE": "{{ .Virtenv }}/access.log",
     "HTTPD_PORT": "8080"
   },
   "create_files": {
     "{{ .DevboxDir }}/httpd.conf": "apache/httpd.conf",
-    "{{ .DevboxDirRoot }}/web/index.html": "web/index.html"
+    "{{ .DevboxDirRoot }}/web/index.html": "web/index.html",
+    "{{ .Virtenv }}/process-compose.yaml": "apache/process-compose.yaml"
   },
   "services": {
     "apache": {

--- a/plugins/php.json
+++ b/plugins/php.json
@@ -9,7 +9,8 @@
     "PHPFPM_PORT": "8082"
   },
   "create_files": {
-    "{{ .DevboxDir }}/php-fpm.conf": "php/php-fpm.conf"
+    "{{ .DevboxDir }}/php-fpm.conf": "php/php-fpm.conf",
+    "{{ .Virtenv }}/process-compose.yaml": "php/process-compose.yaml"
   },
   "services": {
     "php-fpm": {

--- a/plugins/php/process-compose.yaml
+++ b/plugins/php/process-compose.yaml
@@ -1,0 +1,8 @@
+version: "0.5"
+
+processes:
+  php-fpm:
+    command: "php-fpm -y {{ .DevboxDir }}/php-fpm.conf --nodaemonize"
+    availability:
+      restart: "always"
+  


### PR DESCRIPTION
## Summary

This adds process compose for apache and php. It also fixes a hash to ensure we download a version of process compose that allows multiple config files to be merged.

## How was it tested?

```bash
devbox add php apacheHttpd
devbox services manager
```