### PR TITLE
redact: package for redacting error messages

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,11 +40,13 @@ linters-settings:
   varnamelen:
     max-distance: 10
     ignore-decls:
+      - a []any
       - c echo.Context
       - const C
       - e error
       - e watch.Event
       - f *foo.Bar
+      - f fmt.State
       - i int
       - id string
       - m map[string]any
@@ -54,6 +56,7 @@ linters-settings:
       - r *http.Request
       - r io.Reader
       - r *os.File
+      - re *regexp.Regexp
       - sh *Shell
       - sh *shell
       - sh *shell.Shell

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"runtime"
 	"strconv"
 
 	"github.com/getsentry/sentry-go"
@@ -51,29 +52,17 @@ func Recover() {
 	fmt.Println("Error:", r)
 }
 
-func EarliestStackTrace(err error) errors.StackTrace {
-	type stackTracer interface {
-		StackTrace() errors.StackTrace
-	}
+func EarliestStackTrace(err error) error {
+	type pkgErrorsStackTracer interface{ StackTrace() errors.StackTrace }
+	type redactStackTracer interface{ StackTrace() []runtime.Frame }
 
-	type causer interface {
-		Cause() error
-	}
-
-	var st stackTracer
-	var earliestStackTrace errors.StackTrace
-
+	var stErr error
 	for err != nil {
-		if errors.As(err, &st) {
-			earliestStackTrace = st.StackTrace()
+		switch err.(type) {
+		case redactStackTracer, pkgErrorsStackTracer:
+			stErr = err
 		}
-
-		var c causer
-		if !errors.As(err, &c) {
-			break
-		}
-		err = c.Cause()
+		err = errors.Unwrap(err)
 	}
-
-	return earliestStackTrace
+	return stErr
 }

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -58,6 +58,7 @@ func EarliestStackTrace(err error) error {
 
 	var stErr error
 	for err != nil {
+		//nolint:errorlint
 		switch err.(type) {
 		case redactStackTracer, pkgErrorsStackTracer:
 			stErr = err

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -32,7 +32,7 @@
 //		err := &userErr{name: "Alex"}
 //		fmt.Println(err)
 //		// user Alex not found
-
+//
 //		fmt.Println(Error(err))
 //		// user db74c940d447e877d119df613edd2700c4a84cd1cf08beb7cbc319bcfaeab97a not found
 //	}
@@ -51,6 +51,8 @@
 //
 //	fmt.Println(Error(err))
 //	// error getting user <redacted string> with ID 5
+//
+//nolint:errorlint
 package redact
 
 import (

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -1,0 +1,218 @@
+// Package redact implements functions to redact sensitive information from
+// errors.
+//
+// Redacting an error replaces its message with a placeholder while still
+// maintaining wrapped errors:
+//
+//	wrapped := errors.New("not found")
+//	name := "Alex"
+//	err := fmt.Errorf("error getting user %s: %w", name, wrapped)
+//
+//	fmt.Println(err)
+//	// error getting user Alex: not found
+//
+//	fmt.Println(Error(err))
+//	// <redacted *fmt.wrapError>: <redacted *errors.errorString>
+//
+// If an error implements a Redact() string method, then it is said to be
+// redactable. A redactable error defines an alternative message for its
+// redacted form:
+//
+//	type userErr struct{ name string }
+//
+//	func (e *userErr) Error() string {
+//		return fmt.Sprintf("user %s not found", e.name)
+//	}
+//
+//	func (e *userErr) Redact() string {
+//		return fmt.Sprintf("user %x not found", sha256.Sum256([]byte(e.name)))
+//	}
+//
+//	func main() {
+//		err := &userErr{name: "Alex"}
+//		fmt.Println(err)
+//		// user Alex not found
+
+//		fmt.Println(Error(err))
+//		// user db74c940d447e877d119df613edd2700c4a84cd1cf08beb7cbc319bcfaeab97a not found
+//	}
+//
+// The [Errorf] function creates redactable errors that retain their literal
+// format text, but redact any arguments. The format string spec is identical
+// to that of [fmt.Errorf]. Calling [Safe] on an [Errorf] argument will include
+// it in the redacted message.
+//
+//	name := "Alex"
+//	id := 5
+//	err := Errorf("error getting user %s with ID %d", name, Safe(id))
+//
+//	fmt.Println(err)
+//	// error getting user Alex with ID 5
+//
+//	fmt.Println(Error(err))
+//	// error getting user <redacted string> with ID 5
+package redact
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+)
+
+// Error returns a redacted error that wraps err. If err has a Redact() string
+// method, then Error uses it for the redacted error message. Otherwise, Error
+// recursively redacts each wrapped error, joining them with ": " to create the
+// final error message. If it encounters an error that has a Redact() method,
+// then it appends the result of Redact() to the message and stops unwrapping.
+func Error(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	switch t := err.(type) {
+	case *safeError:
+		return t.redacted
+	case redactor:
+		return &redactedError{
+			msg:     t.Redact(),
+			wrapped: err,
+		}
+	default:
+		msg := placeholder(err)
+		wrapped := err
+		for {
+			wrapped = errors.Unwrap(wrapped)
+			if wrapped == nil {
+				break
+			}
+			if redactor, ok := wrapped.(redactor); ok {
+				msg += ": " + redactor.Redact()
+				break
+			}
+			msg += ": " + placeholder(wrapped)
+		}
+		return &redactedError{
+			msg:     msg,
+			wrapped: err,
+		}
+	}
+}
+
+// Errorf creates a redactable error that has an error string identical to that
+// of a [fmt.Errorf] error. Calling [Redact] on the result will redact all
+// format arguments from the error message instead of redacting the entire
+// string.
+//
+// When redacting the error string, Errorf replaces arguments that implement a
+// Redact() string method with the result of that method. To include an
+// argument as-is in the redacted error, first call [Safe]. For example:
+//
+//	username := "bob"
+//	Errorf("cannot find user %s", username).Error()
+//	// cannot find user <redacted string>
+//
+//	Errorf("cannot find user %s", Safe(username)).Error()
+//	// cannot find user bob
+func Errorf(format string, a ...any) error {
+	// Capture a stack trace.
+	safeErr := &safeError{
+		callers: make([]uintptr, 32),
+	}
+	n := runtime.Callers(2, safeErr.callers)
+	safeErr.callers = safeErr.callers[:n]
+
+	// Create the "normal" unredacted error. We need to remove the safe wrapper
+	// from any args so that fmt.Errorf can detect and format their type
+	// correctly.
+	args := make([]any, len(a))
+	for i := range a {
+		if safe, ok := a[i].(safe); ok {
+			args[i] = safe.a
+		} else {
+			args[i] = a[i]
+		}
+	}
+	safeErr.err = fmt.Errorf(format, args...)
+
+	// Now create the redacted error by replacing all args with their redacted
+	// version or by inserting a placeholder if the arg can't be redacted.
+	for i := range a {
+		switch t := a[i].(type) {
+		case safe:
+			args[i] = t.a
+		case error:
+			args[i] = Error(t)
+		case redactor:
+			args[i] = formatter(t.Redact())
+		default:
+			args[i] = formatter(placeholder(t))
+		}
+	}
+	safeErr.redacted = fmt.Errorf(format, args...)
+	return safeErr
+}
+
+// redactor defines the Redact interface for types that can format themselves
+// in redacted errors.
+type redactor interface {
+	Redact() string
+}
+
+// safe wraps a value that is marked as safe for including in a redacted error.
+type safe struct{ a any }
+
+// Safe marks a value as safe for including in a redacted error.
+func Safe(a any) any {
+	return safe{a}
+}
+
+// safeError is an error that can redact its message.
+type safeError struct {
+	err      error
+	redacted error
+	callers  []uintptr
+}
+
+func (e *safeError) Error() string  { return e.err.Error() }
+func (e *safeError) Redact() string { return e.redacted.Error() }
+func (e *safeError) Unwrap() error  { return e.err }
+func (e *safeError) StackTrace() []runtime.Frame {
+	if len(e.callers) == 0 {
+		return nil
+	}
+	frameIter := runtime.CallersFrames(e.callers)
+	frames := make([]runtime.Frame, 0, len(e.callers))
+	for {
+		frame, more := frameIter.Next()
+		frames = append(frames, frame)
+		if !more {
+			break
+		}
+	}
+	return frames
+}
+
+// redactedError is an error containing a redacted message. It is usually the
+// result of calling safeError.Redact.
+type redactedError struct {
+	msg     string
+	wrapped error
+}
+
+func (e *redactedError) Error() string { return e.msg }
+func (e *redactedError) Unwrap() error { return e.wrapped }
+
+// formatter allows a string to be formatted by any fmt verb.
+// For example, fmt.Sprintf("%d", formatter("100")) will return "100" without
+// an error.
+type formatter string
+
+func (f formatter) Format(s fmt.State, verb rune) {
+	s.Write([]byte(f))
+}
+
+// placeholder generates a placeholder string for values that don't satisfy
+// redactor.
+func placeholder(a any) string {
+	return fmt.Sprintf("<redacted %T>", a)
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -207,8 +207,8 @@ func (e *safeError) Format(f fmt.State, verb rune) {
 			}
 			return
 		}
-	default:
-		fmt.Fprintf(f, fmt.FormatString(f, verb), e.Error())
+	case 'q':
+		fmt.Fprintf(f, "%q", e.Error())
 	}
 }
 

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,3 +1,4 @@
+//nolint:errorlint
 package redact
 
 import (

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,0 +1,251 @@
+package redact
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func ExampleError() {
+	// Each error string in a chain of wrapped errors is redacted with a
+	// placeholder describing the error's type.
+	wrapped := errors.New("not found")
+	name := "Alex"
+	err := fmt.Errorf("error getting user %s: %w", name, wrapped)
+
+	fmt.Println("Normal:", err)
+	fmt.Println("Redacted:", Error(err))
+	// Output:
+	// Normal: error getting user Alex: not found
+	// Redacted: <redacted *fmt.wrapError>: <redacted *errors.errorString>
+}
+
+func ExampleErrorf() {
+	// Errors created with Errorf are redacted by omitting any arguments not
+	// marked as safe. The literal portion of the format string is kept.
+	wrapped := errors.New("not found")
+	name := "Alex"
+	id := 5
+	err := Errorf("error getting user %s with ID %d: %w", name, Safe(id), wrapped)
+
+	fmt.Println("Normal:", err)
+	fmt.Println("Redacted:", Error(err))
+	// Output:
+	// Normal: error getting user Alex with ID 5: not found
+	// Redacted: error getting user <redacted string> with ID 5: <redacted *errors.errorString>
+}
+
+func ExampleError_wrapped() {
+	// If an error wraps another, then redacting it results in a message with the
+	// redacted version of each error in the chain up until the first redactable
+	// error.
+	name := "Alex"
+	err := fmt.Errorf("fatal error: %w",
+		Errorf("error getting user %s: %w", name,
+			errors.New("not found")))
+
+	fmt.Println("Normal:", err)
+	fmt.Println("Redacted:", Error(err))
+	// Output:
+	// Normal: fatal error: error getting user Alex: not found
+	// Redacted: <redacted *fmt.wrapError>: error getting user <redacted string>: <redacted *errors.errorString>
+}
+
+func TestNil(t *testing.T) {
+	checkUnredactedError(t, nil, "<nil>")
+	checkRedactedError(t, nil, "<nil>")
+}
+
+func TestSimple(t *testing.T) {
+	err := errors.New("simple")
+	checkUnredactedError(t, err, "simple")
+	checkRedactedError(t, err, "<redacted *errors.errorString>")
+}
+
+func TestSimpleWrapSimple(t *testing.T) {
+	wrapped := errors.New("error 2")
+	err := fmt.Errorf("error 1: %w", wrapped)
+	checkUnredactedError(t, err, "error 1: error 2")
+	checkRedactedError(t, err, "<redacted *fmt.wrapError>: <redacted *errors.errorString>")
+	if !errors.Is(err, wrapped) {
+		t.Error("got errors.Is(err, wrapped) == false")
+	}
+}
+
+func TestRedactor(t *testing.T) {
+	err := &testRedactor{msg: "sensitive", redactedMsg: "safe"}
+	checkUnredactedError(t, err, "sensitive")
+	checkRedactedError(t, err, "safe")
+}
+
+func TestRedactorWrapRedactor(t *testing.T) {
+	wrapped := &testRedactor{
+		msg:         "wrapped sensitive",
+		redactedMsg: "wrapped safe",
+	}
+	err := &testRedactor{
+		msg:         "sensitive",
+		redactedMsg: "safe",
+		err:         wrapped,
+	}
+	checkUnredactedError(t, err, "sensitive")
+	checkRedactedError(t, err, "safe")
+	if !errors.Is(err, wrapped) {
+		t.Error("got errors.Is(err, wrapped) == false")
+	}
+}
+
+func TestSimpleWrapRedactor(t *testing.T) {
+	wrapped := &testRedactor{
+		msg:         "wrapped sensitive",
+		redactedMsg: "wrapped safe",
+	}
+	err := fmt.Errorf("error: %w", wrapped)
+	checkUnredactedError(t, err, "error: wrapped sensitive")
+	checkRedactedError(t, err, "<redacted *fmt.wrapError>: wrapped safe")
+	if !errors.Is(err, wrapped) {
+		t.Error("got errors.Is(err, wrapped) == false")
+	}
+}
+
+func TestNestedWrapRedactor(t *testing.T) {
+	nestedWrapped := &testRedactor{
+		msg:         "wrapped sensitive",
+		redactedMsg: "wrapped safe",
+	}
+	wrapped := fmt.Errorf("error 2: %w", nestedWrapped)
+	err := fmt.Errorf("error 1: %w", wrapped)
+	checkUnredactedError(t, err, "error 1: error 2: wrapped sensitive")
+	checkRedactedError(t, err, "<redacted *fmt.wrapError>: <redacted *fmt.wrapError>: wrapped safe")
+	if !errors.Is(err, wrapped) {
+		t.Error("got errors.Is(err, wrapped) == false")
+	}
+	if !errors.Is(err, nestedWrapped) {
+		t.Error("got errors.Is(err, nestedWrapped) == false")
+	}
+}
+
+func TestErrorf(t *testing.T) {
+	err := Errorf("quoted = %q, quotedSafe = %q, int = %d, intSafe = %d",
+		"sensitive", Safe("safe"),
+		123, Safe(789),
+	)
+	checkUnredactedError(t, err, `quoted = "sensitive", quotedSafe = "safe", int = 123, intSafe = 789`)
+	checkRedactedError(t, err, `quoted = <redacted string>, quotedSafe = "safe", int = <redacted int>, intSafe = 789`)
+}
+
+func TestErrorfWrapErrorf(t *testing.T) {
+	wrapped := Errorf("wrapped string = %s, wrapped safe string = %s", "sensitive", Safe("safe"))
+	err := Errorf("error: %w", wrapped)
+	checkUnredactedError(t, err, "error: wrapped string = sensitive, wrapped safe string = safe")
+	checkRedactedError(t, err, "error: wrapped string = <redacted string>, wrapped safe string = safe")
+}
+
+func TestErrorfAs(t *testing.T) {
+	wrapped := &customError{
+		msg:   "sensitive",
+		value: "value",
+	}
+	err := Errorf("error: %w", wrapped)
+	checkUnredactedError(t, err, "error: sensitive")
+	checkRedactedError(t, err, "error: <redacted *redact.customError>")
+
+	var unwrapped *customError
+	if !errors.As(err, &unwrapped) {
+		t.Error("got errors.As(err, unwrapped) == false")
+	}
+	if unwrapped.value != wrapped.value {
+		t.Error("got unwrapped.value != wrapped.value")
+	}
+
+	var unwrappedRedacted *customError
+	if !errors.As(Error(err), &unwrappedRedacted) {
+		t.Error("got errors.As(Error(err), &unwrappedRedacted) == false")
+	}
+	if unwrappedRedacted.value != wrapped.value {
+		t.Error("got unwrappedRedacted.value != wrapped.value")
+	}
+}
+
+func TestErrorfRedactableArg(t *testing.T) {
+	err := Errorf("%d", redactableInt(123))
+	checkUnredactedError(t, err, "123")
+	checkRedactedError(t, err, "0")
+}
+
+func TestStackTrace(t *testing.T) {
+	err := Errorf("error")
+	stack := err.(interface{ StackTrace() []runtime.Frame }).StackTrace()
+	if len(stack) == 0 {
+		t.Fatal("got empty stack trace")
+	}
+	stackTrace := "got stack trace:\n"
+	for _, frame := range stack {
+		stackTrace += fmt.Sprintf("%v\n", frame)
+	}
+	t.Log(stackTrace)
+
+	if !strings.HasSuffix(stack[0].Function, t.Name()) {
+		t.Errorf("got stack starting with function name %q, want function ending with test name %q",
+			stack[0].Function, t.Name())
+	}
+	lastFrame := stack[len(stack)-1]
+	wantFrame := "runtime.goexit"
+	if lastFrame.Function != wantFrame {
+		t.Errorf("got stack ending with function name %q, want function name %q",
+			lastFrame.Function, wantFrame)
+	}
+}
+
+func TestMissingStackTrace(t *testing.T) {
+	var err interface{ StackTrace() []runtime.Frame } = &safeError{}
+	stack := err.StackTrace()
+	if stack != nil {
+		t.Errorf("got stack with length %d, want nil", len(stack))
+	}
+}
+
+type testRedactor struct {
+	msg         string
+	redactedMsg string
+	err         error
+}
+
+func (e *testRedactor) Error() string  { return e.msg }
+func (e *testRedactor) Redact() string { return e.redactedMsg }
+func (e *testRedactor) Unwrap() error  { return e.err }
+
+type customError struct {
+	msg   string
+	value string
+}
+
+func (e *customError) Error() string {
+	return e.msg
+}
+
+type redactableInt int
+
+func (r redactableInt) Redact() string {
+	return "0"
+}
+
+func checkUnredactedError(t *testing.T, got error, wantMsg string) {
+	t.Helper()
+
+	gotMsg := fmt.Sprint(got)
+	if gotMsg != wantMsg {
+		t.Errorf("got wrong unredacted error:\ngot:  %q\nwant: %q", gotMsg, wantMsg)
+	}
+}
+
+func checkRedactedError(t *testing.T, got error, wantMsg string) {
+	t.Helper()
+
+	gotMsg := fmt.Sprint(Error(got))
+	if gotMsg != wantMsg {
+		t.Errorf("got wrong redacted error:\ngot:  %q\nwant: %q", gotMsg, wantMsg)
+	}
+}


### PR DESCRIPTION
Package redact implements functions to redact sensitive information from errors. A basic example is:

	name := "Alex"
	id := 5
	err := redact.Errorf("error getting user %s with ID %d",
		name, Safe(id))

	fmt.Println(err)
	// error getting user Alex with ID 5

	fmt.Println(redact.Error(err))
	// error getting user <redacted string> with ID 5

See the package docs and tests for more examples.

This will allow us to get more information in Sentry without sending any identifying information.