### PR TITLE
Fix quickstart button to link to tutorial

### DIFF
--- a/docs/app/docs/quickstart.mdx
+++ b/docs/app/docs/quickstart.mdx
@@ -26,7 +26,7 @@ Devbox requires the [Nix Package Manager](https://nixos.org/download.html). If N
 :::note
 If you want to try Devbox before installing it, you can open a cloud shell on your browser using the link below
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/new)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=tutorial)
 :::
 
 ## Create a development environment


### PR DESCRIPTION
## Summary

Quickstart Devbox.sh button now points to the tutorial

## How was it tested?

localhost