### PR TITLE
[flakes] Remove non-flakes code

### DIFF
--- a/internal/boxcli/featureflag/feature.go
+++ b/internal/boxcli/featureflag/feature.go
@@ -46,3 +46,7 @@ func (f *feature) Enabled() bool {
 	}
 	return f.enabled
 }
+
+func (f *feature) Disabled() bool {
+	return !f.Enabled()
+}

--- a/internal/boxcli/featureflag/feature.go
+++ b/internal/boxcli/featureflag/feature.go
@@ -46,7 +46,3 @@ func (f *feature) Enabled() bool {
 	}
 	return f.enabled
 }
-
-func (f *feature) Disabled() bool {
-	return !f.Enabled()
-}

--- a/internal/boxcli/featureflag/flakes.go
+++ b/internal/boxcli/featureflag/flakes.go
@@ -1,3 +1,0 @@
-package featureflag
-
-var Flakes = enabled("FLAKES")

--- a/internal/impl/generate.go
+++ b/internal/impl/generate.go
@@ -15,7 +15,6 @@ import (
 	"text/template"
 
 	"github.com/pkg/errors"
-	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/cuecfg"
 	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/planner/plansdk"
@@ -156,9 +155,6 @@ var templateFuncs = template.FuncMap{
 }
 
 func makeFlakeFile(outPath string, plan *plansdk.ShellPlan) error {
-	if featureflag.Flakes.Disabled() {
-		return nil
-	}
 
 	flakeDir := filepath.Join(outPath, "flake")
 	err := writeFromTemplate(flakeDir, plan, "flake.nix")

--- a/internal/impl/global.go
+++ b/internal/impl/global.go
@@ -33,7 +33,7 @@ const currentGlobalProfile = "default"
 func (d *Devbox) AddGlobal(pkgs ...string) error {
 	// validate all packages exist. Don't install anything if any are missing
 	for _, pkg := range pkgs {
-		if !nix.FlakesPkgExists(plansdk.DefaultNixpkgsCommit, pkg) {
+		if !nix.PkgExists(plansdk.DefaultNixpkgsCommit, pkg) {
 			return nix.ErrPackageNotFound
 		}
 	}

--- a/internal/impl/shell.go
+++ b/internal/impl/shell.go
@@ -6,7 +6,6 @@ package impl
 import (
 	"bytes"
 	_ "embed"
-	"encoding/json"
 	"fmt"
 	"io/fs"
 	"os"
@@ -17,10 +16,8 @@ import (
 
 	"github.com/alessio/shellescape"
 	"github.com/pkg/errors"
-	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/nix"
-	"go.jetpack.io/devbox/internal/planner/plansdk"
 	"go.jetpack.io/devbox/internal/xdg"
 )
 
@@ -109,38 +106,17 @@ func shellPath(nixpkgsCommitHash string) (path string, err error) {
 	// Second, fallback to using the bash that nix uses by default.
 
 	var bashNixStorePath string // of the form /nix/store/{hash}-bash-{version}/
-	if featureflag.Flakes.Enabled() {
-		cmd := exec.Command(
-			"nix", "eval", "--raw",
-			fmt.Sprintf("%s#bash", nix.FlakeNixpkgs(nixpkgsCommitHash)),
-		)
-		cmd.Args = append(cmd.Args, nix.ExperimentalFlags()...)
-		out, err := cmd.Output()
-		if err != nil {
-			return "", errors.WithStack(err)
-		}
-		bashNixStorePath = string(out)
-	} else {
-		nixpkgsInfo, err := plansdk.GetNixpkgsInfo(nixpkgsCommitHash)
-		if err != nil {
-			return "", err
-		}
-		expr := fmt.Sprintf(
-			"let pkgs = import (fetchTarball { url = \"%s\"; }) {}; in {inherit(pkgs.bash) outPath; }",
-			nixpkgsInfo.URL,
-		)
-		cmd := exec.Command("nix-instantiate", "--eval", "--strict",
-			"--json",
-			"--expr", expr,
-		)
-		out, err := cmd.Output()
-		if err != nil {
-			return "", errors.WithStack(err)
-		}
-		if err := json.Unmarshal(out, &bashNixStorePath); err != nil {
-			return "", errors.WithStack(err)
-		}
+
+	cmd := exec.Command(
+		"nix", "eval", "--raw",
+		fmt.Sprintf("%s#bash", nix.FlakeNixpkgs(nixpkgsCommitHash)),
+	)
+	cmd.Args = append(cmd.Args, nix.ExperimentalFlags()...)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", errors.WithStack(err)
 	}
+	bashNixStorePath = string(out)
 
 	if bashNixStorePath != "" {
 		// the output is the raw path to the bash installation in the /nix/store

--- a/internal/nix/profile.go
+++ b/internal/nix/profile.go
@@ -14,16 +14,12 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
-	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 )
 
 const DefaultPriority = 5
 
 // ProfileListItems returns a list of the installed packages
 func ProfileListItems(writer io.Writer, profileDir string) ([]*NixProfileListItem, error) {
-	if featureflag.Flakes.Disabled() {
-		return nil, errors.New("Not supported for legacy non-flakes implementation")
-	}
 
 	cmd := exec.Command(
 		"nix", "profile", "list",
@@ -236,7 +232,7 @@ func ProfileInstall(args *ProfileInstallArgs) error {
 }
 
 func ProfileRemove(profilePath, nixpkgsCommit, pkg string) error {
-	info, found := flakesPkgInfo(nixpkgsCommit, pkg)
+	info, found := PkgInfo(nixpkgsCommit, pkg)
 	if !found {
 		return ErrPackageNotFound
 	}


### PR DESCRIPTION
## Summary

Removes non-flakes code and tries to clean up some branching that is no longer needed.

@savil I removed `featureflag.disabled()` because it makes reasoning about these refactorings quite a bit more difficult and error prone. The words are really similar and some callsites use `!enabled()` which means now I have to think about 4 different combinations. Is this something you feel strongly about? I'm a bit more of the pythonic "only one correct way to do something" than the ruby-like "many ways to write this to make the code sound like english" thoughts?

## How was it tested?

```
devbox add hello
devbox run hello
```