### PR TITLE
[services] Improve auto-port forward and proxy

### DIFF
--- a/internal/boxcli/cloud.go
+++ b/internal/boxcli/cloud.go
@@ -4,7 +4,6 @@
 package boxcli
 
 import (
-	"os"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -12,6 +11,7 @@ import (
 	"go.jetpack.io/devbox"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/cloud"
+	"go.jetpack.io/devbox/internal/cloud/envir"
 )
 
 type cloudShellCmdFlags struct {
@@ -117,7 +117,7 @@ func cloudPortForwardList() *cobra.Command {
 
 func runCloudShellCmd(cmd *cobra.Command, flags *cloudShellCmdFlags) error {
 	// calling `devbox cloud shell` when already in the VM is not allowed.
-	if region := os.Getenv("DEVBOX_REGION"); region != "" {
+	if region := envir.GetRegion(); region != "" {
 		return shellInceptionErrorMsg("devbox cloud shell")
 	}
 

--- a/internal/boxcli/midcobra/telemetry.go
+++ b/internal/boxcli/midcobra/telemetry.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
+	"go.jetpack.io/devbox/internal/cloud/envir"
 	"go.jetpack.io/devbox/internal/telemetry"
 )
 
@@ -128,7 +129,7 @@ func (m *telemetryMiddleware) newEventIfValid(cmd *cobra.Command, args []string,
 			AnonymousID: telemetry.DeviceID(),
 			AppName:     m.opts.AppName,
 			AppVersion:  m.opts.AppVersion,
-			CloudRegion: os.Getenv("DEVBOX_REGION"),
+			CloudRegion: envir.GetRegion(),
 			Duration:    time.Since(m.startTime),
 			OsName:      telemetry.OS(),
 			UserID:      userID,

--- a/internal/cloud/envir/envir.go
+++ b/internal/cloud/envir/envir.go
@@ -1,0 +1,19 @@
+package envir
+
+import (
+	"os"
+	"strconv"
+)
+
+func IsCLICloudShell() bool {
+	cliCloudShell, _ := strconv.ParseBool(os.Getenv("DEVBOX_CLI_CLOUD_SHELL"))
+	return cliCloudShell
+}
+
+func IsDevboxCloud() bool {
+	return GetRegion() != ""
+}
+
+func GetRegion() string {
+	return os.Getenv("DEVBOX_REGION")
+}

--- a/internal/services/status.go
+++ b/internal/services/status.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/internal/cloud/envir"
 )
 
 // updateFunc returns a possibly updated service status and a boolean indicating
@@ -110,7 +111,7 @@ func writeServiceStatusFile(path string, status *ServiceStatus) error {
 }
 
 func updateServiceStatusOnRemote(projectDir string, s *ServiceStatus) error {
-	if os.Getenv("DEVBOX_REGION") == "" {
+	if !envir.IsDevboxCloud() {
 		return nil
 	}
 	host, err := os.Hostname()

--- a/internal/telemetry/segment.go
+++ b/internal/telemetry/segment.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	segment "github.com/segmentio/analytics-go"
 	"go.jetpack.io/devbox/internal/build"
+	"go.jetpack.io/devbox/internal/cloud/envir"
 	"go.jetpack.io/devbox/internal/cloud/openssh"
 )
 
@@ -79,7 +80,7 @@ func LogShellDurationEvent(eventName string, startTime string) error {
 		AnonymousID: DeviceID(),
 		AppName:     opts.AppName,
 		AppVersion:  opts.AppVersion,
-		CloudRegion: os.Getenv("DEVBOX_REGION"),
+		CloudRegion: envir.GetRegion(),
 		Duration:    time.Since(start),
 		OsName:      OS(),
 		UserID:      UserIDFromGithubUsername(),
@@ -156,7 +157,7 @@ func UnixTimestampFromTime(t time.Time) string {
 
 func shellAccess() shellAccessKind {
 	// Check if running in devbox cloud
-	if os.Getenv("DEVBOX_REGION") != "" {
+	if envir.IsDevboxCloud() {
 		// Check if running via ssh tty (i.e. ssh shell)
 		if os.Getenv("SSH_TTY") != "" {
 			return ssh


### PR DESCRIPTION
## Summary

This improves:

* port auto-forwarding only happens on CLI shells
* Print port on service proxy if available.
* Refactor common cloud env variables into a single package

## How was it tested?

builds
