### PR TITLE
[lagobot] add integration tag to separate the tests

### DIFF
--- a/testscripts/testrunner/examplesrunner.go
+++ b/testscripts/testrunner/examplesrunner.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package testrunner
 
 import (
@@ -14,6 +17,11 @@ import (
 	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/impl"
 )
+
+// TestExamples runs testscripts on the devbox-projects in the examples folder.
+func TestExamples(t *testing.T) {
+	RunExamplesTestscripts(t, "../examples")
+}
 
 // RunExamplesTestscripts generates testscripts for each example devbox-project.
 func RunExamplesTestscripts(t *testing.T, examplesDir string) {

--- a/testscripts/testscripts_test.go
+++ b/testscripts/testscripts_test.go
@@ -14,8 +14,3 @@ func TestScripts(t *testing.T) {
 func TestMain(m *testing.M) {
 	os.Exit(testrunner.Main(m))
 }
-
-// TestExamples runs testscripts on the devbox-projects in the examples folder.
-func TestExamples(t *testing.T) {
-	testrunner.RunExamplesTestscripts(t, "../examples")
-}


### PR DESCRIPTION
## Summary

I'm in the middle of adding this but sending this pre-emptively so that Lagobot tests
can stop running in CICD.

The integration tests will only run via `go test -tags=integration`

References:
1. https://www.reddit.com/r/golang/comments/a1iuhg/comment/eat8uyn/?utm_source=reddit&utm_medium=web2x&context=3
2. https://mickey.dev/posts/go-build-tags-testing/

## How was it tested?

ran locally but rm_test testscript is failing (unrelated to this?)
