### PR TITLE
Multi-instance Process Compose

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -47,7 +47,7 @@ type Devbox interface {
 	ShellPlan() (*plansdk.ShellPlan, error)
 	StartProcessManager(ctx context.Context, requestedServices []string, background bool, processComposeFileOrDir string) error
 	StartServices(ctx context.Context, services ...string) error
-	StopServices(ctx context.Context, services ...string) error
+	StopServices(ctx context.Context, allProjects bool, services ...string) error
 	ListServices(ctx context.Context) error
 }
 

--- a/internal/boxcli/services.go
+++ b/internal/boxcli/services.go
@@ -129,7 +129,7 @@ func stopServices(cmd *cobra.Command, services []string, flags serviceStopFlags)
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	if len(services) >= 0 && flags.allProjects {
+	if len(services) > 0 && flags.allProjects {
 		return errors.New("cannot both specify services and --all-projects")
 	}
 	return box.StopServices(cmd.Context(), flags.allProjects, services...)

--- a/internal/boxcli/services.go
+++ b/internal/boxcli/services.go
@@ -40,7 +40,7 @@ func (flags *serviceUpFlags) register(cmd *cobra.Command) {
 func (flags *serviceStopFlags) register(cmd *cobra.Command) {
 	flags.configFlags.register(cmd)
 	cmd.Flags().BoolVar(
-		&flags.allProjects, "all-projects", false, "Stop all running services across all your projects.\nThis flag cannot be used with the [service] argument")
+		&flags.allProjects, "all-projects", false, "Stop all running services across all your projects.\nThis flag cannot be used simultaneously with the [services] argument")
 }
 
 func servicesCmd() *cobra.Command {
@@ -130,7 +130,7 @@ func stopServices(cmd *cobra.Command, services []string, flags serviceStopFlags)
 		return errors.WithStack(err)
 	}
 	if len(services) > 0 && flags.allProjects {
-		return errors.New("cannot both specify services and --all-projects")
+		return errors.New("cannot use both services and --all-projects arguments simultaneously")
 	}
 	return box.StopServices(cmd.Context(), flags.allProjects, services...)
 }

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -459,9 +459,9 @@ func (d *Devbox) StartServices(ctx context.Context, serviceNames ...string) erro
 	for _, s := range serviceNames {
 		err := services.StartServices(ctx, d.writer, s, d.projectDir)
 		if err != nil {
-			fmt.Printf("Error starting service %s: %s", s, err)
+			fmt.Fprintf(d.writer, "Error starting service %s: %s", s, err)
 		} else {
-			fmt.Printf("Service %s started successfully", s)
+			fmt.Fprintf(d.writer, "Service %s started successfully", s)
 		}
 	}
 	return nil
@@ -589,6 +589,12 @@ func (d *Devbox) StartProcessManager(
 
 	if len(svcs) == 0 {
 		return usererr.New("No services found in your project")
+	}
+
+	for _, s := range requestedServices {
+		if _, ok := svcs[s]; !ok {
+			return usererr.New(fmt.Sprintf("Service %s not found in your project", s))
+		}
 	}
 
 	processComposePath, err := utilityLookPath("process-compose")

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -435,7 +435,7 @@ func (d *Devbox) StartServices(ctx context.Context, serviceNames ...string) erro
 		return d.RunScript("devbox", append([]string{"services", "start"}, serviceNames...))
 	}
 
-	if !services.ProcessManagerIsRunning() {
+	if !services.ProcessManagerIsRunning(d.projectDir) {
 		fmt.Fprintln(d.writer, "Process-compose is not running. Starting it now...")
 		fmt.Fprintln(d.writer, "\nNOTE: We recommend using `devbox services up` to start process-compose and your services")
 		return d.StartProcessManager(ctx, serviceNames, true, "")
@@ -481,12 +481,12 @@ func (d *Devbox) StopServices(ctx context.Context, allProjects bool, serviceName
 		return services.StopAllProcessManagers(ctx, d.writer)
 	}
 
-	if !services.ProcessManagerIsRunning() {
+	if !services.ProcessManagerIsRunning(d.projectDir) {
 		return usererr.New("Process manager is not running. Run `devbox services up` to start it.")
 	}
 
 	if len(serviceNames) == 0 {
-		return services.StopProcessManager(ctx, d.writer)
+		return services.StopProcessManager(ctx, d.projectDir, d.writer)
 	}
 
 	svcSet, err := d.Services()
@@ -521,7 +521,7 @@ func (d *Devbox) ListServices(ctx context.Context) error {
 		return nil
 	}
 
-	if !services.ProcessManagerIsRunning() {
+	if !services.ProcessManagerIsRunning(d.projectDir) {
 		fmt.Fprintln(d.writer, "No services currently running. Run `devbox services up` to start them:")
 		fmt.Fprintln(d.writer, "")
 		for _, s := range svcSet {
@@ -549,7 +549,7 @@ func (d *Devbox) RestartServices(ctx context.Context, serviceNames ...string) er
 		return d.RunScript("devbox", append([]string{"services", "restart"}, serviceNames...))
 	}
 
-	if !services.ProcessManagerIsRunning() {
+	if !services.ProcessManagerIsRunning(d.projectDir) {
 		fmt.Fprintln(d.writer, "Process-compose is not running. Starting it now...")
 		fmt.Fprintln(d.writer, "\nTip: We recommend using `devbox services up` to start process-compose and your services")
 		return d.StartProcessManager(ctx, serviceNames, true, "")

--- a/internal/services/client.go
+++ b/internal/services/client.go
@@ -23,7 +23,7 @@ func StartServices(ctx context.Context, w io.Writer, serviceName string, project
 	path := fmt.Sprintf("/process/start/%s", serviceName)
 	method := "POST"
 
-	body, status, err := clientRequest(path, method)
+	body, status, err := clientRequest(path, method, projectDir)
 	if err != nil {
 		return err
 	}
@@ -42,7 +42,7 @@ func StopServices(ctx context.Context, serviceName string, projectDir string, w 
 	path := fmt.Sprintf("/process/stop/%s", serviceName)
 	method := "PATCH"
 
-	body, status, err := clientRequest(path, method)
+	body, status, err := clientRequest(path, method, projectDir)
 	if err != nil {
 		return err
 	}
@@ -60,7 +60,7 @@ func RestartServices(ctx context.Context, serviceName string, projectDir string,
 	path := fmt.Sprintf("/process/restart/%s", serviceName)
 	method := "POST"
 
-	body, status, err := clientRequest(path, method)
+	body, status, err := clientRequest(path, method, projectDir)
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func ListServices(ctx context.Context, projectDir string, w io.Writer) ([]Proces
 	method := "GET"
 	results := []ProcessSummary{}
 
-	body, status, err := clientRequest(path, method)
+	body, status, err := clientRequest(path, method, projectDir)
 	if err != nil {
 		return results, err
 	}
@@ -105,8 +105,8 @@ func ListServices(ctx context.Context, projectDir string, w io.Writer) ([]Proces
 	}
 }
 
-func clientRequest(path string, method string) (string, int, error) {
-	port, err := GetProcessManagerPort()
+func clientRequest(path string, method string, projectDir string) (string, int, error) {
+	port, err := GetProcessManagerPort(projectDir)
 	if err != nil {
 		err := fmt.Errorf("unable to connect to process-compose server: %s", err.Error())
 		return "", 0, err

--- a/internal/services/client.go
+++ b/internal/services/client.go
@@ -106,8 +106,13 @@ func ListServices(ctx context.Context, projectDir string, w io.Writer) ([]Proces
 }
 
 func clientRequest(path string, method string) (string, int, error) {
-	port := "8280"
-	req, err := http.NewRequest(method, fmt.Sprintf("http://localhost:%s%s", port, path), nil)
+	port, err := GetProcessManagerPort()
+	if err != nil {
+		err := fmt.Errorf("unable to connect to process-compose server: %s", err.Error())
+		return "", 0, err
+	}
+
+	req, err := http.NewRequest(method, fmt.Sprintf("http://localhost:%d%s", port, path), nil)
 	if err != nil {
 		return "", 0, err
 	}

--- a/internal/services/client.go
+++ b/internal/services/client.go
@@ -13,7 +13,7 @@ import (
 
 type processStates = types.ProcessStates
 
-type ProcessSummary struct {
+type Process struct {
 	Name     string
 	Status   string
 	ExitCode int
@@ -74,10 +74,10 @@ func RestartServices(ctx context.Context, serviceName string, projectDir string,
 	}
 }
 
-func ListServices(ctx context.Context, projectDir string, w io.Writer) ([]ProcessSummary, error) {
+func ListServices(ctx context.Context, projectDir string, w io.Writer) ([]Process, error) {
 	path := "/processes"
 	method := "GET"
-	results := []ProcessSummary{}
+	results := []Process{}
 
 	body, status, err := clientRequest(path, method, projectDir)
 	if err != nil {
@@ -92,7 +92,7 @@ func ListServices(ctx context.Context, projectDir string, w io.Writer) ([]Proces
 			return results, err
 		}
 		for _, process := range processes.States {
-			results = append(results, ProcessSummary{
+			results = append(results, Process{
 				Name:     process.Name,
 				Status:   process.Status,
 				ExitCode: process.ExitCode,

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -187,7 +187,7 @@ func runProcessManagerInForeground(cmd *exec.Cmd, port int, w io.Writer) error {
 
 	defer cleanupProject(globalProcessComposeConfig, runID)
 	err = cmd.Wait()
-	if err.Error() == "exit status 1" {
+	if err != nil && err.Error() == "exit status 1" {
 		fmt.Fprintln(w, "Process-compose was terminated remotely")
 		return nil
 	}

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -101,12 +101,12 @@ func openGlobalConfigFile() (*os.File, error) {
 
 	globalConfigFile, err := os.OpenFile(configPath, os.O_WRONLY|os.O_CREATE, 0664)
 	if err != nil {
-		return globalConfigFile, fmt.Errorf("failed to open config file: %w", err)
+		return nil, fmt.Errorf("failed to open config file: %w", err)
 	}
 
 	err = lockFile(globalConfigFile)
 	if err != nil {
-		return globalConfigFile, err
+		return nil, err
 	}
 
 	return globalConfigFile, nil
@@ -154,13 +154,13 @@ func StartProcessManager(
 	if len(requestedServices) > 0 {
 		flags = append(requestedServices, flags...)
 		flags = append(upCommand, flags...)
-		fmt.Fprintf(w, "Starting services: %s", strings.Join(requestedServices, ", "))
+		fmt.Fprintf(w, "Starting services: %s \n", strings.Join(requestedServices, ", "))
 	} else {
 		services := []string{}
 		for k := range availableServices {
 			services = append(services, k)
 		}
-		fmt.Fprintf(w, "Starting all services: %s", strings.Join(services, ", "))
+		fmt.Fprintf(w, "Starting all services: %s \n", strings.Join(services, ", "))
 	}
 
 	for _, s := range availableServices {
@@ -208,7 +208,7 @@ func runProcessManagerInForeground(cmd *exec.Cmd, config *globalProcessComposeCo
 	err = cmd.Wait()
 
 	if err != nil && err.Error() == "exit status 1" {
-		fmt.Fprintln(w, "Process-compose was terminated remotely")
+		fmt.Fprintf(w, "Process-compose was terminated remotely, %s\n", err.Error())
 		return nil
 	} else if err != nil {
 		return err
@@ -298,7 +298,6 @@ func StopAllProcessManagers(ctx context.Context, w io.Writer) error {
 	defer configFile.Close()
 
 	config := readGlobalProcessComposeJSON(configFile)
-	// Lock the config file, defer unlocking to the end of the scope
 
 	for _, project := range config.Instances {
 		pid, _ := os.FindProcess(project.Pid)

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -137,7 +138,6 @@ func StartProcessManager(
 	defer configFile.Close()
 
 	// Read the global config file
-	fmt.Printf("Reading global config file: %s", configFile.Name())
 	config := readGlobalProcessComposeJSON(configFile)
 	config.File = configFile
 
@@ -154,6 +154,13 @@ func StartProcessManager(
 	if len(requestedServices) > 0 {
 		flags = append(requestedServices, flags...)
 		flags = append(upCommand, flags...)
+		fmt.Fprintf(w, "Starting services: %s", strings.Join(requestedServices, ", "))
+	} else {
+		services := []string{}
+		for k := range availableServices {
+			services = append(services, k)
+		}
+		fmt.Fprintf(w, "Starting all services: %s", strings.Join(services, ", "))
 	}
 
 	for _, s := range availableServices {

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/internal/cuecfg"
 	"go.jetpack.io/devbox/internal/xdg"
@@ -18,7 +17,6 @@ import (
 
 const (
 	processComposeLogfile = string(".devbox/compose.log")
-	processComposeUIDFile = string(".devbox/compose.uid")
 )
 
 func defaultPorts() [10]int {
@@ -49,37 +47,30 @@ type projectConfig struct {
 type projectMap = map[string]projectConfig
 
 type globalProcessComposeConfig struct {
-	Instances projectMap `json:"instances"`
+	Instances  projectMap
+	GlobalPath string   `json:"-"`
+	FileRef    *os.File `json:"-"`
 }
 
 func globalProcessComposeConfigPath() (string, error) {
 	path := xdg.DataSubpath(filepath.Join("devbox/global/"))
-	return path, errors.WithStack(os.MkdirAll(path, 0755))
+	return filepath.Join(path, "process-compose.json"), errors.WithStack(os.MkdirAll(path, 0755))
 }
 
-func readGlobalProcessComposeConfig() globalProcessComposeConfig {
+func readGlobalProcessComposeConfig(configPath string) globalProcessComposeConfig {
 	config := globalProcessComposeConfig{Instances: map[string]projectConfig{}}
-	path, err := globalProcessComposeConfigPath()
-	if err != nil {
-		return config
-	}
-	path = filepath.Join(path, "process-compose.json")
-	file, err := os.Open(path)
-	if err != nil {
-		return config
-	}
-	defer file.Close()
 
-	err = errors.WithStack(cuecfg.ParseFile(path, &config))
+	err := errors.WithStack(cuecfg.ParseFile(configPath, &config.Instances))
 	if err != nil {
 		return config
 	}
+	config.GlobalPath = configPath
 	return config
 }
 
 func writeGlobalProcessComposeConfig(config globalProcessComposeConfig) error {
 	// convert config to json using cue
-	json, err := cuecfg.MarshalJSON(config)
+	json, err := cuecfg.MarshalJSON(config.Instances)
 	if err != nil {
 		return fmt.Errorf("failed to convert config to json: %w", err)
 	}
@@ -90,19 +81,20 @@ func writeGlobalProcessComposeConfig(config globalProcessComposeConfig) error {
 		return fmt.Errorf("failed to get config path: %w", err)
 	}
 
-	path = filepath.Join(path, "process-compose.json")
-
-	if err = os.WriteFile(path, json, 0666); err != nil {
+	if err := os.WriteFile(path, json, 0666); err != nil {
 		return fmt.Errorf("failed to write global config file: %w", err)
 	}
 
 	return nil
 }
 
-func cleanupProject(globalProcessComposeConfig globalProcessComposeConfig, runID string) {
-	os.Remove(processComposeUIDFile)
-	delete(globalProcessComposeConfig.Instances, runID)
-	err := writeGlobalProcessComposeConfig(globalProcessComposeConfig)
+func cleanupProject(config globalProcessComposeConfig, projectDir string) {
+	fmt.Printf("Cleaning up project with FD: %d", config.FileRef.Fd())
+	lockFile(config.FileRef.Fd())
+	defer unlockFile(config.FileRef.Fd())
+
+	delete(config.Instances, projectDir)
+	err := writeGlobalProcessComposeConfig(config)
 	if err != nil {
 		fmt.Println("failed to write global process-compose config")
 	}
@@ -120,17 +112,38 @@ func StartProcessManager(
 ) error {
 	// Check if process-compose is already running
 
-	if ProcessManagerIsRunning() {
+	if ProcessManagerIsRunning(projectDir) {
 		return fmt.Errorf("process-compose is already running. To stop it, run `devbox services stop`")
 	}
 
-	port, available := getAvailablePort(readGlobalProcessComposeConfig())
+	// Get the right path, based on the user's XDG settings
+	configPath, err := globalProcessComposeConfigPath()
+	if err != nil {
+		return fmt.Errorf("failed to get config path: %w", err)
+	}
+
+	// Open the config file, defer closing to the end of the scope
+	globalConfigFile, err := os.OpenFile(configPath, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		return fmt.Errorf("failed to open config file: %w", err)
+	}
+	defer globalConfigFile.Close()
+
+	// Lock the config file, defer unlocking to the end of the scope
+	lockFile(globalConfigFile.Fd())
+	defer unlockFile(globalConfigFile.Fd())
+
+	//Read the file, store the ref in the config
+	config := readGlobalProcessComposeConfig(configPath)
+	config.FileRef = globalConfigFile
+
+	// Get the port to use for this project
+	port, available := getAvailablePort(config)
 	if !available {
 		return fmt.Errorf("no available ports to start process-compose. You should run `devbox services stop` in your projects to free up ports")
 	}
 
-	//convert port to string
-
+	// Now we have everything we need, let's start building the process-compose command
 	flags := []string{"-p", strconv.Itoa(port)}
 	upCommand := []string{"up"}
 
@@ -155,49 +168,43 @@ func StartProcessManager(
 	if processComposeBackground {
 		flags = append(flags, "-t=false")
 		cmd := exec.Command(processComposePath, flags...)
-		return runProcessManagerInBackground(cmd, port)
+		return runProcessManagerInBackground(cmd, port, config, projectDir)
 	}
 
 	cmd := exec.Command(processComposePath, flags...)
-	return runProcessManagerInForeground(cmd, port, w)
+	return runProcessManagerInForeground(cmd, port, config, projectDir, w)
 }
 
-func runProcessManagerInForeground(cmd *exec.Cmd, port int, w io.Writer) error {
-	runID := uuid.New().String()
+func runProcessManagerInForeground(cmd *exec.Cmd, port int, config globalProcessComposeConfig, projectDir string, w io.Writer) error {
 
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to start process-compose: %w", err)
 	}
-
-	globalProcessComposeConfig := readGlobalProcessComposeConfig()
 
 	projectConfig := projectConfig{
 		Pid:  cmd.Process.Pid,
 		Port: port,
 	}
 
-	globalProcessComposeConfig.Instances[runID] = projectConfig
+	config.Instances[projectDir] = projectConfig
 
-	if err := os.WriteFile(processComposeUIDFile, []byte(runID), 0666); err != nil {
-		return fmt.Errorf("failed to write uidfile: %w", err)
-	}
-
-	err := writeGlobalProcessComposeConfig(globalProcessComposeConfig)
+	err := writeGlobalProcessComposeConfig(config)
 	if err != nil {
 		return fmt.Errorf("failed to write global process-compose config: %w", err)
 	}
 
-	defer cleanupProject(globalProcessComposeConfig, runID)
+	unlockFile(config.FileRef.Fd())
 	err = cmd.Wait()
+	config = readGlobalProcessComposeConfig(config.GlobalPath)
 	if err != nil && err.Error() == "exit status 1" {
 		fmt.Fprintln(w, "Process-compose was terminated remotely")
 		return nil
 	}
+	cleanupProject(config, projectDir)
 	return err
 }
 
-func runProcessManagerInBackground(cmd *exec.Cmd, port int) error {
-	runID := uuid.New().String()
+func runProcessManagerInBackground(cmd *exec.Cmd, port int, config globalProcessComposeConfig, projectDir string) error {
 
 	logfile, err := os.OpenFile(processComposeLogfile, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_TRUNC, 0666)
 	if err != nil {
@@ -211,22 +218,16 @@ func runProcessManagerInBackground(cmd *exec.Cmd, port int) error {
 		return fmt.Errorf("failed to start process-compose: %w", err)
 	}
 
-	globalProcessComposeConfig := readGlobalProcessComposeConfig()
-
 	projectConfig := projectConfig{
 		Pid:  cmd.Process.Pid,
 		Port: port,
 	}
 
-	globalProcessComposeConfig.Instances[runID] = projectConfig
+	config.Instances[projectDir] = projectConfig
 
-	err = writeGlobalProcessComposeConfig(globalProcessComposeConfig)
+	err = writeGlobalProcessComposeConfig(config)
 	if err != nil {
 		return fmt.Errorf("failed to write global process-compose config: %w", err)
-	}
-
-	if err := os.WriteFile(processComposeUIDFile, []byte(runID), 0666); err != nil {
-		return fmt.Errorf("failed to write uidfile: %w", err)
 	}
 
 	return nil
@@ -234,21 +235,34 @@ func runProcessManagerInBackground(cmd *exec.Cmd, port int) error {
 
 func StopProcessManager(
 	ctx context.Context,
+	projectDir string,
 	w io.Writer,
 ) error {
-	globalProcessComposeConfig := readGlobalProcessComposeConfig()
-
-	uid, err := os.ReadFile(processComposeUIDFile)
+	configPath, err := globalProcessComposeConfigPath()
 	if err != nil {
-		return fmt.Errorf("process-compose is not running or it's config is missing. To start it, run `devbox services up`")
+		return fmt.Errorf("failed to get config path: %w", err)
 	}
 
-	project, ok := globalProcessComposeConfig.Instances[string(uid)]
+	// Open the config file, defer closing to the end of the scope
+	globalConfigFile, err := os.OpenFile(configPath, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		return fmt.Errorf("failed to open config file: %w", err)
+	}
+	defer globalConfigFile.Close()
+
+	// Lock the config file, defer unlocking to the end of the scope
+	lockFile(globalConfigFile.Fd())
+	defer unlockFile(globalConfigFile.Fd())
+
+	config := readGlobalProcessComposeConfig(configPath)
+	config.FileRef = globalConfigFile
+
+	project, ok := config.Instances[string(projectDir)]
 	if !ok {
 		return fmt.Errorf("process-compose is not running or it's config is missing. To start it, run `devbox services up`")
 	}
 
-	defer cleanupProject(globalProcessComposeConfig, string(uid))
+	defer cleanupProject(config, projectDir)
 
 	pid, _ := os.FindProcess(project.Pid)
 	err = pid.Signal(os.Interrupt)
@@ -261,9 +275,25 @@ func StopProcessManager(
 }
 
 func StopAllProcessManagers(ctx context.Context, w io.Writer) error {
-	globalProcessComposeConfig := readGlobalProcessComposeConfig()
+	configPath, err := globalProcessComposeConfigPath()
+	if err != nil {
+		return fmt.Errorf("failed to get config path: %w", err)
+	}
 
-	for _, project := range globalProcessComposeConfig.Instances {
+	// Open the config file, defer closing to the end of the scope
+	globalConfigFile, err := os.OpenFile(configPath, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		return fmt.Errorf("failed to open config file: %w", err)
+	}
+	defer globalConfigFile.Close()
+
+	// Lock the config file, defer unlocking to the end of the scope
+	lockFile(globalConfigFile.Fd())
+	defer unlockFile(globalConfigFile.Fd())
+
+	config := readGlobalProcessComposeConfig(configPath)
+
+	for _, project := range config.Instances {
 		pid, _ := os.FindProcess(project.Pid)
 		err := pid.Signal(os.Interrupt)
 		if err != nil {
@@ -271,9 +301,9 @@ func StopAllProcessManagers(ctx context.Context, w io.Writer) error {
 		}
 	}
 
-	globalProcessComposeConfig.Instances = make(map[string]projectConfig)
+	config.Instances = make(map[string]projectConfig)
 
-	err := writeGlobalProcessComposeConfig(globalProcessComposeConfig)
+	err = writeGlobalProcessComposeConfig(config)
 	if err != nil {
 		return fmt.Errorf("failed to write global process-compose config: %w", err)
 	}
@@ -281,18 +311,17 @@ func StopAllProcessManagers(ctx context.Context, w io.Writer) error {
 	return nil
 }
 
-func ProcessManagerIsRunning() bool {
-	config := readGlobalProcessComposeConfig()
+func ProcessManagerIsRunning(projectDir string) bool {
 
-	data, err := os.ReadFile(processComposeUIDFile)
+	configPath, err := globalProcessComposeConfigPath()
 	if err != nil {
 		return false
 	}
 
-	uid := string(data)
-	project, ok := config.Instances[uid]
+	config := readGlobalProcessComposeConfig(configPath)
+
+	project, ok := config.Instances[projectDir]
 	if !ok {
-		os.Remove(processComposeUIDFile)
 		return false
 	}
 
@@ -301,8 +330,7 @@ func ProcessManagerIsRunning() bool {
 	err = process.Signal(syscall.Signal(0))
 	if err != nil {
 		fmt.Printf("Error: %s \n", err)
-		os.Remove(processComposeUIDFile)
-		delete(config.Instances, uid)
+		delete(config.Instances, projectDir)
 		_ = writeGlobalProcessComposeConfig(config)
 		return false
 	}
@@ -310,19 +338,49 @@ func ProcessManagerIsRunning() bool {
 	return true
 }
 
-func GetProcessManagerPort() (int, error) {
-	config := readGlobalProcessComposeConfig()
-
-	uid, err := os.ReadFile(processComposeUIDFile)
+func GetProcessManagerPort(projectDir string) (int, error) {
+	path, err := globalProcessComposeConfigPath()
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("process-compose is not running or it's config is missing. To start it, run `devbox services up`")
 	}
 
-	project, ok := config.Instances[string(uid)]
+	config := readGlobalProcessComposeConfig(path)
+
+	project, ok := config.Instances[string(projectDir)]
 	if !ok {
-		os.Remove(processComposeUIDFile)
 		return 0, fmt.Errorf("process-compose is not running or it's config is missing. To start it, run `devbox services up`")
 	}
 
 	return project.Port, nil
+}
+
+func lockFile(fd uintptr) error {
+
+	lock := syscall.Flock_t{
+		Type:   syscall.F_WRLCK,
+		Whence: int16(os.SEEK_SET),
+		Start:  0,
+		Len:    0,
+	}
+
+	if err := syscall.FcntlFlock(fd, syscall.F_SETLK, &lock); err != nil {
+		fmt.Printf("Error acquiring lock: %s", err)
+		return nil
+	}
+	return nil
+}
+
+func unlockFile(fd uintptr) error {
+	lock := syscall.Flock_t{
+		Type:   syscall.F_UNLCK,
+		Whence: int16(os.SEEK_SET),
+		Start:  0,
+		Len:    0,
+	}
+	if err := syscall.FcntlFlock(fd, syscall.F_SETLK, &lock); err != nil {
+		fmt.Printf("Error unlocking file: %s", err)
+		return nil
+	}
+	return nil
+
 }

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -46,8 +46,10 @@ type projectConfig struct {
 	Port int `json:"port"`
 }
 
+type projectMap = map[string]projectConfig
+
 type globalProcessComposeConfig struct {
-	Instances map[string]projectConfig `json:"instances"`
+	Instances projectMap `json:"instances"`
 }
 
 func globalProcessComposeConfigPath() (string, error) {
@@ -91,7 +93,7 @@ func writeGlobalProcessComposeConfig(config globalProcessComposeConfig) error {
 	path = filepath.Join(path, "process-compose.json")
 
 	if err = os.WriteFile(path, json, 0666); err != nil {
-		return fmt.Errorf("failed to open process-compose log file: %w", err)
+		return fmt.Errorf("failed to write global config file: %w", err)
 	}
 
 	return nil

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -52,6 +52,15 @@ type globalProcessComposeConfig struct {
 	FileRef    *os.File `json:"-"`
 }
 
+func (c *globalProcessComposeConfig) updateFromFile(path string) {
+	// read the config from file
+	config := readGlobalProcessComposeConfig(path)
+
+	// update the config
+	c.Instances = config.Instances
+	c.GlobalPath = config.GlobalPath
+}
+
 func globalProcessComposeConfigPath() (string, error) {
 	path := xdg.DataSubpath(filepath.Join("devbox/global/"))
 	return filepath.Join(path, "process-compose.json"), errors.WithStack(os.MkdirAll(path, 0755))
@@ -195,7 +204,7 @@ func runProcessManagerInForeground(cmd *exec.Cmd, port int, config globalProcess
 
 	unlockFile(config.FileRef.Fd())
 	err = cmd.Wait()
-	config = readGlobalProcessComposeConfig(config.GlobalPath)
+	config.updateFromFile(config.GlobalPath)
 	if err != nil && err.Error() == "exit status 1" {
 		fmt.Fprintln(w, "Process-compose was terminated remotely")
 		return nil

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -15,11 +15,6 @@ import (
 	"go.jetpack.io/devbox/internal/cloud/envir"
 )
 
-const (
-	processComposePidfile = ".devbox/compose.pid"
-	processComposeLogfile = ".devbox/compose.log"
-)
-
 type Services map[string]Service
 
 type Service struct {


### PR DESCRIPTION
## Summary
This PR allows users to run process-compose for multiple devbox projects at the same time, without any collisions or undesirable behavior. This does _not_ provide any isolation between services in different projects, but it does let a user effectively manage them on a per project basis

## How it works

When starting process-compose in a devbox project, we create a UUID for the project, and then store the port + PID of the process-compose instance in a global `process-compose.json` file, with the UUID as the key. 

When making client requests to process-compose, a devbox project looks up the UUID for the project in the .devbox directory, gets the right port, and then makes the request. This ensures each project is communicating with the correct process-compose instance to start and stop services. 

Devbox also uses the same lookup to get the PID of a project's process-compose instance, so it can stop the right instance. 

## Questions: 
* Should the project UUID be permanent or set somewhere else? Is there a better way to identify a project that won't be affected by the user moving it?

## Future features: 
* Let users specify their own process-compose port in `devbox services up`
* ~Add `devbox services stop --all`, which stops all running process-compose files and resets the global config. This could help with situations where a developer accidentally leaves their projects running.~

## How was it tested?

Ran Example Tests to check backward compatibility, tested by running postgres + jekyll simultaneously, starting and stopping them
