### PR TITLE
Fix incorrect docs on `shell -- cmd`

### DIFF
--- a/docs/app/docs/cli_reference/devbox_run.md
+++ b/docs/app/docs/cli_reference/devbox_run.md
@@ -1,11 +1,18 @@
 # devbox run
 
-Starts a new interactive shell and runs your target script in it. The shell will exit once your target script is completed or when it is terminated via CTRL-C. Scripts can be defined in your `devbox.json`
+Starts a new interactive shell and runs your target script in it. The shell will exit once your target script is completed or when it is terminated via CTRL-C. Scripts can be defined in your `devbox.json`.
+
+You can also run arbitrary commands in your devbox shell by passing them as arguments to `devbox run`. For example: 
+
+```bash
+  devbox run echo "Hello World"
+```
+Will print `Hello World` to the console from within your devbox shell. 
 
 For more details, read our [scripts guide](../guides/scripts.md)
 
 ```bash
-  devbox run <script> [flags]
+  devbox run <script | command> [flags]
 ```
 
 ## Options

--- a/docs/app/docs/cli_reference/devbox_shell.md
+++ b/docs/app/docs/cli_reference/devbox_shell.md
@@ -4,12 +4,10 @@ Start a new shell or run a command with access to your packages
 
 ## Synopsis
 
-Start a new shell or run a command with access to your packages. 
-If invoked without `cmd`, this will start an interactive shell based on the devbox.json in your current directory, or the directory provided with `dir`. 
-If invoked with a `cmd`, this will start a shell based on the devbox.json provided in `dir`, run the command, and then exit.
+Start a new shell or run a command with access to your packages. The interactive shell will use the devbox.json in your current directory, or the directory provided with `dir`. 
 
 ```bash
-devbox shell [<dir>] -- [<cmd>] [flags]
+devbox shell [<dir>] [flags]
 ```
 
 ## Options

--- a/docs/app/docs/guides/scripts.md
+++ b/docs/app/docs/guides/scripts.md
@@ -44,10 +44,25 @@ Again
 
 Your devbox shell will exit once the last line of your script has finished running, or when you interrupt the script with CTRL-C (or a SIGINT signal).
 
+## Running a One-off Command
+
+You can use `devbox run` to run any command in your Devbox shell, even if you have not defined it as a script. For example, you can run the command below to print "Hello World" in your Devbox shell:
+
+```bash
+devbox run echo "Hello World"
+```
+
+For commands that use flags, you can use the `--` separator to tell Devbox that the rest of the command is a single command to run. For example, the following command will show you all the processes listening on port 80:
+
+```bash
+devbox run -- lsof -i :80
+```
+
 
 ## Tips on using Scripts
 
 1. Since `init_hook` runs everytime you start your shell, you should use primarily use it for setting environment variables and aliases. For longer running tasks like database setup, you can create and run a Devbox script
-2. You can use Devbox scripts to start and manage long running background processes and daemons. For example -- If you are working on a LAMP stack project, you can use scripts to start MySQL and Apache in separate shells and monitor their logs. Once you are done developing, you can use CTRL-C to exit the processes and shells
+2. You can use Devbox scripts to start and manage long running background processes and daemons. 
+   1. For example -- If you are working on a LAMP stack project, you can use scripts to start MySQL and Apache in separate shells and monitor their logs. Once you are done developing, you can use CTRL-C to exit the processes and shells
 3. If a script feels too long to put it directly in `devbox.json`, you can save it as a shell script in your project, and then invoke it in your `devbox scripts`.
 4. For more ideas, see the LAMP stack example in our [Devbox examples repo](https://github.com/jetpack-io/devbox/tree/main/examples/stacks/lapp-stack). 

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -22,10 +22,8 @@ func ShellCmd() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "shell",
 		Short: "Start a new shell with access to your packages",
-		Long: "Start a new shell or run a command with access to your packages.\n\n" +
-			"If invoked without `cmd`, devbox will start an interactive shell.\n" +
-			"If invoked with a `cmd`, devbox will run the command in a shell and then exit.\n" +
-			"In both cases, the shell will be started using the devbox.json found in the --config flag directory. " +
+		Long: "Start a new shell with access to your packages.\n\n" +
+			"If the --config flag is set, the shell will be started using the devbox.json found in the --config flag directory. " +
 			"If --config isn't set, then devbox recursively searches the current directory and its parents.",
 		Args:    cobra.NoArgs,
 		PreRunE: ensureNixInstalled,


### PR DESCRIPTION
## Summary

Our docs and inline help for `devbox shell` are not updated to show that `devbox shell -- cmd` is deprecated, potentially leading to a lot of user errors. This PR update the docs and inline help.

We should also try to detect when `--` is passed to `devbox shell`, and direct users to `devbox run` instead

## How was it tested?

localhost,
