### PR TITLE
[flakes] enable unfree packages

### DIFF
--- a/examples/testdata/go/go-1.18/devbox.json
+++ b/examples/testdata/go/go-1.18/devbox.json
@@ -1,11 +1,11 @@
 {
   "packages": [
-    "go"
+    "go_1_18"
   ],
   "shell": {
     "init_hook": null
   },
   "nixpkgs": {
-    "commit": "af9e00071d0971eb292fd5abef334e66eda3cb69"
+    "commit": "9e0eed654c705c7cafe192a8eba1610217f70544"
   }
 }

--- a/examples/testdata/go/go-1.18/shell_plan.json
+++ b/examples/testdata/go/go-1.18/shell_plan.json
@@ -1,5 +1,5 @@
 {
   "dev_packages": [
-    "go"
+    "go_1_18"
   ]
 }

--- a/examples/testdata/unfree-packages/devbox.json
+++ b/examples/testdata/unfree-packages/devbox.json
@@ -1,5 +1,6 @@
 {
   "packages": [
+    "slack",
     "vscode"
   ],
   "shell": {
@@ -9,6 +10,6 @@
     }
   },
   "nixpkgs": {
-    "commit": "a3d745e701c337e65ef467d5a9400d9336a303a1"
+    "commit": "9e0eed654c705c7cafe192a8eba1610217f70544"
   }
 }

--- a/examples/testdata/unfree-packages/devbox.json
+++ b/examples/testdata/unfree-packages/devbox.json
@@ -9,6 +9,6 @@
     }
   },
   "nixpkgs": {
-    "commit": "52e3e80afff4b16ccb7c52e9f0f5220552f03d04"
+    "commit": "a3d745e701c337e65ef467d5a9400d9336a303a1"
   }
 }

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -803,7 +803,6 @@ func (d *Devbox) computeNixEnv(setFullPath bool) (map[string]string, error) {
 
 	// These variables are only needed for shell, but we include them here in the computed env
 	// for both shell and run in order to be as identical as possible.
-	env["NIX_PKGS_ALLOW_UNFREE"] = "1"     // Only for shell because we don't expect nix calls within run
 	env["__ETC_PROFILE_NIX_SOURCED"] = "1" // Prevent user init file from loading nix profiles
 	env["DEVBOX_SHELL_ENABLED"] = "1"      // Used to determine whether we're inside a shell (e.g. to prevent shell inception)
 

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -87,6 +87,7 @@ func (d *Devbox) addPackagesToProfile(mode installMode) error {
 			"nix", "profile", "install",
 			"--profile", profileDir,
 			"--extra-experimental-features", "nix-command flakes",
+			"--impure", // Needed to allow flags from environment to be used.
 			nix.FlakeNixpkgs(d.cfg.Nixpkgs.Commit)+"#"+pkg,
 		)
 		cmd.Stdout = &nixPackageInstallWriter{d.writer}

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -154,8 +154,10 @@ func PrintDevEnv(nixShellFilePath, nixFlakesFilePath string) (*varsAndFuncs, err
 		"--extra-experimental-features", "nix-command",
 		"--extra-experimental-features", "ca-derivations",
 		"--option", "experimental-features", "nix-command flakes",
+		"--impure",
 		"--json")
 	debug.Log("Running print-dev-env cmd: %s\n", cmd)
+	cmd.Env = DefaultEnv()
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/testscripts/run/env.test.txt
+++ b/testscripts/run/env.test.txt
@@ -14,8 +14,6 @@ exec devbox run echo '$USER'
 stdout 'test-user'
 
 # Fixed/hard-coded vars are set
-exec devbox run echo '$NIX_PKGS_ALLOW_UNFREE'
-stdout '1'
 exec devbox run echo '$__ETC_PROFILE_NIX_SOURCED'
 stdout '1'
 


### PR DESCRIPTION
## Summary

To enable unfree packages with flakes, we need to do both of:
1. set `NIXPKGS_ALLOW_UNFREE=1`
2. use `--impure` flag

There is also an option to do:
```
nixpkgs {
   config {
      allowUnfree = true;
   } 
}
```
However, I have not done this because:
1. we'd still need `--impure` for `nix profile install` that doesn't use `flake.nix`.
2. I couldn't actually figure out how to set `config.allowUnfree` in our flake.nix since we are using the num-tides flakes-utils to enable the flake to work for all `system` values.

## How was it tested?

in `examples/testdata/unfree-packages`, I can now do:
```
DEVBOX_FEATURE_FLAKES=1 DEVBOX_FEATURE_UNIFIED_ENV=1 DEVBOX_DEBUG=1 devbox shell
```

I was a little concerned that `--impure` would introduce a lot of other environment variables 
into the shell, but I think it is safe for the following reasons.

1. I tested with a specific env-var:
```
> export SAVIL=impure-test
> env | grep SAVIL
SAVIL=impure-test

> DEVBOX_FEATURE_FLAKES=1 DEVBOX_FEATURE_UNIFIED_ENV=1 DEVBOX_DEBUG=1 devbox shell
(devbox) > env | grep SAVIL
```
So, the `SAVIL` env-var was not included in the devbox shell.


2. I compared all the env-vars by doing `env > env_with_{property}.txt` for this branch and the `main` branch.

From visual inspection, the order of env-vars was different but the number of lines were same.

So, I sorted them alphabetically and then compared them:
```
❯ cat env_with_main.txt | sort > env_with_main_sorted.txt
(devbox)

❯ cat env_with_impure.txt | sort > env_with_impure_sorted.txt
(devbox)

❯ diff env_with_main_sorted.txt env_with_impure_sorted.txt
77c77
< STARSHIP_SESSION_KEY=7757126821727611
---
> STARSHIP_SESSION_KEY=3237459778369717
92c92
< ZDOTDIR=/var/folders/zv/r3sx92_94gq86_rq3yn1ky2h0000gn/T/devbox3757196048
---
> ZDOTDIR=/var/folders/zv/r3sx92_94gq86_rq3yn1ky2h0000gn/T/devbox1045668199
```
The differences here are session-specific, and I don't see a lot of other env-vars being introduced due to `--impure`.
