### PR TITLE
feat: add scripts as valid args for shell completion

### DIFF
--- a/internal/boxcli/args.go
+++ b/internal/boxcli/args.go
@@ -15,7 +15,6 @@ import (
 // If args empty, defaults to the current directory
 // Otherwise grabs the path from the first argument
 func configPathFromUser(args []string, flags *configFlags) (string, error) {
-
 	if flags.path != "" && len(args) > 0 {
 		return "", usererr.New(
 			"Cannot specify devbox.json's path via both --config and the command arguments. " +

--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -36,11 +36,28 @@ func RunCmd() *cobra.Command {
 
 	flags.config.register(command)
 
+	command.ValidArgs = listScripts(command, flags)
+
 	return command
 }
 
-func runScriptCmd(cmd *cobra.Command, args []string, flags runCmdFlags) error {
+func listScripts(cmd *cobra.Command, flags runCmdFlags) []string {
+	path, err := configPathFromUser([]string{}, &flags.config)
+	if err != nil {
+		debug.Log("failed to get config path from user: %v", err)
+		return nil
+	}
 
+	box, err := devbox.Open(path, cmd.ErrOrStderr())
+	if err != nil {
+		debug.Log("failed to open devbox: %v", err)
+		return nil
+	}
+
+	return box.ListScripts()
+}
+
+func runScriptCmd(cmd *cobra.Command, args []string, flags runCmdFlags) error {
 	path, script, scriptArgs, err := parseScriptArgs(args, flags)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

Add scripts in `devbox.json` as `devbox run`'s valid arguments and it provides shell completion.

Here's the screenshot: 

<img width="825" alt="Screenshot 2023-03-16 at 21 45 20" src="https://user-images.githubusercontent.com/7611700/225638218-1915e62d-fec9-4ceb-9f73-b1072acde125.png">

And here's a demo:

https://user-images.githubusercontent.com/7611700/225638325-e971c651-7383-4ddc-84db-861e6de4cbd2.mp4





## How was it tested?
