### PR TITLE
[UnifiedEnv] remove env-var from shell_test

### DIFF
--- a/internal/impl/shell_test.go
+++ b/internal/impl/shell_test.go
@@ -15,7 +15,6 @@ import (
 var update = flag.Bool("update", false, "update the golden files with the test results")
 
 func TestWriteDevboxShellrc(t *testing.T) {
-	t.Setenv("DEVBOX_FEATURE_UNIFIED_ENV", "0")
 	testdirs, err := filepath.Glob("testdata/shellrc/*")
 	if err != nil {
 		t.Fatal("Error globbing testdata:", err)


### PR DESCRIPTION
## Summary

Looks like this writeShellrc functionality is still valid?

anyway, we can remove this env-var call

## How was it tested?

test passed locally
