### PR TITLE
[stderr] Fix a few prints that were going to out instead of err DEV-1282

### DIFF
--- a/internal/boxcli/add.go
+++ b/internal/boxcli/add.go
@@ -29,7 +29,7 @@ func AddCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				fmt.Fprintf(
-					cmd.OutOrStdout(),
+					cmd.ErrOrStderr(),
 					"Usage: %s\n\n%s\n",
 					cmd.UseLine(),
 					toSearchForPackages,

--- a/internal/boxcli/global.go
+++ b/internal/boxcli/global.go
@@ -38,7 +38,7 @@ func globalAddCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				fmt.Fprintf(
-					cmd.OutOrStdout(),
+					cmd.ErrOrStderr(),
 					"Usage: %s\n\n%s\n",
 					cmd.UseLine(),
 					toSearchForPackages,
@@ -65,7 +65,7 @@ func globalRemoveCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				fmt.Fprintf(
-					cmd.OutOrStdout(),
+					cmd.ErrOrStderr(),
 					"Usage: %s\n\n%s\n",
 					cmd.UseLine(),
 					toSearchForPackages,
@@ -165,7 +165,7 @@ func pullGlobalCmdFunc(cmd *cobra.Command, args []string) error {
 	if _, err := devbox.InitConfig(path, cmd.ErrOrStderr()); err != nil {
 		return errors.WithStack(err)
 	}
-	box, err := devbox.Open(path, cmd.OutOrStdout())
+	box, err := devbox.Open(path, cmd.ErrOrStderr())
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/internal/boxcli/midcobra/debug.go
+++ b/internal/boxcli/midcobra/debug.go
@@ -57,10 +57,10 @@ func (d *DebugMiddleware) postRun(cmd *cobra.Command, args []string, runErr erro
 		if usererr.IsWarning(runErr) {
 			ux.Fwarning(cmd.ErrOrStderr(), runErr.Error())
 		} else {
-			color.Red("\nError: " + runErr.Error() + "\n\n")
+			color.New(color.FgRed).Fprintf(cmd.ErrOrStderr(), "\nError: %s\n\n", runErr.Error())
 		}
 	} else {
-		fmt.Printf("Error: %v\n", runErr)
+		fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", runErr)
 	}
 
 	st := debug.EarliestStackTrace(runErr)

--- a/testscripts/run/shellception.test.txt
+++ b/testscripts/run/shellception.test.txt
@@ -1,4 +1,4 @@
 # Do not support shell inception
 exec devbox init
 ! exec devbox run devbox shell
-stdout 'Error: You are already in an active devbox shell.'
+stderr 'Error: You are already in an active devbox shell.'


### PR DESCRIPTION
## Summary

This changes output for

* add
* global add
* global pull

(since these are not expected to print anything except diagnostic output)

It also fixes the debug middleware which prints all errors.

## How was it tested?

`devbox run test`
