### PR TITLE
[services] Allow custom process compose

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -44,7 +44,7 @@ type Devbox interface {
 	// ShellPlan creates a plan of the actions that devbox will take to generate its
 	// shell environment.
 	ShellPlan() (*plansdk.ShellPlan, error)
-	StartProcessManager(ctx context.Context) error
+	StartProcessManager(ctx context.Context, processComposeFileOrDir string) error
 	StartServices(ctx context.Context, services ...string) error
 	StopServices(ctx context.Context, services ...string) error
 }

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"go.jetpack.io/devbox/internal/plugin"
 )
@@ -12,6 +13,7 @@ func StartProcessManager(
 	ctx context.Context,
 	processComposePath string,
 	services plugin.Services,
+	processComposeFilePath string,
 ) error {
 	flags := []string{"-p", "8280"}
 	for _, s := range services {
@@ -19,9 +21,35 @@ func StartProcessManager(
 			flags = append(flags, "-f", file)
 		}
 	}
+	if processComposeFilePath != "" {
+		flags = append(flags, "-f", processComposeFilePath)
+	}
 	cmd := exec.Command(processComposePath, flags...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 	return cmd.Run()
+}
+
+func LookupProcessCompose(projectDir, path string) string {
+	if path == "" {
+		path = projectDir
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(projectDir, path)
+	}
+
+	pathsToCheck := []string{
+		path,
+		filepath.Join(path, "process-compose.yaml"),
+		filepath.Join(path, "process-compose.yml"),
+	}
+
+	for _, p := range pathsToCheck {
+		if fi, err := os.Stat(p); err == nil && !fi.IsDir() {
+			return p
+		}
+	}
+
+	return ""
 }


### PR DESCRIPTION
## Summary

Adds new `--process-compose-file` flag that allows user to specify additional process compose services (in addition to ones already specified by plugins). We also auto-detect `process-compose.yaml` or `process-compose.yml` in the root directory.

This allows users to flexibly add new services to process compose without having to write plugins. 
## How was it tested?

Created `process-compose.yml` in root and added simple hello world printing service. Also added nginx. Ran `devbox process manager` with and without new flag.
