### PR TITLE
[lagobot] enable pip and django

### DIFF
--- a/examples/development/python/pip/devbox.json
+++ b/examples/development/python/pip/devbox.json
@@ -5,7 +5,7 @@
     ],
     "shell": {
         "init_hook": [
-            "source $VENV_DIR/bin/activate",
+            ". $VENV_DIR/bin/activate",
             "pip install -r requirements.txt"
         ],
         "scripts": {

--- a/examples/stacks/django/devbox.json
+++ b/examples/stacks/django/devbox.json
@@ -7,7 +7,7 @@
     ],
     "shell": {
         "init_hook": [
-            "source $VENV_DIR/bin/activate",
+            ". $VENV_DIR/bin/activate",
             "pip install -r requirements.txt"
         ],
         "scripts": {

--- a/testscripts/testrunner/examplesrunner.go
+++ b/testscripts/testrunner/examplesrunner.go
@@ -45,7 +45,7 @@ func RunExamplesTestscripts(t *testing.T, examplesDir string) {
 		skipList := []string{
 
 			// pip: $WORK/.devbox/virtenv/python310Packages.pip/.venv/bin/activate: No such file or directory
-			"pip",
+			//"pip",
 
 			// django: $WORK/.devbox/virtenv/python310Packages.pip/.venv/bin/activate: No such file or directory
 			"django",

--- a/testscripts/testrunner/examplesrunner.go
+++ b/testscripts/testrunner/examplesrunner.go
@@ -44,12 +44,6 @@ func RunExamplesTestscripts(t *testing.T, examplesDir string) {
 		// TODO savil. Resolve these.
 		skipList := []string{
 
-			// pip: $WORK/.devbox/virtenv/python310Packages.pip/.venv/bin/activate: No such file or directory
-			//"pip",
-
-			// django: $WORK/.devbox/virtenv/python310Packages.pip/.venv/bin/activate: No such file or directory
-			"django",
-
 			// drupal:
 			// https://gist.github.com/savil/9c67ffa50a2c51d118f3a4ce29ab920d
 			"drupal",


### PR DESCRIPTION
## Summary

We use period `.` instead of `source`, and can now enable pip and django.

Not entirely sure why but I think the testscripts run in `sh` and not `bash`. `source` is a bash-ism.

## How was it tested?

buildkite run needs to be green
