### PR TITLE
[fish] fix command substitution to support older fish shells

### DIFF
--- a/internal/impl/shellrc_fish.tmpl
+++ b/internal/impl/shellrc_fish.tmpl
@@ -84,6 +84,6 @@ devbox log shell-interactive {{ .ShellStartTime }}
 
 # Add refresh alias (only if it doesn't already exist)
 if not type refresh >/dev/null 2>&1
-    alias refresh='eval (devbox shellenv)'
+    alias refresh='eval (devbox shellenv | string collect)'
     export DEVBOX_REFRESH_ALIAS="refresh"
 end

--- a/internal/impl/shellrc_fish.tmpl
+++ b/internal/impl/shellrc_fish.tmpl
@@ -52,7 +52,7 @@ devbox log shell-ready {{ .ShellStartTime }}
 # End Devbox Post-init Hook
 
 # Switch to the directory where devbox.json config is
-set workingDir "$(pwd)"
+set workingDir (pwd)
 cd "{{ .ProjectDir }}" || exit
 
 {{- if .PluginInitHook }}
@@ -84,6 +84,6 @@ devbox log shell-interactive {{ .ShellStartTime }}
 
 # Add refresh alias (only if it doesn't already exist)
 if not type refresh >/dev/null 2>&1
-    alias refresh='eval $(devbox shellenv)'
+    alias refresh='eval (devbox shellenv)'
     export DEVBOX_REFRESH_ALIAS="refresh"
 end


### PR DESCRIPTION
## Summary

In [fish 3.4.0](https://fishshell.com/docs/current/relnotes.html#id16), command substitution was added to enable bash-style: `$(var)`. The reported bug is from a user who is using an older version 3.3.

In this PR, I drop the `$(var)` in favor of the older command substitution of `(var)`.

One interesting point to note is that (from the above announcement post) one can use `(expr | string collect)` to prevent line splitting of the `expr` results. I use this in the evaluation of `devbox shellenv`. I _think_ this makes sense, but not totally sure. [Docs for string collect are here](https://fishshell.com/docs/current/cmds/string-collect.html).

For `(pwd)` I do not use `string collect` since I expect it to be just one line.

Fixes #850 

## How was it tested?

1. used https://lazamar.co.uk/nix-versions/ to find the nixpkgs-unstable hash for fish: https://lazamar.co.uk/nix-versions/?channel=nixpkgs-unstable&package=fish
  -  3.3.1 : 7592790b9e02f7f99ddcb1bd33fd44ff8df6a9a7
  - 3.6.0: 8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8
2. put the hash in my devbox global config's devbox.json. Then did `devbox global rm fish` and `devbox global add fish`.

```
❯ fish --version
fish, version 3.3.1

```

to repro:
```
❯ SHELL=$(which fish) devbox shell
Ensuring packages are installed.
Starting a devbox shell...
cd: The directory “(pwd)” does not exist
/nix/store/imm9js9vnni9vvcgwvawbhgjzky0771r-fish-3.3.1/share/fish/functions/cd.fish (line 30):
    builtin cd $argv
    ^
in function 'cd' with arguments '\(pwd\)'
	called on line 140 of file /var/folders/zv/r3sx92_94gq86_rq3yn1ky2h0000gn/T/devbox936646579/config.fish
from sourcing file /var/folders/zv/r3sx92_94gq86_rq3yn1ky2h0000gn/T/devbox936646579/config.fish
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish
(devbox) savil@Savil-Srivastavas-MacBook-Pro ~/c/j/p/fish-shell [1]> exit
```

after building `devbox` with these changes:
```

❯ SHELL=$(which fish) devbox shell
Ensuring packages are installed.
Starting a devbox shell...
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish
(devbox) savil@Savil-Srivastavas-MacBook-Pro ~/c/j/p/fish-shell> refresh

(devbox) savil@Savil-Srivastavas-MacBook-Pro ~/c/j/p/fish-shell> alias
alias fish_key_reader /nix/store/imm9js9vnni9vvcgwvawbhgjzky0771r-fish-3.3.1/bin/fish_key_reader
alias refresh 'eval (devbox shellenv)'
(devbox) savil@Savil-Srivastavas-MacBook-Pro ~/c/j/p/fish-shell> exit

```

To verify this works with latest fish 3.6.0:
```
❯ fish --version
fish, version 3.6.0

❯  SHELL=$(which fish) devbox shell
Ensuring packages are installed.
Starting a devbox shell...
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish
(devbox) savil@Savil-Srivastavas-MacBook-Pro ~/c/j/p/fish-shell> refresh
(devbox) savil@Savil-Srivastavas-MacBook-Pro ~/c/j/p/fish-shell> exit
```