### PR TITLE
[nix] Simplify profile priority, make it match flake file

### DIFF
--- a/internal/impl/config.go
+++ b/internal/impl/config.go
@@ -53,6 +53,8 @@ type Stage struct {
 
 var commitMismatchWarningShown = false
 
+// Packages returns the list of packages to install, including global packages.
+// It returns higher priority packages first.
 func (c *Config) Packages(w io.Writer) []string {
 	dataPath, err := GlobalDataPath()
 	if err != nil {

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -639,6 +639,9 @@ func (d *Devbox) nixFlakesFilePath() string {
 	return filepath.Join(d.projectDir, ".devbox/gen/flake/flake.nix")
 }
 
+// packages returns the list of packages to be installed in the nix shell as
+// specified by config and globals. It maintains the order of packages
+// as specified by Config.Packages() (higher priority first)
 func (d *Devbox) packages() []string {
 	return d.cfg.Packages(d.writer)
 }

--- a/internal/nix/profile.go
+++ b/internal/nix/profile.go
@@ -3,18 +3,21 @@ package nix
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
-	"go.jetpack.io/devbox/internal/debug"
 )
+
+const DefaultPriority = 5
 
 // ProfileListItems returns a list of the installed packages
 func ProfileListItems(writer io.Writer, profileDir string) ([]*NixProfileListItem, error) {
@@ -180,7 +183,6 @@ func (item *NixProfileListItem) String() string {
 
 type ProfileInstallArgs struct {
 	CustomStepMessage string
-	Priority          string
 	ExtraFlags        []string
 	NixpkgsCommit     string
 	Package           string
@@ -201,90 +203,32 @@ func ProfileInstall(args *ProfileInstallArgs) error {
 		fmt.Fprintf(args.Writer, "%s\n", stepMsg)
 	}
 
-	err := profileInstall(args)
-	if err != nil {
-		if errors.Is(err, ErrPackageNotFound) {
-			return err
-		}
-
-		fmt.Fprintf(args.Writer, "%s: ", stepMsg)
-		color.New(color.FgRed).Fprintf(args.Writer, "Fail\n")
-		return err
-	}
-
-	fmt.Fprintf(args.Writer, "%s: ", stepMsg)
-	color.New(color.FgGreen).Fprintf(args.Writer, "Success\n")
-
-	return nil
-}
-
-func profileInstall(args *ProfileInstallArgs) error {
-
 	cmd := exec.Command(
 		"nix", "profile", "install",
 		"--profile", args.ProfilePath,
 		"--impure", // for NIXPKGS_ALLOW_UNFREE
+		// Using an arbitrary priority to avoid conflicts with other packages.
+		// Note that this is not really the priority we care about, since we
+		// use the flake.nix to specify the priority.
+		"--priority", nextPriority(args.ProfilePath),
 		FlakeNixpkgs(args.NixpkgsCommit)+"#"+args.Package,
 	)
 	cmd.Env = AllowUnfreeEnv()
 	cmd.Args = append(cmd.Args, ExperimentalFlags()...)
-	if args.Priority != "" {
-		cmd.Args = append(cmd.Args, "--priority", args.Priority)
-	}
 	cmd.Args = append(cmd.Args, args.ExtraFlags...)
-	writer := &PackageInstallWriter{args.Writer}
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = io.MultiWriter(&stdout, writer)
-	cmd.Stderr = io.MultiWriter(&stderr, writer)
+	cmd.Stdout = &PackageInstallWriter{args.Writer}
+	var stderr bytes.Buffer
+	cmd.Stderr = io.MultiWriter(&stderr, cmd.Stdout)
 
 	if err := cmd.Run(); err != nil {
 		if strings.Contains(stderr.String(), "does not provide attribute") {
 			return ErrPackageNotFound
 		}
-
-		// If two packages being installed seek to install two nix packages (could be themselves,
-		// or could be a dependency) that have the same binary name,
-		// then `nix profile install` will fail with `conflicting packages` error (as of nix version 2.14.0)
-		//
-		// An example error message looks like the following:
-		// error: files '/nix/store/spgr12gk13af8flz7akbs18fj4whqss2-bundler-2.4.5/bin/bundle' and
-		// '/nix/store/l4wmx8lfn6hlcfmbyhmksm024f8hixm1-ruby-3.1.2/bin/bundle' have the same priority 5;
-		// use 'nix-env --set-flag priority NUMBER INSTALLED_PKGNAME' or type 'nix profile install --help'
-		// if using 'nix profile' to find out howto change the priority of one of the conflicting packages
-		// (0 being the highest priority)
-		//
-		// However, for the purposes of starting a shell with these packages, nix flakes will give
-		// precedence to the later package. We enable similar functionality by increasing the priority
-		// of any package being installed and conflicting with a previously installed package: the
-		// package being installed later "wins".
-		isConflictingPackagesError := strings.Contains(stdout.String(), "conflicting packages") ||
-			strings.Contains(stderr.String(), "conflicting packages")
-		if isConflictingPackagesError && args.Priority != "0" {
-
-			priority := args.Priority
-			if priority == "" {
-				priority = "5" // 5 is the default priority in `nix profile`
-			}
-
-			intPriority, strconvErr := strconv.Atoi(priority)
-			if strconvErr != nil {
-				debug.Log(
-					"Error: falling back to regular error handling logic due to strconv.Atoi error: %s",
-					strconvErr)
-				// fallthrough to the regular error handling logic
-			} else {
-				// to give higher priority, we need to assign a lower priority number
-				args.Priority = strconv.Itoa(intPriority - 1)
-				debug.Log("Re-trying nix profile install with priority %s for package %s\n",
-					args.Priority,
-					args.Package,
-				)
-				return profileInstall(args)
-			}
-		}
-
 		return errors.Wrapf(err, "Command: %s", cmd)
 	}
+
+	fmt.Fprintf(args.Writer, "%s: ", stepMsg)
+	color.New(color.FgGreen).Fprintf(args.Writer, "Success\n")
 	return nil
 }
 
@@ -310,4 +254,36 @@ func ProfileRemove(profilePath, nixpkgsCommit, pkg string) error {
 
 func AllowUnfreeEnv() []string {
 	return append(os.Environ(), "NIXPKGS_ALLOW_UNFREE=1")
+}
+
+type manifest struct {
+	Elements []struct {
+		Priority int `json:"priority"`
+	} `json:"elements"`
+}
+
+func readManifest(profilePath string) (manifest, error) {
+	data, err := os.ReadFile(filepath.Join(profilePath, "manifest.json"))
+	if os.IsNotExist(err) {
+		return manifest{}, nil
+	} else if err != nil {
+		return manifest{}, err
+	}
+
+	var m manifest
+	return m, json.Unmarshal(data, &m)
+}
+
+func nextPriority(profilePath string) string {
+	// error is ignored because it's ok if the file doesn't exist
+	m, _ := readManifest(profilePath)
+	max := DefaultPriority
+	for _, e := range m.Elements {
+		if e.Priority < max {
+			max = e.Priority
+		}
+	}
+	// Each subsequent package gets a lower priority. This matches how flake.nix
+	// behaves
+	return fmt.Sprintf("%d", max+1)
 }

--- a/internal/nix/profile.go
+++ b/internal/nix/profile.go
@@ -279,7 +279,7 @@ func nextPriority(profilePath string) string {
 	m, _ := readManifest(profilePath)
 	max := DefaultPriority
 	for _, e := range m.Elements {
-		if e.Priority < max {
+		if e.Priority > max {
 			max = e.Priority
 		}
 	}

--- a/internal/nix/writer.go
+++ b/internal/nix/writer.go
@@ -12,7 +12,6 @@ import (
 var packageInstallIgnore = map[string]bool{
 	`replacing old 'devbox-development'`: false,
 	`installing 'devbox-development'`:    false,
-	`conflicting packages`:               true,
 }
 
 type PackageInstallWriter struct {


### PR DESCRIPTION
## Summary

I was implementing a progress indicator for global install, and the profile install retry logic was making it a bit complicated. I then realized that the order we were assigning to priorities (latter package takes precedence) is actually inverse to what flake `buildInputs` does (it uses earlier precedence). In practice, this means the profile generated by devbox and the flake generated by devbox would have different behaviors. This is not terrible but also not ideal. So I removed the sorting and added some documentation to ensure we always keep the same (local, global) order.

Finally, I tried out a slightly different approach which doesn't require a profile install with retries. By reading the profile manifest file we're able to see what the highest number existing priority (lowest priority)  is and just increment it to achieve the next lowest priority. I tried this up to numbers in the thousands there doesn't seem to be any limits. 

Some benefits of this approach:

* It's easier to implement progress indicators that read stdout/err in a goroutine. 
* Better performance (no retries needed)
* more deterministic
* Code is a bit simpler

Drawbacks:
* Depends on the manifest
* Needlessly assigns more priorities than are needed

@savil curious your thoughts on this?

## How was it tested?

```bash
devbox global add php82
devbox add php
devbox run "php -v"
```
