### PR TITLE
[nix] Re-add profile to path

### DIFF
--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime/trace"
 
 	"github.com/pkg/errors"
@@ -18,8 +19,6 @@ import (
 // ProfilePath contains the contents of the profile generated via `nix-env --profile ProfilePath <command>`
 // or `nix profile install --profile ProfilePath <package...>`
 // Instead of using directory, prefer using the devbox.ProfileDir() function that ensures the directory exists.
-// Warning: don't use the bins in default/bin, they won't always match bins
-// produced by the flakes.nix. Use devbox.NixBins() instead.
 const ProfilePath = ".devbox/nix/profile/default"
 
 var ErrPackageNotFound = errors.New("package not found")
@@ -128,4 +127,10 @@ func ExperimentalFlags() []string {
 		"--extra-experimental-features", "ca-derivations",
 		"--option", "experimental-features", "nix-command flakes",
 	}
+}
+
+// Warning: be careful using the bins in default/bin, they won't always match bins
+// produced by the flakes.nix. Use devbox.NixBins() instead.
+func ProfileBinPath(projectDir string) string {
+	return filepath.Join(projectDir, ProfilePath, "bin")
 }


### PR DESCRIPTION
## Summary

Re-add profile to path to ensure we expose binaries exposed by `propagated-build-inputs`

Some packages like `curl` expose binaries using `propagated-build-inputs`. We need to make sure these are in path.

A better solution is to just revert to using profile to create all the wrappers. This requires some work to avoid breaking php and Haskell because they do some pre-processing in the top level flake that would not be in the files installed in the profile. 

## How was it tested?

```
devbox shell
which curl # shows system curl
devbox add curl
hash -r
which curl # shows profile curl
```
