### PR TITLE
telemetry: report errors in separate process

### DIFF
--- a/internal/boxcli/midcobra/telemetry.go
+++ b/internal/boxcli/midcobra/telemetry.go
@@ -76,6 +76,9 @@ func (m *telemetryMiddleware) postRun(cmd *cobra.Command, args []string, runErr 
 	meta.InCloud = envir.IsDevboxCloud()
 	telemetry.Error(runErr, meta)
 
+	if !telemetry.Enabled() {
+		return
+	}
 	evt := m.newEventIfValid(cmd, args, runErr)
 	if evt == nil {
 		return

--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -13,6 +13,7 @@ import (
 	"go.jetpack.io/devbox/internal/boxcli/midcobra"
 	"go.jetpack.io/devbox/internal/cloud/openssh/sshshim"
 	"go.jetpack.io/devbox/internal/debug"
+	"go.jetpack.io/devbox/internal/telemetry"
 	"go.jetpack.io/devbox/internal/vercheck"
 )
 
@@ -82,6 +83,10 @@ func Main() {
 		strings.HasSuffix(os.Args[0], "scp") {
 		code := sshshim.Execute(os.Args)
 		os.Exit(code)
+	}
+	if len(os.Args) > 1 && os.Args[1] == "bug" {
+		telemetry.ReportErrors()
+		return
 	}
 	code := Execute(context.Background(), os.Args[1:])
 	os.Exit(code)

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/denisbrodbeck/machineid"
+	"go.jetpack.io/devbox/internal/build"
 )
 
 var DeviceID string
@@ -15,8 +16,9 @@ const (
 )
 
 func init() {
-
-	if DoNotTrack() {
+	// TODO(gcurtis): clean this up so that Sentry and Segment use the same
+	// start/stop functions.
+	if DoNotTrack() || build.TelemetryKey == "" {
 		return
 	}
 	enabled = true


### PR DESCRIPTION
Instead of immediately sending errors to Sentry, write them to an XDG state directory as JSON and then upload them in a separate process. This allows devbox to exit faster (Segment still uploads synchronously).

Error reporting works by executing another devbox process with a single "bug" argument (i.e., `devbox bug`). This argument causes the child devbox process to immediately upload any Sentry events and then exit. It skips all other initialization. Because the parent devbox process exits without waiting for the child, the child process may become orphaned. There's a 3 second timeout for uploading events to help ensure that the process always exits.