### PR TITLE
[config] early return if cannot find GlobalDataPath

### DIFF
--- a/internal/impl/config.go
+++ b/internal/impl/config.go
@@ -57,6 +57,7 @@ func (c *Config) Packages(w io.Writer) []string {
 	dataPath, err := GlobalDataPath()
 	if err != nil {
 		ux.Ferror(w, "unable to get devbox global data path: %s\n", err)
+		return c.RawPackages
 	}
 	global, err := readConfig(filepath.Join(dataPath, "devbox.json"))
 	if err != nil {


### PR DESCRIPTION
## Summary

From inspecting the code, I think this should early return. The following statement
about `readConfig(filepath.Join(dataPath, "devbox.json"))` doesn't make sense
to execute if there's been an error in retrieving the `dataPath`.

## How was it tested?

buildkite testscripts
