### PR TITLE
bump the timeouts for example tests

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -92,7 +92,7 @@ jobs:
           - is-main: true
             run-example-tests: false
     runs-on: ${{ matrix.os }}
-    timeout-minutes: ${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && 25 || 10 }}
+    timeout-minutes: ${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && 30 || 15 }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3.5.0
@@ -119,7 +119,7 @@ jobs:
         env:
           DEVBOX_EXAMPLE_TESTS: ${{ matrix.run-example-tests }}
           # Used in `go test -timeout` flag. Needs a value that time.ParseDuration can parse.
-          DEVBOX_GOLANG_TEST_TIMEOUT: "${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && '25m' || '10m' }}"
+          DEVBOX_GOLANG_TEST_TIMEOUT: "${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && '30m' || '15m' }}"
         run: |
           go test -timeout $DEVBOX_GOLANG_TEST_TIMEOUT ./...
 


### PR DESCRIPTION
## Summary

The macos tests seem to timeout fairly regularly (though not always).

I'm bumping the non-macos tests timeout in anticipation of us hitting this limit
once we add more tests for redis, and other databases.

In a separate line of work, we should find a way to have these tests run faster.

## How was it tested?

buildkite run should be green
