### PR TITLE
[nix] create common ExperimentalFlags function

### DIFF
--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -86,10 +86,10 @@ func (d *Devbox) addPackagesToProfile(mode installMode) error {
 		cmd := exec.Command(
 			"nix", "profile", "install",
 			"--profile", profileDir,
-			"--extra-experimental-features", "nix-command flakes",
 			"--impure", // Needed to allow flags from environment to be used.
 			nix.FlakeNixpkgs(d.cfg.Nixpkgs.Commit)+"#"+pkg,
 		)
+		cmd.Args = append(cmd.Args, nix.ExperimentalFlags()...)
 		cmd.Stdout = &nixPackageInstallWriter{d.writer}
 
 		cmd.Env = nix.DefaultEnv()
@@ -145,9 +145,9 @@ func (d *Devbox) removePackagesFromProfile(pkgs []string) error {
 
 		cmd := exec.Command("nix", "profile", "remove",
 			"--profile", profileDir,
-			"--extra-experimental-features", "nix-command flakes",
 			attrPath,
 		)
+		cmd.Args = append(cmd.Args, nix.ExperimentalFlags()...)
 		cmd.Stdout = d.writer
 		cmd.Stderr = d.writer
 		err = cmd.Run()
@@ -231,9 +231,9 @@ func (d *Devbox) ensureNixpkgsPrefetched() error {
 	fmt.Fprintf(d.writer, "Ensuring nixpkgs registry is downloaded.\n")
 	cmd := exec.Command(
 		"nix", "flake", "prefetch",
-		"--extra-experimental-features", "nix-command flakes",
 		nix.FlakeNixpkgs(d.cfg.Nixpkgs.Commit),
 	)
+	cmd.Args = append(cmd.Args, nix.ExperimentalFlags()...)
 	cmd.Env = nix.DefaultEnv()
 	cmd.Stdout = d.writer
 	cmd.Stderr = cmd.Stdout

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -87,9 +87,8 @@ func flakesPkgInfo(nixpkgsCommit, pkg string) (*Info, bool) {
 		exactPackage = fmt.Sprintf("nixpkgs#%s", pkg)
 	}
 
-	cmd := exec.Command("nix", "search",
-		"--extra-experimental-features", "nix-command flakes",
-		"--json", exactPackage)
+	cmd := exec.Command("nix", "search", "--json", exactPackage)
+	cmd.Args = append(cmd.Args, ExperimentalFlags()...)
 	return pkgInfo(cmd, pkg)
 }
 
@@ -150,12 +149,8 @@ func PrintDevEnv(nixShellFilePath, nixFlakesFilePath string) (*varsAndFuncs, err
 	} else {
 		cmd.Args = append(cmd.Args, "-f", nixShellFilePath)
 	}
-	cmd.Args = append(cmd.Args,
-		"--extra-experimental-features", "nix-command",
-		"--extra-experimental-features", "ca-derivations",
-		"--option", "experimental-features", "nix-command flakes",
-		"--impure",
-		"--json")
+	cmd.Args = append(cmd.Args, ExperimentalFlags()...)
+	cmd.Args = append(cmd.Args, "--impure", "--json")
 	debug.Log("Running print-dev-env cmd: %s\n", cmd)
 	cmd.Env = DefaultEnv()
 	out, err := cmd.Output()
@@ -177,4 +172,11 @@ func FlakeNixpkgs(commit string) string {
 	// Using nixpkgs/<commit> means:
 	// The nixpkgs entry in the flake registry, with its Git revision overridden to a specific value.
 	return "nixpkgs/" + commit
+}
+
+func ExperimentalFlags() []string {
+	return []string{
+		"--extra-experimental-features", "ca-derivations",
+		"--option", "experimental-features", "nix-command flakes",
+	}
 }

--- a/internal/nix/profile.go
+++ b/internal/nix/profile.go
@@ -21,9 +21,9 @@ func ProfileListItems(writer io.Writer, profileDir string) ([]*NixProfileListIte
 
 	cmd := exec.Command(
 		"nix", "profile", "list",
-		"--extra-experimental-features", "nix-command flakes",
 		"--profile", profileDir,
 	)
+	cmd.Args = append(cmd.Args, ExperimentalFlags()...)
 
 	// We set stderr to a different output than stdout
 	// to ensure error output is not mingled with the stdout output
@@ -188,8 +188,8 @@ func ProfileInstall(profilePath, nixpkgsCommit, pkg string) error {
 	cmd := exec.Command("nix", "profile", "install",
 		"--profile", profilePath,
 		"nixpkgs/"+nixpkgsCommit+"#"+pkg,
-		"--extra-experimental-features", "nix-command flakes",
 	)
+	cmd.Args = append(cmd.Args, ExperimentalFlags()...)
 	cmd.Env = DefaultEnv()
 	out, err := cmd.CombinedOutput()
 	if bytes.Contains(out, []byte("does not provide attribute")) {
@@ -207,8 +207,8 @@ func ProfileRemove(profilePath, nixpkgsCommit, pkg string) error {
 	cmd := exec.Command("nix", "profile", "remove",
 		"--profile", profilePath,
 		info.attributeKey,
-		"--extra-experimental-features", "nix-command flakes",
 	)
+	cmd.Args = append(cmd.Args, ExperimentalFlags()...)
 	cmd.Env = DefaultEnv()
 	out, err := cmd.CombinedOutput()
 	if bytes.Contains(out, []byte("does not match any packages")) {


### PR DESCRIPTION
## Summary

I noticed that print-dev-env and nix profile commands were using a different set
of nix experimental features.

I think we should unify these so that they're writing to the store in a common fashion.

**Implementation Note**
It appears that: `"--extra-experimental-features", "nix-command flakes"`, is different from `"--option", "experimental-features", "nix-command flakes"` for our `nix print-dev-env` testscripts.

We must have the latter. The former is insufficient and not needed.

This confuses me because the docs suggest that `--extra-experimental-features` should append these experimental features, whereas `--option` replaces the experimental features:
>  --option name value
 Set the Nix configuration setting name to value (overriding nix.conf).

and

>  --extra-experimental-features value
 Append to the experimental-features setting.


Concretely, this works:
```
		"--extra-experimental-features", "ca-derivations",
		"--option", "experimental-features", "nix-command flakes",
```
but this does not work:
```
"--option", "experimental-features", "ca-derivations nix-command flakes",
```
and nor does this:
```
		"--extra-experimental-features", "nix-command flakes",
		"--extra-experimental-features", "ca-derivations",
```

## How was it tested?

`go test ./...`

in `examples/testdata/go/go-1.19` with flakes feature flag on for all commands:
```
> devbox shell
(devbox)> devbox add vim emacs
(devbox)> source activate shell...

(devbox)> devbox rm emacs
```
