### PR TITLE
feat: add scripts as commands for shell completion

### DIFF
--- a/internal/boxcli/args.go
+++ b/internal/boxcli/args.go
@@ -15,7 +15,6 @@ import (
 // If args empty, defaults to the current directory
 // Otherwise grabs the path from the first argument
 func configPathFromUser(args []string, flags *configFlags) (string, error) {
-
 	if flags.path != "" && len(args) > 0 {
 		return "", usererr.New(
 			"Cannot specify devbox.json's path via both --config and the command arguments. " +

--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
-	debugMiddleware *midcobra.DebugMiddleware = &midcobra.DebugMiddleware{}
-	traceMiddleware *midcobra.TraceMiddleware = &midcobra.TraceMiddleware{}
+	debugMiddleware = &midcobra.DebugMiddleware{}
+	traceMiddleware = &midcobra.TraceMiddleware{}
 )
 
 type rootCmdFlags struct {

--- a/internal/planner/plansdk/analyzer.go
+++ b/internal/planner/plansdk/analyzer.go
@@ -11,7 +11,7 @@ import (
 	"go.jetpack.io/devbox/internal/cuecfg"
 )
 
-// Analyzers help understand the source code present in a given directory
+// Analyzer helps understand the source code present in a given directory
 // Handy when implementing new Planners that need to analyze files in order
 // to determine what to do.
 type Analyzer struct {


### PR DESCRIPTION
## Summary

Add scripts defined in `devbox.json` as commands to `devbox run` for shell completion.

## How was it tested?
