### PR TITLE
List Services and Status via Process Compose

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -48,6 +48,7 @@ type Devbox interface {
 	StartProcessManager(ctx context.Context, requestedServices []string, background bool, processComposeFileOrDir string) error
 	StartServices(ctx context.Context, services ...string) error
 	StopServices(ctx context.Context, services ...string) error
+	ListServices(ctx context.Context) error
 }
 
 // Open opens a devbox by reading the config file in dir.

--- a/internal/boxcli/services.go
+++ b/internal/boxcli/services.go
@@ -96,14 +96,9 @@ func listServices(cmd *cobra.Command, flags servicesCmdFlags) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	services, err := box.Services()
-	if err != nil {
-		return err
-	}
-	for _, service := range services {
-		cmd.Println(service.Name)
-	}
-	return nil
+
+	return box.ListServices(cmd.Context())
+
 }
 
 func startServices(cmd *cobra.Command, services []string, flags servicesCmdFlags) error {

--- a/internal/services/client.go
+++ b/internal/services/client.go
@@ -77,7 +77,7 @@ func RestartServices(ctx context.Context, serviceName string, projectDir string,
 func ListServices(ctx context.Context, projectDir string, w io.Writer) ([]ProcessSummary, error) {
 	path := "/processes"
 	method := "GET"
-	var results = []ProcessSummary{}
+	results := []ProcessSummary{}
 
 	body, status, err := clientRequest(path, method)
 	if err != nil {

--- a/internal/services/client.go
+++ b/internal/services/client.go
@@ -3,12 +3,22 @@ package services
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+
+	"github.com/f1bonacc1/process-compose/src/types"
 )
 
-type SubCommand int
+type processState = types.ProcessState
+type processStates = types.ProcessStates
+
+type ProcessSummary struct {
+	Name     string
+	Status   string
+	ExitCode int
+}
 
 func StartServices(ctx context.Context, w io.Writer, serviceName string, projectDir string) error {
 	path := fmt.Sprintf("/process/start/%s", serviceName)
@@ -65,20 +75,34 @@ func RestartServices(ctx context.Context, serviceName string, projectDir string,
 	}
 }
 
-func ListServices(ctx context.Context, serviceName string, projectDir string, w io.Writer) (string, error) {
+func ListServices(ctx context.Context, projectDir string, w io.Writer) ([]ProcessSummary, error) {
 	path := "/processes"
 	method := "GET"
+	var results = []ProcessSummary{}
 
 	body, status, err := clientRequest(path, method)
 	if err != nil {
-		return "", err
+		return results, err
 	}
 
 	switch status {
 	case http.StatusOK:
-		return body, nil
+		var processes processStates
+		err := json.Unmarshal([]byte(body), &processes)
+		if err != nil {
+			return results, err
+		}
+		for _, process := range processes.States {
+			results = append(results, ProcessSummary{
+				Name:     process.Name,
+				Status:   process.Status,
+				ExitCode: process.ExitCode,
+			})
+		}
+		return results, nil
+
 	default:
-		return body, fmt.Errorf("unable to list services: %s", body)
+		return results, fmt.Errorf("unable to list services: %s", body)
 	}
 }
 

--- a/internal/services/client.go
+++ b/internal/services/client.go
@@ -11,7 +11,6 @@ import (
 	"github.com/f1bonacc1/process-compose/src/types"
 )
 
-type processState = types.ProcessState
 type processStates = types.ProcessStates
 
 type ProcessSummary struct {

--- a/plugins/postgresql/process-compose.yaml
+++ b/plugins/postgresql/process-compose.yaml
@@ -2,10 +2,9 @@ version: "0.5"
 
 processes:
   postgresql:
-    command: "pg_ctl start -l $PGHOST/logfile -o \"-k $PGHOST\""
-    isDaemon: true
+    command: "pg_ctl start -o \"-k $PGHOST\""
+    is_daemon: true
     shutdown: 
       command: "pg_ctl stop -m fast"
     availability:
-      restart: "on_failure"
-      max_restarts: 5
+      restart: "always"


### PR DESCRIPTION
## Summary

`devbox services ls` can now show the services available in your project, as well as the ones running in process-compose with their status: 

<img width="411" alt="Screenshot 2023-04-05 at 3 35 52 PM" src="https://user-images.githubusercontent.com/750845/230226727-f2a37103-3d6e-4862-8876-158ee1073586.png">

Still needs some tweaking to only show services, and not all processes

## How was it tested?
Localhost on examples. Should not affect backwards compatibility
