### PR TITLE
nix,impl: avoid modifying flake.nix; don't use --impure

### DIFF
--- a/internal/impl/generate_test.go
+++ b/internal/impl/generate_test.go
@@ -1,0 +1,146 @@
+package impl
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestWriteFromTemplate(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "makeme")
+	outPath := filepath.Join(dir, "flake.nix")
+	err := writeFromTemplate(dir, testFlakeTmplPlan, "flake.nix")
+	if err != nil {
+		t.Fatal("got error writing flake template:", err)
+	}
+	fi, err := os.Stat(outPath)
+	if err != nil {
+		t.Fatal("got stat error for new flake file:", err)
+	}
+	originalModTime := fi.ModTime()
+	cmpGoldenFile(t, outPath, "testdata/flake.nix.golden")
+
+	t.Run("WriteUnmodified", func(t *testing.T) {
+		err = writeFromTemplate(dir, testFlakeTmplPlan, "flake.nix")
+		if err != nil {
+			t.Fatal("got error writing flake template:", err)
+		}
+		fi, err := os.Stat(outPath)
+		if err != nil {
+			t.Fatal("got stat error for flake file:", err)
+		}
+		if !originalModTime.Equal(fi.ModTime()) {
+			t.Errorf("flake mod time changed from %s to %s", originalModTime, fi.ModTime())
+		}
+		cmpGoldenFile(t, outPath, "testdata/flake.nix.golden")
+	})
+	t.Run("WriteModifiedSmaller", func(t *testing.T) {
+		emptyPlan := struct {
+			NixpkgsInfo struct {
+				URL string
+			}
+			Definitions []string
+			DevPackages []string
+		}{}
+		err = writeFromTemplate(dir, emptyPlan, "flake.nix")
+		if err != nil {
+			t.Fatal("got error writing flake template:", err)
+		}
+		fi, err := os.Stat(filepath.Join(dir, "flake.nix"))
+		if err != nil {
+			t.Fatal("got stat error for flake file:", err)
+		}
+		if originalModTime.Equal(fi.ModTime()) {
+			t.Errorf("flake mod time didn't change from %s", originalModTime)
+		}
+		cmpGoldenFile(t, outPath, "testdata/flake-empty.nix.golden")
+	})
+	t.Run("WriteModifiedBigger", func(t *testing.T) {
+		err = writeFromTemplate(dir, testFlakeTmplPlan, "flake.nix")
+		if err != nil {
+			t.Fatal("got error writing flake template:", err)
+		}
+		fi, err := os.Stat(filepath.Join(dir, "flake.nix"))
+		if err != nil {
+			t.Fatal("got stat error for flake file:", err)
+		}
+		if originalModTime.Equal(fi.ModTime()) {
+			t.Errorf("flake mod time didn't change from %s", originalModTime)
+		}
+		cmpGoldenFile(t, outPath, "testdata/flake.nix.golden")
+	})
+}
+
+func cmpGoldenFile(t *testing.T, gotPath, wantGoldenPath string) {
+	got, err := os.ReadFile(gotPath)
+	if err != nil {
+		t.Fatal("got error reading generated file:", err)
+	}
+	if *update {
+		err = os.WriteFile(wantGoldenPath, got, 0666)
+		if err != nil {
+			t.Error("got error updating golden file:", err)
+		}
+	}
+	golden, err := os.ReadFile(wantGoldenPath)
+	if err != nil {
+		t.Fatal("got error reading golden file:", err)
+	}
+	diff := cmp.Diff(golden, got)
+	if diff != "" {
+		t.Errorf(strings.TrimSpace(`
+got wrong file contents (-%s +%s):
+
+%s
+If the new file is correct, you can update the golden file with:
+
+	go test -run "^%s$" -update`),
+			filepath.Base(wantGoldenPath), filepath.Base(gotPath),
+			diff, t.Name())
+	}
+}
+
+var testFlakeTmplPlan = &struct {
+	NixpkgsInfo struct {
+		URL string
+	}
+	Definitions []string
+	DevPackages []string
+}{
+	NixpkgsInfo: struct {
+		URL string
+	}{
+		URL: "https://github.com/nixos/nixpkgs/archive/b9c00c1d41ccd6385da243415299b39aa73357be.tar.gz",
+	},
+	Definitions: []string{
+		"php = pkgs.php.withExtensions ({ enabled, all }: enabled ++ (with all; [ blackfire ]));",
+		"php81Packages.composer = php.packages.composer;",
+	},
+	DevPackages: []string{
+		"php",
+		"php81Packages.composer",
+		"php81Extensions.blackfire",
+		"flyctl",
+		"postgresql",
+		"tree",
+		"git",
+		"zsh",
+		"openssh",
+		"vim",
+		"sqlite",
+		"jq",
+		"delve",
+		"ripgrep",
+		"shellcheck",
+		"terraform",
+		"xz",
+		"zstd",
+		"gnupg",
+		"go_1_20",
+		"python3",
+		"graphviz",
+	},
+}

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -219,7 +219,6 @@ func (d *Devbox) installNixProfile() (err error) {
 		"-f", filepath.Join(d.projectDir, ".devbox/gen/development.nix"),
 	)
 
-	cmd.Env = nix.DefaultEnv()
 	cmd.Stdout = &nix.PackageInstallWriter{Writer: d.writer}
 
 	cmd.Stderr = cmd.Stdout

--- a/internal/impl/testdata/flake-empty.nix.golden
+++ b/internal/impl/testdata/flake-empty.nix.golden
@@ -2,7 +2,7 @@
   description = "A devbox shell";
 
   inputs = {
-    nixpkgs.url = "{{ .NixpkgsInfo.URL }}";
+    nixpkgs.url = "";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -13,16 +13,10 @@
           inherit system;
           config.allowUnfree = true;
         });
-        {{- range .Definitions}}
-        {{.}}
-        {{- end }}
       in
       {
         devShell = pkgs.mkShell {
           buildInputs = with pkgs; [
-            {{- range .DevPackages}}
-            {{.}}
-            {{- end}}
           ];
         };
       }

--- a/internal/impl/testdata/flake.nix.golden
+++ b/internal/impl/testdata/flake.nix.golden
@@ -1,0 +1,48 @@
+{
+  description = "A devbox shell";
+
+  inputs = {
+    nixpkgs.url = "https://github.com/nixos/nixpkgs/archive/b9c00c1d41ccd6385da243415299b39aa73357be.tar.gz";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = (import nixpkgs {
+          inherit system;
+          config.allowUnfree = true;
+        });
+        php = pkgs.php.withExtensions ({ enabled, all }: enabled ++ (with all; [ blackfire ]));
+        php81Packages.composer = php.packages.composer;
+      in
+      {
+        devShell = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            php
+            php81Packages.composer
+            php81Extensions.blackfire
+            flyctl
+            postgresql
+            tree
+            git
+            zsh
+            openssh
+            vim
+            sqlite
+            jq
+            delve
+            ripgrep
+            shellcheck
+            terraform
+            xz
+            zstd
+            gnupg
+            go_1_20
+            python3
+            graphviz
+          ];
+        };
+      }
+    );
+}

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -76,7 +76,6 @@ func flakesPkgInfo(nixpkgsCommit, pkg string) (*Info, bool) {
 }
 
 func pkgInfo(cmd *exec.Cmd, pkg string) (*Info, bool) {
-	cmd.Env = DefaultEnv()
 	cmd.Stderr = os.Stderr
 	debug.Log("running command: %s\n", cmd)
 	out, err := cmd.Output()
@@ -110,10 +109,6 @@ func parseInfo(pkg string, data []byte) *Info {
 	return nil
 }
 
-func DefaultEnv() []string {
-	return append(os.Environ(), "NIXPKGS_ALLOW_UNFREE=1")
-}
-
 type varsAndFuncs struct {
 	Functions map[string]string   // the key is the name, the value is the body.
 	Variables map[string]variable // the key is the name.
@@ -133,9 +128,8 @@ func PrintDevEnv(nixShellFilePath, nixFlakesFilePath string) (*varsAndFuncs, err
 		cmd.Args = append(cmd.Args, "-f", nixShellFilePath)
 	}
 	cmd.Args = append(cmd.Args, ExperimentalFlags()...)
-	cmd.Args = append(cmd.Args, "--impure", "--json")
+	cmd.Args = append(cmd.Args, "--json")
 	debug.Log("Running print-dev-env cmd: %s\n", cmd)
-	cmd.Env = DefaultEnv()
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, errors.Wrapf(err, "Command: %s", cmd)

--- a/internal/nix/nixpkgs.go
+++ b/internal/nix/nixpkgs.go
@@ -38,7 +38,6 @@ func ensureNixpkgsPrefetched(w io.Writer, commit string) error {
 		FlakeNixpkgs(commit),
 	)
 	cmd.Args = append(cmd.Args, ExperimentalFlags()...)
-	cmd.Env = DefaultEnv()
 	cmd.Stdout = w
 	cmd.Stderr = cmd.Stdout
 	if err := cmd.Run(); err != nil {

--- a/internal/nix/profile.go
+++ b/internal/nix/profile.go
@@ -230,7 +230,6 @@ func profileInstall(args *ProfileInstallArgs) error {
 	cmd := exec.Command(
 		"nix", "profile", "install",
 		"--profile", args.ProfilePath,
-		"--impure", // Needed to allow flags from environment to be used.
 		FlakeNixpkgs(args.NixpkgsCommit)+"#"+args.Package,
 	)
 	cmd.Args = append(cmd.Args, ExperimentalFlags()...)
@@ -238,8 +237,6 @@ func profileInstall(args *ProfileInstallArgs) error {
 		cmd.Args = append(cmd.Args, "--priority", args.Priority)
 	}
 	cmd.Args = append(cmd.Args, args.ExtraFlags...)
-
-	cmd.Env = DefaultEnv()
 	writer := &PackageInstallWriter{args.Writer}
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = io.MultiWriter(&stdout, writer)
@@ -306,7 +303,6 @@ func ProfileRemove(profilePath, nixpkgsCommit, pkg string) error {
 		info.attributeKey,
 	)
 	cmd.Args = append(cmd.Args, ExperimentalFlags()...)
-	cmd.Env = DefaultEnv()
 	out, err := cmd.CombinedOutput()
 	if bytes.Contains(out, []byte("does not match any packages")) {
 		return ErrPackageNotInstalled


### PR DESCRIPTION
## Summary

The previous devbox shell/run startup time was taking about 3.5x longer than `nix develop` for "warm" runs where the flake had already been evaluated once:

	$ time nix develop .devbox/gen/flake -c echo hi
	hi
	0.12s user 0.04s system 45% cpu 0.356 total

	$ time devbox run -- echo hi
	hi
	0.66s user 0.17s system 62% cpu 1.330 total

This was due to two reasons:

1. Devbox was passing `--impure` so that `NIXPKGS_ALLOW_UNFREE` could be used. This prevents Nix from using its eval cache. Fix it by setting the `allowUnfree` attribute directly in the flake.
2. Under certain circumstances, Nix uses the flake file's modified time stamp to determine if it can use its eval cache. Devbox unconditionally writes generated files on every run, which was changing the modified timestamp of the flake. Update the `writeFromTemplate` function to not write to existing files if the contents haven't changed.

After these changes, the new devbox times are more in-line with Nix:

	$ time devbox run -- echo hi
	hi
	0.19s user 0.09s system 59% cpu 0.466 total

Also ran `nixpgs-fmt` on the flake file templates and added tests to ensure they stay correct.

## How was it tested?

Added tests.