### PR TITLE
[config] Set PATH as ENV instead of hook

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -3,10 +3,12 @@
     "go_1_19",
     "golangci-lint"
   ],
+  "env": {
+    "PATH": "$PWD/dist:$PATH"
+  },
   "shell": {
     "init_hook": [
-      "export \"GOROOT=$(go env GOROOT)\"",
-      "export \"PATH=$(pwd)/dist:$PATH\""
+      "export \"GOROOT=$(go env GOROOT)\""
     ],
     "scripts": {
       "build": "go build -o dist/devbox cmd/devbox/main.go",

--- a/docs/app/docs/devbox_examples/languages/ruby.md
+++ b/docs/app/docs/devbox_examples/languages/ruby.md
@@ -38,12 +38,5 @@ These environment variables configure Gem to install your gems locally, and set 
 RUBY_CONFDIR={PROJECT_DIR}/.devbox/virtenv/ruby
 GEMRC={PROJECT_DIR}/.devbox/virtenv/ruby/.gemrc
 GEM_HOME={PROJECT_DIR}/.devbox/virtenv/ruby
-```
-
-### Init Hook
-
-This hook ensures that your locally installed Gems are in your PATH while running `devbox shell`
-
-```bash
-"export PATH=\"{{ .Virtenv }}/bin:$PATH\""
+PATH={PROJECT_DIR}/.devbox/virtenv/ruby/bin:$PATH
 ```

--- a/internal/boxcli/global.go
+++ b/internal/boxcli/global.go
@@ -104,8 +104,9 @@ func globalShellenvCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "shellenv",
 		Short: "Print shell commands that add global Devbox packages to your PATH",
-		Run: func(*cobra.Command, []string) {
-			fmt.Print(impl.GenerateShellEnv())
+		Run: func(cmd *cobra.Command, _ []string) {
+			fmt.Fprintln(cmd.OutOrStdout(), impl.GenerateShellEnv())
+			fmt.Fprintln(cmd.OutOrStdout(), "hash -r")
 		},
 	}
 }

--- a/internal/boxcli/shellenv.go
+++ b/internal/boxcli/shellenv.go
@@ -27,6 +27,7 @@ func shellEnvCmd() *cobra.Command {
 				return err
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), s)
+			fmt.Fprintln(cmd.OutOrStdout(), ";hash -r")
 			return nil
 		},
 	}

--- a/internal/conf/doc.go
+++ b/internal/conf/doc.go
@@ -1,0 +1,3 @@
+// package conf is future home of the config (devbox.json) management code.
+// it will merge exiting plugin and impl/config.go code.
+package conf

--- a/internal/conf/env.go
+++ b/internal/conf/env.go
@@ -1,0 +1,30 @@
+package conf
+
+import (
+	"os"
+)
+
+func OSExpandEnvMap(
+	env map[string]string,
+	projectDir string,
+	existingEnv map[string]string,
+) map[string]string {
+	mapperfunc := func(value string) string {
+		// Special variables that should return correct value
+		switch value {
+		case "PWD":
+			return projectDir
+		}
+		// check if referenced variables exists in computed environment
+		if v, ok := existingEnv[value]; ok {
+			return v
+		}
+		return ""
+	}
+
+	res := map[string]string{}
+	for k, v := range env {
+		res[k] = os.Expand(v, mapperfunc)
+	}
+	return res
+}

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -22,6 +22,7 @@ import (
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/boxcli/generate"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
+	"go.jetpack.io/devbox/internal/conf"
 	"go.jetpack.io/devbox/internal/cuecfg"
 	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/fileutil"
@@ -170,7 +171,6 @@ func (d *Devbox) Shell() error {
 		WithHistoryFile(filepath.Join(d.projectDir, shellHistoryFile)),
 		WithProjectDir(d.projectDir),
 		WithEnvVariables(env),
-		WithPKGConfigDir(d.pluginVirtenvPath()),
 		WithShellStartTime(shellStartTime),
 	}
 
@@ -515,8 +515,6 @@ func (d *Devbox) computeNixEnv(ctx context.Context) (map[string]string, error) {
 
 		env[key] = val.Value.(string)
 	}
-	nixEnvPath := env["PATH"]
-	debug.Log("nix environment PATH is: %s", nixEnvPath)
 
 	// These variables are only needed for shell, but we include them here in the computed env
 	// for both shell and run in order to be as identical as possible.
@@ -524,7 +522,7 @@ func (d *Devbox) computeNixEnv(ctx context.Context) (map[string]string, error) {
 	env["DEVBOX_SHELL_ENABLED"] = "1"      // Used to determine whether we're inside a shell (e.g. to prevent shell inception)
 
 	// Add any vars defined in plugins.
-	pluginEnv, err := plugin.Env(d.packages(), d.projectDir)
+	pluginEnv, err := plugin.Env(d.packages(), d.projectDir, env)
 	if err != nil {
 		return nil, err
 	}
@@ -534,17 +532,15 @@ func (d *Devbox) computeNixEnv(ctx context.Context) (map[string]string, error) {
 
 	// Include env variables in devbox.json
 	if featureflag.EnvConfig.Enabled() {
-		// TODO: if the uer defines PATH here, how should it be handled?
 		for k, v := range d.configEnvs(env) {
 			env[k] = v
 		}
 	}
 
-	// TODO: consider removing this; not being used?
-	pluginVirtenvPath := d.pluginVirtenvPath()
-	debug.Log("plugin virtual environment PATH is: %s", pluginVirtenvPath)
+	nixEnvPath := env["PATH"]
+	debug.Log("nix environment PATH is: %s", nixEnvPath)
 
-	env["PATH"] = JoinPathLists(pluginVirtenvPath, nixEnvPath, originalPath)
+	env["PATH"] = JoinPathLists(nixEnvPath, originalPath)
 	debug.Log("computed unified environment PATH is: %s", env["PATH"])
 
 	return env, nil
@@ -646,10 +642,6 @@ func (d *Devbox) packages() []string {
 	return d.cfg.Packages(d.writer)
 }
 
-func (d *Devbox) pluginVirtenvPath() string {
-	return filepath.Join(d.projectDir, plugin.VirtenvBinPath)
-}
-
 // configEnvs takes the computed env variables (nix + plugin) and adds env
 // variables defined in Config. It also parses variables in config
 // that are referenced by $VAR or ${VAR} and replaces them with
@@ -657,26 +649,7 @@ func (d *Devbox) pluginVirtenvPath() string {
 // allow env variables from outside the shell to be referenced so
 // no leaked variables are caused by this function.
 func (d *Devbox) configEnvs(computedEnv map[string]string) map[string]string {
-	mapperfunc := func(value string) string {
-		// Special variables that should return correct value
-		switch value {
-		case "PWD":
-			return d.ProjectDir()
-		}
-		// check if referenced variables exists in computed environment
-		if v, ok := computedEnv[value]; ok {
-			return v
-		}
-		return ""
-	}
-	configEnvs := map[string]string{}
-	// Include env variables in config
-	for key, value := range d.cfg.Env {
-		// parse values for "$VAR" or "${VAR}"
-		parsedValue := os.Expand(value, mapperfunc)
-		configEnvs[key] = parsedValue
-	}
-	return configEnvs
+	return conf.OSExpandEnvMap(d.cfg.Env, d.ProjectDir(), computedEnv)
 }
 
 // Move to a utility package?

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -42,14 +42,6 @@ func toggleServices(
 	if err != nil {
 		return err
 	}
-	envVars, err := plugin.Env(pkgs, projectDir)
-	if err != nil {
-		return err
-	}
-	env := []string{}
-	for k, v := range envVars {
-		env = append(env, fmt.Sprintf("%s=%s", k, v))
-	}
 	contextChannels := []<-chan struct{}{}
 	for _, name := range serviceNames {
 		service, found := services[name]
@@ -63,8 +55,6 @@ func toggleServices(
 		)
 		cmd.Stdout = w
 		cmd.Stderr = w
-		cmd.Env = env
-		cmd.Env = append(cmd.Env, os.Environ()...)
 		if err = cmd.Run(); err != nil {
 			actionString := lo.Ternary(action == startService, "start", "stop")
 			if len(serviceNames) == 1 {

--- a/plugins/ruby.json
+++ b/plugins/ruby.json
@@ -5,11 +5,7 @@
   "env": {
     "RUBY_CONFDIR": "{{ .Virtenv }}",
     "GEMRC": "{{ .Virtenv }}/.gemrc",
-    "GEM_HOME": "{{ .Virtenv }}"
-  },
-  "shell": {
-    "init_hook": [
-      "export PATH=\"{{ .Virtenv }}/bin:$PATH\""
-    ]
+    "GEM_HOME": "{{ .Virtenv }}",
+    "PATH": "{{ .Virtenv }}/bin:$PATH"
   }
 }


### PR DESCRIPTION
## Summary

This change improves devbox.json and plugin jsons by allowing `PATH` to be set as an env variable instead of a hook.

For example, it allows `"PATH": "$PWD/dist:$PATH"`. 

In general any environment variable that is defined at the time of parsing is accessible. This means for plugins, the HOST environment is accessible, and for `devbox.json` the HOST environment and also the plugin environment is accessible. In practice this allows the user to override any plugin environment using an existing variable as base. On the other hand, the plugin environment variables will not take into account any changes that are made in the `devbox.json`

Some benefits of this change:

* We no longer need to export init hooks. One of the main use cases of init hooks is now moved to env instead.
* `refresh` no longer breaks changes to PATH. This is because init hooks don't get run by refresh, but the environment is reset correctly.

Related fixes:

* Removed code that was adding virtenv/<pkg>/bin to path. This is not used. 
* Removed code that was creating `env` files for each plugin. This is no longer used.
* Added `hash -r` to refresh functions
* No longer fetch plugin env vars when starting a service (this was only needed previously when adding a package while in shell would add it to profile but would not add env vars to current shell. Today `refresh` does this)

## How was it tested?

```bash
devbox shell
echo $PATH
devbox add ruby 
refresh
echo PATH
```
