### PR TITLE
[lib-path] Add a few common env variables

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -546,6 +546,8 @@ func (d *Devbox) computeNixEnv(ctx context.Context) (map[string]string, error) {
 	env["PATH"] = JoinPathLists(nixEnvPath, originalPath)
 	debug.Log("computed environment PATH is: %s", env["PATH"])
 
+	d.setCommonHelperEnvVars(env)
+
 	return env, nil
 }
 
@@ -708,4 +710,11 @@ var ignoreDevEnvVar = map[string]bool{
 	"TMPDIR":             true,
 	"TZ":                 true,
 	"UID":                true,
+}
+
+// setCommonHelperEnvVars sets environment variables that are required by some
+// common setups (e.g. gradio, rust)
+func (d *Devbox) setCommonHelperEnvVars(env map[string]string) {
+	env["LD_LIBRARY_PATH"] = filepath.Join(d.projectDir, nix.ProfilePath, "lib") + ":" + env["LD_LIBRARY_PATH"]
+	env["LIBRARY_PATH"] = filepath.Join(d.projectDir, nix.ProfilePath, "lib") + ":" + env["LIBRARY_PATH"]
 }


### PR DESCRIPTION
## Summary

Adds `LD_LIBRARY_PATH` and `LIBRARY_PATH` env vars to shellenv (pointing to profile lib directory). 

This is a bit of a blunt approach, so not sure if it's best. This would fix https://github.com/jetpack-io/devbox/issues/760 and also lets us simplify the [rust plugin](https://github.com/jetpack-io/devbox/blob/main/plugins/rustup.json#L7-L7)

Two questions/considerations:

* I considered adding to the flake.nix file instead, but wasn't example sure how to point to the right directory (without hard coding). It might look something like `LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath...` 
* I also read the following:

> Not setting LD_LIBRARY_PATH is usually the right choice because usually the native binaries find their libraries using RUNPATH which is specific to the binary. Setting LD_LIBRARY_PATH has an obvious problem of potentially messing up other programs.

@gcurtis any idea how accurate this is?

## How was it tested?

`devbox shell` and confirmed env vars are set.

Also tested with this example: https://github.com/jetpack-io/devbox/issues/710#issuecomment-1451162069
