### PR TITLE
Fix fish shell after #706

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -1048,6 +1048,9 @@ var ignoreCurrentEnvVar = map[string]bool{
 
 	// The parent shell isn't guaranteed to be the same as the Devbox shell.
 	"SHELL": true,
+
+	// The "_" variable is read-only, so we ignore it to avoid attempting to write it later.
+	"_": true,
 }
 
 // ignoreDevEnvVar contains environment variables that Devbox should remove from

--- a/internal/nix/shell.go
+++ b/internal/nix/shell.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"text/template"
 
@@ -217,8 +218,14 @@ func WithHistoryFile(historyFile string) ShellOption {
 // via wrapper scripts.
 func WithEnvVariables(envVariables map[string]string) ShellOption {
 	return func(s *DevboxShell) {
-		for k, v := range envVariables {
-			s.env = append(s.env, fmt.Sprintf("%s=%s", k, v))
+		keys := make([]string, 0, len(envVariables))
+		for k := range envVariables {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			s.env = append(s.env, fmt.Sprintf("%s=%s", k, envVariables[k]))
 		}
 	}
 }

--- a/internal/nix/shellrc.tmpl
+++ b/internal/nix/shellrc.tmpl
@@ -1,5 +1,7 @@
 {{- /*
 
+IF YOU EDIT THIS FILE, REMEMBER TO MAKE EQUIVALENT CHANGES TO shellrc_fish.tmpl
+
 This template defines the shellrc file that the devbox shell will run at
 startup.
 

--- a/internal/nix/shellrc_fish.tmpl
+++ b/internal/nix/shellrc_fish.tmpl
@@ -17,12 +17,6 @@ content readable.
 
 */ -}}
 
-{{- if .UnifiedEnv -}}
-# Run the shell hook defined in shell.nix or flake.nix
-eval $shellHook
-
-{{ end -}}
-
 # Begin Devbox Post-init Hook
 
 {{- /*
@@ -31,8 +25,8 @@ add string-splitting logic here nor parametrize computeNixEnv based on the shell
 used. So here we (ab)use the fact that using "export" ahead of the variable definition
 makes fish do exactly what we want and behave in the same way as other shells.
 */ -}}
-{{ if .UnifiedEnv }}
-export PATH="$DEVBOX_PATH_PREPEND:$PATH"
+{{ with .ExportEnv }}
+{{ . }}
 {{- else }}
 export PATH="{{ .PathPrepend }}:$PATH"
 {{- end }}
@@ -60,8 +54,8 @@ devbox log shell-ready {{ .ShellStartTime }}
 # End Devbox Post-init Hook
 
 # Switch to the directory where devbox.json config is
-set workingDir $(pwd)
-cd {{ .ProjectDir }}
+set workingDir "$(pwd)"
+cd "{{ .ProjectDir }}" || exit
 
 {{- if .PluginInitHook }}
 
@@ -83,7 +77,7 @@ cd {{ .ProjectDir }}
 
 {{- end }}
 
-cd $workingDir
+cd "$workingDir" || exit
 
 {{- if .ShellStartTime }}
 # log that the shell is interactive now!
@@ -95,13 +89,14 @@ devbox log shell-interactive {{ .ShellStartTime }}
 {{- if .ScriptCommand }}
 
 function run_script
-    set workingDir $(pwd)
-    cd {{ .ProjectDir }}
+    set workingDir "$(pwd)"
+    cd "{{ .ProjectDir }}" || exit
 
     {{  .ScriptCommand }}
 
-    cd $workingDir
+    cd "$workingDir" || exit
 end
-{{- end }}
 
 # End Script command
+
+{{- end }}


### PR DESCRIPTION
## Summary
* Applies the same changes from #706 to the fish shellrc.
* Ignores the `_` variable. It's read-only and `fish` complains if we try to write it.
* Added a note in `shellrc` so we remember do edit `shellrc_fish` too. If we had tests for fish we could remove this silly note.
* Alphabetized vars so the generated shellrc is a bit cleaner (imo).

Fixes #719 

## How was it tested?
```
SHELL=fish ./devbox shell
```

I'll add some shellrc_fish tests in a future PR
