### PR TITLE
Fix typo in installing_devbox.mdx

### DIFF
--- a/docs/app/docs/installing_devbox.mdx
+++ b/docs/app/docs/installing_devbox.mdx
@@ -82,7 +82,7 @@ nix-env -iA nixos.devbox
 To install on a non NixOS:
 
 ```bash
-nix-env -iA nixpkg.devbox
+nix-env -iA nixpkgs.devbox
 ```
 
 </TabItem>


### PR DESCRIPTION
## Summary
Fix typo in command for installing on non-NixOS

## How was it tested?
By running the corrected command
