### PR TITLE
Shellenv prepends to original path, not current path

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -470,6 +470,13 @@ func (d *Devbox) computeNixEnv() (map[string]string, error) {
 	}
 	currentEnvPath := env["PATH"]
 	debug.Log("current environment PATH is: %s", currentEnvPath)
+	// Use the original path, if available. If not available, set it for future calls.
+	// See https://github.com/jetpack-io/devbox/issues/687
+	originalPath, ok := env["DEVBOX_OG_PATH"]
+	if !ok {
+		env["DEVBOX_OG_PATH"] = currentEnvPath
+		originalPath = currentEnvPath
+	}
 
 	vaf, err := nix.PrintDevEnv(d.nixShellFilePath(), d.nixFlakesFilePath())
 	if err != nil {
@@ -535,7 +542,7 @@ func (d *Devbox) computeNixEnv() (map[string]string, error) {
 	pluginVirtenvPath := d.pluginVirtenvPath()
 	debug.Log("plugin virtual environment PATH is: %s", pluginVirtenvPath)
 
-	env["PATH"] = JoinPathLists(pluginVirtenvPath, nixEnvPath, currentEnvPath)
+	env["PATH"] = JoinPathLists(pluginVirtenvPath, nixEnvPath, originalPath)
 	debug.Log("computed unified environment PATH is: %s", env["PATH"])
 
 	return env, nil


### PR DESCRIPTION
## Summary
Fixes #687 

## How was it tested?
```
echo $PATH
devbox shell
hello # fails
devbox add hello
eval $(devbox shellenv)
hello # ok!
devbox rm hello
eval $(devbox shellenv)
hello # fails
```