### PR TITLE
[hooks] Fix hook order

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -591,7 +591,7 @@ func (d *Devbox) writeScriptsToFiles() error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	hooks := strings.Join(append([]string{d.cfg.Shell.InitHook.String()}, pluginHooks...), "\n\n")
+	hooks := strings.Join(append(pluginHooks, d.cfg.Shell.InitHook.String()), "\n\n")
 	// always write it, even if there are no hooks, because scripts will source it.
 	err = d.writeScriptFile(hooksFilename, hooks)
 	if err != nil {


### PR DESCRIPTION
## Summary

plugin hooks should run first, user hooks last

## How was it tested?

```bash
➜  devbox git:(main) ✗ cd examples/development/python/pip
➜  pip git:(main) ✗ devbox run run_test
```