### PR TITLE
[Lagobot] enable haskell

### DIFF
--- a/examples/development/haskell/devbox.json
+++ b/examples/development/haskell/devbox.json
@@ -1,10 +1,15 @@
 {
     "packages": [
+        "gcc",
+        "gmp",
         "stack",
         "cabal-install",
         "zlib",
         "hpack"
     ],
+    "env": {
+        "LD_LIBRARY_PATH": "$PWD/.devbox/nix/profile/default/lib:/usr/lib/wsl/lib"
+    },
     "shell": {
         "init_hook": null,
         "scripts": {

--- a/examples/development/haskell/devbox.json
+++ b/examples/development/haskell/devbox.json
@@ -1,15 +1,11 @@
 {
     "packages": [
-        "gcc",
         "gmp",
         "stack",
         "cabal-install",
         "zlib",
         "hpack"
     ],
-    "env": {
-        "LD_LIBRARY_PATH": "$PWD/.devbox/nix/profile/default/lib:/usr/lib/wsl/lib"
-    },
     "shell": {
         "init_hook": null,
         "scripts": {

--- a/testscripts/testrunner/examplesrunner.go
+++ b/testscripts/testrunner/examplesrunner.go
@@ -52,7 +52,7 @@ func RunExamplesTestscripts(t *testing.T, examplesDir string) {
 			"elixir",
 
 			// failing: https://github.com/jetpack-io/devbox/actions/runs/4504377069/jobs/7928774568
-			"haskell",
+			//"haskell",
 
 			// pip: $WORK/.devbox/virtenv/python310Packages.pip/.venv/bin/activate: No such file or directory
 			"pip",

--- a/testscripts/testrunner/examplesrunner.go
+++ b/testscripts/testrunner/examplesrunner.go
@@ -51,9 +51,6 @@ func RunExamplesTestscripts(t *testing.T, examplesDir string) {
 			//         update it with "mix deps.update ranch" or clean it with "mix deps.clean ranch"
 			"elixir",
 
-			// failing: https://github.com/jetpack-io/devbox/actions/runs/4504377069/jobs/7928774568
-			//"haskell",
-
 			// pip: $WORK/.devbox/virtenv/python310Packages.pip/.venv/bin/activate: No such file or directory
 			"pip",
 


### PR DESCRIPTION
## Summary

Failure message was:
> [2 of 2] Compiling StackSetupShim   ( /tmp/TestExamples4181845809/020/.stack/setup-exe-src/setup-shim-Z6RU0evB.hs, /tmp/TestExamples4181845809/020/.stack/setup-exe-src/setup-shim-Z6RU0evB.o )
[198](https://github.com/jetpack-io/devbox/actions/runs/4504377069/jobs/7928774568#step:7:199)
            Linking /tmp/TestExamples4181845809/020/.stack/setup-exe-cache/x86_64-linux-tinfo6/tmp-Cabal-simple_Z6RU0evB_3.6.3.0_ghc-9.2.5 ...
[199](https://github.com/jetpack-io/devbox/actions/runs/4504377069/jobs/7928774568#step:7:200)
            /nix/store/178vvank67pg2ckr5ic5gmdkm3ri72f3-binutils-2.39/bin/ld: cannot find -lgmp: No such file or directory
[200](https://github.com/jetpack-io/devbox/actions/runs/4504377069/jobs/7928774568#step:7:201)
            collect2: error: ld returned 1 exit status
[201](https://github.com/jetpack-io/devbox/actions/runs/4504377069/jobs/7928774568#step:7:202)
            `gcc' failed in phase `Linker'. (Exit code: 1)
[202](https://github.com/jetpack-io/devbox/actions/runs/4504377069/jobs/7928774568#step:7:203)

from: https://github.com/jetpack-io/devbox/actions/runs/4504377069/jobs/7928774568

I tried adding `gcc` and fixing `LD_LIBRARY_PATH` but those failed.

Finally, just adding `gmp` seems to succeed. Lets go with this for now, even though I believe there's likely a better way to set up this devbox.json.

## How was it tested?

buildkite run should pass
