### PR TITLE
[virtenv] Create symlinks for support dirs, move wrappers to a subdir.

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -573,7 +573,7 @@ func (d *Devbox) computeNixEnv(ctx context.Context) (map[string]string, error) {
 
 	// Prepend virtenv bin path first so user can override it if needed. Virtenv
 	// is where the bin wrappers live
-	env["PATH"] = JoinPathLists(d.virtenvBinPath(), env["PATH"])
+	env["PATH"] = JoinPathLists(filepath.Join(d.projectDir, plugin.WrapperBinPath), env["PATH"])
 
 	// Include env variables in devbox.json
 	configEnv := d.configEnvs(env)
@@ -799,10 +799,6 @@ var ignoreDevEnvVar = map[string]bool{
 func (d *Devbox) setCommonHelperEnvVars(env map[string]string) {
 	env["LD_LIBRARY_PATH"] = filepath.Join(d.projectDir, nix.ProfilePath, "lib") + ":" + env["LD_LIBRARY_PATH"]
 	env["LIBRARY_PATH"] = filepath.Join(d.projectDir, nix.ProfilePath, "lib") + ":" + env["LIBRARY_PATH"]
-}
-
-func (d *Devbox) virtenvBinPath() string {
-	return filepath.Join(d.projectDir, plugin.VirtenvBinPath)
 }
 
 // nix bins returns the paths to all the nix binaries that are installed by

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -22,7 +22,7 @@ const (
 	VirtenvPath         = ".devbox/virtenv"
 )
 
-var WrapperPath = filepath.Join(VirtenvPath, "devbox-wrappers")
+var WrapperPath = filepath.Join(VirtenvPath, ".wrappers")
 var WrapperBinPath = filepath.Join(WrapperPath, "bin")
 
 type config struct {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -19,9 +19,11 @@ import (
 const (
 	devboxDirName       = "devbox.d"
 	devboxHiddenDirName = ".devbox"
-	VirtenvBinPath      = ".devbox/virtenv/bin"
 	VirtenvPath         = ".devbox/virtenv"
 )
+
+var WrapperPath = filepath.Join(VirtenvPath, "devbox-wrappers")
+var WrapperBinPath = filepath.Join(WrapperPath, "bin")
 
 type config struct {
 	Name        string            `json:"name"`

--- a/internal/plugin/rm.go
+++ b/internal/plugin/rm.go
@@ -17,7 +17,7 @@ func Remove(projectDir string, pkgs []string) error {
 }
 
 func RemoveInvalidSymlinks(projectDir string) error {
-	binPath := filepath.Join(projectDir, WrapperBinPath)
+	binPath := filepath.Join(projectDir, VirtenvPath, "bin")
 	if _, err := os.Stat(binPath); errors.Is(err, os.ErrNotExist) {
 		return nil
 	}

--- a/internal/plugin/rm.go
+++ b/internal/plugin/rm.go
@@ -17,7 +17,7 @@ func Remove(projectDir string, pkgs []string) error {
 }
 
 func RemoveInvalidSymlinks(projectDir string) error {
-	binPath := filepath.Join(projectDir, VirtenvBinPath)
+	binPath := filepath.Join(projectDir, WrapperBinPath)
 	if _, err := os.Stat(binPath); errors.Is(err, os.ErrNotExist) {
 		return nil
 	}

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -53,7 +53,7 @@ func toggleServices(
 
 		serviceBinPath := filepath.Join(
 			projectDir,
-			plugin.VirtenvBinPath,
+			plugin.WrapperBinPath,
 			fmt.Sprintf("%s-service-%s", name, lo.Ternary(action == startService, "start", "stop")),
 		)
 		cmd := exec.Command(serviceBinPath)

--- a/internal/wrapnix/wrapper.go
+++ b/internal/wrapnix/wrapper.go
@@ -110,6 +110,10 @@ func createWrapper(args *createWrapperArgs) error {
 // will contain the union of both. We need to do the same.
 func createSymlinksForSupportDirs(projectDir string) error {
 	profilePath := filepath.Join(projectDir, nix.ProfilePath)
+	if _, err := os.Stat(profilePath); errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+
 	supportDirs, err := os.ReadDir(profilePath)
 	if err != nil {
 		return err

--- a/internal/wrapnix/wrapper.go
+++ b/internal/wrapnix/wrapper.go
@@ -9,6 +9,7 @@ import (
 	"text/template"
 
 	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/internal/nix"
 	"go.jetpack.io/devbox/internal/plugin"
 )
 
@@ -73,7 +74,7 @@ func CreateWrappers(ctx context.Context, devbox devboxer) error {
 		}
 	}
 
-	return nil
+	return createSymlinksForSupportDirs(devbox.ProjectDir())
 }
 
 type createWrapperArgs struct {
@@ -96,4 +97,31 @@ func createWrapper(args *createWrapperArgs) error {
 
 func virtenvBinPath(projectDir string) string {
 	return filepath.Join(projectDir, plugin.VirtenvBinPath)
+}
+
+// createSymlinksForSupportDirs creates symlinks for the support dirs
+// (etc, lib, share) in the virtenv. Some tools (like mariadb) expect
+// these to be in a dir relative to the bin.
+//
+// TODO: this is not perfect. using the profile path will not take into account
+// any special stuff we do in flake.nix. We should use the nix store directly,
+// but that is a bit more complicated. Nix merges any support directories
+// recursively, so we need to do the same.
+// e.g. if go_1_19 and go_1_20 are installed, .devbox/nix/profile/default/share/go/api
+// will contain the union of both. We need to do the same.
+func createSymlinksForSupportDirs(projectDir string) error {
+	for _, dir := range []string{"etc", "lib", "share"} {
+		oldname := filepath.Join(projectDir, nix.ProfilePath, dir)
+		newname := filepath.Join(projectDir, plugin.VirtenvPath, dir)
+
+		_ = os.Remove(newname)
+		if _, err := os.Stat(oldname); os.IsNotExist(err) {
+			continue
+		}
+
+		if err := os.Symlink(oldname, newname); err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

This creates symlinks for all dirs in profile dir except `bin` (because that has wrappers). Also moved bin dir from

`.devbox/virtenv/bin` to `.devbox/virtenv/.wrappers/bin`

and all support symlinks are in `.devbox/virtenv/.wrappers`. This ensures we can't have collisions with plugin data which is stored in `.devbox/virtenv/[plugin-name]`

This fixes https://github.com/jetpack-io/devbox/issues/851

## How was it tested?

```
devbox shell 
ls -al .devbox/virtenv
ls -al .devbox/virtenv/.wrappers
which go
```

Also tested mariadb example
