### PR TITLE
[cloud] Print message telling users how they can access their services

### DIFF
--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -101,6 +101,10 @@ func toggleServices(
 		<-c
 	}
 
+	if action == startService {
+		return printProxyURL(w)
+	}
+
 	return nil
 }
 
@@ -146,4 +150,23 @@ func listenToAutoPortForwardingChangesOnRemote(
 			},
 		},
 	)
+}
+
+func printProxyURL(w io.Writer) error {
+
+	if os.Getenv("DEVBOX_REGION") == "" {
+		return nil
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	color.New(color.FgHiGreen).Fprintf(
+		w,
+		"To access services on this vm use: %s-<port>.svc.devbox.sh\n",
+		hostname,
+	)
+	return nil
 }


### PR DESCRIPTION
## Summary

Print message telling user how they can access their services on devbox cloud. We could improve this in the future by trying to figure out what port the user is using for this particular service. (we can reuse port field that was already added for auto-port forwarding)

Ideally this is not part of the CLI since it's only important for cloud, but this was quickest implementation.

## How was it tested?

```bash
(devbox) ➜  devbox git:(main) ✗ DEVBOX_REGION=lax devbox services restart
Service "nginx" stopped
Service "nginx" started
To access services on this vm use: Mike.local-<port>.svc.devbox.sh
```
