### PR TITLE
Improve handling when no SHELL env-var is defined

### DIFF
--- a/internal/boxcli/shell_test.go
+++ b/internal/boxcli/shell_test.go
@@ -16,8 +16,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"go.jetpack.io/devbox/internal/boxcli/featureflag"
-	"go.jetpack.io/devbox/internal/nix"
 	"go.jetpack.io/devbox/internal/testframework"
 )
 
@@ -314,13 +312,6 @@ func TestShell(t *testing.T) {
 	err := td.SetDevboxJSON(devboxJSON)
 	assert.NoError(t, err)
 	output, err := td.RunCommand(ShellCmd())
-	if featureflag.Flakes.Enabled() {
-		assert.Error(t, err)
-		if !errors.Is(err, nix.ErrNoDefaultShellUnsupportedInFlakesMode) {
-			assert.Fail(t, "Expected error %s but received %s", nix.ErrNoDefaultShellUnsupportedInFlakesMode, err)
-		}
-	} else {
-		assert.NoError(t, err)
-		assert.Contains(t, output, "Starting a devbox shell...")
-	}
+	assert.NoError(t, err)
+	assert.Contains(t, output, "Starting a devbox shell...")
 }

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -271,7 +271,7 @@ func (d *Devbox) Shell() error {
 		nix.WithShellStartTime(shellStartTime),
 	}
 
-	shell, err := nix.NewShell(opts...)
+	shell, err := nix.NewShell(d.cfg.Nixpkgs.Commit, opts...)
 	if err != nil {
 		return err
 	}
@@ -357,7 +357,7 @@ func (d *Devbox) RunScriptInNewNixShell(scriptName string) error {
 		nix.WithPKGConfigDir(d.pluginVirtenvPath()),
 	}
 
-	shell, err := nix.NewShell(opts...)
+	shell, err := nix.NewShell(d.cfg.Nixpkgs.Commit, opts...)
 
 	if err != nil {
 		fmt.Fprint(d.writer, err)
@@ -381,6 +381,7 @@ func (d *Devbox) RunScriptInShell(scriptName string) error {
 	}
 
 	shell, err := nix.NewShell(
+		d.cfg.Nixpkgs.Commit,
 		nix.WithProfile(profileDir),
 		nix.WithHistoryFile(filepath.Join(d.projectDir, shellHistoryFile)),
 		nix.WithUserScript(scriptName, script.String()),

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -271,7 +271,7 @@ func (d *Devbox) Shell() error {
 		nix.WithShellStartTime(shellStartTime),
 	}
 
-	shell, err := nix.NewShell(d.cfg.Nixpkgs.Commit, opts...)
+	shell, err := nix.NewDevboxShell(d.cfg.Nixpkgs.Commit, opts...)
 	if err != nil {
 		return err
 	}
@@ -357,7 +357,7 @@ func (d *Devbox) RunScriptInNewNixShell(scriptName string) error {
 		nix.WithPKGConfigDir(d.pluginVirtenvPath()),
 	}
 
-	shell, err := nix.NewShell(d.cfg.Nixpkgs.Commit, opts...)
+	shell, err := nix.NewDevboxShell(d.cfg.Nixpkgs.Commit, opts...)
 
 	if err != nil {
 		fmt.Fprint(d.writer, err)
@@ -380,7 +380,7 @@ func (d *Devbox) RunScriptInShell(scriptName string) error {
 		return usererr.New("unable to find a script with name %s", scriptName)
 	}
 
-	shell, err := nix.NewShell(
+	shell, err := nix.NewDevboxShell(
 		d.cfg.Nixpkgs.Commit,
 		nix.WithProfile(profileDir),
 		nix.WithHistoryFile(filepath.Join(d.projectDir, shellHistoryFile)),

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -271,10 +271,9 @@ func (d *Devbox) Shell() error {
 		nix.WithShellStartTime(shellStartTime),
 	}
 
-	shell, err := nix.DetectShell(opts...)
+	shell, err := nix.NewShell(opts...)
 	if err != nil {
-		// Fall back to using a plain Nix shell.
-		shell = &nix.Shell{}
+		return err
 	}
 
 	shell.UserInitHook = d.cfg.Shell.InitHook.String()
@@ -358,11 +357,11 @@ func (d *Devbox) RunScriptInNewNixShell(scriptName string) error {
 		nix.WithPKGConfigDir(d.pluginVirtenvPath()),
 	}
 
-	shell, err := nix.DetectShell(opts...)
+	shell, err := nix.NewShell(opts...)
 
 	if err != nil {
 		fmt.Fprint(d.writer, err)
-		shell = &nix.Shell{}
+		return err
 	}
 
 	shell.UserInitHook = d.cfg.Shell.InitHook.String()
@@ -381,7 +380,7 @@ func (d *Devbox) RunScriptInShell(scriptName string) error {
 		return usererr.New("unable to find a script with name %s", scriptName)
 	}
 
-	shell, err := nix.DetectShell(
+	shell, err := nix.NewShell(
 		nix.WithProfile(profileDir),
 		nix.WithHistoryFile(filepath.Join(d.projectDir, shellHistoryFile)),
 		nix.WithUserScript(scriptName, script.String()),
@@ -390,7 +389,7 @@ func (d *Devbox) RunScriptInShell(scriptName string) error {
 
 	if err != nil {
 		fmt.Fprint(d.writer, err)
-		shell = &nix.Shell{}
+		return err
 	}
 
 	return shell.RunInShell()

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -159,7 +159,7 @@ func shellPath(nixpkgsCommitHash string) (path string, err error) {
 // for the devbox shell.
 func initShellBinaryFields(path string) *DevboxShell {
 
-	sh := &DevboxShell{binPath: path}
+	shell := &DevboxShell{binPath: path}
 	base := filepath.Base(path)
 	// Login shell
 	if base[0] == '-' {
@@ -167,30 +167,30 @@ func initShellBinaryFields(path string) *DevboxShell {
 	}
 	switch base {
 	case "bash":
-		sh.name = shBash
-		sh.userShellrcPath = rcfilePath(".bashrc")
+		shell.name = shBash
+		shell.userShellrcPath = rcfilePath(".bashrc")
 	case "zsh":
-		sh.name = shZsh
-		sh.userShellrcPath = rcfilePath(".zshrc")
+		shell.name = shZsh
+		shell.userShellrcPath = rcfilePath(".zshrc")
 	case "ksh":
-		sh.name = shKsh
-		sh.userShellrcPath = rcfilePath(".kshrc")
+		shell.name = shKsh
+		shell.userShellrcPath = rcfilePath(".kshrc")
 	case "fish":
-		sh.name = shFish
-		sh.userShellrcPath = fishConfig()
-	case "dash", "ash", "sh":
-		sh.name = shPosix
-		sh.userShellrcPath = os.Getenv("ENV")
+		shell.name = shFish
+		shell.userShellrcPath = fishConfig()
+	case "dash", "ash", "shell":
+		shell.name = shPosix
+		shell.userShellrcPath = os.Getenv("ENV")
 
 		// Just make up a name if there isn't already an init file set
 		// so we have somewhere to put a new one.
-		if sh.userShellrcPath == "" {
-			sh.userShellrcPath = ".shinit"
+		if shell.userShellrcPath == "" {
+			shell.userShellrcPath = ".shinit"
 		}
 	default:
-		sh.name = shUnknown
+		shell.name = shUnknown
 	}
-	return sh
+	return shell
 }
 
 // If/once we end up making plugins the same as devbox.json we probably want

--- a/internal/nix/shell_test.go
+++ b/internal/nix/shell_test.go
@@ -62,7 +62,7 @@ func testWriteDevboxShellrc(t *testing.T, testdirs []string) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			s := &Shell{
+			s := &DevboxShell{
 				projectDir:      "path/to/projectDir",
 				userShellrcPath: test.shellrcPath,
 				UserInitHook:    test.hook,


### PR DESCRIPTION
## Summary

Previously, if `SHELL` env-var was not set, we'd return an error from `nix.DetectShell`
and initialize an empty struct `nix.Shell{}`. Then, in `Shell.Run` we'd see that `Shell.binPath` is empty
and call `nix-shell`.

This has the following problems:
1. Initializing an empty `nix.Shell{}` means that we drop all the other `ShellOptions`
in the constructor.
2. In `Shell.Run`, we'd use `nix-shell` but fail if the flakes feature was not enabled. This `nix-shell` also loses all the print-dev-env work that we have done for Unified-Env.

To solve and/or mitigate these issues, I propose the following changes:
- Rename `nix.Shell` to `nix.DevboxShell` to make it clear that its not a raw nix shell. TODO for future to move this out of `nix` package.
- Rename `nix.DetectShell` to `nix.NewDevboxShell` to make clear that it is a constructor function. Decompose its functionality into helper functions `shellPath` and `initShellBinaryFields`.
- If `SHELL` is undefined, ~we loop over a list of common shells to see if they are accessible in the `PATH`.~ we use the bash from nix.
- Failing to find ~any recognizable shell in `PATH`,~ bash from nix, we fail the program with an error.
- Remove the fallback to `nix-shell` in `Shell.Run`. This means we _always_ use the Unified-Env codepath.
- Update `shell_test` for Flakes feature, since it now finds a shell from PATH and uses that (previously, would error).


## How was it tested?

in `examples/testdata/go/go-1.19`:
```
❯ DEVBOX_DEBUG=0 SHELL= DEVBOX_FEATURE_FLAKES=0 devbox shell
Ensuring packages are installed.
Starting a devbox shell...
(devbox) Savil-Srivastavas-MacBook-Pro:go-1.19 savil$ echo $SHELL
/nix/store/1bsjl5incfnszv7scdh4d02sh45vw2w1-bash-5.1-p16/bin/bash
(devbox) Savil-Srivastavas-MacBook-Pro:go-1.19 savil$ exit
exit

❯ DEVBOX_DEBUG=0 SHELL= DEVBOX_FEATURE_FLAKES=1 devbox shell
Ensuring packages are installed.

Installing package: go_1_19.

[1/1] go_1_19
[1/1] go_1_19: Success
Starting a devbox shell...
(devbox) Savil-Srivastavas-MacBook-Pro:go-1.19 savil$ echo $SHELL
/nix/store/1bsjl5incfnszv7scdh4d02sh45vw2w1-bash-5.1-p16/bin/bash
(devbox) Savil-Srivastavas-MacBook-Pro:go-1.19 savil$
```

Also: `go test ./...` with flakes feature enabled and disabled.

