### PR TITLE
set HOME for testscripts

### DIFF
--- a/testscripts/run/env.test.txt
+++ b/testscripts/run/env.test.txt
@@ -1,10 +1,10 @@
 # Tests related to setting the environment for devbox run.
 
 # Parent shell vars should leak into the run environment
-env HOME=/home/test
+env HOMETEST=/home/test
 env USER=test-user
 env FOO=bar
-exec devbox run echo '$HOME'
+exec devbox run echo '$HOMETEST'
 stdout '/home/test'
 exec devbox run echo '$USER'
 stdout 'test-user'

--- a/testscripts/testrunner/examplesrunner.go
+++ b/testscripts/testrunner/examplesrunner.go
@@ -77,7 +77,7 @@ func runSingleExampleTestscript(t *testing.T, examplesDir, projectDir string) {
 		t.Error(err)
 	}
 
-	params := getTestscriptParams(testscriptDir)
+	params := getTestscriptParams(t, testscriptDir)
 
 	// save a reference to the original params.Setup so that we can wrap it below
 	setup := params.Setup
@@ -86,14 +86,6 @@ func runSingleExampleTestscript(t *testing.T, examplesDir, projectDir string) {
 		if err := setup(env); err != nil {
 			return errors.WithStack(err)
 		}
-
-		// We set a HOME env-var because:
-		// 1. testscripts overrides it to /no-home, presumably to improve isolation
-		// 2. but many language tools rely on a $HOME being set, and break due to 1.
-		//    examples include ~/.dotnet folder and GOCACHE=$HOME/Library/Caches/go-build
-		// We deliberately set this for examplesrunner since we are dealing with
-		// language stacks, and not for the testrunner which has devbox unit tests.
-		env.Setenv("HOME", t.TempDir())
 
 		// copy all the files and folders of the devbox-project being tested to the workdir
 		debug.Log("copying projectDir: %s to env.WorkDir: %s\n", projectDir, env.WorkDir)

--- a/testscripts/testrunner/setupenv.go
+++ b/testscripts/testrunner/setupenv.go
@@ -4,13 +4,16 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"testing"
 
 	"github.com/rogpeppe/go-internal/testscript"
 	"go.jetpack.io/devbox/internal/xdg"
 )
 
-func setupTestEnv(env *testscript.Env) error {
+func setupTestEnv(t *testing.T, env *testscript.Env) error {
 	setupPATH(env)
+
+	setupHome(t, env)
 
 	err := setupCacheHome(env)
 	if err != nil {
@@ -19,6 +22,15 @@ func setupTestEnv(env *testscript.Env) error {
 
 	env.Setenv("DEVBOX_DEBUG", os.Getenv("DEVBOX_DEBUG"))
 	return nil
+}
+
+func setupHome(t *testing.T, env *testscript.Env) {
+
+	// We set a HOME env-var because:
+	// 1. testscripts overrides it to /no-home, presumably to improve isolation
+	// 2. but many language tools rely on a $HOME being set, and break due to 1.
+	//    examples include ~/.dotnet folder and GOCACHE=$HOME/Library/Caches/go-build
+	env.Setenv("HOME", t.TempDir())
 }
 
 func setupPATH(env *testscript.Env) {

--- a/testscripts/testrunner/testrunner.go
+++ b/testscripts/testrunner/testrunner.go
@@ -42,7 +42,7 @@ func RunTestscripts(t *testing.T, testscriptsDir string) {
 			continue
 		}
 
-		testscript.Run(t, getTestscriptParams(dir))
+		testscript.Run(t, getTestscriptParams(t, dir))
 	}
 }
 
@@ -67,12 +67,12 @@ func globDirs(pattern string) []string {
 	return directories
 }
 
-func getTestscriptParams(dir string) testscript.Params {
+func getTestscriptParams(t *testing.T, dir string) testscript.Params {
 	return testscript.Params{
 		Dir:                 dir,
 		RequireExplicitExec: true,
 		TestWork:            false, // Set to true if you're trying to debug a test.
-		Setup:               setupTestEnv,
+		Setup:               func(env *testscript.Env) error { return setupTestEnv(t, env) },
 		Cmds: map[string]func(ts *testscript.TestScript, neg bool, args []string){
 			"env.path.len":  assertPathLength,
 			"json.superset": assertJSONSuperset,


### PR DESCRIPTION
## Summary
We set `HOME` for testscripts. 

Previously, we discussed in #744 wanting to enable HOME env-var, so I do it now.
Will follow up with the other recommendation for explicitly setting up the env in testscripts.

Motivation:
In the next PR, the xdg.RuntimeDirSubpath change creates a HOME/.local/run/ directory and sets 0700 permissions.
We need `HOME` to be valid to exercise this code.

## How was it tested?

`go test -v -run TestScripts ./testscripts/...`
