### PR TITLE
[lagobot] properly extend timeout for macos tests

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -21,6 +21,8 @@ on:
     inputs:
       run-example-tests:
         type: boolean
+      run-mac-tests:
+        type: boolean
 
 permissions:
   contents: read
@@ -49,7 +51,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3.5.0
@@ -86,11 +88,11 @@ jobs:
         run-example-tests: [true, false]
         exclude:
           - is-main: false
-            os: macos-latest
+            os: "${{ inputs.run-mac-tests && 'dummy' || 'macos-latest' }}"
           - is-main: true
             run-example-tests: false
     runs-on: ${{ matrix.os }}
-    timeout-minutes: ${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && 20 || 10 }}
+    timeout-minutes: ${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && 25 || 10 }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3.5.0
@@ -116,8 +118,10 @@ jobs:
       - name: Run tests
         env:
           DEVBOX_EXAMPLE_TESTS: ${{ matrix.run-example-tests }}
+          # Used in `go test -timeout` flag. Needs a value that time.ParseDuration can parse.
+          DEVBOX_GOLANG_TEST_TIMEOUT: "${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && '25m' || '10m' }}"
         run: |
-          go test ./...
+          go test -v -timeout $DEVBOX_GOLANG_TEST_TIMEOUT ./...
 
   auto-nix-install: # ensure Devbox installs nix and works properly after installation.
     strategy:

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -121,7 +121,7 @@ jobs:
           # Used in `go test -timeout` flag. Needs a value that time.ParseDuration can parse.
           DEVBOX_GOLANG_TEST_TIMEOUT: "${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && '25m' || '10m' }}"
         run: |
-          go test -v -timeout $DEVBOX_GOLANG_TEST_TIMEOUT ./...
+          go test -timeout $DEVBOX_GOLANG_TEST_TIMEOUT ./...
 
   auto-nix-install: # ensure Devbox installs nix and works properly after installation.
     strategy:

--- a/devbox.json
+++ b/devbox.json
@@ -1,7 +1,8 @@
 {
   "packages": [
     "go_1_19",
-    "golangci-lint"
+    "golangci-lint",
+    "actionlint"
   ],
   "env": {
     "PATH": "$PATH:$PWD/dist"


### PR DESCRIPTION
## Summary

My previous PR was done in a rush and I didn't properly verify that it worked (newsflash: it did not).

Changes:
- undo mistaken timeout change of golangci-lint: back from 15 min to 10 min
- add `actionlint` to devbox.json. Useful for spotting errors in github actions, although the lint seems a bit overeager, so we shouldn't enforce it is clean (yet).
- ~add `-v` to `go test` so we get incremental output~
- extend the `-timeout` on `go test`. The default is 10 minutes, but macos tests need longer.
- turn off `pipenv` example project from running on `darwin` in CICD, since it took over 1100 seconds. Will revisit why this is so slow, but aiming to get CICD in a stable place first.

## How was it tested?

- [x] PR's buildkite run should be green
- [x] test run with `run-with-examples` and `run-with-macos` inputs set to `true`: https://github.com/jetpack-io/devbox/actions/runs/4538067300
