### PR TITLE
[testscripts] respect DEVBOX_DEBUG flag instead of always setting it on

### DIFF
--- a/testscripts/testrunner/setupenv.go
+++ b/testscripts/testrunner/setupenv.go
@@ -17,10 +17,7 @@ func setupTestEnv(env *testscript.Env) error {
 		return err
 	}
 
-	// Enable new `devbox run` so we can use it in tests. This is temporary,
-	// and should be removed once we enable this feature flag.
-	env.Setenv("DEVBOX_FEATURE_UNIFIED_ENV", "1")
-	env.Setenv("DEVBOX_DEBUG", "1")
+	env.Setenv("DEVBOX_DEBUG", os.Getenv("DEVBOX_DEBUG"))
 	return nil
 }
 


### PR DESCRIPTION
## Summary

It is very hard to parse the output from testscripts because we always turn on DEVBOX_DEBUG output as well.

Instead, we should respect the invoking user's DEVBOX_DEBUG value.

## How was it tested?

shows output as before:
```
 DEVBOX_DEBUG=1 go test -v ./testscripts/...
```

cleaner output:
```
go test -v ./testscripts/...
```
