### PR TITLE
[lagobot] ensure default nixpkgs commit by deleting the commits from devbox.json

### DIFF
--- a/examples/cloud_development/argo-workflows/devbox.json
+++ b/examples/cloud_development/argo-workflows/devbox.json
@@ -27,8 +27,5 @@
                 "minikube -p argo-test logs -f"
             ]
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/cloud_development/maelstrom/devbox.json
+++ b/examples/cloud_development/maelstrom/devbox.json
@@ -23,8 +23,5 @@
                 "glow maelstrom/doc"
             ]
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/cloud_development/minikube/devbox.json
+++ b/examples/cloud_development/minikube/devbox.json
@@ -21,8 +21,5 @@
                 "minikube logs -f"
             ]
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/cloud_development/temporal/devbox.json
+++ b/examples/cloud_development/temporal/devbox.json
@@ -19,8 +19,5 @@
         "scripts": {
             "start-temporal": "temporalite start --namespace default --log-level warn --log-format pretty --ephemeral"
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/data_science/jupyter/devbox.json
+++ b/examples/data_science/jupyter/devbox.json
@@ -13,8 +13,5 @@
   },
   "shell": {
     "init_hook": null
-  },
-  "nixpkgs": {
-    "commit": "2321fbe1ffd79b9caf5ff0dab8284ed178029bac"
   }
 }

--- a/examples/data_science/pytorch/basic-example/devbox.json
+++ b/examples/data_science/pytorch/basic-example/devbox.json
@@ -14,8 +14,5 @@
             "install": "poetry install",
             "main": "poetry run python main.py"
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/data_science/pytorch/gradio/devbox.json
+++ b/examples/data_science/pytorch/gradio/devbox.json
@@ -12,8 +12,5 @@
       "source $VENV_DIR/bin/activate",
       "pip install -r requirements.txt"
     ]
-  },
-  "nixpkgs": {
-    "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
   }
 }

--- a/examples/databases/mariadb/devbox.json
+++ b/examples/databases/mariadb/devbox.json
@@ -14,8 +14,5 @@
             "conf/mysql/mysql.sh",
             "source conf/set-exit.sh"
         ]
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/databases/postgres/devbox.json
+++ b/examples/databases/postgres/devbox.json
@@ -4,8 +4,5 @@
   ],
   "shell": {
     "init_hook": null
-  },
-  "nixpkgs": {
-    "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
   }
 }

--- a/examples/databases/redis/devbox.json
+++ b/examples/databases/redis/devbox.json
@@ -7,8 +7,5 @@
     "scripts": {
       "redis-cli": "redis-cli"
     }
-  },
-  "nixpkgs": {
-    "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
   }
 }

--- a/examples/development/csharp/hello-world/devbox.json
+++ b/examples/development/csharp/hello-world/devbox.json
@@ -7,8 +7,5 @@
         "scripts": {
             "run_test": "dotnet run"
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/development/elixir/elixir_hello/devbox.json
+++ b/examples/development/elixir/elixir_hello/devbox.json
@@ -18,8 +18,5 @@
         "scripts": {
             "run_test": "mix run"
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/development/fsharp/hello-world/devbox.json
+++ b/examples/development/fsharp/hello-world/devbox.json
@@ -7,8 +7,5 @@
         "scripts": {
             "run_test": "dotnet run"
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/development/go/hello-world/devbox.json
+++ b/examples/development/go/hello-world/devbox.json
@@ -7,8 +7,5 @@
         "scripts": {
             "run_test": "go run main.go"
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/development/haskell/devbox.json
+++ b/examples/development/haskell/devbox.json
@@ -15,8 +15,5 @@
                 "stack exec my-project-exe"
             ]
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/development/java/gradle/hello-world/devbox.json
+++ b/examples/development/java/gradle/hello-world/devbox.json
@@ -12,8 +12,5 @@
                 "gradle run"
             ]
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/development/java/maven/hello-world/devbox.json
+++ b/examples/development/java/maven/hello-world/devbox.json
@@ -12,8 +12,5 @@
                 "java -jar target/devbox-maven-app-1.0-SNAPSHOT.jar"
             ]
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/development/nim/spinnytest/devbox.json
+++ b/examples/development/nim/spinnytest/devbox.json
@@ -9,8 +9,5 @@
         "scripts": {
             "nim-build": "nimble build --threads:on"
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/development/nodejs/nodejs-npm/devbox.json
+++ b/examples/development/nodejs/nodejs-npm/devbox.json
@@ -7,8 +7,5 @@
             "npm install",
             "npm run start"
         ]
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/development/nodejs/nodejs-typescript/devbox.json
+++ b/examples/development/nodejs/nodejs-typescript/devbox.json
@@ -5,8 +5,5 @@
     ],
     "shell": {
         "init_hook": null
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/development/nodejs/nodejs-yarn/devbox.json
+++ b/examples/development/nodejs/nodejs-yarn/devbox.json
@@ -5,8 +5,5 @@
   ],
   "shell": {
     "init_hook": null
-  },
-  "nixpkgs": {
-    "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
   }
 }

--- a/examples/development/php/php8.1/devbox.json
+++ b/examples/development/php/php8.1/devbox.json
@@ -11,8 +11,5 @@
         "run_test": [
             "php public/index.php"
         ]
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/development/python/pip/devbox.json
+++ b/examples/development/python/pip/devbox.json
@@ -11,8 +11,5 @@
         "scripts": {
             "run_test": "python main.py"
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/development/python/pipenv/devbox.json
+++ b/examples/development/python/pipenv/devbox.json
@@ -10,8 +10,5 @@
         "scripts": {
             "run_test": "pipenv run python main.py"
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/development/python/poetry/poetry-demo/devbox.json
+++ b/examples/development/python/poetry/poetry-demo/devbox.json
@@ -11,8 +11,5 @@
             "run_test": "poetry run python -m poetry_demo",
             "test": "poetry run pytest"
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/development/ruby/devbox.json
+++ b/examples/development/ruby/devbox.json
@@ -9,8 +9,5 @@
             "run_test": "ruby -e 'puts \"Hello from Ruby #{RUBY_VERSION}\"'"
 
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/development/rust/rust-stable-hello-world/devbox.json
+++ b/examples/development/rust/rust-stable-hello-world/devbox.json
@@ -19,8 +19,5 @@
             "start": "cargo run",
             "run_test": "cargo test -- --show-output"
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/development/zig/zig-hello-world/devbox.json
+++ b/examples/development/zig/zig-hello-world/devbox.json
@@ -10,8 +10,5 @@
                 "zig build run"
             ]
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/servers/apache/devbox.json
+++ b/examples/servers/apache/devbox.json
@@ -6,8 +6,5 @@
   ],
   "shell": {
     "init_hook": []
-  },
-  "nixpkgs": {
-    "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
   }
 }

--- a/examples/servers/caddy/devbox.json
+++ b/examples/servers/caddy/devbox.json
@@ -4,8 +4,5 @@
   ],
   "shell": {
     "init_hook": null
-  },
-  "nixpkgs": {
-    "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
   }
 }

--- a/examples/servers/nginx/devbox.json
+++ b/examples/servers/nginx/devbox.json
@@ -4,8 +4,5 @@
   ],
   "shell": {
     "init_hook": null
-  },
-  "nixpkgs": {
-    "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
   }
 }

--- a/examples/stacks/django/devbox.json
+++ b/examples/stacks/django/devbox.json
@@ -32,8 +32,5 @@
                 "python todo_project/manage.py test"
             ]
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/stacks/drupal/devbox.json
+++ b/examples/stacks/drupal/devbox.json
@@ -28,8 +28,5 @@
                 "mysqladmin -u root --socket=$MYSQL_UNIX_PORT shutdown"
             ]
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/stacks/jekyll/devbox.json
+++ b/examples/stacks/jekyll/devbox.json
@@ -25,8 +25,5 @@
                 "bundler exec $GEM_HOME/bin/jekyll build --trace"
             ]
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/stacks/lapp-stack/devbox.json
+++ b/examples/stacks/lapp-stack/devbox.json
@@ -21,8 +21,5 @@
                 "devbox services stop"
             ]
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/stacks/lepp-stack/devbox.json
+++ b/examples/stacks/lepp-stack/devbox.json
@@ -21,8 +21,5 @@
                 "devbox services stop"
             ]
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/stacks/rails/devbox.json
+++ b/examples/stacks/rails/devbox.json
@@ -16,8 +16,5 @@
         "scripts": {
             "run_test": ["./blog/bin/rails test"]
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }

--- a/examples/tutorial/devbox.json
+++ b/examples/tutorial/devbox.json
@@ -11,8 +11,5 @@
         "scripts": {
             "readme": "clear && PAGER=cat glow README.md"
         }
-    },
-    "nixpkgs": {
-        "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
     }
 }


### PR DESCRIPTION
## Summary

We want to ensure that the default Nixpkgs commit that we use works with all
Lagobot example projects. So, we delete the nixpkgs commit hash from the devbox.json.
When the testscript will execute `devbox run run_test`, the default nixpkgs commit
hash will be added to the devbox.json and used.

## How was it tested?

tests should pass in buildkite

