### PR TITLE
[CICD] Fix mac tests

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -102,11 +102,13 @@ jobs:
           echo "PATH=$PATH" >> $GITHUB_ENV
       - name: Run tests
         run: |
-          export NIX_PATH=nixpkgs=https://github.com/nixos/nixpkgs/tarball/nixos-unstable
           go test -race -cover -v ./...
 
   auto-nix-install: # ensure Devbox installs nix and works properly after installation.
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3.5.0

--- a/internal/boxcli/shell_test.go
+++ b/internal/boxcli/shell_test.go
@@ -295,6 +295,7 @@ func (sh *shell) exit(t *testing.T) {
 }
 
 func TestShell(t *testing.T) {
+	t.Setenv("NIX_PATH", "nixpkgs=https://github.com/nixos/nixpkgs/tarball/nixos-unstable")
 	devboxJSON := `
 	{
 		"packages": [],


### PR DESCRIPTION
## Summary

This fixes mac os tests by setting `NIX_PATH` on the test itself. This should not be needed so it makes me a bit nervous we are covering up another issue.

Added auto-install test for mac

## How was it tested?

CICD
