### PR TITLE
ci: update docs when deploying prod version

### DIFF
--- a/.github/workflows/docs-deploy-prod.yaml
+++ b/.github/workflows/docs-deploy-prod.yaml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Generate docs from current commands
+        run: devbox gen-docs docs/app/docs/cli_reference/
       - uses: dorny/paths-filter@v2
         id: filter
         with:


### PR DESCRIPTION
## Summary

When deploying the prod version, use `devbox gen-docs` to update cli reference up-to-date.

## How was it tested?
