### PR TITLE
[devcontainer] Updated dockerfile to use devbox run dash dash

### DIFF
--- a/internal/impl/tmpl/devcontainerDockerfile.tmpl
+++ b/internal/impl/tmpl/devcontainerDockerfile.tmpl
@@ -25,6 +25,6 @@ ENV PATH="/home/${DEVBOX_USER}/.nix-profile/bin:/home/${DEVBOX_USER}/.devbox/nix
 WORKDIR /code
 RUN sudo chown $DEVBOX_USER:root /code
 COPY devbox.json devbox.json
-RUN devbox shell -- echo "Installing packages"
+RUN devbox run -- echo "Installing packages"
 CMD ["devbox", "shell"]
 


### PR DESCRIPTION
## Summary
Fixed devcontainer fail due to `devbox shell -- ` being deprecated.

## How was it tested?
devbox generate devcontainer
open in vscode
cmd + shift + p -> devcontainer: rebuild and reopen in container