### PR TITLE
[lagobot] clear .devbox dirs

### DIFF
--- a/testscripts/testrunner/examplesrunner.go
+++ b/testscripts/testrunner/examplesrunner.go
@@ -96,11 +96,17 @@ func runSingleExampleTestscript(t *testing.T, examplesDir, projectDir string) {
 		// implementation detail: the period at the end of the projectDir/.
 		// is important to ensure this works for both mac and linux.
 		// Ref.https://dev.to/ackshaey/macos-vs-linux-the-cp-command-will-trip-you-up-2p00
-		err = exec.Command("cp", "-r", projectDir+"/.", env.WorkDir).Run()
+
+		cmd := exec.Command("rm", "-rf", projectDir+"/.devbox")
+		err = cmd.Run()
 		if err != nil {
+			debug.Log("failed %s before doing cp", cmd)
 			return errors.WithStack(err)
 		}
 
+		cmd = exec.Command("cp", "-r", projectDir+"/.", env.WorkDir)
+		debug.Log("Running cmd: %s\n", cmd)
+		err = cmd.Run()
 		return errors.WithStack(err)
 	}
 


### PR DESCRIPTION
## Summary

**Problem:**
If we have a `.devbox` directory in an example project, then running the testscript
seems to fail. Something about copying that `.devbox` directory is breaking some logic.
We should clear the `.devbox` directory before we execute the testscript.

**Approach:**
In this PR, I clear the `.devbox` directory in the example project __before__ 
copying the contents over into the testscript's workdir.

This has the downside that if we have a `devbox shell` active for that project,
then its `.devbox` directory will get cleared out under it. This is sub-optimal
but also not a common scenario.

I tried deleting the `.devbox` directory __after__ copying it into the testscript's workdir,
but that failed. I think but couldn't confirm that it was due to some permissions issue.

## How was it tested?

for `examples/development/csharp/hello-world`:
1. ran `devbox run run_test` to generate the `.devbox` dir
2. ran `DEVBOX_DEBUG=0 DEVBOX_EXAMPLE_TESTS=1 go test -v -run TestExamples/development_csharp -count 1 ./testscripts`
   - also, manually had to filter for `csharp` in the code because the filtering happens _after_  we copy all the projects into the testscript workdirs. I'll send another PR to fix this.
