### PR TITLE
[Lagobot 2.0] part 3: set HOME to temp-dir to enable a few example projects

### DIFF
--- a/testscripts/testrunner/setupenv.go
+++ b/testscripts/testrunner/setupenv.go
@@ -60,12 +60,5 @@ func setupCacheHome(env *testscript.Env) error {
 		return err
 	}
 
-	// Golang caches build outputs for reuse in future builds in GOCACHE
-	goBuildCache := filepath.Join(cacheHome, "go-build")
-	env.Setenv("GOCACHE", goBuildCache)
-	if err = os.MkdirAll(goBuildCache, 0755); err != nil {
-		return err
-	}
-
 	return nil
 }


### PR DESCRIPTION
## Summary

Many language toolchains rely on $HOME being set. For example:
1. csharp and fsharp were failing due to `~/.dotnet` not being writable.
2. golang was failing due to `GOCACHE=$HOME/Library/Caches/go-build`

In this PR, I set HOME to a temp-dir. This continues to ensure isolation.
I also only do this for examplesrunner, and not for the testrunner so that 
we continue to ensure devbox unit tests do not rely on this.

This enables quite a few projects: csharp, fsharp, haskell, poetry, ... and golang (removed the specific GOCACHE code for golang)

I also wrote comments for why the remaining ones are failing and will address
them in followups.


## How was it tested?

```
DEVBOX_DEBUG=0 go test -v -run TestExamples/development_go -count 1 ./testscripts
...
--- PASS: TestExamples (2.09s)
    --- PASS: TestExamples/development_ruby_run_test.test (6.69s)
    --- PASS: TestExamples/development_java_maven_hello-world_run_test.test (14.22s)
    --- PASS: TestExamples/development_csharp_hello-world_run_test.test (17.13s)
    --- PASS: TestExamples/development_java_gradle_hello-world_run_test.test (14.84s)
    --- PASS: TestExamples/development_zig_zig-hello-world_run_test.test (23.72s)
    --- PASS: TestExamples/development_go_hello-world_run_test.test (10.61s)
    --- PASS: TestExamples/stacks_lepp-stack_run_test.test (24.92s)
    --- PASS: TestExamples/development_fsharp_hello-world_run_test.test (18.92s)
    --- PASS: TestExamples/development_python_poetry_poetry-demo_run_test.test (38.52s)
    --- PASS: TestExamples/development_rust_rust-stable-hello-world_run_test.test (43.40s)
    --- PASS: TestExamples/stacks_lapp-stack_run_test.test (24.77s)
    --- PASS: TestExamples/development_haskell_run_test.test (167.18s)
PASS
ok      go.jetpack.io/devbox/testscripts        169.612s
```
