### PR TITLE
Adjust paths order

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -4,7 +4,7 @@
     "golangci-lint"
   ],
   "env": {
-    "PATH": "$PWD/dist:$PATH"
+    "PATH": "$PATH:$PWD/dist"
   },
   "shell": {
     "init_hook": [


### PR DESCRIPTION
## Summary

Move `$(pwd)/dist` to the end of `PATH` as the last choice of `devbox` binary.

## How was it tested?
