### PR TITLE
[vscode-extension] open vscode browser

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -100,16 +100,21 @@
     "test": "node ./out/test/runTest.js"
   },
   "devDependencies": {
-    "@types/vscode": "^1.72.0",
     "@types/glob": "^8.0.0",
     "@types/mocha": "^10.0.0",
     "@types/node": "16.x",
+    "@types/node-fetch": "2",
+    "@types/vscode": "^1.72.0",
     "@typescript-eslint/eslint-plugin": "^5.38.1",
     "@typescript-eslint/parser": "^5.38.1",
+    "@vscode/test-electron": "^2.1.5",
     "eslint": "^8.24.0",
     "glob": "^8.0.3",
     "mocha": "^10.0.0",
-    "typescript": "^4.8.4",
-    "@vscode/test-electron": "^2.1.5"
+    "typescript": "^4.8.4"
+  },
+  "dependencies": {
+    "form-data": "^4.0.0",
+    "node-fetch": "2"
   }
 }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -37,14 +37,18 @@ export function activate(context: ExtensionContext) {
 		handleUri: (uri: Uri) => {
 			const queryParams = new URLSearchParams(uri.query);
 
-			if (queryParams.has('vm_id')) {
+			if (queryParams.has('vm_id') && queryParams.has('gh_user')) {
 				const vmId = queryParams.get('vm_id');
-				const host = `${vmId}`;
-				const pathToFile = '/home/mohsenari/';
+				const host = `${vmId}.vm.devbox-vms.internal`;
+				const ghUser = queryParams.get('gh_user');
+				const pathToFile = `/home/${ghUser}/`;
+
 				const workspaceURI = `vscode-remote://ssh-remote+${host}${pathToFile}`;
 				const uriToOpen = Uri.parse(workspaceURI);
 				window.showInformationMessage(uriToOpen.toString());
 				commands.executeCommand("vscode.openFolder", uriToOpen, false);
+			} else {
+				window.showErrorMessage('Error parsing information for remote environment.');
 			}
 		}
 	});

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -35,6 +35,7 @@ export function activate(context: ExtensionContext) {
 		}
 	});
 
+	// open in vscode URI handler
 	const handleVSCodeUri = window.registerUriHandler({ handleUri: handleOpenInVSCode });
 
 	const devboxAdd = commands.registerCommand('devbox.add', async () => {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,11 +1,8 @@
 // The module 'vscode' contains the VS Code extensibility API
-import { workspace, window, commands, Uri, ExtensionContext, FileSystem } from 'vscode';
+import { workspace, window, commands, Uri, ExtensionContext } from 'vscode';
 import { posix } from 'path';
-import fetch from 'node-fetch';
-import FormData = require('form-data');
-import { exec } from 'child_process';
-import { open, writeFile } from 'fs/promises';
 
+import { handleOpenInVSCode } from './openinvscode';
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
@@ -38,63 +35,7 @@ export function activate(context: ExtensionContext) {
 		}
 	});
 
-	const handleVSCodeUri = window.registerUriHandler({
-		handleUri: async (uri: Uri) => {
-			const queryParams = new URLSearchParams(uri.query);
-
-			if (queryParams.has('vm_id') && queryParams.has('token')) {
-				window.showInformationMessage("TTTTTTTT");
-				const vmId = queryParams.get('vm_id');
-				const host = `${vmId}.vm.devbox-vms.internal`;
-				const gatewayHost = 'https://api.devbox.sh/g/vm_info';
-				const token = queryParams.get('token');
-				const data = new FormData();
-				data.append("vm_id", "91857266c16283");
-				// send post request to https://api.web.devbox.sh/g/vm_info
-				// authorization header: Bearer {token}
-				// body: vm_id={vm_id}
-				const response = await fetch(gatewayHost, {
-					method: 'post',
-					body: data,
-					headers: {
-						'Authorization': `Bearer ${token}`
-					}
-				});
-				const res = await response.json();
-				console.log("data:\n");
-				console.log(res);
-				// set ssh config
-				exec('./devbox generate ssh-config --config=./', (error, stdout, stderr) => {
-					if (error) {
-						console.error(`exec error: ${error}`);
-						return;
-					}
-					console.log(`stdout: ${stdout}`);
-					console.log(`stderr: ${stderr}`);
-				});
-				// save private key 
-				const prkeyPath = `${process.env['HOME']}/.config/devbox/ssh/keys/${res['vm_id']}.vm.devbox-vms.internal`;
-				try {
-
-					const data = new Uint8Array(Buffer.from(res['private_key']));
-					const fileHandler = await open(prkeyPath, 'w');
-					await writeFile(fileHandler, data, { flag: 'w' });
-					await fileHandler.close();
-				} catch (err) {
-					// When a request is aborted - err is an AbortError
-					console.error(err);
-				}
-				const pathToFile = `/home/${res['username']}/`;
-
-				const workspaceURI = `vscode-remote://ssh-remote+${host}${pathToFile}`;
-				const uriToOpen = Uri.parse(workspaceURI);
-				window.showInformationMessage(uriToOpen.toString());
-				commands.executeCommand("vscode.openFolder", uriToOpen, false);
-			} else {
-				window.showErrorMessage('Error parsing information for remote environment.');
-			}
-		}
-	});
+	const handleVSCodeUri = window.registerUriHandler({ handleUri: handleOpenInVSCode });
 
 	const devboxAdd = commands.registerCommand('devbox.add', async () => {
 		const result = await window.showInputBox({

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,5 +1,5 @@
 // The module 'vscode' contains the VS Code extensibility API
-import { workspace, window, commands, Uri, ExtensionContext } from 'vscode';
+import { workspace, window, commands, Uri, UriHandler, ExtensionContext } from 'vscode';
 import { posix } from 'path';
 
 // This method is called when your extension is activated
@@ -30,6 +30,22 @@ export function activate(context: ExtensionContext) {
 			&& context.workspaceState.get("configFileExists")
 		) {
 			await runInTerminal('devbox shell', true);
+		}
+	});
+
+	const handleVSCodeUri = window.registerUriHandler({
+		handleUri: (uri: Uri) => {
+			const queryParams = new URLSearchParams(uri.query);
+
+			if (queryParams.has('vm_id')) {
+				const vmId = queryParams.get('vm_id');
+				const host = `${vmId}`;
+				const pathToFile = '/home/mohsenari/';
+				const workspaceURI = `vscode-remote://ssh-remote+${host}${pathToFile}`;
+				const uriToOpen = Uri.parse(workspaceURI);
+				window.showInformationMessage(uriToOpen.toString());
+				commands.executeCommand("vscode.openFolder", uriToOpen, false);
+			}
 		}
 	});
 
@@ -85,6 +101,7 @@ export function activate(context: ExtensionContext) {
 	context.subscriptions.push(devboxShell);
 	context.subscriptions.push(setupDevcontainer);
 	context.subscriptions.push(generateDockerfile);
+	context.subscriptions.push(handleVSCodeUri);
 }
 
 async function initialCheckDevboxJSON(context: ExtensionContext) {

--- a/vscode-extension/src/openinvscode.ts
+++ b/vscode-extension/src/openinvscode.ts
@@ -1,0 +1,73 @@
+import { Uri, commands, window } from 'vscode';
+import fetch from 'node-fetch';
+import { exec } from 'child_process';
+import FormData = require('form-data');
+import { open, writeFile } from 'fs/promises';
+
+export async function handleOpenInVSCode(uri: Uri) {
+    const queryParams = new URLSearchParams(uri.query);
+
+    if (queryParams.has('vm_id') && queryParams.has('token')) {
+        window.showInformationMessage('Setting up devbox');
+
+        // getting ssh keys
+        const response = await getVMInfo(queryParams.get('token'), queryParams.get('vm_id'));
+        const res = await response.json();
+        // TODO: remove debug
+        console.log("data:\n");
+        console.log(res);
+        // set ssh config
+        await setupSSHConfig(res['vm_id'], res['private_key']);
+        // connect to remote vm
+        connectToRemote(res['username'], res['vm_id']);
+    } else {
+        window.showErrorMessage('Error parsing information for remote environment.');
+    };
+}
+
+async function getVMInfo(token: string | null, vmId: string | null): Promise<any> {
+    // send post request to gateway to get vm info and ssh keys
+    const gatewayHost = 'https://api.devbox.sh/g/vm_info';
+    const data = new FormData();
+    data.append("vm_id", vmId);
+    const response = await fetch(gatewayHost, {
+        method: 'post',
+        body: data,
+        headers: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            'Authorization': `Bearer ${token}`
+        }
+    });
+    return response;
+}
+
+async function setupSSHConfig(vmId: string, prKey: string) {
+    exec('./devbox generate ssh-config --config=./', (error, stdout, stderr) => {
+        if (error) {
+            console.error(`exec error: ${error}`);
+            return;
+        }
+        console.log(`stdout: ${stdout}`);
+        console.log(`stderr: ${stderr}`);
+    });
+    // save private key to file
+    const prkeyPath = `${process.env['HOME']}/.config/devbox/ssh/keys/${vmId}.vm.devbox-vms.internal`;
+    try {
+        const prKeydata = new Uint8Array(Buffer.from(prKey));
+        const fileHandler = await open(prkeyPath, 'w');
+        await writeFile(fileHandler, prKeydata, { flag: 'w' });
+        await fileHandler.close();
+    } catch (err) {
+        // When a request is aborted - err is an AbortError
+        console.error(err);
+    }
+}
+
+function connectToRemote(username: string, vmId: string) {
+    const pathToFile = `/home/${username}/`;
+    const host = `${vmId}.vm.devbox-vms.internal`;
+    const workspaceURI = `vscode-remote://ssh-remote+${host}${pathToFile}`;
+    const uriToOpen = Uri.parse(workspaceURI);
+    window.showInformationMessage(uriToOpen.toString());
+    commands.executeCommand("vscode.openFolder", uriToOpen, false);
+}

--- a/vscode-extension/src/openinvscode.ts
+++ b/vscode-extension/src/openinvscode.ts
@@ -14,7 +14,7 @@ export async function handleOpenInVSCode(uri: Uri) {
         const response = await getVMInfo(queryParams.get('token'), queryParams.get('vm_id'));
         const res = await response.json();
         // TODO: remove debug
-        console.log("data:\n");
+        console.log("data:");
         console.log(res);
         // set ssh config
         await setupSSHConfig(res['vm_id'], res['private_key']);
@@ -42,7 +42,8 @@ async function getVMInfo(token: string | null, vmId: string | null): Promise<any
 }
 
 async function setupSSHConfig(vmId: string, prKey: string) {
-    exec('./devbox generate ssh-config --config=./', (error, stdout, stderr) => {
+    // TODO: change this back before to devbox generate ssh-config
+    exec('/Users/mohsenansari/code/jetpack/go.jetpack.io/direnvexamples/sample1/devbox generate ssh-config --config=/Users/mohsenansari/code/jetpack/go.jetpack.io/direnvexamples/sample1/', (error, stdout, stderr) => {
         if (error) {
             console.error(`exec error: ${error}`);
             return;

--- a/vscode-extension/src/openinvscode.ts
+++ b/vscode-extension/src/openinvscode.ts
@@ -2,7 +2,7 @@ import { Uri, commands, window } from 'vscode';
 import fetch from 'node-fetch';
 import { exec } from 'child_process';
 import FormData = require('form-data');
-import { open, writeFile } from 'fs/promises';
+import { chmod, open, writeFile } from 'fs/promises';
 
 export async function handleOpenInVSCode(uri: Uri) {
     const queryParams = new URLSearchParams(uri.query);
@@ -57,6 +57,7 @@ async function setupSSHConfig(vmId: string, prKey: string) {
         const prKeydata = new Uint8Array(Buffer.from(prKey));
         const fileHandler = await open(prkeyPath, 'w');
         await writeFile(fileHandler, prKeydata, { flag: 'w' });
+        await chmod(prkeyPath, 0o600);
         await fileHandler.close();
     } catch (err) {
         // When a request is aborted - err is an AbortError
@@ -66,7 +67,7 @@ async function setupSSHConfig(vmId: string, prKey: string) {
 
 function connectToRemote(username: string, vmId: string) {
     const pathToFile = `/home/${username}/`;
-    const host = `${vmId}.vm.devbox-vms.internal`;
+    const host = `${username}@${vmId}.vm.devbox-vms.internal`;
     const workspaceURI = `vscode-remote://ssh-remote+${host}${pathToFile}`;
     const uriToOpen = Uri.parse(workspaceURI);
     window.showInformationMessage(uriToOpen.toString());

--- a/vscode-extension/yarn.lock
+++ b/vscode-extension/yarn.lock
@@ -85,6 +85,14 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.0.tgz#3d9018c575f0e3f7386c1de80ee66cc21fbb7a52"
   integrity sha512-rADY+HtTOA52l9VZWtgQfn4p+UDVM2eDVkMZT1I6syp0YKxW2F9v+0pbRZLsvskhQv/vMb6ZfCay81GHbz5SHg==
 
+"@types/node-fetch@2":
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.2.tgz#d1a9c5fd049d9415dce61571557104dec3ec81da"
+  integrity sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*":
   version "18.11.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.0.tgz#f38c7139247a1d619f6cc6f27b072606af7c289d"
@@ -259,6 +267,11 @@ array-union@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -385,6 +398,13 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -420,6 +440,11 @@ deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 diff@5.0.0:
   version "5.0.0"
@@ -649,6 +674,24 @@ flatted@^3.1.0:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
+
+form-data@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
+  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -935,6 +978,18 @@ micromatch@^4.0.4:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 minimatch@5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
@@ -1014,6 +1069,13 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+node-fetch@2:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.9.tgz#7c7f744b5cc6eb5fd404e0c7a9fec630a55657e6"
+  integrity sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
@@ -1273,6 +1335,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 "traverse@>=0.3.0 <0.4":
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
@@ -1334,6 +1401,19 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
## Summary
Added capability to parse vscode:// urls which can be used for `open-in-vscode` button. 
The extension still needs handling when OS is not linux/macos and cover more edge cases. But Happy path works.

## How was it tested?
- go to devbox.sh and create a new VM (from examples or /new)
- inspect element from elements tab save vm_id and from application tab for cookies under `<vm_id>.vm.devbox.sh` save `id_token`'s value.
- create a link with this format: `vscode://jetpack-io.devbox?vm_id=<vm_id>&token=<id_token>` and save this.
- while on this branch open `vscode-extension` directory in vscode (`code devbox/vscode-extension`)
- Go to debug tab from the left side menu and click run and debug (this spawns a new vscode window with devbox extension loaded into it).
- open a random file in the newly opened vscode window then on the browser go to the link that you saved 3 steps before
- follow the prompts on browser and vscode and it should connect your new vscode window's environment to devbox cloud vm.