### PR TITLE
[plugin] Added gradle plugin and fixed typo in docs

### DIFF
--- a/docs/app/docs/devbox_examples/languages/java.md
+++ b/docs/app/docs/devbox_examples/languages/java.md
@@ -51,7 +51,7 @@ Gradle is a popular, multi-language build tool that is commonly used with JVM pr
         mainClassName = 'hello.HelloWorld'
         jar {
             manifest {
-              /* assuming main class is in src/main/hello/HelloWorld.java */
+              /* assuming main class is in src/main/java/hello/HelloWorld.java */
                 attributes 'Main-Class': 'hello.HelloWorld'
             }
         }

--- a/plugins/gradle.json
+++ b/plugins/gradle.json
@@ -3,9 +3,6 @@
     "version": "0.0.1",
     "match": "^(gradle|gradle_[0-9])$",
     "readme": "You can customize which JDK gradle will use by specifying the value of `org.gradle.java.home` in gradle.properties file",
-    "create_files": {
-        "{{ .DevboxDirRoot }}/gradle.properties": "gradle/gradle.properties"
-    },
     "shell": {
         "init_hook": [
             "[ -s gradle.properties ] || echo org.gradle.java.home=$JAVA_HOME >> gradle.properties"

--- a/plugins/gradle.json
+++ b/plugins/gradle.json
@@ -1,0 +1,14 @@
+{
+    "name": "gradle",
+    "version": "0.0.1",
+    "match": "^(gradle|gradle_[0-9])$",
+    "readme": "You can customize which JDK gradle will use by specifying the value of `org.gradle.java.home` in gradle.properties file",
+    "create_files": {
+        "{{ .DevboxDirRoot }}/gradle.properties": "gradle/gradle.properties"
+    },
+    "shell": {
+        "init_hook": [
+            "[ -s gradle.properties ] || echo org.gradle.java.home=$JAVA_HOME >> gradle.properties"
+        ]
+    }
+}

--- a/plugins/gradle/gradle.properties
+++ b/plugins/gradle/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.java.home=

--- a/plugins/gradle/gradle.properties
+++ b/plugins/gradle/gradle.properties
@@ -1,1 +1,0 @@
-org.gradle.java.home=


### PR DESCRIPTION
## Summary
Added plugin for gradle to force it to use the installed jdk version instead of default (17).
Also fixed a small error in documentation for gradle setup

## How was it tested?
- compile
- in empty directory run `./devbox init`
- `./devbox add gradle jdk11`
- `./devbox shell`
- confirm a gradle.properties file is created with content similar to below:
```gradle.properties
org.gradle.java.home=/nix/store/3y1sh00km4c616prn19brd3vj9ikc2h2-zulu11.48.21-ca-jdk-11.0.11
```