### PR TITLE
Fix build: only go:embed .json files in plugins dir

### DIFF
--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -2,5 +2,5 @@ package plugins
 
 import "embed"
 
-//go:embed *
+//go:embed *.json
 var BuiltIn embed.FS


### PR DESCRIPTION
## Summary
TSIA. See #742 for context.

## How was it tested?
Ran `devbox shell`