### PR TITLE
[easy][errors] Fix double error

### DIFF
--- a/internal/boxcli/midcobra/debug.go
+++ b/internal/boxcli/midcobra/debug.go
@@ -57,13 +57,15 @@ func (d *DebugMiddleware) postRun(cmd *cobra.Command, args []string, runErr erro
 	if usererr.HasUserMessage(runErr) {
 		if usererr.IsWarning(runErr) {
 			ux.Fwarning(cmd.ErrOrStderr(), runErr.Error())
+			return
 		} else {
 			color.New(color.FgRed).Fprintf(cmd.ErrOrStderr(), "\nError: %s\n\n", runErr.Error())
 		}
+	} else {
+		color.New(color.FgRed).Fprintf(cmd.ErrOrStderr(), "Error: %v\n\n", runErr)
 	}
 
 	st := debug.EarliestStackTrace(runErr)
-	color.New(color.FgRed).Fprintf(cmd.ErrOrStderr(), "Error: %v\n\n", runErr)
 	var exitErr *exec.ExitError
 	if errors.As(runErr, &exitErr) {
 		debug.Log("Command stderr: %s\n", exitErr.Stderr)


### PR DESCRIPTION
## Summary

Fixes minor double error issue. (This was pulled out of https://github.com/jetpack-io/devbox/pull/695)

## How was it tested?

```bash
devbox global add hello
hello is now installed
Warning: the devbox global profile is not in your $PATH.

Add the following line to your shell's rcfile (e.g., ~/.bashrc or ~/.zshrc)
and restart your shell to fix this:

	eval "$(devbox global shellenv)"
```