### PR TITLE
[Cloud] Added cloud init command for open in vscode

### DIFF
--- a/internal/boxcli/cloud.go
+++ b/internal/boxcli/cloud.go
@@ -18,6 +18,7 @@ type cloudShellCmdFlags struct {
 	config configFlags
 
 	githubUsername string
+	interactive    bool
 }
 
 func CloudCmd() *cobra.Command {
@@ -50,6 +51,9 @@ func cloudShellCmd() *cobra.Command {
 	flags.config.register(command)
 	command.Flags().StringVarP(
 		&flags.githubUsername, "username", "u", "", "Github username to use for ssh",
+	)
+	command.Flags().BoolVarP(
+		&flags.interactive, "interactive", "i", true, "Start an interactive shell after creating a cloud instance",
 	)
 	return command
 }
@@ -125,5 +129,5 @@ func runCloudShellCmd(cmd *cobra.Command, flags *cloudShellCmdFlags) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	return cloud.Shell(cmd.Context(), cmd.ErrOrStderr(), box.ProjectDir(), flags.githubUsername)
+	return cloud.Shell(cmd.Context(), cmd.ErrOrStderr(), box.ProjectDir(), flags.githubUsername, flags.interactive)
 }

--- a/internal/boxcli/cloud.go
+++ b/internal/boxcli/cloud.go
@@ -4,6 +4,7 @@
 package boxcli
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -153,5 +154,12 @@ func runCloudInit(cmd *cobra.Command, flags *cloudShellCmdFlags) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	return cloud.InitShell(cmd.Context(), cmd.ErrOrStderr(), box.ProjectDir(), flags.githubUsername)
+	_, vmhostname, err := cloud.InitVM(cmd.Context(), cmd.ErrOrStderr(), box.ProjectDir(), flags.githubUsername)
+	if err != nil {
+		return err
+	}
+	// printing vmHostname so that the output of devbox cloud init can be read by
+	// devbox extension
+	fmt.Fprintln(cmd.ErrOrStderr(), vmhostname)
+	return nil
 }

--- a/internal/boxcli/cloud.go
+++ b/internal/boxcli/cloud.go
@@ -154,7 +154,7 @@ func runCloudInit(cmd *cobra.Command, flags *cloudShellCmdFlags) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	_, vmhostname, err := cloud.InitVM(cmd.Context(), cmd.ErrOrStderr(), box.ProjectDir(), flags.githubUsername)
+	_, vmhostname, _, err := cloud.InitVM(cmd.Context(), cmd.ErrOrStderr(), box.ProjectDir(), flags.githubUsername)
 	if err != nil {
 		return err
 	}

--- a/internal/boxcli/generate.go
+++ b/internal/boxcli/generate.go
@@ -101,10 +101,11 @@ func direnvCmd() *cobra.Command {
 func sshConfigCmd() *cobra.Command {
 	flags := &generateCmdFlags{}
 	command := &cobra.Command{
-		Use:   "ssh-config",
-		Short: "Generates ssh config to connect to devbox cloud",
-		Long:  "Checks ssh config and if they don't exist, it generates the configs necessary to connect to devbox cloud VMs.",
-		Args:  cobra.MaximumNArgs(0),
+		Use:    "ssh-config",
+		Hidden: true,
+		Short:  "Generates ssh config to connect to devbox cloud",
+		Long:   "Checks ssh config and if they don't exist, it generates the configs necessary to connect to devbox cloud VMs.",
+		Args:   cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runGenerateCmd(cmd, args, flags)
 		},

--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -29,7 +29,7 @@ import (
 	"go.jetpack.io/devbox/internal/ux/stepper"
 )
 
-func sshSetup(username string) (*openssh.Cmd, error) {
+func SSHSetup(username string) (*openssh.Cmd, error) {
 	sshCmd := &openssh.Cmd{
 		Username:        username,
 		DestinationAddr: "gateway.devbox.sh",
@@ -108,7 +108,7 @@ func Shell(ctx context.Context, w io.Writer, projectDir string, githubUsername s
 	debug.Log("username: %s", username)
 
 	// setup ssh config
-	sshCmd, err := sshSetup(username)
+	sshCmd, err := SSHSetup(username)
 	if err != nil {
 		return err
 	}
@@ -167,7 +167,7 @@ func InitShell(ctx context.Context, w io.Writer, projectDir string, githubUserna
 	debug.Log("username: %s", username)
 
 	// setup ssh config
-	sshCmd, err := sshSetup(username)
+	sshCmd, err := SSHSetup(username)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
Added a `devbox cloud init` command similar to devbox cloud shell but it can be called in to create a cloud vm (if it's not created already) and sets up ssh configs without dropping user in an interactive cloud shell.
This will be used in the extension so that the extension can ensure:
1. the remote vm exists
2. get its ssh address (vm ID)
3. the client (vscode) can connect to it via ssh

Also, added `devbox generate ssh-config` command that only sets ssh-config without creating cloud VMs.

## How was it tested?
`devbox cloud init`
and 
`devbox generate ssh-config`
