### PR TITLE
testscripts: enable DEVBOX_DEBUG

### DIFF
--- a/testscripts/testrunner/setupenv.go
+++ b/testscripts/testrunner/setupenv.go
@@ -20,6 +20,7 @@ func setupTestEnv(env *testscript.Env) error {
 	// Enable new `devbox run` so we can use it in tests. This is temporary,
 	// and should be removed once we enable this feature flag.
 	env.Setenv("DEVBOX_FEATURE_UNIFIED_ENV", "1")
+	env.Setenv("DEVBOX_DEBUG", "1")
 	return nil
 }
 


### PR DESCRIPTION
The testscript tests clear out the environment, so we need to re-enable DEVBOX_DEBUG in order to get more info when a command fails.