### PR TITLE
[nix] Add additional source path

### DIFF
--- a/internal/nix/source.go
+++ b/internal/nix/source.go
@@ -20,6 +20,7 @@ func nixLinks() []string {
 		filepath.Join(os.Getenv("HOME"), ".nix-profile/etc/profile.d/nix.sh"),
 		// logic introduced in https://github.com/NixOS/nix/pull/5588/files
 		xdg.StateSubpath("nix/profile/etc/profile.d/nix.sh"),
+		xdg.StateSubpath("nix/profiles/profile/etc/profile.d/nix.sh"),
 	}
 }
 


### PR DESCRIPTION
## Summary

This should not be needed, but nice to have until nix fixes bad nix link.

## How was it tested?

Tested in devbox cloud, but it didn't completely work because `.nix-profile` sym link was broken.
