### PR TITLE
[Lagobot 2.0] disable haskell

### DIFF
--- a/testscripts/testrunner/examplesrunner.go
+++ b/testscripts/testrunner/examplesrunner.go
@@ -51,6 +51,9 @@ func RunExamplesTestscripts(t *testing.T, examplesDir string) {
 			//         update it with "mix deps.update ranch" or clean it with "mix deps.clean ranch"
 			"elixir",
 
+			// failing: https://github.com/jetpack-io/devbox/actions/runs/4504377069/jobs/7928774568
+			"haskell",
+
 			// pip: $WORK/.devbox/virtenv/python310Packages.pip/.venv/bin/activate: No such file or directory
 			"pip",
 


### PR DESCRIPTION
## Summary

failing in buildkite

## How was it tested?

buildkite run should be green

local:

```
 DEVBOX_DEBUG=0 go test -v -run TestExamples/ -count 1 ./testscripts
 --- PASS: TestExamples (0.39s)
    --- PASS: TestExamples/development_go_hello-world_run_test.test (5.82s)
    --- PASS: TestExamples/development_ruby_run_test.test (5.93s)
    --- PASS: TestExamples/development_java_gradle_hello-world_run_test.test (12.75s)
    --- PASS: TestExamples/stacks_lepp-stack_run_test.test (22.42s)
    --- PASS: TestExamples/development_java_maven_hello-world_run_test.test (16.85s)
    --- PASS: TestExamples/development_csharp_hello-world_run_test.test (23.49s)
    --- PASS: TestExamples/development_fsharp_hello-world_run_test.test (23.50s)
    --- PASS: TestExamples/development_zig_zig-hello-world_run_test.test (21.52s)
    --- PASS: TestExamples/stacks_lapp-stack_run_test.test (29.99s)
    --- PASS: TestExamples/development_python_poetry_poetry-demo_run_test.test (35.07s)
    --- PASS: TestExamples/development_rust_rust-stable-hello-world_run_test.test (35.96s)
PASS
ok      go.jetpack.io/devbox/testscripts        49.355s
```