### PR TITLE
Add support for fish

### DIFF
--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -19,6 +19,7 @@ import (
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/debug"
+	"go.jetpack.io/devbox/internal/xdg"
 )
 
 //go:embed shellrc.tmpl
@@ -181,16 +182,7 @@ func rcfilePath(basename string) string {
 }
 
 func fishConfig() string {
-	xdg := os.Getenv("XDG_CONFIG_HOME")
-	if xdg != "" {
-		return filepath.Join(xdg, "fish", "config.fish")
-	} else {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return ""
-		}
-		return filepath.Join(home, ".config", "fish", "config.fish")
-	}
+	return filepath.Join(xdg.ConfigDir(), "fish", "config.fish")
 }
 
 func (s *Shell) Run(nixShellFilePath, nixFlakesFilePath string) error {

--- a/internal/nix/shellrc_fish.tmpl
+++ b/internal/nix/shellrc_fish.tmpl
@@ -1,0 +1,109 @@
+{{- /*
+
+This template defines the shellrc file that the devbox shell will run at
+startup when using the fish shell.
+
+It does _not_ include the user's original fish config, because unlike other
+shells, fish has multiple files as part of its config, and it's difficult
+to start a fish shell with a custom fish config. Instead, we let fish read
+the user's original config directly, and run these commands next.
+
+Devbox needs to ensure that the shell's PATH, prompt, and a few other things are
+set correctly after the user's shellrc runs. The commands to do this are in
+the "Devbox Post-init Hook" section.
+
+This file is useful for debugging shell errors, so try to keep the generated
+content readable.
+
+*/ -}}
+
+{{- if .UnifiedEnv -}}
+# Run the shell hook defined in shell.nix or flake.nix
+eval $shellHook
+
+{{ end -}}
+
+# Begin Devbox Post-init Hook
+
+{{- /*
+NOTE: fish_add_path doesn't play nicely with colon:separated:paths, and I'd rather not
+add string-splitting logic here nor parametrize computeNixEnv based on the shell being
+used. So here we (ab)use the fact that using "export" ahead of the variable definition
+makes fish do exactly what we want and behave in the same way as other shells.
+*/ -}}
+{{ if .UnifiedEnv -}}
+export PATH="$DEVBOX_PATH_PREPEND:$PATH"
+{{- else -}}
+export PATH="{{ .PathPrepend }}:$PATH"
+{{- end }}
+
+{{- /*
+Set the history file by setting fish_history. This is not exactly the same as with other
+shells, because we're not setting the file, but rather the session name, but it's a good
+enough approximation for now.
+*/ -}}
+{{- if .HistoryFile }}
+set fish_history devbox
+{{- end }}
+
+# Prepend to the prompt to make it clear we're in a devbox shell.
+functions -c fish_prompt __devbox_fish_prompt_orig
+function fish_prompt
+    echo "(devbox)" (__devbox_fish_prompt_orig)
+end
+
+{{- if .ShellStartTime }}
+# log that the shell is ready now!
+devbox log shell-ready {{ .ShellStartTime }}
+{{ end }}
+
+# End Devbox Post-init Hook
+
+# Switch to the directory where devbox.json config is
+set workingDir $(pwd)
+cd {{ .ProjectDir }}
+
+{{- if .PluginInitHook }}
+
+# Begin Plugin Init Hook
+
+{{ .PluginInitHook }}
+
+# End Plugin Init Hook
+
+{{- end }}
+
+{{- if .UserHook }}
+
+# Begin Devbox User Hook
+
+{{ .UserHook }}
+
+# End Devbox User Hook
+
+{{- end }}
+
+cd $workingDir
+
+{{- if .ShellStartTime }}
+# log that the shell is interactive now!
+devbox log shell-interactive {{ .ShellStartTime }}
+{{ end }}
+
+# Begin Script command
+
+{{- if .ScriptCommand }}
+
+function run_script
+    set workingDir $(pwd)
+    cd {{ .ProjectDir }}
+
+    {{  .ScriptCommand }}
+
+    cd $workingDir
+end
+{{- end }}
+
+# End Script command
+
+echo "finished"

--- a/internal/nix/shellrc_fish.tmpl
+++ b/internal/nix/shellrc_fish.tmpl
@@ -105,5 +105,3 @@ end
 {{- end }}
 
 # End Script command
-
-echo "finished"


### PR DESCRIPTION
## Summary
Adds support for `fish` shell.

When running `devbox shell`:
We write the post-initialization steps into a "shellrc" file (see `shellrc_fish.tmpl`). I attempted to reuse the existing `shellrc.tmpl`, but the differences in syntax between fish and other shells were large enough that I had to separate them. Next, we invoke `fish -C <shellrc>`. This will make `fish` use the user's existing config first, and _then_ run whatever is in `<shellrc>`, which is similar to what we do for non-fish shells.

When running `devbox run`:
- If unified env is ON, then we invoke `sh -c <script>` just like we do for every other shell.
- If unified env is OFF, then we'll invoke `fish -C <shellrc> -c <script>`. However, note that #650 already enables unified env by default, so this branch is mainly here just in case something goes wrong with unified env and we need to revert.

Caveats:
- We don't check any of the syntax in devbox.json's init hook or scripts. If an init hook uses fish-specific syntax, then it will work for users using `fish`, but it won't for users using a different shell. Similarly for scripts. Conversely, if an init hook uses POSIX syntax that fish doesn't support (e.g. `FOO=bar`), then the init hook will fail for fish users.
- Any plugins that use init hooks should write them in such a way that they work for both fish and non-fish. So far, it seems only `pip` and `ruby` use init hooks, and they're written in a compatible way (AFAIK).

## How was it tested?
I tested that both `devbox shell` and `devbox run` worked with and without unified env. I verified that `PATH` was being set, user's config is being run (for shell only), init hooks are being run, history file is set (shell only), prompt is set (shell only), and scripts are written and run.
To test with fish, it's as easy as invoking devbox as such:
```
SHELL=fish devbox shell
```