### PR TITLE
[lagobot] extend macos test timeout to 15 mins

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3.5.0


### PR DESCRIPTION
## Summary

this needs to be longer for lagobot tests

## How was it tested?

will test on landing
