### PR TITLE
First Pass at a Haskell Package Planner

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -123,8 +123,6 @@ func (d *Devbox) ShellPlan() (*plansdk.ShellPlan, error) {
 	userDefinedPkgs := d.packages()
 	shellPlan := planner.GetShellPlan(d.projectDir, userDefinedPkgs)
 
-	// set shellPlan.DevPackages equal to the union of userDefinedPkgs and shellPlan.DevPackages
-
 	shellPlan.DevPackages = pkgslice.Unique(append(shellPlan.DevPackages, userDefinedPkgs...))
 
 	nixpkgsInfo, err := plansdk.GetNixpkgsInfo(d.cfg.Nixpkgs.Commit)

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -121,7 +121,11 @@ func (d *Devbox) Config() *Config {
 func (d *Devbox) ShellPlan() (*plansdk.ShellPlan, error) {
 	userDefinedPkgs := d.packages()
 	shellPlan := planner.GetShellPlan(d.projectDir, userDefinedPkgs)
-	//shellPlan.DevPackages = userDefinedPkgs
+
+	// If the DevPackages are empty, set them to userDefinedPkgs.
+	if len(shellPlan.DevPackages) == 0 {
+		shellPlan.DevPackages = userDefinedPkgs
+	}
 
 	nixpkgsInfo, err := plansdk.GetNixpkgsInfo(d.cfg.Nixpkgs.Commit)
 	if err != nil {

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -28,6 +28,7 @@ import (
 	"go.jetpack.io/devbox/internal/fileutil"
 	"go.jetpack.io/devbox/internal/initrec"
 	"go.jetpack.io/devbox/internal/nix"
+	"go.jetpack.io/devbox/internal/pkgslice"
 	"go.jetpack.io/devbox/internal/planner"
 	"go.jetpack.io/devbox/internal/planner/plansdk"
 	"go.jetpack.io/devbox/internal/plugin"
@@ -122,10 +123,9 @@ func (d *Devbox) ShellPlan() (*plansdk.ShellPlan, error) {
 	userDefinedPkgs := d.packages()
 	shellPlan := planner.GetShellPlan(d.projectDir, userDefinedPkgs)
 
-	// If the DevPackages are empty, set them to userDefinedPkgs.
-	if len(shellPlan.DevPackages) == 0 {
-		shellPlan.DevPackages = userDefinedPkgs
-	}
+	// set shellPlan.DevPackages equal to the union of userDefinedPkgs and shellPlan.DevPackages
+
+	shellPlan.DevPackages = pkgslice.Unique(append(shellPlan.DevPackages, userDefinedPkgs...))
 
 	nixpkgsInfo, err := plansdk.GetNixpkgsInfo(d.cfg.Nixpkgs.Commit)
 	if err != nil {

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -121,7 +121,7 @@ func (d *Devbox) Config() *Config {
 func (d *Devbox) ShellPlan() (*plansdk.ShellPlan, error) {
 	userDefinedPkgs := d.packages()
 	shellPlan := planner.GetShellPlan(d.projectDir, userDefinedPkgs)
-	shellPlan.DevPackages = userDefinedPkgs
+	//shellPlan.DevPackages = userDefinedPkgs
 
 	nixpkgsInfo, err := plansdk.GetNixpkgsInfo(d.cfg.Nixpkgs.Commit)
 	if err != nil {

--- a/internal/planner/languages/haskell/haskell_v1_planner.go
+++ b/internal/planner/languages/haskell/haskell_v1_planner.go
@@ -24,11 +24,10 @@ type V2Planner struct {
 	userPackages []string
 }
 
-// PHPV2Planner implements interface PlannerForPackages (compile-time check)
 var _ plansdk.PlannerForPackages = (*V2Planner)(nil)
 
 func (p *V2Planner) Name() string {
-	return "php.v2.Planner"
+	return "haskell.v2.Planner"
 }
 
 func (p *V2Planner) IsRelevant(srcDir string) bool {

--- a/internal/planner/languages/haskell/haskell_v1_planner.go
+++ b/internal/planner/languages/haskell/haskell_v1_planner.go
@@ -1,0 +1,75 @@
+// Copyright 2022 Jetpack Technologies Inc and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package haskell
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"go.jetpack.io/devbox/internal/planner/plansdk"
+)
+
+var haskellPackageRegex = regexp.MustCompile(`^haskellPackages.[a-zA-Z0-9\-\_\.]+$`)
+
+// TODO: We should also support different GHC versions.
+// These can take the format of `haskell.compiler.ghc90` or similar
+var ghcRegex = regexp.MustCompile(`^ghc$`)
+
+var stackRegex = regexp.MustCompile(`^stack$`)
+var cabalRegex = regexp.MustCompile(`^cabal-install$`)
+
+type V2Planner struct {
+	userPackages []string
+}
+
+// PHPV2Planner implements interface PlannerForPackages (compile-time check)
+var _ plansdk.PlannerForPackages = (*V2Planner)(nil)
+
+func (p *V2Planner) Name() string {
+	return "php.v2.Planner"
+}
+
+func (p *V2Planner) IsRelevant(srcDir string) bool {
+	return false
+}
+
+func (p *V2Planner) IsRelevantForPackages(packages []string) bool {
+	p.userPackages = packages
+	return p.getGHCPackage() != "" && len(p.getHaskellPackages()) > 0
+}
+
+func (p *V2Planner) GetShellPlan(srcDir string) *plansdk.ShellPlan {
+	ghcPackage := p.getGHCPackage()
+	definitions := []string{
+		fmt.Sprintf(
+			"%s = pkgs.haskellPackages.ghcWithPackages (ps: with ps; [ %s ]);",
+			ghcPackage,
+			strings.Join(p.getHaskellPackages(), " "),
+		),
+	}
+
+	return &plansdk.ShellPlan{Definitions: definitions}
+}
+
+func (p *V2Planner) getGHCPackage() string {
+	for _, pkg := range p.userPackages {
+		if ghcRegex.Match([]byte(pkg)) {
+			return pkg
+		}
+	}
+	return ""
+}
+
+func (p *V2Planner) getHaskellPackages() []string {
+	var haskellPackages []string
+	for _, pkg := range p.userPackages {
+		if haskellPackageRegex.Match([]byte(pkg)) {
+			haskellPackages = append(haskellPackages, strings.Split(pkg, ".")[1])
+		} else if stackRegex.Match([]byte(pkg)) || cabalRegex.Match([]byte(pkg)) {
+			haskellPackages = append(haskellPackages, pkg)
+		}
+	}
+	return haskellPackages
+}

--- a/internal/planner/languages/haskell/haskell_v1_planner.go
+++ b/internal/planner/languages/haskell/haskell_v1_planner.go
@@ -17,8 +17,6 @@ var haskellPackageRegex = regexp.MustCompile(`^haskellPackages.[a-zA-Z0-9\-\_\.]
 // Compiler will be in Mathches[0][1] and package name in Matches[1][2]
 var haskellPackageVersionRegex = regexp.MustCompile(`^haskell\.packages\.(.*)\.(.*)$`)
 
-// TODO: We should also support different GHC versions.
-// These can take the format of `haskell.compiler.ghc90` or similar
 var ghcRegex = regexp.MustCompile(`^ghc$`)
 var ghcVersionRegex = regexp.MustCompile(`^haskell\.compiler\.(.*)$`)
 
@@ -28,6 +26,8 @@ var cabalRegex = regexp.MustCompile(`^cabal-install$`)
 type V2Planner struct {
 	userPackages []string
 }
+
+// Create types and struct that tells us which GHC compiler we're using
 
 type CompilerType string
 
@@ -54,14 +54,17 @@ func (p *V2Planner) IsRelevant(srcDir string) bool {
 
 func (p *V2Planner) IsRelevantForPackages(packages []string) bool {
 	p.userPackages = packages
-	return p.getGHCPackage().compilerType != None
+	_, index := p.getGHCPackage()
+	return index != -1
 }
 
 func (p *V2Planner) GetShellPlan(srcDir string) *plansdk.ShellPlan {
-	ghcPackage := p.getGHCPackage()
+	ghcPackage, index := p.getGHCPackage()
+	// Remove the ghc package from the list of user packages
+	p.userPackages = append(p.userPackages[:index], p.userPackages[index+1:]...)
 	haskellPackages := p.getHaskellPackages(ghcPackage)
 	definitions := []string{}
-	fmt.Print(ghcPackage.compilerType)
+	// Create the haskell-pkg definition based on the compiler type
 	switch ghcPackage.compilerType {
 	case Default:
 		definitions = []string{
@@ -79,26 +82,28 @@ func (p *V2Planner) GetShellPlan(srcDir string) *plansdk.ShellPlan {
 			),
 		}
 	}
-
 	return &plansdk.ShellPlan{
 		Definitions: definitions,
-		DevPackages: []string{"haskell-pkg"},
+		// Prepend "haskell-pkg" to the list of user packages
+		DevPackages: append([]string{"haskell-pkg"}, p.userPackages...),
 	}
 }
 
-func (p *V2Planner) getGHCPackage() GHCPackage {
-	for _, pkg := range p.userPackages {
+func (p *V2Planner) getGHCPackage() (GHCPackage, int) {
+	// packages := p.userPackages
+	for index, pkg := range p.userPackages {
 		if ghcRegex.Match([]byte(pkg)) {
-			return GHCPackage{compilerType: Default, pkg: pkg}
+			return GHCPackage{compilerType: Default, pkg: pkg}, index
 		} else if matches := ghcVersionRegex.FindStringSubmatch(pkg); matches != nil {
-			return GHCPackage{compilerType: Versioned, pkg: matches[1]}
+			return GHCPackage{compilerType: Versioned, pkg: matches[1]}, index
 		}
 	}
-	return GHCPackage{compilerType: None, pkg: ""}
+	return GHCPackage{compilerType: None, pkg: ""}, -1
 }
 
 func (p *V2Planner) getHaskellPackages(ghcPackage GHCPackage) []string {
 	var haskellPackages []string
+	var filteredPackages []string
 	for _, pkg := range p.userPackages {
 		switch ghcPackage.compilerType {
 		case Default:
@@ -106,6 +111,8 @@ func (p *V2Planner) getHaskellPackages(ghcPackage GHCPackage) []string {
 				haskellPackages = append(haskellPackages, pkg)
 			} else if haskellPackageRegex.Match([]byte(pkg)) {
 				haskellPackages = append(haskellPackages, strings.Split(pkg, ".")[1])
+			} else {
+				filteredPackages = append(filteredPackages, pkg)
 			}
 		case Versioned:
 			if matches := haskellPackageVersionRegex.FindAllStringSubmatch(pkg, -1); matches != nil {
@@ -113,8 +120,13 @@ func (p *V2Planner) getHaskellPackages(ghcPackage GHCPackage) []string {
 				if matches[0][1] == ghcPackage.pkg {
 					haskellPackages = append(haskellPackages, matches[0][2])
 				}
+			} else {
+				filteredPackages = append(filteredPackages, pkg)
 			}
 		}
 	}
+	//  Remove the packages that we've already added to the haskellPackages
+	// list from the userPackages list
+	p.userPackages = filteredPackages
 	return haskellPackages
 }

--- a/internal/planner/languages/haskell/haskell_v1_planner.go
+++ b/internal/planner/languages/haskell/haskell_v1_planner.go
@@ -11,11 +11,16 @@ import (
 	"go.jetpack.io/devbox/internal/planner/plansdk"
 )
 
-var haskellPackageRegex = regexp.MustCompile(`^haskellPackages.[a-zA-Z0-9\-\_\.]+$`)
+var haskellPackageRegex = regexp.MustCompile(`^haskellPackages.[a-zA-Z0-9\-\_\.]*$`)
+
+// Use matchgroups to get the compiler, then the package name
+// Compiler will be in Mathches[0][1] and package name in Matches[1][2]
+var haskellPackageVersionRegex = regexp.MustCompile(`^haskell\.packages\.(.*)\.(.*)$`)
 
 // TODO: We should also support different GHC versions.
 // These can take the format of `haskell.compiler.ghc90` or similar
 var ghcRegex = regexp.MustCompile(`^ghc$`)
+var ghcVersionRegex = regexp.MustCompile(`^haskell\.compiler\.(.*)$`)
 
 var stackRegex = regexp.MustCompile(`^stack$`)
 var cabalRegex = regexp.MustCompile(`^cabal-install$`)
@@ -24,10 +29,23 @@ type V2Planner struct {
 	userPackages []string
 }
 
+type CompilerType string
+
+const (
+	Default   CompilerType = "default"
+	Versioned CompilerType = "versioned"
+	None      CompilerType = ""
+)
+
+type GHCPackage struct {
+	compilerType CompilerType
+	pkg          string
+}
+
 var _ plansdk.PlannerForPackages = (*V2Planner)(nil)
 
 func (p *V2Planner) Name() string {
-	return "haskell.v2.Planner"
+	return "haskell.v1.Planner"
 }
 
 func (p *V2Planner) IsRelevant(srcDir string) bool {
@@ -36,38 +54,66 @@ func (p *V2Planner) IsRelevant(srcDir string) bool {
 
 func (p *V2Planner) IsRelevantForPackages(packages []string) bool {
 	p.userPackages = packages
-	return p.getGHCPackage() != "" && len(p.getHaskellPackages()) > 0
+	return p.getGHCPackage().compilerType != None
 }
 
 func (p *V2Planner) GetShellPlan(srcDir string) *plansdk.ShellPlan {
 	ghcPackage := p.getGHCPackage()
-	definitions := []string{
-		fmt.Sprintf(
-			"%s = pkgs.haskellPackages.ghcWithPackages (ps: with ps; [ %s ]);",
-			ghcPackage,
-			strings.Join(p.getHaskellPackages(), " "),
-		),
-	}
-
-	return &plansdk.ShellPlan{Definitions: definitions}
-}
-
-func (p *V2Planner) getGHCPackage() string {
-	for _, pkg := range p.userPackages {
-		if ghcRegex.Match([]byte(pkg)) {
-			return pkg
+	haskellPackages := p.getHaskellPackages(ghcPackage)
+	definitions := []string{}
+	fmt.Print(ghcPackage.compilerType)
+	switch ghcPackage.compilerType {
+	case Default:
+		definitions = []string{
+			fmt.Sprintf(
+				"haskell-pkg = pkgs.haskellPackages.ghcWithPackages (ps: with ps; [ %s ]);",
+				strings.Join(haskellPackages, " "),
+			),
+		}
+	case Versioned:
+		definitions = []string{
+			fmt.Sprintf(
+				"haskell-pkg = pkgs.haskell.packages.%s.ghcWithPackages (ps: with ps; [ %s ]);",
+				ghcPackage.pkg,
+				strings.Join(haskellPackages, " "),
+			),
 		}
 	}
-	return ""
+
+	return &plansdk.ShellPlan{
+		Definitions: definitions,
+		DevPackages: []string{"haskell-pkg"},
+	}
 }
 
-func (p *V2Planner) getHaskellPackages() []string {
+func (p *V2Planner) getGHCPackage() GHCPackage {
+	for _, pkg := range p.userPackages {
+		if ghcRegex.Match([]byte(pkg)) {
+			return GHCPackage{compilerType: Default, pkg: pkg}
+		} else if matches := ghcVersionRegex.FindStringSubmatch(pkg); matches != nil {
+			return GHCPackage{compilerType: Versioned, pkg: matches[1]}
+		}
+	}
+	return GHCPackage{compilerType: None, pkg: ""}
+}
+
+func (p *V2Planner) getHaskellPackages(ghcPackage GHCPackage) []string {
 	var haskellPackages []string
 	for _, pkg := range p.userPackages {
-		if haskellPackageRegex.Match([]byte(pkg)) {
-			haskellPackages = append(haskellPackages, strings.Split(pkg, ".")[1])
-		} else if stackRegex.Match([]byte(pkg)) || cabalRegex.Match([]byte(pkg)) {
-			haskellPackages = append(haskellPackages, pkg)
+		switch ghcPackage.compilerType {
+		case Default:
+			if stackRegex.Match([]byte(pkg)) || cabalRegex.Match([]byte(pkg)) {
+				haskellPackages = append(haskellPackages, pkg)
+			} else if haskellPackageRegex.Match([]byte(pkg)) {
+				haskellPackages = append(haskellPackages, strings.Split(pkg, ".")[1])
+			}
+		case Versioned:
+			if matches := haskellPackageVersionRegex.FindAllStringSubmatch(pkg, -1); matches != nil {
+				fmt.Println(matches)
+				if matches[0][1] == ghcPackage.pkg {
+					haskellPackages = append(haskellPackages, matches[0][2])
+				}
+			}
 		}
 	}
 	return haskellPackages

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -8,12 +8,14 @@ import (
 	"runtime/trace"
 
 	"github.com/samber/lo"
+	"go.jetpack.io/devbox/internal/planner/languages/haskell"
 	"go.jetpack.io/devbox/internal/planner/languages/php"
 	"go.jetpack.io/devbox/internal/planner/plansdk"
 )
 
 var PLANNERS = []plansdk.Planner{
 	&php.V2Planner{},
+	&haskell.V2Planner{},
 }
 
 // Return a merged shell plan from shell planners if user defined packages

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -25,13 +25,7 @@ func GetShellPlan(srcDir string, userPkgs []string) *plansdk.ShellPlan {
 	result := &plansdk.ShellPlan{}
 	planners := getRelevantPlanners(srcDir, userPkgs)
 	for _, p := range planners {
-		// pkgs := p.GetShellPlan(srcDir).DevPackages
-		// mutualPkgs := lo.Intersect(userPkgs, pkgs)
-		// Only apply shell plan if user packages list all the packages from shell plan.
-		//if len(mutualPkgs) == len(pkgs) {
-		// if merge fails, we return no errors for now.
 		result, _ = plansdk.MergeShellPlans(result, p.GetShellPlan(srcDir))
-		//}
 	}
 	return result
 }

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"runtime/trace"
 
-	"github.com/samber/lo"
 	"go.jetpack.io/devbox/internal/planner/languages/haskell"
 	"go.jetpack.io/devbox/internal/planner/languages/php"
 	"go.jetpack.io/devbox/internal/planner/plansdk"
@@ -26,13 +25,13 @@ func GetShellPlan(srcDir string, userPkgs []string) *plansdk.ShellPlan {
 	result := &plansdk.ShellPlan{}
 	planners := getRelevantPlanners(srcDir, userPkgs)
 	for _, p := range planners {
-		pkgs := p.GetShellPlan(srcDir).DevPackages
-		mutualPkgs := lo.Intersect(userPkgs, pkgs)
+		// pkgs := p.GetShellPlan(srcDir).DevPackages
+		// mutualPkgs := lo.Intersect(userPkgs, pkgs)
 		// Only apply shell plan if user packages list all the packages from shell plan.
-		if len(mutualPkgs) == len(pkgs) {
-			// if merge fails, we return no errors for now.
-			result, _ = plansdk.MergeShellPlans(result, p.GetShellPlan(srcDir))
-		}
+		//if len(mutualPkgs) == len(pkgs) {
+		// if merge fails, we return no errors for now.
+		result, _ = plansdk.MergeShellPlans(result, p.GetShellPlan(srcDir))
+		//}
 	}
 	return result
 }


### PR DESCRIPTION
## Summary
This PR addresses #29, using a similar framework as our PHP planner. It makes it possible to use Haskell packages installed via `haskellPackages` alongside GHC.

This PR is incomplete - right now it only works for the default `ghc` in Nixpkg. We should make sure that we can detect when users request a different compiler version (like `haskell.compiler.ghc810`)

## How was it tested?

**Default GHC:** Use the following devbox.json:

```json
{
  "packages": [
    "haskellPackages.aeson",
    "ghc",
    "stack"
  ],
  "shell": {
    "init_hook": null
  },
  "nixpkgs": {
    "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
  }
}
  ```
  
Run `devbox shell`, then run `ghc-pkg list | grep aeson` to make sure that it installed correctly

**Versioned GHC:** Use the following devbox.json

```json
{
  "packages": [
    "haskell.compiler.ghc92",
    "haskell.packages.ghc92.aeson",
    "tree",
    "direnv",
    "ghc",
  ],
  "shell": {
    "init_hook": null
  },
  "nixpkgs": {
    "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
  }
}
```
Run `devbox shell`, then run `ghc-pkg list | grep aeson` to make sure that it installed correctly. Also confirm that other packages installed as expected