### PR TITLE
[Devcontainer] Fixed path for python interpreter in devcontainer.json

### DIFF
--- a/internal/boxcli/generate/devcontainer_util.go
+++ b/internal/boxcli/generate/devcontainer_util.go
@@ -117,7 +117,7 @@ func getDevcontainerContent(pkgs []string) *devcontainerObject {
 	for _, pkg := range pkgs {
 		if strings.Contains(pkg, "python3") {
 			devcontainerContent.Customizations.Vscode.Settings = map[string]any{
-				"python.defaultInterpreterPath": "/devbox/.devbox/nix/profile/default/bin/python3",
+				"python.defaultInterpreterPath": "/code/.devbox/nix/profile/default/bin/python3",
 			}
 			devcontainerContent.Customizations.Vscode.Extensions =
 				append(devcontainerContent.Customizations.Vscode.Extensions, "ms-python.python")


### PR DESCRIPTION
## Summary
The generated dockerfile puts the devbox packages and files in `/code/.devbox/` in the container. But in devcontainer.json the path is set to `/devbox/.devbox/`. This makes this small fix.

## How was it tested?
- `devbox generate devcontainer`
- run `code .`
- reopen and rebuild in container
- confirm python interpreter path is set correctly in vscode