### PR TITLE
[nix] Show nix profile install progress

### DIFF
--- a/internal/impl/global.go
+++ b/internal/impl/global.go
@@ -47,18 +47,22 @@ func (d *Devbox) AddGlobal(pkgs ...string) error {
 	for idx, pkg := range pkgs {
 		stepNum := idx + 1
 		stepMsg := fmt.Sprintf("[%d/%d] %s", stepNum, total, pkg)
-		if err := nix.ProfileInstall(&nix.ProfileInstallArgs{
+		err = nix.ProfileInstall(&nix.ProfileInstallArgs{
 			CustomStepMessage: stepMsg,
 			NixpkgsCommit:     d.cfg.Nixpkgs.Commit,
 			Package:           pkg,
 			ProfilePath:       profilePath,
 			Writer:            d.writer,
-		}); err != nil {
+		})
+		if err != nil {
 			fmt.Fprintf(d.writer, "Error installing %s: %s", pkg, err)
 		} else {
 			fmt.Fprintf(d.writer, "%s is now installed\n", pkg)
 			added = append(added, pkg)
 		}
+	}
+	if len(added) == 0 && err != nil {
+		return err
 	}
 	d.cfg.RawPackages = lo.Uniq(append(d.cfg.RawPackages, added...))
 	if err := d.saveCfg(); err != nil {
@@ -82,7 +86,11 @@ func (d *Devbox) RemoveGlobal(pkgs ...string) error {
 	}
 	for _, pkg := range lo.Intersect(d.cfg.RawPackages, pkgs) {
 		if err := nix.ProfileRemove(profilePath, plansdk.DefaultNixpkgsCommit, pkg); err != nil {
-			fmt.Fprintf(d.writer, "Error removing %s: %s", pkg, err)
+			if errors.Is(err, nix.ErrPackageNotInstalled) {
+				removed = append(removed, pkg)
+			} else {
+				fmt.Fprintf(d.writer, "Error removing %s: %s", pkg, err)
+			}
 		} else {
 			fmt.Fprintf(d.writer, "%s was removed\n", pkg)
 			removed = append(removed, pkg)

--- a/internal/impl/global.go
+++ b/internal/impl/global.go
@@ -57,7 +57,6 @@ func (d *Devbox) AddGlobal(pkgs ...string) error {
 		if err != nil {
 			fmt.Fprintf(d.writer, "Error installing %s: %s", pkg, err)
 		} else {
-			fmt.Fprintf(d.writer, "%s is now installed\n", pkg)
 			added = append(added, pkg)
 		}
 	}

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -75,7 +75,15 @@ func (d *Devbox) Add(pkgs ...string) error {
 		}
 	}
 
-	return d.printPackageUpdateMessage(install, pkgs)
+	if IsDevboxShellEnabled() {
+		if err := plugin.PrintEnvUpdateMessage(
+			d.projectDir,
+			d.writer,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Remove removes the `pkgs` from the config (i.e. devbox.json) and nix profile for this devbox project
@@ -112,7 +120,15 @@ func (d *Devbox) Remove(pkgs ...string) error {
 		return err
 	}
 
-	return d.printPackageUpdateMessage(uninstall, uninstalledPackages)
+	if IsDevboxShellEnabled() {
+		if err := plugin.PrintEnvUpdateMessage(
+			d.projectDir,
+			d.writer,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // installMode is an enum for helping with ensurePackagesAreInstalled implementation
@@ -159,36 +175,6 @@ func (d *Devbox) ensurePackagesAreInstalled(ctx context.Context, mode installMod
 	}
 
 	return plugin.RemoveInvalidSymlinks(d.projectDir)
-}
-
-func (d *Devbox) printPackageUpdateMessage(mode installMode, pkgs []string) error {
-	verb := "installed"
-	var infos []*nix.Info
-	for _, pkg := range pkgs {
-		info, _ := nix.PkgInfo(d.cfg.Nixpkgs.Commit, pkg)
-		infos = append(infos, info)
-	}
-	if mode == uninstall {
-		verb = "removed"
-	}
-
-	if len(pkgs) > 0 {
-
-		// (Only when in devbox shell) Prompt the user to run hash -r
-		// to ensure we refresh the shell hash and load the proper environment.
-		if IsDevboxShellEnabled() {
-			if err := plugin.PrintEnvUpdateMessage(
-				lo.Ternary(mode == install, pkgs, []string{}),
-				d.projectDir,
-				d.writer,
-			); err != nil {
-				return err
-			}
-		}
-	} else {
-		fmt.Fprintf(d.writer, "No packages %s.\n", verb)
-	}
-	return nil
 }
 
 // installNixProfile installs or uninstalls packages to or from this

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -173,22 +173,6 @@ func (d *Devbox) printPackageUpdateMessage(mode installMode, pkgs []string) erro
 	}
 
 	if len(pkgs) > 0 {
-		successMsg := fmt.Sprintf("%s (%s) is now %s.\n", pkgs[0], infos[0], verb)
-		if len(pkgs) > 1 {
-			pkgsWithVersion := []string{}
-			for idx, pkg := range pkgs {
-				pkgsWithVersion = append(
-					pkgsWithVersion,
-					fmt.Sprintf("%s (%s)", pkg, infos[idx]),
-				)
-			}
-			successMsg = fmt.Sprintf(
-				"%s are now %s.\n",
-				strings.Join(pkgsWithVersion, ", "),
-				verb,
-			)
-		}
-		fmt.Fprint(d.writer, successMsg)
 
 		// (Only when in devbox shell) Prompt the user to run hash -r
 		// to ensure we refresh the shell hash and load the proper environment.

--- a/internal/nix/profile.go
+++ b/internal/nix/profile.go
@@ -225,6 +225,8 @@ func ProfileInstall(args *ProfileInstallArgs) error {
 	cmd.Stderr = args.Writer
 
 	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(args.Writer, "%s: ", stepMsg)
+		color.New(color.FgRed).Fprintf(args.Writer, "Fail\n")
 		return errors.Wrapf(err, "Command: %s", cmd)
 	}
 

--- a/internal/nix/profile.go
+++ b/internal/nix/profile.go
@@ -216,14 +216,15 @@ func ProfileInstall(args *ProfileInstallArgs) error {
 	cmd.Env = AllowUnfreeEnv()
 	cmd.Args = append(cmd.Args, ExperimentalFlags()...)
 	cmd.Args = append(cmd.Args, args.ExtraFlags...)
-	cmd.Stdout = &PackageInstallWriter{args.Writer}
-	var stderr bytes.Buffer
-	cmd.Stderr = io.MultiWriter(&stderr, cmd.Stdout)
+
+	// If nix profile install runs as tty, the output is much nicer. If we ever
+	// need to change this to our own writers, consider that you may need
+	// to implement your own nicer output. --print-build-logs flag may be useful.
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = args.Writer
+	cmd.Stderr = args.Writer
 
 	if err := cmd.Run(); err != nil {
-		if strings.Contains(stderr.String(), "does not provide attribute") {
-			return ErrPackageNotFound
-		}
 		return errors.Wrapf(err, "Command: %s", cmd)
 	}
 

--- a/internal/plugin/info.go
+++ b/internal/plugin/info.go
@@ -122,7 +122,7 @@ func printInfoInstructions(pkg string, w io.Writer) error {
 	return errors.WithStack(err)
 }
 
-func PrintEnvUpdateMessage(pkgs []string, projectDir string, w io.Writer) error {
+func PrintEnvUpdateMessage(projectDir string, w io.Writer) error {
 	color.New(color.FgYellow).Fprint(
 		w,
 		"\nTo update your shell and ensure your new packages are usable, "+

--- a/testscripts/packages/unfree.test.txt
+++ b/testscripts/packages/unfree.test.txt
@@ -5,7 +5,5 @@ exec devbox init
 # we could test with slack and/or vscode. Using slack since it is lighter.
 exec devbox add slack
 stderr 'Installing package: slack.'
-stderr 'is now installed.'
 
 exec devbox rm slack
-stderr 'is now removed.'


### PR DESCRIPTION
## Summary

This shows inline progress when installing new packages (both global and local). `nix profile install` does this automatically but only in tty mode. @gcurtis curious if we can somehow make nix believe we're in tty mode without having to specify stdin and stdout?

Removed 2 blockers that are no longer needed:

* `PackageInstallWriter` is no longer needed I don't think. It could not see the lines it was meant to supress.
* Returning package not found is a bit redundant because all callsites of `ProfileInstall` already defensivelly check if package exists. If the user somehow does end up trying to install a package that doesn't exist, we still show a decent error  

Fixed 2 semi-related errors:

* global add  would print success message even if nothing was installed because of errors
* Removing a package from global devbox is impossible if the nix package was not installed

## How was it tested?

```bash
devbox add curl hello bazel
devbox add global curl hello bazel
```
