### PR TITLE
[example tests] generate "set -e" to exit scripts upon failure

### DIFF
--- a/examples/development/rust/rust-stable-hello-world/devbox.json
+++ b/examples/development/rust/rust-stable-hello-world/devbox.json
@@ -13,7 +13,6 @@
             "build-docs": "cargo doc",
             "start": "cargo run",
             "run_test": [
-                "set -e",
                 "cargo test -- --show-output"
             ]
         }

--- a/examples/stacks/django/devbox.json
+++ b/examples/stacks/django/devbox.json
@@ -29,7 +29,6 @@
                 "python todo_project/manage.py runserver"
             ],
             "run_test": [
-                "set -e",
                 "initdb",
                 "devbox services start",
                 "devbox run create_db",

--- a/examples/stacks/lapp-stack/devbox.json
+++ b/examples/stacks/lapp-stack/devbox.json
@@ -18,7 +18,6 @@
                 "psql devbox_lapp < setup_postgres_db.sql"
             ],
             "run_test": [
-                "set -e",
                 "initdb",
                 "devbox services start",
                 "devbox run create_db",

--- a/examples/stacks/lepp-stack/devbox.json
+++ b/examples/stacks/lepp-stack/devbox.json
@@ -18,7 +18,6 @@
                 "psql devbox_lepp < setup_postgres_db.sql"
             ],
             "run_test": [
-                "set -e",
                 "initdb",
                 "devbox services start",
                 "devbox run create_db",

--- a/internal/boxcli/featureflag/script_exit_on_error.go
+++ b/internal/boxcli/featureflag/script_exit_on_error.go
@@ -1,0 +1,5 @@
+package featureflag
+
+// ScriptExitOnError controls whether scripts defined in devbox.json
+// and executed via `devbox run` should exit if any command within them errors.
+var ScriptExitOnError = disabled("SCRIPT_EXIT_ON_ERROR")

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -880,6 +880,9 @@ func (d *Devbox) writeScriptFile(name string, body string) (err error) {
 		return errors.WithStack(err)
 	}
 
+	if featureflag.ScriptExitOnError.Enabled() {
+		body = fmt.Sprintf("set -e\n\n%s", body)
+	}
 	_, err = script.WriteString(body)
 	return errors.WithStack(err)
 }

--- a/testscripts/testrunner/run_test.test.txt
+++ b/testscripts/testrunner/run_test.test.txt
@@ -1,1 +1,2 @@
+env DEVBOX_FEATURE_SCRIPT_EXIT_ON_ERROR=1
 exec devbox run run_test


### PR DESCRIPTION
## Summary

RFC: we should have failures in the devbox-scripts reflect in a non-zero exit status
from `devbox run <script>`.

There is some risk that customers whose code was previously running will now fail. However, their scripts were indeed failing and its just that this failure will now be exposed. 

Update: Based on John's feedback in a comment below I am adding a featuregate that is activated in examples tests. We'll make a plan for rolling this out to users, in a way that is not a big surprise for them.

TODO:
- [x] fix examples which have failures that were previously masked. Done in previous PRs in the stack.

## How was it tested?

Removed `curl` from `lepp-stack` packages, and ran:
```
DEVBOX_EXAMPLE_TESTS=1 DEVBOX_DEBUG=0 go test -count 1 -v -run TestExamples/stacks_lepp ./testscripts/...
```
This failed, demonstrating that the `set -e` was working as intended.

I then added the `curl` back and the above command passed.
