### PR TITLE
Fix Elixir Example

### DIFF
--- a/examples/development/elixir/elixir_hello/devbox.json
+++ b/examples/development/elixir/elixir_hello/devbox.json
@@ -3,8 +3,8 @@
         "elixir"
     ],
     "env": {
-        "MIX_HOME": ".nix-mix",
-        "HEX_HOME": ".nix-hex",
+        "MIX_HOME": "$PWD/.nix-mix",
+        "HEX_HOME": "$PWD/.nix-hex",
         "ERL_AFLAGS": "-kernel shell_history enabled"
     },
     "shell": {

--- a/testscripts/testrunner/examplesrunner.go
+++ b/testscripts/testrunner/examplesrunner.go
@@ -43,13 +43,6 @@ func RunExamplesTestscripts(t *testing.T, examplesDir string) {
 
 		// TODO savil. Resolve these.
 		skipList := []string{
-			// elixir:
-			//         ** (Mix) Could not compile dependency :ranch,
-			//         ".nix-mix/elixir/1-14/rebar3 bare compile --paths $WORK/_build/dev/lib/*/ebin"
-			//         command failed. Errors may have been logged above.
-			//         You can recompile this dependency with "mix deps.compile ranch",
-			//         update it with "mix deps.update ranch" or clean it with "mix deps.clean ranch"
-			"elixir",
 
 			// pip: $WORK/.devbox/virtenv/python310Packages.pip/.venv/bin/activate: No such file or directory
 			"pip",


### PR DESCRIPTION
## Summary

Add $PWD to the environment variables to fix the elixir example

This is probably worth noting — The env variables are passed as-is to the `sh` binary in the nix store, so without the $PWD, `sh` and `mix` are looking for the elixir deps in /nix/store/<hash>-sh/.nix-mix/ instead of in the project directory. Adding $PWD seems to fix this

## How was it tested?
`devbox run run_test` in the elixir dir