### PR TITLE
[Lagobot 2.0] part 1: generate testscript for a single devbox example project

### DIFF
--- a/testscripts/testrunner/examplesrunner.go
+++ b/testscripts/testrunner/examplesrunner.go
@@ -1,0 +1,97 @@
+package testrunner
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/rogpeppe/go-internal/testscript"
+	"go.jetpack.io/devbox/internal/debug"
+)
+
+// RunExamplesTestscripts generates testscripts for each example devbox-project.
+// For now, we prototype with the "go" example project. TODO savil: generalize.
+func RunExamplesTestscripts(t *testing.T, examplesDir string) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// TODO savil. Change this to handle _all_ of the example folder's devbox-projects
+	examplesDir = filepath.Join(wd, examplesDir)
+	projectDir := filepath.Join(examplesDir, "development", "go", "hello-world")
+	runSingleExampleTestscript(t, examplesDir, projectDir)
+}
+
+func runSingleExampleTestscript(t *testing.T, examplesDir, projectDir string) {
+	testscriptDir, err := generateTestscript()
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.RemoveAll(testscriptDir)
+
+	testName, err := filepath.Rel(examplesDir, projectDir)
+	if err != nil {
+		t.Error(err)
+	}
+
+	t.Run(testName, func(t *testing.T) {
+		params := getTestscriptParams(testscriptDir)
+
+		// save a reference to the original params.Setup so that we can wrap it below
+		setup := params.Setup
+		params.Setup = func(env *testscript.Env) error {
+			// setup the devbox testscript environment
+			if err := setup(env); err != nil {
+				return errors.WithStack(err)
+			}
+
+			// copy all the files and folders of the devbox-project being tested to the workdir
+			debug.Log("copying projectDir: %s to env.WorkDir: %s\n", projectDir, env.WorkDir)
+			// implementation detail: the period at the end of the projectDir/.
+			// is important to ensure this works for both mac and linux.
+			// Ref.https://dev.to/ackshaey/macos-vs-linux-the-cp-command-will-trip-you-up-2p00
+			err = exec.Command("cp", "-r", projectDir+"/.", env.WorkDir).Run()
+			if err != nil {
+				return errors.WithStack(err)
+			}
+
+			return errors.WithStack(err)
+		}
+
+		testscript.Run(t, params)
+	})
+}
+
+// generateTestscript will create a temp-directory and place the generic
+// testscript file (.test.txt) for all examples devbox-projects in it.
+// Unless there was an error, it returns the directory containing the testscript file
+// and the caller is responsible for cleaning up the directory.
+func generateTestscript() (testscriptDir string, err error) {
+	defer func() {
+		// cleanup the temp-dir if there was any error
+		if err != nil {
+			os.RemoveAll(testscriptDir)
+		}
+	}()
+
+	// create a temp-dir to place the testscript file
+	testscriptDir, err = os.MkdirTemp("", "example")
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return testscriptDir, errors.WithStack(err)
+	}
+
+	// Copy the testscript file to the temp-dir
+	runTestScriptPath := filepath.Join(wd, "testrunner", "run_test.test.txt")
+	debug.Log("copying run_test.test.txt from %s to %s\n", runTestScriptPath, testscriptDir)
+	// Using os's cp command for expediency.
+	err = exec.Command("cp", runTestScriptPath, testscriptDir).Run()
+	return testscriptDir, errors.WithStack(err)
+}

--- a/testscripts/testrunner/run_test.test.txt
+++ b/testscripts/testrunner/run_test.test.txt
@@ -1,0 +1,1 @@
+exec devbox run run_test

--- a/testscripts/testrunner/setupenv.go
+++ b/testscripts/testrunner/setupenv.go
@@ -60,5 +60,12 @@ func setupCacheHome(env *testscript.Env) error {
 		return err
 	}
 
+	// Golang caches build outputs for reuse in future builds in GOCACHE
+	goBuildCache := filepath.Join(cacheHome, "go-build")
+	env.Setenv("GOCACHE", goBuildCache)
+	if err = os.MkdirAll(goBuildCache, 0755); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/testscripts/testrunner/testrunner.go
+++ b/testscripts/testrunner/testrunner.go
@@ -36,6 +36,12 @@ func RunTestscripts(t *testing.T, testscriptsDir string) {
 	// Loop through all the directories and run all tests scripts (files ending
 	// in .test.txt)
 	for _, dir := range dirs {
+		// The testrunner dir has the testscript we use for projects in examples/ directory.
+		// We should skip that one since it is run separately (see RunExamplesTestscripts).
+		if filepath.Base(dir) == "testrunner" {
+			continue
+		}
+
 		testscript.Run(t, getTestscriptParams(dir))
 	}
 }

--- a/testscripts/testscripts_test.go
+++ b/testscripts/testscripts_test.go
@@ -14,3 +14,8 @@ func TestScripts(t *testing.T) {
 func TestMain(m *testing.M) {
 	os.Exit(testrunner.Main(m))
 }
+
+// TestExamples runs testscripts on the devbox-projects in the examples folder.
+func TestExamples(t *testing.T) {
+	testrunner.RunExamplesTestscripts(t, "../examples")
+}


### PR DESCRIPTION
## Summary

**Why**
Our goal is to make each Devbox release higher-quality by ensuring that all the devbox-projects in `examples/` are able to run.

**What**
We aim to do so by adding a `run_test` devbox script to each project in `examples/`, and ensuring that it can run. This has the additional benefit of making the `devbox.json` self-documenting for any user who is reading the code in the `examples/` directory: they can refer to the `run_test` to understand how to execute that example project.

**How**
To do so in our automated tests:
1. We will generate a simple testscript for each of these devbox-projects that calls
`devbox run run_test`.
2. We copy the devbox project's files and directories into the testscript's workdir.

As a proof of concept, this PR runs a testscript for the `examples/development/go/hello-world` project. A future PR will generalize this to all of the devbox projects in `examples/`

## How was it tested?

Ran with this command:
```
DEVBOX_DEBUG=0 go test -run TestExamples/development/go/hello-world -count 1 ./testscripts
```
