### PR TITLE
[xdg]: unexport xxxDir() and use xxxSubpath() only

### DIFF
--- a/internal/impl/shell.go
+++ b/internal/impl/shell.go
@@ -253,13 +253,13 @@ func WithShellStartTime(time string) ShellOption {
 func rcfilePath(basename string) string {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return ""
+		return "~"
 	}
 	return filepath.Join(home, basename)
 }
 
 func fishConfig() string {
-	return filepath.Join(xdg.ConfigDir(), "fish", "config.fish")
+	return xdg.ConfigSubpath("fish/config.fish")
 }
 
 func (s *DevboxShell) Run() error {

--- a/internal/impl/shellcmd/command.go
+++ b/internal/impl/shellcmd/command.go
@@ -33,7 +33,7 @@ func (c CmdFormat) String() string {
 	}
 }
 
-// ConfigShellCmds marshals and unmarshals shell commands from a devbox config
+// Commands marshals and unmarshals shell commands from a devbox config
 // as either a single string or an array of strings. It preserves the original
 // value such that:
 //

--- a/internal/xdg/xdg.go
+++ b/internal/xdg/xdg.go
@@ -5,37 +5,26 @@ import (
 	"path/filepath"
 )
 
-func DataDir() string {
-	return resolveDir("XDG_DATA_HOME", ".local/share")
-}
-
 func DataSubpath(subpath string) string {
-	return filepath.Join(DataDir(), subpath)
-}
-
-func ConfigDir() string {
-	return resolveDir("XDG_CONFIG_HOME", ".config")
+	return filepath.Join(dataDir(), subpath)
 }
 
 func ConfigSubpath(subpath string) string {
-	return filepath.Join(ConfigDir(), subpath)
-}
-
-func CacheDir() string {
-	return resolveDir("XDG_CACHE_HOME", ".cache")
+	return filepath.Join(configDir(), subpath)
 }
 
 func CacheSubpath(subpath string) string {
-	return filepath.Join(CacheDir(), subpath)
-}
-
-func StateDir() string {
-	return resolveDir("XDG_STATE_HOME", ".local/state")
+	return filepath.Join(cacheDir(), subpath)
 }
 
 func StateSubpath(subpath string) string {
-	return filepath.Join(StateDir(), subpath)
+	return filepath.Join(stateDir(), subpath)
 }
+
+func dataDir() string   { return resolveDir("XDG_DATA_HOME", ".local/share") }
+func configDir() string { return resolveDir("XDG_CONFIG_HOME", ".config") }
+func cacheDir() string  { return resolveDir("XDG_CACHE_HOME", ".cache") }
+func stateDir() string  { return resolveDir("XDG_STATE_HOME", ".local/state") }
 
 func resolveDir(envvar string, defaultPath string) string {
 	dir := os.Getenv(envvar)


### PR DESCRIPTION
## Summary

1. Unexport `xxxDir()`s
2. Use `xxxSubpath()` outside of pckage `xdg`
3. update `rcfilePath` based on `resolveDir`

## How was it tested?

tests