### PR TITLE
[update] Remove devbox update

### DIFF
--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -54,7 +54,6 @@ func RootCmd() *cobra.Command {
 	command.AddCommand(PlanCmd())
 	command.AddCommand(RemoveCmd())
 	command.AddCommand(RunCmd())
-	command.AddCommand(selfUpdateCmd())
 	command.AddCommand(ServicesCmd())
 	command.AddCommand(SetupCmd())
 	command.AddCommand(ShellCmd())


### PR DESCRIPTION
## Summary

There should only by `devbox version update`

Fixes https://github.com/jetpack-io/devbox/issues/838

## How was it tested?

`devbox update --help`
`devbox version update --help`
