### PR TITLE
migrate links: devbox-examples -> devbox/examples

### DIFF
--- a/docs/app/docs/devbox_cloud/browser_getting_started.md
+++ b/docs/app/docs/devbox_cloud/browser_getting_started.md
@@ -32,7 +32,7 @@ For example: https://devbox.sh/github.com/org/repo?branch=staging would clone th
 
 You can start your Devbox Cloud Shell in a subfolder of your project, using the `folder` query parameter. This can be useful when working with a monorepo where your project's `devbox.json` lives in a subfolder. 
 
-For example: https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=development/ruby will start your terminal in the Ruby example in the Devbox Examples repo, load the configuration from the `devbox.json` in that folder, and then start a Devbox Shell.
+For example: https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/development/ruby will start your terminal in the Ruby example in the Devbox repo, load the configuration from the `devbox.json` in that folder, and then start a Devbox Shell.
 
 
 ### Open in Devbox Badge

--- a/docs/app/docs/devbox_examples/databases/mariadb.md
+++ b/docs/app/docs/devbox_examples/databases/mariadb.md
@@ -3,9 +3,9 @@ title: MariaDB
 ---
 To use a local MariaDB for development with Devbox and Nix, you will need to configure MariaDB to install and manage the configuration locally. This can be done using Environment variables to create the data directory, pidfile, and unix sock locally.
 
-[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/examples/databases/mariadb)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/databases/mariadb)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/examples/databases/mariadb)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/databases/mariadb)
 
 ## Adding MariaDB to your Shell
 

--- a/docs/app/docs/devbox_examples/databases/mariadb.md
+++ b/docs/app/docs/devbox_examples/databases/mariadb.md
@@ -3,9 +3,9 @@ title: MariaDB
 ---
 To use a local MariaDB for development with Devbox and Nix, you will need to configure MariaDB to install and manage the configuration locally. This can be done using Environment variables to create the data directory, pidfile, and unix sock locally.
 
-[**Example Repo**](https://github.com/jetpack-io/devbox-examples/tree/main/databases/mariadb)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/examples/databases/mariadb)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=databases/mariadb)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/examples/databases/mariadb)
 
 ## Adding MariaDB to your Shell
 

--- a/docs/app/docs/devbox_examples/databases/postgres.md
+++ b/docs/app/docs/devbox_examples/databases/postgres.md
@@ -3,7 +3,7 @@ title: PostgreSQL
 ---
 PostgreSQL can be automatically configured by Devbox via the built-in Postgres Plugin. This plugin will activate automatically when you install Postgres using `devbox add postgresql`
 
-[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/examples/databases/postgres)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/databases/postgres)
 
 [![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/databases/postgres)
 

--- a/docs/app/docs/devbox_examples/databases/postgres.md
+++ b/docs/app/docs/devbox_examples/databases/postgres.md
@@ -3,9 +3,9 @@ title: PostgreSQL
 ---
 PostgreSQL can be automatically configured by Devbox via the built-in Postgres Plugin. This plugin will activate automatically when you install Postgres using `devbox add postgresql`
 
-[**Example Repo**](https://github.com/jetpack-io/devbox-examples/tree/main/databases/postgres)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/examples/databases/postgres)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=databases/postgres)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/databases/postgres)
 
 ## Adding Postgres to your Shell
 

--- a/docs/app/docs/devbox_examples/databases/redis.md
+++ b/docs/app/docs/devbox_examples/databases/redis.md
@@ -4,9 +4,9 @@ title: Redis
 
 Redis can be configured automatically using Devbox's built in Redis plugin. This plugin will activate automatically when you install Redis using `devbox add redis`
 
-[**Example Repo**](https://github.com/jetpack-io/devbox-examples/tree/main/databases/redis)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/databases/redis)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=databases/redis)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/databases/redis)
 
 ## Adding Redis to your shell
 

--- a/docs/app/docs/devbox_examples/index.md
+++ b/docs/app/docs/devbox_examples/index.md
@@ -3,7 +3,7 @@ title: Devbox Examples
 ---
 Devbox strives to provide a balance between the immutability of Nix's global store, and the mutability of local project configuration. The examples below show how to configure Devbox for a wide range of development environments and project types. 
 
-You can view the full list of examples in our [Example Repo](https://github.com/jetpack-io/devbox-examples/)
+You can view the full list of examples in our [Example Repo](https://github.com/jetpack-io/devbox/)
 
 ## Languages
 * [C#/.NET](languages/csharp.md)

--- a/docs/app/docs/devbox_examples/languages/csharp.md
+++ b/docs/app/docs/devbox_examples/languages/csharp.md
@@ -4,9 +4,9 @@ title: C# and .NET
 
 C# and .NET projects can be easily generated in Devbox by adding the dotnet SDK to your project. You can then create new projects using `dotnet new`
 
-[**Example Repo**](https://github.com/jetpack-io/devbox-examples/tree/main/development/csharp)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/development/csharp)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=development/csharp/hello-world)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/development/csharp/hello-world)
 
 ## Adding .NET to your project
 

--- a/docs/app/docs/devbox_examples/languages/elixir.md
+++ b/docs/app/docs/devbox_examples/languages/elixir.md
@@ -4,9 +4,9 @@ title: Elixir
 
 Elixir can be configured to install Hex and Rebar dependencies in a local directory. This will keep Elixir from trying to install in your immutable Nix Store: 
 
-[**Example Repo**](https://github.com/jetpack-io/devbox-examples/tree/main/development/elixir/elixir_hello)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/development/elixir/elixir_hello)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=development/elixir/elixir_hello)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/development/elixir/elixir_hello)
 
 
 ## Adding Elixir to your project

--- a/docs/app/docs/devbox_examples/languages/fsharp.md
+++ b/docs/app/docs/devbox_examples/languages/fsharp.md
@@ -4,9 +4,9 @@ title: F# and .NET
 
 F# and .NET projects can be easily generated in Devbox by adding the dotnet SDK to your project. You can then create new projects using `dotnet new`
 
-[**Example Repo**](https://github.com/jetpack-io/devbox-examples/tree/main/development/fsharp)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/development/fsharp)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=development/fsharp/hello-world)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/development/fsharp/hello-world)
 
 ## Adding .NET to your project
 

--- a/docs/app/docs/devbox_examples/languages/go.md
+++ b/docs/app/docs/devbox_examples/languages/go.md
@@ -4,9 +4,9 @@ title: Go
 
 Go projects can be run in Devbox by adding the Go SDK to your project. If your project uses cgo or compiles against C libraries, you should also include them in your packages to ensure Go can compile successfully
 
-[**Example Repo**](https://github.com/jetpack-io/devbox-examples/tree/main/development/go/hello-world)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/development/go/hello-world)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=development/go/hello-world)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/development/go/hello-world)
 
 ## Adding Go to your Project
 

--- a/docs/app/docs/devbox_examples/languages/haskell.md
+++ b/docs/app/docs/devbox_examples/languages/haskell.md
@@ -4,9 +4,9 @@ title: Haskell
 
 Haskell projects that use the Stack Framework can be run in Devbox by adding the Stack and the Cabal packages to your project. You may also want to include libraries that Stack requires for compilation (described below)
 
-[**Example Repo**](https://github.com/jetpack-io/devbox-examples/tree/main/development/haskell/)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/development/haskell/)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=development/development/haskell)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/development/development/haskell)
 
 ## Adding Haskell and Stack to your Project
 

--- a/docs/app/docs/devbox_examples/languages/java.md
+++ b/docs/app/docs/devbox_examples/languages/java.md
@@ -6,7 +6,7 @@ In addition to installing the JDK, you'll need to install either the Maven or Gr
 
 In both cases, you'll want to first activate `devbox shell` before generating your Maven or Gradle projects, so that the tools use the right version of the JDK for creating your project. 
 
-[**Example Repo**](https://github.com/jetpack-io/devbox-examples/tree/main/development/java)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/development/java)
 
 ## Adding the JDK to your project
 
@@ -30,9 +30,9 @@ Other distributions of the JDK (such as OracleJDK and Eclipse Temurin) are avail
 
 ## Gradle
 
-[**Example Repo**](https://github.com/jetpack-io/devbox-examples/tree/main/development/java/gradle/hello-world)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/development/java/gradle/hello-world)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=development/java/gradle/hello-world)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/development/java/gradle/hello-world)
 
 Gradle is a popular, multi-language build tool that is commonly used with JVM projects. To setup an example project using Gradle, follow the instructions below: 
 
@@ -83,9 +83,9 @@ An example `devbox.json` would look like the following:
 
 ## Maven
 
-[**Example Repo**](https://github.com/jetpack-io/devbox-examples/tree/main/development/java/maven/hello-world)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/development/java/maven/hello-world)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=development/java/maven/hello-world)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/development/java/maven/hello-world)
 
 Maven is an all-in-one CI-CD tool for building testing and deploying Java projects. To setup a sample project with Java and Maven in devbox follow the steps below:
 

--- a/docs/app/docs/devbox_examples/languages/nim.md
+++ b/docs/app/docs/devbox_examples/languages/nim.md
@@ -4,9 +4,9 @@ title: Nim
 
 Nim projects can be run in Devbox by adding Nim and Nimble to your project. For some platforms, Nimble may return an error if OpenSSL is not available, so we recommend including `openssl_1_1` in your packages as well
 
-[**Example Repo**](https://github.com/jetpack-io/devbox-examples/tree/main/development/nim/spinnytest)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/development/nim/spinnytest)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=development/development/nim/spinnytest)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/development/development/nim/spinnytest)
 
 ## Adding Nim to your Project
 

--- a/docs/app/docs/devbox_examples/languages/nodejs.md
+++ b/docs/app/docs/devbox_examples/languages/nodejs.md
@@ -4,9 +4,9 @@ title: NodeJS
 
 Most NodeJS Projects will install their dependencies locally using NPM or Yarn, and thus can work with Devbox with minimal additional configuration. Per project packages can be managed via NPM or Yarn.
 
-[**Example Repo**](https://github.com/jetpack-io/devbox-examples/tree/main/development/nodejs)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/development/nodejs)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=development/nodejs/nodejs-npm)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/development/nodejs/nodejs-npm)
 
 
 ## Adding NodeJS to your Shell
@@ -27,9 +27,9 @@ Other versions available include:
 
 ## Adding Yarn as your Package Manager
 
-[**Example Repo**](https://github.com/jetpack-io/devbox-examples/tree/main/development/nodejs/nodejs-yarn)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/development/nodejs/nodejs-yarn)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=development/nodejs/nodejs-yarn)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/development/nodejs/nodejs-yarn)
 
 `devbox add yarn`, or in your `devbox.json` add: 
 ```json

--- a/docs/app/docs/devbox_examples/languages/php.md
+++ b/docs/app/docs/devbox_examples/languages/php.md
@@ -4,9 +4,9 @@ title: PHP
 
 PHP projects can manage most of their dependencies locally with `composer`. Some PHP extensions, however, need to be bundled with PHP at compile time. 
 
-[**Example Repo**](https://github.com/jetpack-io/devbox-examples/tree/main/development/php/php8.1)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/development/php/php8.1)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=development/php/php8.1)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/development/php/php8.1)
 
 ## Adding PHP to your Project
 

--- a/docs/app/docs/devbox_examples/languages/python.md
+++ b/docs/app/docs/devbox_examples/languages/python.md
@@ -4,7 +4,7 @@ title: Python
 
 Python by default will attempt to install your packages globally, or in the Nix Store (which it does not have permissions to modify). To use Python with Devbox, we recommend setting up a Virtual Environment using pipenv or Poetry (see below).
 
-[**Example Repo**](https://github.com/jetpack-io/devbox-examples/tree/main/development/python)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/development/python)
 
 ## Adding Python to your Project
 
@@ -28,9 +28,9 @@ Other versions available include:
 
 ## Installing Packages with Pip
 
-[**Example Repo**](https://github.com/jetpack-io/devbox-examples/tree/main/development/python/pip)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/development/python/pip)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=development/python/pip)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/development/python/pip)
 
 [pip](https://pip.pypa.io/en/stable/) is the standard package manager for Python. Since it installs python packages globally, we strongly recommend using a virtual environment.
 
@@ -52,9 +52,9 @@ Your virtual environment is created in the `.devbox/virtenv/pip` directory by de
 
 ## Pipenv
 
-[**Example Repo**](https://github.com/jetpack-io/devbox-examples/tree/main/development/python/pipenv)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/development/python/pipenv)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=development/python/pipenv)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/development/python/pipenv)
 
 [pipenv](https://pipenv.pypa.io/en/latest/) is a tool that will automatically set up a virtual environment for installing your PyPi packages. 
 
@@ -75,9 +75,9 @@ This init_hook will automatically start your virtualenv when you run `devbox she
 
 ## Poetry
 
-[**Example Link**](https://github.com/jetpack-io/devbox-examples/tree/main/development/python/poetry/poetry-demo)
+[**Example Link**](https://github.com/jetpack-io/devbox/tree/main/examples/development/python/poetry/poetry-demo)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=development/python/poetry/poetry-demo)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/development/python/poetry/poetry-demo)
 
 [Poetry](https://python-poetry.org/) is a packaging and dependency manager for Python that helps you manage your Python packages, and can automatically create a virtual environment for your project. 
 

--- a/docs/app/docs/devbox_examples/languages/ruby.md
+++ b/docs/app/docs/devbox_examples/languages/ruby.md
@@ -2,9 +2,9 @@
 title: Ruby
 ---
 
-[**Example Repo**](https://github.com/jetpack-io/devbox-examples/tree/main/development/ruby)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/development/ruby)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=development/ruby)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/development/ruby)
 
 Ruby can be automatically configured by Devbox via the built-in Ruby Plugin. This plugin will activate automatically when you install Ruby 2.7 using `devbox add ruby`. 
 

--- a/docs/app/docs/devbox_examples/languages/rust.md
+++ b/docs/app/docs/devbox_examples/languages/rust.md
@@ -4,9 +4,9 @@ title: Rust
 
 The easiest way to manage Rust with Devbox is to install `rustup`, and then configure the channel you wish to install via Devbox's `init_hook`. You can also use the `init_hook` to configure `rustup` to install the Rust toolchain locally. 
 
-[**Example Repo**](https://github.com/jetpack-io/devbox-examples/tree/main/development/rust)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/development/rust)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=development/rust)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/development/rust)
 
 ```json
 {

--- a/docs/app/docs/devbox_examples/languages/zig.md
+++ b/docs/app/docs/devbox_examples/languages/zig.md
@@ -4,9 +4,9 @@ title: Zig
 
 Zig projects can be run in Devbox by adding Zig and Nimble to your project.
 
-[**Example Repo**](https://github.com/jetpack-io/devbox-examples/tree/main/development/zig/zig-hello-world)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/development/zig/zig-hello-world)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=development/development/zig/zig-hello-world)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/development/development/zig/zig-hello-world)
 
 ## Adding Go to your Project
 

--- a/docs/app/docs/devbox_examples/servers/apache.md
+++ b/docs/app/docs/devbox_examples/servers/apache.md
@@ -4,9 +4,9 @@ title: Apache
 
 Apache can be automatically configured by Devbox via the built-in Apache Plugin. This plugin will activate automatically when you install Apache using `devbox add apacheHttpd`
 
-[**Example Repo**](https://github.com/jetpack-io/devbox-examples/tree/main/servers/apache)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/servers/apache)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=servers/apache)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/servers/apache)
 
 ### Adding Apache to your Shell
 

--- a/docs/app/docs/devbox_examples/servers/caddy.md
+++ b/docs/app/docs/devbox_examples/servers/caddy.md
@@ -4,9 +4,9 @@ title: Caddy
 
 Caddy can be configured automatically using Devbox's built in Caddy plugin. This plugin will activate automatically when you install Caddy using `devbox add caddy`
 
-[**Example Repo**](https://github.com/jetpack-io/devbox-examples/tree/main/servers/caddy)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/servers/caddy)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=servers/caddy)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/servers/caddy)
 
 ### Adding Caddy to your Shell
 

--- a/docs/app/docs/devbox_examples/servers/nginx.md
+++ b/docs/app/docs/devbox_examples/servers/nginx.md
@@ -4,9 +4,9 @@ title: Nginx
 
 NGINX can be automatically configured by Devbox via the built-in NGINX Plugin. This plugin will activate automatically when you install NGINX using `devbox add nginx`
 
-[**Example Repo**](https://github.com/jetpack-io/devbox-examples/tree/main/servers/nginx)
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/servers/nginx)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=servers/nginx)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/servers/nginx)
 
 ## Adding NGINX to your Shell
 

--- a/docs/app/docs/devbox_examples/stacks/django.md
+++ b/docs/app/docs/devbox_examples/stacks/django.md
@@ -2,9 +2,9 @@
 
 This example demonstrates how to configure and run a Django app using Devbox. It installs Python, PostgreSQL, and uses `pip` to install your Python dependencies in a virtual environment.
 
-[Example Repo](https://github.com/jetpack-io/devbox-examples/tree/main/stacks/django)
+[Example Repo](https://github.com/jetpack-io/devbox/tree/main/examples/stacks/django)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=stacks/django)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/stacks/django)
 
 ## How to Use
 

--- a/docs/app/docs/devbox_examples/stacks/drupal.md
+++ b/docs/app/docs/devbox_examples/stacks/drupal.md
@@ -4,9 +4,9 @@ title: Drupal
 
 This example shows how to run a Drupal application in Devbox. It makes use of the PHP and Apache Plugins, while demonstrating how to configure a MariaDB instance to work with Devbox Cloud.
 
-[Example Repo](https://github.com/jetpack-io/devbox-examples/tree/main/stacks/drupal)
+[Example Repo](https://github.com/jetpack-io/devbox/tree/main/examples/stacks/drupal)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=stacks/drupal)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/stacks/drupal)
 
 ## How to Run 
 

--- a/docs/app/docs/devbox_examples/stacks/jekyll.md
+++ b/docs/app/docs/devbox_examples/stacks/jekyll.md
@@ -4,9 +4,9 @@ title: Jekyll
 
 This example demonstrates how to create and run a Jekyll blog in Devbox. It makes use of the Ruby Plugin to configure and setup your project. 
 
-[Example Repo](https://github.com/jetpack-io/devbox-examples/tree/main/stacks/jekyll)
+[Example Repo](https://github.com/jetpack-io/devbox/tree/main/examples/stacks/jekyll)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=stacks/jekyll)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/stacks/jekyll)
 
 Inspired by https://litchipi.github.io/nix/2023/01/12/build-jekyll-blog-with-nix.html 
 

--- a/docs/app/docs/devbox_examples/stacks/lapp.md
+++ b/docs/app/docs/devbox_examples/stacks/lapp.md
@@ -4,9 +4,9 @@ title: LAPP (Linux, Apache, PHP, Postgres)
 
 This example shows how to build a simple application using Apache, PHP, and PostgreSQL. It uses Devbox Plugins for all 3 packages to simplify configuration
 
-[Example Repo](https://github.com/jetpack-io/devbox-examples/tree/main/stacks/lapp-stack)
+[Example Repo](https://github.com/jetpack-io/devbox/tree/main/examples/stacks/lapp-stack)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=stacks/lapp-stack)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/stacks/lapp-stack)
 
 ## How to Run
 

--- a/docs/app/docs/devbox_examples/stacks/lepp.md
+++ b/docs/app/docs/devbox_examples/stacks/lepp.md
@@ -5,9 +5,9 @@ title: LEPP (Linux, Nginx, PHP, Postgres)
 
 An example Devbox shell for NGINX, Postgres, and PHP. This example uses Devbox Plugins for all 3 packages to simplify configuration
 
-[Example Repo](https://github.com/jetpack-io/devbox-examples/tree/main/stacks/lepp-stack)
+[Example Repo](https://github.com/jetpack-io/devbox/tree/main/examples/stacks/lepp-stack)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=stacks/lepp-stack)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/stacks/lepp-stack)
 
 ## How to Run
 

--- a/docs/app/docs/devbox_examples/stacks/rails.md
+++ b/docs/app/docs/devbox_examples/stacks/rails.md
@@ -4,9 +4,9 @@ title: Ruby on Rails
 
 This example demonstrates how to setup a simple Rails application. It makes use of the Ruby Plugin, and installs SQLite to use as a database. 
 
-[Example Repo](https://github.com/jetpack-io/devbox-examples/tree/main/stacks/rails)
+[Example Repo](https://github.com/jetpack-io/devbox/tree/main/examples/stacks/rails)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=stacks/rails)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/stacks/rails)
 
 ## How To Run
 

--- a/docs/app/docs/guides/scripts.md
+++ b/docs/app/docs/guides/scripts.md
@@ -50,4 +50,4 @@ Your devbox shell will exit once the last line of your script has finished runni
 1. Since `init_hook` runs everytime you start your shell, you should use primarily use it for setting environment variables and aliases. For longer running tasks like database setup, you can create and run a Devbox script
 2. You can use Devbox scripts to start and manage long running background processes and daemons. For example -- If you are working on a LAMP stack project, you can use scripts to start MySQL and Apache in separate shells and monitor their logs. Once you are done developing, you can use CTRL-C to exit the processes and shells
 3. If a script feels too long to put it directly in `devbox.json`, you can save it as a shell script in your project, and then invoke it in your `devbox scripts`.
-4. For more ideas, see the LAMP stack example in our [Devbox examples repo](https://github.com/jetpack-io/devbox-examples/tree/main/stacks/lamp-stack). 
+4. For more ideas, see the LAMP stack example in our [Devbox examples repo](https://github.com/jetpack-io/devbox/tree/main/examples/stacks/lapp-stack). 

--- a/docs/app/docs/quickstart.mdx
+++ b/docs/app/docs/quickstart.mdx
@@ -26,7 +26,7 @@ Devbox requires the [Nix Package Manager](https://nixos.org/download.html). If N
 :::note
 If you want to try Devbox before installing it, you can open a cloud shell on your browser using the link below
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox-examples?folder=tutorial)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/tutorial)
 :::
 
 ## Create a development environment


### PR DESCRIPTION
## Summary

Replaced all links that pointed to Devbox Examples to point to the examples folder in the devbox repo

## How was it tested?

Manual verification