### PR TITLE
[plugins] explicitly embed plugin folders

### DIFF
--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -2,5 +2,5 @@ package plugins
 
 import "embed"
 
-//go:embed *.json
+//go:embed *.json apache caddy mariadb nginx php pip redis web
 var BuiltIn embed.FS


### PR DESCRIPTION
## Summary

Don't love this since it relies on an author of a new plugin to remember to 
embed the folder here.

I couldn't find an exclude pattern for "include all except README". Will look
since i think golang uses glob patterns.

## How was it tested?

BEFORE:
```
go test ./testscripts/...
--- FAIL: TestScripts (10.63s)
    --- FAIL: TestScripts/languages (0.00s)
        --- FAIL: TestScripts/languages/php.test (0.03s)
            testscript.go:429: > exec devbox run -- php index.php
                [stderr]
                Error: unable to get devbox global data path: mkdir /no-home: read-only file system
                Error: open php/process-compose.yaml: file does not exist

                [exit status 1]
                FAIL: languages/php.test.txt:1: unexpected command failure

    --- FAIL: TestScripts/run (0.00s)
        --- FAIL: TestScripts/run/env.test (0.24s)
            testscript.go:429: # Tests related to setting the environment for devbox run.
                # Parent shell vars should leak into the run environment (0.238s)
"~/code/jetpack/devbox/.git/COMMIT_EDITMSG" 8L, 250B
  1 [plugins] explicitly embed plugin folders
                > env HOME=/home/test
                > env USER=test-user
                > env FOO=bar
                > exec devbox run echo '$HOME'
                [stderr]
                Error: unable to get devbox global data path: mkdir /home/test: operation not supported
                Error: open nginx/process-compose.yaml: file does not exist

                [exit status 1]
                FAIL: run/env.test.txt:7: unexpected command failure

FAIL
FAIL    go.jetpack.io/devbox/testscripts        10.899s
?       go.jetpack.io/devbox/testscripts/testrunner     [no test files]
FAIL

```

AFTER: passes
