### PR TITLE
ci: remove go test -race and -cover

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -105,7 +105,7 @@ jobs:
           nix-build-user-count: 4
       - name: Run tests
         run: |
-          go test -race -cover ./...
+          go test ./...
 
   auto-nix-install: # ensure Devbox installs nix and works properly after installation.
     strategy:


### PR DESCRIPTION
We don't have any tests that would make -race useful and we're not looking at code coverage. These flags (especially when combined) can slow down tests by a lot.