### PR TITLE
[shellenv] PrintEnv should generate just in case

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -256,6 +256,11 @@ func (d *Devbox) PrintEnv() (string, error) {
 	ctx, task := trace.NewTask(context.Background(), "devboxPrintEnv")
 	defer task.End()
 
+	// generate in case user has old .devbox dir and is missing any files.
+	if err := d.Generate(); err != nil {
+		return "", err
+	}
+
 	envs, err := d.cachedComputeNixEnv(ctx)
 	if err != nil {
 		return "", err

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -257,8 +257,10 @@ func (d *Devbox) PrintEnv() (string, error) {
 	defer task.End()
 
 	// generate in case user has old .devbox dir and is missing any files.
-	if err := d.Generate(); err != nil {
-		return "", err
+	if !d.isDotDevboxVersionCurrent() {
+		if err := d.Generate(); err != nil {
+			return "", err
+		}
 	}
 
 	envs, err := d.cachedComputeNixEnv(ctx)

--- a/internal/impl/generate.go
+++ b/internal/impl/generate.go
@@ -15,6 +15,7 @@ import (
 	"text/template"
 
 	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/internal/build"
 	"go.jetpack.io/devbox/internal/cuecfg"
 	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/planner/plansdk"
@@ -60,7 +61,7 @@ func generateForShell(rootPath string, plan *plansdk.ShellPlan, pluginManager *p
 		}
 	}
 
-	return nil
+	return os.WriteFile(".devbox/version", []byte(build.Version), 0644)
 }
 
 // Cache and buffers for generating templated files.
@@ -208,4 +209,13 @@ func isProjectInGitRepo(dir string) bool {
 	// We reached the fs-root dir, climbed the highest mountain and
 	// we still haven't found what we're looking for.
 	return false
+}
+
+func (d *Devbox) isDotDevboxVersionCurrent() bool {
+	b, err := os.ReadFile(filepath.Join(d.projectDir, ".devbox/version"))
+	if err != nil {
+		return false
+	}
+
+	return strings.TrimSpace(string(b)) == build.Version
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/jetpack-io/devbox/issues/829

`run` and `shell` always call generate but using `shell --print-env` and `shellenv` don't. This means that sometimes the `.devbox` directory might be out of date (e.g. when we turned on flakes, not everyone has `flake.nix` file). Since not all workflows involve `shell` and `run`, some users never update it. For performance reasons, we only update if the devbox version doesn't match whatever version created the `.devbox` dir.

This change may not be sufficient to fix all cases, but it fixes the attached issue.


## How was it tested?

```bash
rm .devbox/gen/flake/flake.nix
devbox shellenv > /dev/null
rm .devbox/gen/flake/flake.nix
devbox shell --print-env > /dev/nul
``

no error (previously this gave me same error as issue)
