### PR TITLE
telemetry: improve stack traces, error names, contexts

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,11 +40,13 @@ linters-settings:
   varnamelen:
     max-distance: 10
     ignore-decls:
+      - a []any
       - c echo.Context
       - const C
       - e error
       - e watch.Event
       - f *foo.Bar
+      - f fmt.State
       - i int
       - id string
       - m map[string]any
@@ -54,6 +56,7 @@ linters-settings:
       - r *http.Request
       - r io.Reader
       - r *os.File
+      - re *regexp.Regexp
       - sh *Shell
       - sh *shell
       - sh *shell.Shell

--- a/internal/boxcli/featureflag/feature.go
+++ b/internal/boxcli/featureflag/feature.go
@@ -50,3 +50,12 @@ func (f *feature) Enabled() bool {
 func (f *feature) Disabled() bool {
 	return !f.Enabled()
 }
+
+// All returns a map of all known features flags and whether they're enabled.
+func All() map[string]bool {
+	m := make(map[string]bool, len(features))
+	for name, feat := range features {
+		m[name] = feat.Enabled()
+	}
+	return m
+}

--- a/internal/boxcli/midcobra/debug.go
+++ b/internal/boxcli/midcobra/debug.go
@@ -14,12 +14,12 @@ import (
 	"github.com/spf13/pflag"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/debug"
+	"go.jetpack.io/devbox/internal/telemetry"
 	"go.jetpack.io/devbox/internal/ux"
 )
 
 type DebugMiddleware struct {
-	executionID string // uuid
-	flag        *pflag.Flag
+	flag *pflag.Flag
 }
 
 var _ Middleware = (*DebugMiddleware)(nil)
@@ -69,10 +69,5 @@ func (d *DebugMiddleware) postRun(cmd *cobra.Command, args []string, runErr erro
 	if errors.As(runErr, &exitErr) {
 		debug.Log("Command stderr: %s\n", exitErr.Stderr)
 	}
-	debug.Log("\nExecutionID:%s\n%+v\n", d.executionID, st)
-}
-
-func (d *DebugMiddleware) withExecutionID(execID string) Middleware {
-	d.executionID = execID
-	return d
+	debug.Log("\nExecutionID:%s\n%+v\n", telemetry.ExecutionID, st)
 }

--- a/internal/boxcli/midcobra/telemetry.go
+++ b/internal/boxcli/midcobra/telemetry.go
@@ -8,14 +8,17 @@ import (
 	"io"
 	"os"
 	"runtime/trace"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
-	"github.com/getsentry/sentry-go"
 	segment "github.com/segmentio/analytics-go"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"go.jetpack.io/devbox"
-	"go.jetpack.io/devbox/internal/boxcli/usererr"
+	"go.jetpack.io/devbox/internal/boxcli/featureflag"
+	"go.jetpack.io/devbox/internal/build"
 	"go.jetpack.io/devbox/internal/cloud/envir"
 	"go.jetpack.io/devbox/internal/telemetry"
 )
@@ -27,60 +30,56 @@ import (
 // 2. Data is only stored in SOC 2 compliant systems, and we are SOC 2 compliant ourselves.
 // 3. Users should always have the ability to opt-out.
 func Telemetry() Middleware {
-
-	opts := telemetry.InitOpts()
-
-	return &telemetryMiddleware{
-		opts:     *opts,
-		disabled: telemetry.IsDisabled(opts),
-	}
+	return &telemetryMiddleware{}
 }
 
 type telemetryMiddleware struct {
-	// Setup:
-	opts     telemetry.Opts
-	disabled bool
-
 	// Used during execution:
 	startTime time.Time
-
-	executionID string
 }
 
 // telemetryMiddleware implements interface Middleware (compile-time check)
 var _ Middleware = (*telemetryMiddleware)(nil)
 
-func (m *telemetryMiddleware) withExecutionID(execID string) Middleware {
-	m.executionID = execID
-	return m
-}
-
 func (m *telemetryMiddleware) preRun(cmd *cobra.Command, args []string) {
 	m.startTime = telemetry.CommandStartTime()
 
+	telemetry.Start(telemetry.AppDevbox)
 	ctx := cmd.Context()
 	defer trace.StartRegion(ctx, "telemetryPreRun").End()
-	if m.disabled {
+	if !telemetry.Enabled() {
 		trace.Log(ctx, "telemetry", "telemetry is disabled")
 		return
 	}
-	sentry := telemetry.NewSentry(m.opts.SentryDSN)
-	sentry.Init(m.opts.AppName, m.opts.AppVersion, m.executionID)
 }
 
 func (m *telemetryMiddleware) postRun(cmd *cobra.Command, args []string, runErr error) {
 	defer trace.StartRegion(cmd.Context(), "telemetryPostRun").End()
-	if m.disabled {
+	defer telemetry.Stop()
+
+	meta := telemetry.Metadata{
+		FeatureFlags: featureflag.All(),
+		CloudRegion:  os.Getenv("DEVBOX_REGION"),
+		CloudCache:   os.Getenv("DEVBOX_CACHE"),
+	}
+
+	subcmd, flags, err := getSubcommand(cmd, args)
+	if err != nil {
+		// Ignore invalid commands/flags.
 		return
 	}
+	meta.Command = subcmd.CommandPath()
+	meta.CommandFlags = flags
+	meta.Packages, meta.NixpkgsHash = getPackagesAndCommitHash(cmd)
+	meta.InShell, _ = strconv.ParseBool(os.Getenv("DEVBOX_SHELL_ENABLED"))
+	meta.InBrowser, _ = strconv.ParseBool(os.Getenv("START_WEB_TERMINAL"))
+	meta.InCloud = meta.CloudRegion != ""
+	telemetry.Error(runErr, meta)
 
 	evt := m.newEventIfValid(cmd, args, runErr)
 	if evt == nil {
 		return
 	}
-
-	m.trackError(evt) // Sentry
-
 	m.trackEvent(evt) // Segment
 }
 
@@ -105,7 +104,7 @@ type event struct {
 // a valid event.
 func (m *telemetryMiddleware) newEventIfValid(cmd *cobra.Command, args []string, runErr error) *event {
 
-	subcmd, subargs, parseErr := getSubcommand(cmd, args)
+	subcmd, flags, parseErr := getSubcommand(cmd, args)
 	if parseErr != nil {
 		// Ignore invalid commands
 		return nil
@@ -126,16 +125,16 @@ func (m *telemetryMiddleware) newEventIfValid(cmd *cobra.Command, args []string,
 
 	return &event{
 		Event: telemetry.Event{
-			AnonymousID: telemetry.DeviceID(),
-			AppName:     m.opts.AppName,
-			AppVersion:  m.opts.AppVersion,
+			AnonymousID: telemetry.DeviceID,
+			AppName:     telemetry.AppDevbox,
+			AppVersion:  build.Version,
 			CloudRegion: envir.GetRegion(),
 			Duration:    time.Since(m.startTime),
-			OsName:      telemetry.OS(),
+			OsName:      build.OS(),
 			UserID:      userID,
 		},
 		Command:      subcmd.CommandPath(),
-		CommandArgs:  subargs,
+		CommandArgs:  flags,
 		CommandError: runErr,
 		// The command is hidden if either the top-level command is hidden or
 		// the specific sub-command that was executed is hidden.
@@ -149,38 +148,15 @@ func (m *telemetryMiddleware) newEventIfValid(cmd *cobra.Command, args []string,
 	}
 }
 
-func (m *telemetryMiddleware) trackError(evt *event) {
-	// Ensure error is not nil and not a non-loggable user error
-	if evt == nil || !usererr.ShouldLogError(evt.CommandError) {
-		return
-	}
-
-	sentry.ConfigureScope(func(scope *sentry.Scope) {
-		scope.SetTag("command", evt.Command)
-		scope.SetContext("command", map[string]interface{}{
-			"command":      evt.Command,
-			"command args": evt.CommandArgs,
-			"packages":     evt.Packages,
-			"nixpkgs hash": evt.CommitHash,
-			"in shell":     evt.InDevboxShell,
-		})
-		scope.SetContext("devbox env", evt.DevboxEnv)
-	})
-	sentry.CaptureException(evt.CommandError)
-}
-
 func (m *telemetryMiddleware) trackEvent(evt *event) {
 	if evt == nil || evt.CommandHidden {
 		return
 	}
 
 	if evt.CommandError != nil {
-		// verified with manual testing that the sentryID returned by CaptureException
-		// is the same as m.ExecutionID, since we set EventID = m.ExecutionID in sentry.Init
-		evt.SentryEventID = m.executionID
+		evt.SentryEventID = telemetry.ExecutionID
 	}
-
-	segmentClient := telemetry.NewSegmentClient(m.opts.TelemetryKey)
+	segmentClient := telemetry.NewSegmentClient(build.TelemetryKey)
 	defer func() {
 		_ = segmentClient.Close()
 	}()
@@ -219,13 +195,18 @@ func (m *telemetryMiddleware) trackEvent(evt *event) {
 	})
 }
 
-func getSubcommand(c *cobra.Command, args []string) (subcmd *cobra.Command, subargs []string, err error) {
-	if c.TraverseChildren {
-		subcmd, subargs, err = c.Traverse(args)
+func getSubcommand(cmd *cobra.Command, args []string) (subcmd *cobra.Command, flags []string, err error) {
+	if cmd.TraverseChildren {
+		subcmd, _, err = cmd.Traverse(args)
 	} else {
-		subcmd, subargs, err = c.Find(args)
+		subcmd, _, err = cmd.Find(args)
 	}
-	return subcmd, subargs, err
+
+	subcmd.Flags().Visit(func(f *pflag.Flag) {
+		flags = append(flags, "--"+f.Name)
+	})
+	sort.Strings(flags)
+	return subcmd, flags, err
 }
 
 func getPackagesAndCommitHash(c *cobra.Command) ([]string, string) {

--- a/internal/boxcli/midcobra/telemetry.go
+++ b/internal/boxcli/midcobra/telemetry.go
@@ -59,7 +59,7 @@ func (m *telemetryMiddleware) postRun(cmd *cobra.Command, args []string, runErr 
 
 	meta := telemetry.Metadata{
 		FeatureFlags: featureflag.All(),
-		CloudRegion:  os.Getenv("DEVBOX_REGION"),
+		CloudRegion:  envir.GetRegion(),
 		CloudCache:   os.Getenv("DEVBOX_CACHE"),
 	}
 
@@ -73,7 +73,7 @@ func (m *telemetryMiddleware) postRun(cmd *cobra.Command, args []string, runErr 
 	meta.Packages, meta.NixpkgsHash = getPackagesAndCommitHash(cmd)
 	meta.InShell, _ = strconv.ParseBool(os.Getenv("DEVBOX_SHELL_ENABLED"))
 	meta.InBrowser, _ = strconv.ParseBool(os.Getenv("START_WEB_TERMINAL"))
-	meta.InCloud = meta.CloudRegion != ""
+	meta.InCloud = envir.IsDevboxCloud()
 	telemetry.Error(runErr, meta)
 
 	evt := m.newEventIfValid(cmd, args, runErr)

--- a/internal/boxcli/midcobra/trace.go
+++ b/internal/boxcli/midcobra/trace.go
@@ -13,10 +13,9 @@ import (
 )
 
 type TraceMiddleware struct {
-	executionID string // uuid
-	tracef      *os.File
-	flag        *pflag.Flag
-	task        *trace.Task
+	tracef *os.File
+	flag   *pflag.Flag
+	task   *trace.Task
 }
 
 var _ Middleware = (*DebugMiddleware)(nil)
@@ -59,9 +58,4 @@ func (t *TraceMiddleware) postRun(cmd *cobra.Command, args []string, runErr erro
 	if err := t.tracef.Close(); err != nil {
 		panic("error closing trace file: " + err.Error())
 	}
-}
-
-func (t *TraceMiddleware) withExecutionID(execID string) Middleware {
-	t.executionID = execID
-	return t
 }

--- a/internal/boxcli/midcobra/trace.go
+++ b/internal/boxcli/midcobra/trace.go
@@ -27,7 +27,7 @@ func (t *TraceMiddleware) AttachToFlag(flags *pflag.FlagSet, flagName string) {
 	t.flag.NoOptDefVal = "trace.out"
 }
 
-func (t *TraceMiddleware) preRun(cmd *cobra.Command, args []string) {
+func (t *TraceMiddleware) preRun(cmd *cobra.Command, _ []string) {
 	if t == nil {
 		return
 	}
@@ -49,7 +49,7 @@ func (t *TraceMiddleware) preRun(cmd *cobra.Command, args []string) {
 	cmd.SetContext(ctx)
 }
 
-func (t *TraceMiddleware) postRun(cmd *cobra.Command, args []string, runErr error) {
+func (t *TraceMiddleware) postRun(*cobra.Command, []string, error) {
 	if t.tracef == nil {
 		return
 	}

--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -82,7 +82,7 @@ func Execute(ctx context.Context, args []string) int {
 func Main() {
 	if strings.HasSuffix(os.Args[0], "ssh") ||
 		strings.HasSuffix(os.Args[0], "scp") {
-		code := sshshim.Execute(context.Background(), os.Args)
+		code := sshshim.Execute(os.Args)
 		os.Exit(code)
 	}
 	code := Execute(context.Background(), os.Args[1:])

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1,7 +1,15 @@
 package build
 
+import (
+	"runtime"
+	"sync"
+
+	"go.jetpack.io/devbox/internal/fileutil"
+)
+
 // Variables in this file are set via ldflags.
 var (
+	IsDev      = Version == "0.0.0-dev"
 	Version    = "0.0.0-dev"
 	Commit     = "none"
 	CommitDate = "unknown"
@@ -9,3 +17,32 @@ var (
 	SentryDSN    = "" // Disabled by default
 	TelemetryKey = "" // Disabled by default
 )
+
+// User-presentable names of operating systems supported by Devbox.
+const (
+	OSLinux  = "Linux"
+	OSDarwin = "macOS"
+	OSWSL    = "WSL"
+)
+
+var (
+	osName string
+	osOnce sync.Once
+)
+
+func OS() string {
+	osOnce.Do(func() {
+		switch runtime.GOOS {
+		case "linux":
+			if fileutil.Exists("/proc/sys/fs/binfmt_misc/WSLInterop") || fileutil.Exists("/run/WSL") {
+				osName = OSWSL
+			}
+			osName = OSLinux
+		case "darwin":
+			osName = OSDarwin
+		default:
+			osName = runtime.GOOS
+		}
+	})
+	return osName
+}

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"runtime"
 	"strconv"
 
 	"github.com/getsentry/sentry-go"
@@ -51,29 +52,17 @@ func Recover() {
 	fmt.Println("Error:", r)
 }
 
-func EarliestStackTrace(err error) errors.StackTrace {
-	type stackTracer interface {
-		StackTrace() errors.StackTrace
-	}
+func EarliestStackTrace(err error) error {
+	type pkgErrorsStackTracer interface{ StackTrace() errors.StackTrace }
+	type redactStackTracer interface{ StackTrace() []runtime.Frame }
 
-	type causer interface {
-		Cause() error
-	}
-
-	var st stackTracer
-	var earliestStackTrace errors.StackTrace
-
+	var stErr error
 	for err != nil {
-		if errors.As(err, &st) {
-			earliestStackTrace = st.StackTrace()
+		switch err.(type) {
+		case redactStackTracer, pkgErrorsStackTracer:
+			stErr = err
 		}
-
-		var c causer
-		if !errors.As(err, &c) {
-			break
-		}
-		err = c.Cause()
+		err = errors.Unwrap(err)
 	}
-
-	return earliestStackTrace
+	return stErr
 }

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -58,6 +58,7 @@ func EarliestStackTrace(err error) error {
 
 	var stErr error
 	for err != nil {
+		//nolint:errorlint
 		switch err.(type) {
 		case redactStackTracer, pkgErrorsStackTracer:
 			stErr = err

--- a/internal/nix/install.go
+++ b/internal/nix/install.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
-	"go.jetpack.io/devbox/internal/telemetry"
+	"go.jetpack.io/devbox/internal/build"
 )
 
 const rootError = "warning: installing Nix as root is not supported by this script!"
@@ -20,7 +20,7 @@ const rootError = "warning: installing Nix as root is not supported by this scri
 // Install runs the install script for Nix. daemon has 3 states
 // nil is unset. false is --no-daemon. true is --daemon.
 func Install(writer io.Writer, daemon *bool) error {
-	if isRoot() && telemetry.IsWSL() {
+	if isRoot() && build.OS() == build.OSWSL {
 		return usererr.New("Nix cannot be installed as root on WSL. Please run as a normal user with sudo access.")
 	}
 	r, w, err := os.Pipe()

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -32,7 +32,7 @@
 //		err := &userErr{name: "Alex"}
 //		fmt.Println(err)
 //		// user Alex not found
-
+//
 //		fmt.Println(Error(err))
 //		// user db74c940d447e877d119df613edd2700c4a84cd1cf08beb7cbc319bcfaeab97a not found
 //	}
@@ -51,6 +51,8 @@
 //
 //	fmt.Println(Error(err))
 //	// error getting user <redacted string> with ID 5
+//
+//nolint:errorlint
 package redact
 
 import (

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -1,0 +1,218 @@
+// Package redact implements functions to redact sensitive information from
+// errors.
+//
+// Redacting an error replaces its message with a placeholder while still
+// maintaining wrapped errors:
+//
+//	wrapped := errors.New("not found")
+//	name := "Alex"
+//	err := fmt.Errorf("error getting user %s: %w", name, wrapped)
+//
+//	fmt.Println(err)
+//	// error getting user Alex: not found
+//
+//	fmt.Println(Error(err))
+//	// <redacted *fmt.wrapError>: <redacted *errors.errorString>
+//
+// If an error implements a Redact() string method, then it is said to be
+// redactable. A redactable error defines an alternative message for its
+// redacted form:
+//
+//	type userErr struct{ name string }
+//
+//	func (e *userErr) Error() string {
+//		return fmt.Sprintf("user %s not found", e.name)
+//	}
+//
+//	func (e *userErr) Redact() string {
+//		return fmt.Sprintf("user %x not found", sha256.Sum256([]byte(e.name)))
+//	}
+//
+//	func main() {
+//		err := &userErr{name: "Alex"}
+//		fmt.Println(err)
+//		// user Alex not found
+
+//		fmt.Println(Error(err))
+//		// user db74c940d447e877d119df613edd2700c4a84cd1cf08beb7cbc319bcfaeab97a not found
+//	}
+//
+// The [Errorf] function creates redactable errors that retain their literal
+// format text, but redact any arguments. The format string spec is identical
+// to that of [fmt.Errorf]. Calling [Safe] on an [Errorf] argument will include
+// it in the redacted message.
+//
+//	name := "Alex"
+//	id := 5
+//	err := Errorf("error getting user %s with ID %d", name, Safe(id))
+//
+//	fmt.Println(err)
+//	// error getting user Alex with ID 5
+//
+//	fmt.Println(Error(err))
+//	// error getting user <redacted string> with ID 5
+package redact
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+)
+
+// Error returns a redacted error that wraps err. If err has a Redact() string
+// method, then Error uses it for the redacted error message. Otherwise, Error
+// recursively redacts each wrapped error, joining them with ": " to create the
+// final error message. If it encounters an error that has a Redact() method,
+// then it appends the result of Redact() to the message and stops unwrapping.
+func Error(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	switch t := err.(type) {
+	case *safeError:
+		return t.redacted
+	case redactor:
+		return &redactedError{
+			msg:     t.Redact(),
+			wrapped: err,
+		}
+	default:
+		msg := placeholder(err)
+		wrapped := err
+		for {
+			wrapped = errors.Unwrap(wrapped)
+			if wrapped == nil {
+				break
+			}
+			if redactor, ok := wrapped.(redactor); ok {
+				msg += ": " + redactor.Redact()
+				break
+			}
+			msg += ": " + placeholder(wrapped)
+		}
+		return &redactedError{
+			msg:     msg,
+			wrapped: err,
+		}
+	}
+}
+
+// Errorf creates a redactable error that has an error string identical to that
+// of a [fmt.Errorf] error. Calling [Redact] on the result will redact all
+// format arguments from the error message instead of redacting the entire
+// string.
+//
+// When redacting the error string, Errorf replaces arguments that implement a
+// Redact() string method with the result of that method. To include an
+// argument as-is in the redacted error, first call [Safe]. For example:
+//
+//	username := "bob"
+//	Errorf("cannot find user %s", username).Error()
+//	// cannot find user <redacted string>
+//
+//	Errorf("cannot find user %s", Safe(username)).Error()
+//	// cannot find user bob
+func Errorf(format string, a ...any) error {
+	// Capture a stack trace.
+	safeErr := &safeError{
+		callers: make([]uintptr, 32),
+	}
+	n := runtime.Callers(2, safeErr.callers)
+	safeErr.callers = safeErr.callers[:n]
+
+	// Create the "normal" unredacted error. We need to remove the safe wrapper
+	// from any args so that fmt.Errorf can detect and format their type
+	// correctly.
+	args := make([]any, len(a))
+	for i := range a {
+		if safe, ok := a[i].(safe); ok {
+			args[i] = safe.a
+		} else {
+			args[i] = a[i]
+		}
+	}
+	safeErr.err = fmt.Errorf(format, args...)
+
+	// Now create the redacted error by replacing all args with their redacted
+	// version or by inserting a placeholder if the arg can't be redacted.
+	for i := range a {
+		switch t := a[i].(type) {
+		case safe:
+			args[i] = t.a
+		case error:
+			args[i] = Error(t)
+		case redactor:
+			args[i] = formatter(t.Redact())
+		default:
+			args[i] = formatter(placeholder(t))
+		}
+	}
+	safeErr.redacted = fmt.Errorf(format, args...)
+	return safeErr
+}
+
+// redactor defines the Redact interface for types that can format themselves
+// in redacted errors.
+type redactor interface {
+	Redact() string
+}
+
+// safe wraps a value that is marked as safe for including in a redacted error.
+type safe struct{ a any }
+
+// Safe marks a value as safe for including in a redacted error.
+func Safe(a any) any {
+	return safe{a}
+}
+
+// safeError is an error that can redact its message.
+type safeError struct {
+	err      error
+	redacted error
+	callers  []uintptr
+}
+
+func (e *safeError) Error() string  { return e.err.Error() }
+func (e *safeError) Redact() string { return e.redacted.Error() }
+func (e *safeError) Unwrap() error  { return e.err }
+func (e *safeError) StackTrace() []runtime.Frame {
+	if len(e.callers) == 0 {
+		return nil
+	}
+	frameIter := runtime.CallersFrames(e.callers)
+	frames := make([]runtime.Frame, 0, len(e.callers))
+	for {
+		frame, more := frameIter.Next()
+		frames = append(frames, frame)
+		if !more {
+			break
+		}
+	}
+	return frames
+}
+
+// redactedError is an error containing a redacted message. It is usually the
+// result of calling safeError.Redact.
+type redactedError struct {
+	msg     string
+	wrapped error
+}
+
+func (e *redactedError) Error() string { return e.msg }
+func (e *redactedError) Unwrap() error { return e.wrapped }
+
+// formatter allows a string to be formatted by any fmt verb.
+// For example, fmt.Sprintf("%d", formatter("100")) will return "100" without
+// an error.
+type formatter string
+
+func (f formatter) Format(s fmt.State, verb rune) {
+	s.Write([]byte(f))
+}
+
+// placeholder generates a placeholder string for values that don't satisfy
+// redactor.
+func placeholder(a any) string {
+	return fmt.Sprintf("<redacted %T>", a)
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -207,8 +207,8 @@ func (e *safeError) Format(f fmt.State, verb rune) {
 			}
 			return
 		}
-	default:
-		fmt.Fprintf(f, fmt.FormatString(f, verb), e.Error())
+	case 'q':
+		fmt.Fprintf(f, "%q", e.Error())
 	}
 }
 

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,3 +1,4 @@
+//nolint:errorlint
 package redact
 
 import (

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,0 +1,251 @@
+package redact
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func ExampleError() {
+	// Each error string in a chain of wrapped errors is redacted with a
+	// placeholder describing the error's type.
+	wrapped := errors.New("not found")
+	name := "Alex"
+	err := fmt.Errorf("error getting user %s: %w", name, wrapped)
+
+	fmt.Println("Normal:", err)
+	fmt.Println("Redacted:", Error(err))
+	// Output:
+	// Normal: error getting user Alex: not found
+	// Redacted: <redacted *fmt.wrapError>: <redacted *errors.errorString>
+}
+
+func ExampleErrorf() {
+	// Errors created with Errorf are redacted by omitting any arguments not
+	// marked as safe. The literal portion of the format string is kept.
+	wrapped := errors.New("not found")
+	name := "Alex"
+	id := 5
+	err := Errorf("error getting user %s with ID %d: %w", name, Safe(id), wrapped)
+
+	fmt.Println("Normal:", err)
+	fmt.Println("Redacted:", Error(err))
+	// Output:
+	// Normal: error getting user Alex with ID 5: not found
+	// Redacted: error getting user <redacted string> with ID 5: <redacted *errors.errorString>
+}
+
+func ExampleError_wrapped() {
+	// If an error wraps another, then redacting it results in a message with the
+	// redacted version of each error in the chain up until the first redactable
+	// error.
+	name := "Alex"
+	err := fmt.Errorf("fatal error: %w",
+		Errorf("error getting user %s: %w", name,
+			errors.New("not found")))
+
+	fmt.Println("Normal:", err)
+	fmt.Println("Redacted:", Error(err))
+	// Output:
+	// Normal: fatal error: error getting user Alex: not found
+	// Redacted: <redacted *fmt.wrapError>: error getting user <redacted string>: <redacted *errors.errorString>
+}
+
+func TestNil(t *testing.T) {
+	checkUnredactedError(t, nil, "<nil>")
+	checkRedactedError(t, nil, "<nil>")
+}
+
+func TestSimple(t *testing.T) {
+	err := errors.New("simple")
+	checkUnredactedError(t, err, "simple")
+	checkRedactedError(t, err, "<redacted *errors.errorString>")
+}
+
+func TestSimpleWrapSimple(t *testing.T) {
+	wrapped := errors.New("error 2")
+	err := fmt.Errorf("error 1: %w", wrapped)
+	checkUnredactedError(t, err, "error 1: error 2")
+	checkRedactedError(t, err, "<redacted *fmt.wrapError>: <redacted *errors.errorString>")
+	if !errors.Is(err, wrapped) {
+		t.Error("got errors.Is(err, wrapped) == false")
+	}
+}
+
+func TestRedactor(t *testing.T) {
+	err := &testRedactor{msg: "sensitive", redactedMsg: "safe"}
+	checkUnredactedError(t, err, "sensitive")
+	checkRedactedError(t, err, "safe")
+}
+
+func TestRedactorWrapRedactor(t *testing.T) {
+	wrapped := &testRedactor{
+		msg:         "wrapped sensitive",
+		redactedMsg: "wrapped safe",
+	}
+	err := &testRedactor{
+		msg:         "sensitive",
+		redactedMsg: "safe",
+		err:         wrapped,
+	}
+	checkUnredactedError(t, err, "sensitive")
+	checkRedactedError(t, err, "safe")
+	if !errors.Is(err, wrapped) {
+		t.Error("got errors.Is(err, wrapped) == false")
+	}
+}
+
+func TestSimpleWrapRedactor(t *testing.T) {
+	wrapped := &testRedactor{
+		msg:         "wrapped sensitive",
+		redactedMsg: "wrapped safe",
+	}
+	err := fmt.Errorf("error: %w", wrapped)
+	checkUnredactedError(t, err, "error: wrapped sensitive")
+	checkRedactedError(t, err, "<redacted *fmt.wrapError>: wrapped safe")
+	if !errors.Is(err, wrapped) {
+		t.Error("got errors.Is(err, wrapped) == false")
+	}
+}
+
+func TestNestedWrapRedactor(t *testing.T) {
+	nestedWrapped := &testRedactor{
+		msg:         "wrapped sensitive",
+		redactedMsg: "wrapped safe",
+	}
+	wrapped := fmt.Errorf("error 2: %w", nestedWrapped)
+	err := fmt.Errorf("error 1: %w", wrapped)
+	checkUnredactedError(t, err, "error 1: error 2: wrapped sensitive")
+	checkRedactedError(t, err, "<redacted *fmt.wrapError>: <redacted *fmt.wrapError>: wrapped safe")
+	if !errors.Is(err, wrapped) {
+		t.Error("got errors.Is(err, wrapped) == false")
+	}
+	if !errors.Is(err, nestedWrapped) {
+		t.Error("got errors.Is(err, nestedWrapped) == false")
+	}
+}
+
+func TestErrorf(t *testing.T) {
+	err := Errorf("quoted = %q, quotedSafe = %q, int = %d, intSafe = %d",
+		"sensitive", Safe("safe"),
+		123, Safe(789),
+	)
+	checkUnredactedError(t, err, `quoted = "sensitive", quotedSafe = "safe", int = 123, intSafe = 789`)
+	checkRedactedError(t, err, `quoted = <redacted string>, quotedSafe = "safe", int = <redacted int>, intSafe = 789`)
+}
+
+func TestErrorfWrapErrorf(t *testing.T) {
+	wrapped := Errorf("wrapped string = %s, wrapped safe string = %s", "sensitive", Safe("safe"))
+	err := Errorf("error: %w", wrapped)
+	checkUnredactedError(t, err, "error: wrapped string = sensitive, wrapped safe string = safe")
+	checkRedactedError(t, err, "error: wrapped string = <redacted string>, wrapped safe string = safe")
+}
+
+func TestErrorfAs(t *testing.T) {
+	wrapped := &customError{
+		msg:   "sensitive",
+		value: "value",
+	}
+	err := Errorf("error: %w", wrapped)
+	checkUnredactedError(t, err, "error: sensitive")
+	checkRedactedError(t, err, "error: <redacted *redact.customError>")
+
+	var unwrapped *customError
+	if !errors.As(err, &unwrapped) {
+		t.Error("got errors.As(err, unwrapped) == false")
+	}
+	if unwrapped.value != wrapped.value {
+		t.Error("got unwrapped.value != wrapped.value")
+	}
+
+	var unwrappedRedacted *customError
+	if !errors.As(Error(err), &unwrappedRedacted) {
+		t.Error("got errors.As(Error(err), &unwrappedRedacted) == false")
+	}
+	if unwrappedRedacted.value != wrapped.value {
+		t.Error("got unwrappedRedacted.value != wrapped.value")
+	}
+}
+
+func TestErrorfRedactableArg(t *testing.T) {
+	err := Errorf("%d", redactableInt(123))
+	checkUnredactedError(t, err, "123")
+	checkRedactedError(t, err, "0")
+}
+
+func TestStackTrace(t *testing.T) {
+	err := Errorf("error")
+	stack := err.(interface{ StackTrace() []runtime.Frame }).StackTrace()
+	if len(stack) == 0 {
+		t.Fatal("got empty stack trace")
+	}
+	stackTrace := "got stack trace:\n"
+	for _, frame := range stack {
+		stackTrace += fmt.Sprintf("%v\n", frame)
+	}
+	t.Log(stackTrace)
+
+	if !strings.HasSuffix(stack[0].Function, t.Name()) {
+		t.Errorf("got stack starting with function name %q, want function ending with test name %q",
+			stack[0].Function, t.Name())
+	}
+	lastFrame := stack[len(stack)-1]
+	wantFrame := "runtime.goexit"
+	if lastFrame.Function != wantFrame {
+		t.Errorf("got stack ending with function name %q, want function name %q",
+			lastFrame.Function, wantFrame)
+	}
+}
+
+func TestMissingStackTrace(t *testing.T) {
+	var err interface{ StackTrace() []runtime.Frame } = &safeError{}
+	stack := err.StackTrace()
+	if stack != nil {
+		t.Errorf("got stack with length %d, want nil", len(stack))
+	}
+}
+
+type testRedactor struct {
+	msg         string
+	redactedMsg string
+	err         error
+}
+
+func (e *testRedactor) Error() string  { return e.msg }
+func (e *testRedactor) Redact() string { return e.redactedMsg }
+func (e *testRedactor) Unwrap() error  { return e.err }
+
+type customError struct {
+	msg   string
+	value string
+}
+
+func (e *customError) Error() string {
+	return e.msg
+}
+
+type redactableInt int
+
+func (r redactableInt) Redact() string {
+	return "0"
+}
+
+func checkUnredactedError(t *testing.T, got error, wantMsg string) {
+	t.Helper()
+
+	gotMsg := fmt.Sprint(got)
+	if gotMsg != wantMsg {
+		t.Errorf("got wrong unredacted error:\ngot:  %q\nwant: %q", gotMsg, wantMsg)
+	}
+}
+
+func checkRedactedError(t *testing.T, got error, wantMsg string) {
+	t.Helper()
+
+	gotMsg := fmt.Sprint(Error(got))
+	if gotMsg != wantMsg {
+		t.Errorf("got wrong redacted error:\ngot:  %q\nwant: %q", gotMsg, wantMsg)
+	}
+}

--- a/internal/telemetry/segment.go
+++ b/internal/telemetry/segment.go
@@ -65,9 +65,7 @@ func CommandStartTime() time.Time {
 // LogShellDurationEvent logs the duration from start of the command
 // till the shell was ready to be interactive.
 func LogShellDurationEvent(eventName string, startTime string) error {
-	opts := InitOpts()
-	if IsDisabled(opts) {
-		// disabled
+	if !Enabled() {
 		return nil
 	}
 
@@ -77,12 +75,12 @@ func LogShellDurationEvent(eventName string, startTime string) error {
 	}
 
 	evt := Event{
-		AnonymousID: DeviceID(),
-		AppName:     opts.AppName,
-		AppVersion:  opts.AppVersion,
+		AnonymousID: DeviceID,
+		AppName:     AppDevbox,
+		AppVersion:  build.Version,
 		CloudRegion: envir.GetRegion(),
 		Duration:    time.Since(start),
-		OsName:      OS(),
+		OsName:      build.OS(),
 		UserID:      UserIDFromGithubUsername(),
 	}
 

--- a/internal/telemetry/sentry.go
+++ b/internal/telemetry/sentry.go
@@ -26,7 +26,7 @@ func init() {
 	// Generate event UUIDs the same way the Sentry SDK does:
 	// https://github.com/getsentry/sentry-go/blob/d9ce5344e7e1819921ea4901dd31e47a200de7e0/util.go#L15
 	id := make([]byte, 16)
-	rand.Read(id)
+	_, _ = rand.Read(id)
 	id[6] &= 0x0F
 	id[6] |= 0x40
 	id[8] &= 0x3F
@@ -128,20 +128,20 @@ func (m *Metadata) featureContext() map[string]any {
 	return sentryCtx
 }
 
-func (meta *Metadata) pkgContext() map[string]any {
-	if len(meta.Packages) == 0 {
+func (m *Metadata) pkgContext() map[string]any {
+	if len(m.Packages) == 0 {
 		return nil
 	}
 
 	// Every package currently has the same commit hash as its version, but this
 	// format will allow us to use individual package versions in the future.
 	pkgVersion := "nixpkgs"
-	if meta.NixpkgsHash != "" {
-		pkgVersion += "/" + meta.NixpkgsHash
+	if m.NixpkgsHash != "" {
+		pkgVersion += "/" + m.NixpkgsHash
 	}
 	pkgVersion += "#"
-	pkgContext := make(map[string]any, len(meta.Packages))
-	for _, pkg := range meta.Packages {
+	pkgContext := make(map[string]any, len(m.Packages))
+	for _, pkg := range m.Packages {
 		pkgContext[pkg] = pkgVersion + pkg
 	}
 	return pkgContext
@@ -208,6 +208,7 @@ func newSentryException(err error) []sentry.Exception {
 			errType = t
 		}
 
+		//nolint:errorlint
 		switch stackErr := err.(type) {
 		// If the error implements the StackTrace method in the redact package, then
 		// prefer that. The Sentry SDK gets some things wrong when guessing how

--- a/internal/telemetry/sentry.go
+++ b/internal/telemetry/sentry.go
@@ -1,71 +1,322 @@
 package telemetry
 
 import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"path"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"runtime/debug"
+	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/getsentry/sentry-go"
+	pkgerrors "github.com/pkg/errors"
+	"go.jetpack.io/devbox/internal/build"
+	"go.jetpack.io/devbox/internal/redact"
 )
 
-type Sentry struct {
-	disabled bool
+var ExecutionID string
 
-	dsn string
+func init() {
+	// Generate event UUIDs the same way the Sentry SDK does:
+	// https://github.com/getsentry/sentry-go/blob/d9ce5344e7e1819921ea4901dd31e47a200de7e0/util.go#L15
+	id := make([]byte, 16)
+	rand.Read(id)
+	id[6] &= 0x0F
+	id[6] |= 0x40
+	id[8] &= 0x3F
+	id[8] |= 0x80
+	ExecutionID = hex.EncodeToString(id)
 }
 
-func NewSentry(dsn string) *Sentry {
-	return &Sentry{
-		disabled: DoNotTrack() || dsn == "",
-		dsn:      dsn,
+var started bool
+
+// Start enables telemetry for the current program.
+func Start(appName string) {
+	if appName == "" {
+		panic("telemetry.Start: app name is empty")
 	}
-}
-
-func (s *Sentry) Init(appName, appVersion, executionID string) {
-	if s.disabled {
+	if started || DoNotTrack() {
 		return
 	}
 
-	sentrySyncTransport := sentry.NewHTTPSyncTransport()
-	sentrySyncTransport.Timeout = time.Second * 2
-	release := appName + "@" + appVersion
+	transport := sentry.NewHTTPTransport()
+	transport.Timeout = time.Second * 2
 	environment := "production"
-	if appVersion == "0.0.0-dev" {
+	if build.IsDev {
 		environment = "development"
 	}
-
 	_ = sentry.Init(sentry.ClientOptions{
-		AttachStacktrace: true,
-		Dsn:              s.dsn,
+		Dsn:              build.SentryDSN,
 		Environment:      environment,
-		Release:          release,
-		Transport:        sentrySyncTransport,
+		Release:          appName + "@" + build.Version,
+		Transport:        transport,
 		TracesSampleRate: 1,
-		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
-			for i := range event.Exception {
-				// edit in place and remove error message from tracking
-				event.Exception[i].Value = ""
-			}
-			event.EventID = sentry.EventID(executionID)
+		BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
+			event.ServerName = "" // redact the hostname, which the SDK automatically adds
 			return event
 		},
 	})
-	sentry.ConfigureScope(func(scope *sentry.Scope) {
-		scope.SetUser(sentry.User{ID: DeviceID()})
-		scope.SetContext("os", map[string]interface{}{
-			"name": OS(),
-		})
-	})
+	started = true
 }
 
-// CaptureException
-func (s *Sentry) CaptureException(runErr error) string {
-	if s.disabled || runErr == nil {
-		return ""
+// Stop stops gathering telemetry and flushes buffered events to the server.
+func Stop() {
+	if !started {
+		return
 	}
-	defer sentry.Flush(2 * time.Second)
+	sentry.Flush(2 * time.Second)
+	started = false
+}
 
-	eventIDPointer := sentry.CaptureException(runErr)
-	if eventIDPointer == nil {
+type Metadata struct {
+	Command      string
+	CommandFlags []string
+	FeatureFlags map[string]bool
+
+	InShell   bool
+	InCloud   bool
+	InBrowser bool
+
+	NixpkgsHash string
+	Packages    []string
+
+	CloudRegion string
+	CloudCache  string
+}
+
+func (m *Metadata) cmdContext() map[string]any {
+	sentryCtx := map[string]any{}
+	if m.Command != "" {
+		sentryCtx["Name"] = m.Command
+	}
+	if len(m.CommandFlags) > 0 {
+		sentryCtx["Flags"] = m.CommandFlags
+	}
+	return sentryCtx
+}
+
+func (m *Metadata) envContext() map[string]any {
+	sentryCtx := map[string]any{
+		"In Shell":   m.InShell,
+		"In Cloud":   m.InCloud,
+		"In Browser": m.InBrowser,
+	}
+	if m.CloudCache != "" {
+		sentryCtx["Cloud Cache"] = m.CloudCache
+	}
+	if m.CloudRegion != "" {
+		sentryCtx["Cloud Region"] = m.CloudRegion
+	}
+	return sentryCtx
+}
+
+func (m *Metadata) featureContext() map[string]any {
+	if len(m.FeatureFlags) == 0 {
+		return nil
+	}
+
+	sentryCtx := make(map[string]any, len(m.FeatureFlags))
+	for name, enabled := range m.FeatureFlags {
+		sentryCtx[name] = enabled
+	}
+	return sentryCtx
+}
+
+func (meta *Metadata) pkgContext() map[string]any {
+	if len(meta.Packages) == 0 {
+		return nil
+	}
+
+	// Every package currently has the same commit hash as its version, but this
+	// format will allow us to use individual package versions in the future.
+	pkgVersion := "nixpkgs"
+	if meta.NixpkgsHash != "" {
+		pkgVersion += "/" + meta.NixpkgsHash
+	}
+	pkgVersion += "#"
+	pkgContext := make(map[string]any, len(meta.Packages))
+	for _, pkg := range meta.Packages {
+		pkgContext[pkg] = pkgVersion + pkg
+	}
+	return pkgContext
+}
+
+// Error reports an error to the telemetry server.
+func Error(err error, meta Metadata) {
+	if !started || err == nil {
+		return
+	}
+
+	event := &sentry.Event{
+		EventID:   sentry.EventID(ExecutionID),
+		Level:     sentry.LevelError,
+		User:      sentry.User{ID: DeviceID},
+		Exception: newSentryException(redact.Error(err)),
+		Contexts: map[string]map[string]any{
+			"os": {
+				"name": build.OS(),
+			},
+			"device": {
+				"arch": runtime.GOARCH,
+			},
+			"runtime": {
+				"name":    "Go",
+				"version": strings.TrimPrefix(runtime.Version(), "go"),
+			},
+		},
+	}
+	if meta.Command != "" {
+		event.Tags = map[string]string{"command": meta.Command}
+	}
+	if sentryCtx := meta.cmdContext(); len(sentryCtx) > 0 {
+		event.Contexts["Command"] = sentryCtx
+	}
+	if sentryCtx := meta.envContext(); len(sentryCtx) > 0 {
+		event.Contexts["Devbox Environment"] = sentryCtx
+	}
+	if sentryCtx := meta.featureContext(); len(sentryCtx) > 0 {
+		event.Contexts["Feature Flags"] = sentryCtx
+	}
+	if sentryCtx := meta.pkgContext(); len(sentryCtx) > 0 {
+		event.Contexts["Devbox Packages"] = sentryCtx
+	}
+	sentry.CaptureEvent(event)
+}
+
+func newSentryException(err error) []sentry.Exception {
+	errMsg := err.Error()
+	binPkg := ""
+	modPath := ""
+	if build, ok := debug.ReadBuildInfo(); ok {
+		binPkg = build.Path
+		modPath = build.Main.Path
+	}
+
+	// Unwrap in a loop to get the most recent stack trace. stFunc is set to a
+	// function that can generate a stack trace for the most recent error. This
+	// avoids computing the full stack trace for every error.
+	var stFunc func() []runtime.Frame
+	errType := "Generic Error"
+	for {
+		if t := exportedErrType(err); t != "" {
+			errType = t
+		}
+
+		switch stackErr := err.(type) {
+		// If the error implements the StackTrace method in the redact package, then
+		// prefer that. The Sentry SDK gets some things wrong when guessing how
+		// to extract the stack trace.
+		case interface{ StackTrace() []runtime.Frame }:
+			stFunc = stackErr.StackTrace
+		// Otherwise use the pkg/errors StackTracer interface.
+		case interface{ StackTrace() pkgerrors.StackTrace }:
+			// Normalize the pkgs/errors.StackTrace type to a slice of runtime.Frame.
+			stFunc = func() []runtime.Frame {
+				pkgStack := stackErr.StackTrace()
+				pc := make([]uintptr, len(pkgStack))
+				for i := range pkgStack {
+					pc[i] = uintptr(pkgStack[i])
+				}
+				frameIter := runtime.CallersFrames(pc)
+				frames := make([]runtime.Frame, 0, len(pc))
+				for {
+					frame, more := frameIter.Next()
+					frames = append(frames, frame)
+					if !more {
+						break
+					}
+				}
+				return frames
+			}
+		}
+		uw := errors.Unwrap(err)
+		if uw == nil {
+			break
+		}
+		err = uw
+	}
+	ex := []sentry.Exception{{Type: errType, Value: errMsg}}
+	if stFunc != nil {
+		ex[0].Stacktrace = newSentryStack(stFunc(), binPkg, modPath)
+	}
+	return ex
+}
+
+func newSentryStack(frames []runtime.Frame, binPkg, modPath string) *sentry.Stacktrace {
+	stack := &sentry.Stacktrace{
+		Frames: make([]sentry.Frame, len(frames)),
+	}
+	for i, frame := range frames {
+		pkgName, funcName := splitPkgFunc(frame.Function)
+
+		// The entrypoint has the full function name "main.main". Replace the
+		// package name with its full package path to make it easier to find.
+		if pkgName == "main" {
+			pkgName = binPkg
+		}
+
+		// The file path will be absolute unless the binary was built with -trimpath
+		// (which releases should be). Absolute paths make it more difficult for
+		// Sentry to correctly group errors, but there's no way to infer a relative
+		// path from an absolute path at runtime.
+		var absPath, relPath string
+		if filepath.IsAbs(frame.File) {
+			absPath = frame.File
+		} else {
+			relPath = frame.File
+		}
+
+		// Reverse the frames - Sentry wants the most recent call first.
+		stack.Frames[len(frames)-i-1] = sentry.Frame{
+			Function: funcName,
+			Module:   pkgName,
+			Filename: relPath,
+			AbsPath:  absPath,
+			Lineno:   frame.Line,
+			InApp:    strings.HasPrefix(frame.Function, modPath) || pkgName == binPkg,
+		}
+	}
+	return stack
+}
+
+// exportedErrType returns the underlying type name of err if it's exported.
+// Otherwise, it returns an empty string.
+func exportedErrType(err error) string {
+	t := reflect.TypeOf(err)
+	if t == nil {
 		return ""
 	}
-	return string(*eventIDPointer)
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	name := t.Name()
+	if r, _ := utf8.DecodeRuneInString(name); unicode.IsUpper(r) {
+		return t.String()
+	}
+	return ""
+}
+
+// splitPkgFunc splits a fully-qualified function or method name into its
+// package path and base name components.
+func splitPkgFunc(name string) (pkgPath string, funcName string) {
+	// Using the following fully-qualified function name as an example:
+	// go.jetpack.io/devbox/internal/impl.(*Devbox).RunScript
+
+	// dir = go.jetpack.io/devbox/internal/
+	// base = impl.(*Devbox).RunScript
+	dir, base := path.Split(name)
+
+	// pkgName = impl
+	// fn = (*Devbox).RunScript
+	pkgName, fn, _ := strings.Cut(base, ".")
+
+	// pkgPath = go.jetpack.io/devbox/internal/impl
+	// funcName = (*Devbox).RunScript
+	return dir + pkgName, fn
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -2,60 +2,37 @@ package telemetry
 
 import (
 	"os"
-	"runtime"
 	"strconv"
 
 	"github.com/denisbrodbeck/machineid"
-	"go.jetpack.io/devbox/internal/build"
-	"go.jetpack.io/devbox/internal/fileutil"
 )
 
-// Opts are global values that apply to the entire devbox binary
-type Opts struct {
-	AppName      string
-	AppVersion   string
-	SentryDSN    string // used by error reporting
-	TelemetryKey string
-}
+var DeviceID string
 
-func InitOpts() *Opts {
-	return &Opts{
-		AppName:      "devbox",
-		AppVersion:   build.Version,
-		SentryDSN:    build.SentryDSN,
-		TelemetryKey: build.TelemetryKey,
+const (
+	AppDevbox  = "devbox"
+	AppSSHShim = "devbox-sshshim"
+)
+
+func init() {
+
+	if DoNotTrack() {
+		return
 	}
+	enabled = true
+
+	const salt = "64ee464f-9450-4b14-8d9c-014c0012ac1a"
+	DeviceID, _ = machineid.ProtectedID(salt) // Ensure machine id is hashed and non-identifiable
 }
 
-func IsDisabled(opts *Opts) bool {
-	return DoNotTrack() || opts.TelemetryKey == "" || opts.SentryDSN == ""
+var enabled bool
+
+func Enabled() bool {
+	return enabled
 }
 
 func DoNotTrack() bool {
 	// https://consoledonottrack.com/
-	doNotTrack, err := strconv.ParseBool(os.Getenv("DO_NOT_TRACK"))
-	if err != nil {
-		doNotTrack = false
-	}
+	doNotTrack, _ := strconv.ParseBool(os.Getenv("DO_NOT_TRACK"))
 	return doNotTrack
-}
-
-func DeviceID() string {
-	salt := "64ee464f-9450-4b14-8d9c-014c0012ac1a"
-	hashedID, _ := machineid.ProtectedID(salt) // Ensure machine id is hashed and non-identifiable
-	return hashedID
-}
-
-func OS() string {
-	os := runtime.GOOS
-	// Special case for WSL, which is reported as 'linux' otherwise.
-	if fileutil.Exists("/proc/sys/fs/binfmt_misc/WSLInterop") || fileutil.Exists("/run/WSL") {
-		os = "wsl"
-	}
-
-	return os
-}
-
-func IsWSL() bool {
-	return OS() == "wsl"
 }


### PR DESCRIPTION
Clean up and fix telemetry so that it can be actually useful. This commit is rather large because telemetry happens to touch a lot of different things.

Example of what it looks like in Sentry: https://jetpack-io.sentry.io/issues/4047374127

Depends on #841.

Client
------

- Remove unnecessary telemetry configuration, such as `InitOpts`. Make the `build` package the source of truth for version information and link-time variables. Generate a global execution ID once at startup.
- Standardize the contexts to use names and values recognized by Sentry.
- Remove arbitrary CLI args and DEVBOX_ environment variables from the context, as these were leaking information.

Errors
------

- In combination with the `redact` package, errors can now include data that has been marked as safe for telemetry.
- Errors that haven't been marked as safe have a more helpful placeholder containing the chain of error types up until the first exported error.

Stack Traces
------------

- Use the correct file and function names. This allows Sentry to group errors correctly.
- Don't record every wrapped error. This doesn't make sense in Go since an error is a value containing the entire message. Otherwise you end up with a bunch of error messages that repeat themselves.
