### PR TITLE
[CLI] Added install command

### DIFF
--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -47,6 +47,7 @@ func RootCmd() *cobra.Command {
 	command.AddCommand(globalCmd())
 	command.AddCommand(InfoCmd())
 	command.AddCommand(InitCmd())
+	command.AddCommand(InstallCmd())
 	command.AddCommand(LogCmd())
 	command.AddCommand(PlanCmd())
 	command.AddCommand(RemoveCmd())

--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -48,7 +48,7 @@ func InstallCmd() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "install",
 		Short: "Installs all packages mentioned in devbox.json",
-		Long: "Starts a new devbox shell and installs all packages mentioned in devbox.json in currect directory or" +
+		Long: "Starts a new devbox shell and installs all packages mentioned in devbox.json in current directory or" +
 			"a directory specified via --config. \n\n Then exits the shell when packages are done installing.\n\n ",
 		Args:    cobra.MaximumNArgs(0),
 		PreRunE: ensureNixInstalled,

--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -4,6 +4,8 @@
 package boxcli
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
@@ -37,6 +39,30 @@ func RunCmd() *cobra.Command {
 	flags.config.register(command)
 
 	command.ValidArgs = listScripts(command, flags)
+
+	return command
+}
+
+func InstallCmd() *cobra.Command {
+	flags := runCmdFlags{}
+	command := &cobra.Command{
+		Use:   "install",
+		Short: "Installs all packages mentioned in devbox.json",
+		Long: "Starts a new shell and installs all packages mentioned in devbox.json or a json file" +
+			"specified via --config. \n\n Then exits the shell when packages are done installing.\n\n ",
+		Args:    cobra.MaximumNArgs(0),
+		PreRunE: ensureNixInstalled,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := runScriptCmd(cmd, []string{":"}, flags)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(cmd.ErrOrStderr(), "Finished installing packages.")
+			return nil
+		},
+	}
+
+	flags.config.register(command)
 
 	return command
 }

--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -48,11 +48,13 @@ func InstallCmd() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "install",
 		Short: "Installs all packages mentioned in devbox.json",
-		Long: "Starts a new shell and installs all packages mentioned in devbox.json or a json file" +
-			"specified via --config. \n\n Then exits the shell when packages are done installing.\n\n ",
+		Long: "Starts a new devbox shell and installs all packages mentioned in devbox.json in currect directory or" +
+			"a directory specified via --config. \n\n Then exits the shell when packages are done installing.\n\n ",
 		Args:    cobra.MaximumNArgs(0),
 		PreRunE: ensureNixInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// the colon ':' character in standard shell means noop.
+			// So essentially, this command is running devbox run noop
 			err := runScriptCmd(cmd, []string{":"}, flags)
 			if err != nil {
 				return err


### PR DESCRIPTION
## Summary
Added devbox install command. Re-used the same functions as devbox run since it's just an alias for calling `devbox run -- :` ( `:` is noop in shell).

## How was it tested?
`./devbox install`