### PR TITLE
Fix building target path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ If you are unable to install or use Devbox, you can manually replicate the envir
 * Build Devbox:
 
     ```bash
-    go build -o ./devbox cmd/devbox/main.go
+    go build -o ./dist/devbox cmd/devbox/main.go
     ```
 
     This will build an executable file.

--- a/internal/impl/config.go
+++ b/internal/impl/config.go
@@ -46,7 +46,7 @@ type NixpkgsConfig struct {
 	Commit string `json:"commit,omitempty"`
 }
 
-// This contains a subset of fields from plansdk.Stage
+// Stage contains a subset of fields from plansdk.Stage
 type Stage struct {
 	Command string `cue:"string" json:"command"`
 }
@@ -215,8 +215,7 @@ func missingConfigError(path string, didCheckParents bool) error {
 }
 
 func validateConfig(cfg *Config) error {
-
-	fns := [](func(cfg *Config) error){
+	fns := []func(cfg *Config) error{
 		validateNixpkg,
 		validateScripts,
 	}

--- a/internal/impl/generate.go
+++ b/internal/impl/generate.go
@@ -134,10 +134,7 @@ func writeFromTemplate(path string, plan any, tmplName string) error {
 	if _, err := io.Copy(outFile, tmplNewBuf); err != nil {
 		return errors.WithStack(err)
 	}
-	if err := outFile.Close(); err != nil {
-		return errors.WithStack(err)
-	}
-	return nil
+	return errors.WithStack(outFile.Close())
 }
 
 func toJSON(a any) string {


### PR DESCRIPTION
## Summary

Update the output path of `go build` to be compatible with the following run and test in `CONTRIBUTING.md`.

## How was it tested?
