### PR TITLE
Escape env vars in shellenv the same way as in shellrc

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -233,14 +233,7 @@ func (d *Devbox) PrintEnv() (string, error) {
 		return "", err
 	}
 
-	script := ""
-	for k, v := range envs {
-		// %q is for escaping quotes in env variables that
-		// have quotes in them e.g., shellHook
-		script += fmt.Sprintf("export %s=%q\n", k, v)
-	}
-
-	return script, nil
+	return exportify(envs), nil
 }
 
 func (d *Devbox) Info(pkg string, markdown bool) error {

--- a/internal/impl/envvars.go
+++ b/internal/impl/envvars.go
@@ -1,0 +1,43 @@
+package impl
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func mapToPairs(m map[string]string) []string {
+	pairs := []string{}
+	for k, v := range m {
+		pairs = append(pairs, fmt.Sprintf("%s=%s", k, v))
+	}
+	return pairs
+}
+
+// exportify takes an array of strings of the form VAR=VAL and returns a bash script
+// that exports all the vars after properly escaping them.
+func exportify(vars map[string]string) string {
+	keys := make([]string, 0, len(vars))
+	for k := range vars {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	strb := strings.Builder{}
+	for _, k := range keys {
+		strb.WriteString("export ")
+		strb.WriteString(k)
+		strb.WriteString(`="`)
+		for _, r := range vars[k] {
+			switch r {
+			// Special characters inside double quotes:
+			// https://pubs.opengroup.org/onlinepubs/009604499/utilities/xcu_chap02.html#tag_02_02_03
+			case '$', '`', '"', '\\', '\n':
+				strb.WriteRune('\\')
+			}
+			strb.WriteRune(r)
+		}
+		strb.WriteString("\"\n")
+	}
+	return strings.TrimSpace(strb.String())
+}


### PR DESCRIPTION
## Summary
Before, running `eval $(devbox shellenv)` would fail for me, because my `PS1` var wasn't being escaped properly. Now it is and we reuse the function.

## How was it tested?
Ran `eval $(devbox shellenv)`