### PR TITLE
Skip interactive survey if devbox is not executed in a terminal

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -363,8 +363,8 @@ func (d *Devbox) GenerateEnvrc(force bool, source string) error {
 	if commandExists("direnv") {
 		// prompt for direnv allow
 		var result string
-
-		if isatty.IsTerminal(os.Stdin.Fd()) {
+		isInteractiveMode := isatty.IsTerminal(os.Stdin.Fd())
+		if isInteractiveMode {
 			prompt := &survey.Input{
 				Message: "Do you want to enable direnv integration for this devbox project? [y/N]",
 			}
@@ -374,7 +374,7 @@ func (d *Devbox) GenerateEnvrc(force bool, source string) error {
 			}
 		}
 
-		if strings.ToLower(result) == "y" || !isatty.IsTerminal(os.Stdin.Fd()) {
+		if strings.ToLower(result) == "y" || !isInteractiveMode {
 			// .envrc file creation
 			err := generate.CreateEnvrc(tmplFS, d.projectDir)
 			if err != nil {

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/fatih/color"
+	"github.com/mattn/go-isatty"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
@@ -362,15 +363,18 @@ func (d *Devbox) GenerateEnvrc(force bool, source string) error {
 	if commandExists("direnv") {
 		// prompt for direnv allow
 		var result string
-		prompt := &survey.Input{
-			Message: "Do you want to enable direnv integration for this devbox project? [y/N]",
-		}
-		err := survey.AskOne(prompt, &result)
-		if err != nil {
-			return errors.WithStack(err)
+
+		if isatty.IsTerminal(os.Stdin.Fd()) {
+			prompt := &survey.Input{
+				Message: "Do you want to enable direnv integration for this devbox project? [y/N]",
+			}
+			err := survey.AskOne(prompt, &result)
+			if err != nil {
+				return errors.WithStack(err)
+			}
 		}
 
-		if strings.ToLower(result) == "y" {
+		if strings.ToLower(result) == "y" || !isatty.IsTerminal(os.Stdin.Fd()) {
 			// .envrc file creation
 			err := generate.CreateEnvrc(tmplFS, d.projectDir)
 			if err != nil {


### PR DESCRIPTION
## Summary
Skip interactive survey if devbox is not executed in a terminal. When `devbox init` or `devbox generate direnv` is called in a dockerfile for example, we do not want to prompt for user input.

I tried `echo 'y' | devbox generate direnv` or `yes | devbox generate direnv` or `devbox generate direnv <<< "y"`. None of them worked.

Bug in the survey package: https://github.com/go-survey/survey/issues/394

## How was it tested?
devbox run build
./dist/devbox init (interactive mode)

docker build -t devbox-cli .
docker run --entrypoint=/bin/sh -ti devbox-cli (non interactive mode)
