### PR TITLE
[CICD] auto-nix-install: export env-var and add DEVBOX_DEBUG=1

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -127,5 +127,6 @@ jobs:
         run: go install ./cmd/devbox
       - name: Install nix and devbox packages
         run: |
-          NIX_INSTALLER_NO_CHANNEL_ADD=1
+          export NIX_INSTALLER_NO_CHANNEL_ADD=1
+          export DEVBOX_DEBUG=1
           devbox run echo "Installing packages..."


### PR DESCRIPTION
## Summary

I've been seeing this `auto-nix-install` test falsely fail on multiple PRs. For example:
https://github.com/jetpack-io/devbox/actions/runs/4356921852/jobs/7615570020

title says it for the two changes

## How was it tested?

buildkite run
