### PR TITLE
Unhide Global 

### DIFF
--- a/internal/boxcli/global.go
+++ b/internal/boxcli/global.go
@@ -18,7 +18,7 @@ func globalCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "global",
 		Short:  "Manage global devbox packages",
-		Hidden: true,
+		Hidden: false,
 	}
 
 	cmd.AddCommand(globalAddCmd())


### PR DESCRIPTION
## Summary

This PR unhides the global feature. I'm leaving ENV hidden for another release, so we can do some more validation of the feature. 

## How was it tested?

Tested locally, verified help text appeared when running devbox
