### PR TITLE
[flakes] remove shell hook

### DIFF
--- a/internal/impl/tmpl/flake.nix.tmpl
+++ b/internal/impl/tmpl/flake.nix.tmpl
@@ -16,31 +16,6 @@
 
       in {
         devShell = pkgs.mkShell {
-          shellHook =
-            ''
-              # We're technically no longer in a Nix shell after this hook because we
-              # exec a devbox shell.
-              export IN_NIX_SHELL=0
-              export DEVBOX_SHELL_ENABLED=1
-
-              # Undo the effects of "nix-shell --pure" on SSL certs.
-              # See https://github.com/NixOS/nixpkgs/blob/dae204faa0243b4d0c0234a5f5f83a2549ecb5b7/pkgs/stdenv/generic/setup.sh#L677-L685
-              if [ "$NIX_SSL_CERT_FILE" = "/no-cert-file.crt" ]; then
-                 unset NIX_SSL_CERT_FILE
-              fi
-              if [ "$SSL_CERT_FILE" = "/no-cert-file.crt" ]; then
-                 unset SSL_CERT_FILE
-              fi
-
-              # Append the parent shell's PATH so that we retain access to
-              # non-Nix programs, while still preferring the Nix ones.
-              export "PATH=$PATH:$PARENT_PATH"
-
-              {{ if debug }}
-              echo "PATH=$PATH"
-              {{- end }}
-            '';
-
           buildInputs = with pkgs; [
             {{- range .DevPackages}}
             {{.}}


### PR DESCRIPTION
## Summary

https://github.com/jetpack-io/devbox/pull/635 hid the shell hook from `shell.nix` behind the unified-env flag (where shell hook is active when flag is OFF).
So, this PR removes it from `flake.nix`, since flakes depend on unified-env being turned on.



## How was it tested?

opened `devbox shell` in `examples/testdata/go/go-1.19` project

