### PR TITLE
Add init hook flag to shellenv command

### DIFF
--- a/internal/boxcli/shellenv.go
+++ b/internal/boxcli/shellenv.go
@@ -28,10 +28,6 @@ func shellEnvCmd() *cobra.Command {
 				return err
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), s)
-
-			if flags.runInitHook {
-				fmt.Fprintln(cmd.OutOrStdout(), shellEnvInitHookFunc(cmd, flags))
-			}
 			return nil
 		},
 	}
@@ -49,14 +45,15 @@ func shellEnvFunc(cmd *cobra.Command, flags shellEnvCmdFlags) (string, error) {
 		return "", err
 	}
 
-	return box.PrintEnv()
-}
-
-func shellEnvInitHookFunc(cmd *cobra.Command, flags shellEnvCmdFlags) string {
-	box, err := devbox.Open(flags.config.path, cmd.ErrOrStderr())
+	envStr, err := box.PrintEnv()
 	if err != nil {
-		return ""
+		return "", err
 	}
 
-	return box.Config().Shell.InitHook.String()
+	if flags.runInitHook {
+		initHookStr := box.Config().Shell.InitHook.String()
+		return fmt.Sprintf("%s\n%s", envStr, initHookStr), nil
+	}
+
+	return envStr, nil
 }


### PR DESCRIPTION
## Summary
Add init hook flag to shellenv command. This prints out the env variables and the init hooks to stdout, and should replicate the behavior of a `devbox shell` within the context of the current shell.

## How was it tested?
```
devbox shellenv --init-hook
```
And changing the shell by
```
eval "$(devbox shellenv --init-hook)"
```