### PR TITLE
Update and activate stale-issue-cleanup

### DIFF
--- a/.github/workflows/stale-issue-cleanup.yml
+++ b/.github/workflows/stale-issue-cleanup.yml
@@ -1,4 +1,4 @@
-name: 'Close stale issues and PRs'
+name: close-stale-issues
 # Marks issues and PRs as stale after 30 days, then closes them if marked stale for 5 days
 on:
   schedule:
@@ -14,6 +14,6 @@ jobs:
           stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove the `stale` label or add a comment, otherwise this PR will be closed in 5 days.'
           exempt-issue-labels: 'future'
           exempt-pr-labels: 'awaiting-approval, work-in-progress'
-          days-before-stale: 30
+          days-before-stale: 45
           days-before-close: 5
-          debug-only: true
+          operations: 100


### PR DESCRIPTION
## Summary
Updates the stale-issue-cleanup action with the following changes

1. Turns off `debug-only` mode so it can run on live issues
2. Increases operations, so that we can process the full list of issues
3. Increases stale timer to 45 days, giving us ~2 cycles to act on an issue/PR before it gets marked stale

## How was it tested?

This action has been running daily in debug mode for over a week. See logs and actions here: 

https://github.com/jetpack-io/devbox/actions/workflows/stale-issue-cleanup.yml