### PR TITLE
[plugins] Always create plugin dir

### DIFF
--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -49,7 +49,7 @@ func (m *Manager) CreateFilesAndShowReadme(pkg, projectDir string) error {
 		return nil
 	}
 
-	// Always cerate this dir because some plugins depend on it.
+	// Always create this dir because some plugins depend on it.
 	if err = createDir(filepath.Join(projectDir, VirtenvPath, pkg)); err != nil {
 		return err
 	}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -49,6 +49,11 @@ func (m *Manager) CreateFilesAndShowReadme(pkg, projectDir string) error {
 		return nil
 	}
 
+	// Always cerate this dir because some plugins depend on it.
+	if err = createDir(filepath.Join(projectDir, VirtenvPath, pkg)); err != nil {
+		return err
+	}
+
 	debug.Log("Creating files for package %q create files", pkg)
 	for filePath, contentPath := range cfg.CreateFiles {
 


### PR DESCRIPTION
## Summary

We were not creating the plugin dir if there were no files in it but the redis plugin depends on the directory existing. Solution is to always create directory.

Fixes https://github.com/jetpack-io/devbox/issues/856

## How was it tested?

```
devbox add redis
devbox services start redis
```