### PR TITLE
[lagobot] run cli-tests with DEVBOX_EXAMPLE_TESTS on main or input.run-example-tests

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -18,6 +18,9 @@ on:
       run-mac-tests:
         type: boolean
   workflow_dispatch:
+    inputs:
+      run-example-tests:
+        type: boolean
 
 permissions:
   contents: read
@@ -104,6 +107,8 @@ jobs:
           logger: pretty
           nix-build-user-count: 4
       - name: Run tests
+        env:
+          DEVBOX_EXAMPLE_TESTS: "${{ (github.ref == 'refs/heads/main' || inputs.run-example-tests) && 1 || 0 }}"
         run: |
           go test ./...
 


### PR DESCRIPTION
## Summary

The example-tests take too long to run, so they only run if DEVBOX_EXAMPLE_TESTS are enabled.

In CICD, we do not run them on regular PRs.

We want to run the example-tests on `main` or if the workflow_dispatch has `input.run-example-tests` set to `true` (for debugging)

## How was it tested?

Github Action run for this PR:
1. Cli tests ran in 1 min 23 sec https://github.com/jetpack-io/devbox/actions/runs/4515550386/jobs/7952967257

2. I manually did a workflow dispatch with `run-example-tests` enabled. Cli tests ran in 7 min https://github.com/jetpack-io/devbox/actions/runs/4515569436/jobs/7953008609
