### PR TITLE
chore: get config path from --config only

### DIFF
--- a/internal/boxcli/args.go
+++ b/internal/boxcli/args.go
@@ -7,34 +7,9 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
-	"go.jetpack.io/devbox/internal/boxcli/usererr"
 )
 
 // Functions that help parse arguments
-
-// If args empty, defaults to the current directory
-// Otherwise grabs the path from the first argument
-func configPathFromUser(args []string, flags *configFlags) (string, error) {
-	if flags.path != "" && len(args) > 0 {
-		return "", usererr.New(
-			"Cannot specify devbox.json's path via both --config and the command arguments. " +
-				"Please use --config only.",
-		)
-	}
-
-	if flags.path != "" {
-		return flags.path, nil
-	}
-
-	if len(args) > 0 {
-		return "", usererr.New(
-			"devbox <command> <path> is deprecated, use devbox <command> --config <path> instead.",
-		)
-	}
-
-	// current directory is ""
-	return "", nil
-}
 
 func pathArg(args []string) string {
 	if len(args) > 0 {

--- a/internal/boxcli/generate.go
+++ b/internal/boxcli/generate.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
 	"go.jetpack.io/devbox"
 	"go.jetpack.io/devbox/internal/cloud"
 )
@@ -43,7 +44,7 @@ func debugCmd() *cobra.Command {
 		Hidden: true,
 		Args:   cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runGenerateCmd(cmd, args, flags)
+			return runGenerateCmd(cmd, flags)
 		},
 	}
 	return command
@@ -57,7 +58,7 @@ func devcontainerCmd() *cobra.Command {
 		Long:  "Generate Dockerfile and devcontainer.json files necessary to run VSCode in remote container environments.",
 		Args:  cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runGenerateCmd(cmd, args, flags)
+			return runGenerateCmd(cmd, flags)
 		},
 	}
 	command.Flags().BoolVarP(
@@ -73,7 +74,7 @@ func dockerfileCmd() *cobra.Command {
 		Long:  "Generate a Dockerfile that replicates devbox shell. Can be used to run devbox shell environment in an OCI container.",
 		Args:  cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runGenerateCmd(cmd, args, flags)
+			return runGenerateCmd(cmd, flags)
 		},
 	}
 	command.Flags().BoolVarP(
@@ -91,7 +92,7 @@ func direnvCmd() *cobra.Command {
 			"Requires direnv to be installed.",
 		Args: cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runGenerateCmd(cmd, args, flags)
+			return runGenerateCmd(cmd, flags)
 		},
 	}
 	command.Flags().BoolVarP(
@@ -109,7 +110,7 @@ func sshConfigCmd() *cobra.Command {
 		Long:   "Check ssh config and if they don't exist, it generates the configs necessary to connect to devbox cloud VMs.",
 		Args:   cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runGenerateCmd(cmd, args, flags)
+			return runGenerateCmd(cmd, flags)
 		},
 	}
 	command.Flags().StringVarP(
@@ -119,7 +120,7 @@ func sshConfigCmd() *cobra.Command {
 	return command
 }
 
-func runGenerateCmd(cmd *cobra.Command, args []string, flags *generateCmdFlags) error {
+func runGenerateCmd(cmd *cobra.Command, flags *generateCmdFlags) error {
 	// ssh-config command is exception and it should run without a config file present
 	if cmd.Use == "ssh-config" {
 		_, err := cloud.SSHSetup(flags.githubUsername)
@@ -129,12 +130,8 @@ func runGenerateCmd(cmd *cobra.Command, args []string, flags *generateCmdFlags) 
 		return nil
 	}
 
-	path, err := configPathFromUser(args, &flags.config)
-	if err != nil {
-		return err
-	}
 	// Check the directory exists.
-	box, err := devbox.Open(path, os.Stdout)
+	box, err := devbox.Open(flags.config.path, os.Stdout)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/internal/boxcli/plan.go
+++ b/internal/boxcli/plan.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
 	"go.jetpack.io/devbox"
 )
 
@@ -24,7 +25,7 @@ func planCmd() *cobra.Command {
 		Short:  "Preview the plan used to build your environment",
 		Args:   cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPlanCmd(cmd, args, flags)
+			return runPlanCmd(cmd, flags)
 		},
 	}
 
@@ -32,14 +33,9 @@ func planCmd() *cobra.Command {
 	return command
 }
 
-func runPlanCmd(cmd *cobra.Command, args []string, flags planCmdFlags) error {
-	path, err := configPathFromUser(args, &flags.config)
-	if err != nil {
-		return err
-	}
-
+func runPlanCmd(cmd *cobra.Command, flags planCmdFlags) error {
 	// Check the directory exists.
-	box, err := devbox.Open(path, cmd.ErrOrStderr())
+	box, err := devbox.Open(flags.config.path, cmd.ErrOrStderr())
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -5,6 +5,7 @@ package boxcli
 
 import (
 	"github.com/spf13/cobra"
+
 	"go.jetpack.io/devbox"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/debug"
@@ -42,13 +43,7 @@ func runCmd() *cobra.Command {
 }
 
 func listScripts(cmd *cobra.Command, flags runCmdFlags) []string {
-	path, err := configPathFromUser([]string{}, &flags.config)
-	if err != nil {
-		debug.Log("failed to get config path from user: %v", err)
-		return nil
-	}
-
-	box, err := devbox.Open(path, cmd.ErrOrStderr())
+	box, err := devbox.Open(flags.config.path, cmd.ErrOrStderr())
 	if err != nil {
 		debug.Log("failed to open devbox: %v", err)
 		return nil
@@ -78,11 +73,6 @@ func runScriptCmd(cmd *cobra.Command, args []string, flags runCmdFlags) error {
 }
 
 func parseScriptArgs(args []string, flags runCmdFlags) (string, string, []string, error) {
-	path, err := configPathFromUser([]string{}, &flags.config)
-	if err != nil {
-		return "", "", nil, err
-	}
-
 	if len(args) == 0 {
 		// this should never happen because cobra should prevent it, but it's better to be defensive.
 		return "", "", nil, usererr.New("no command or script provided")
@@ -91,5 +81,5 @@ func parseScriptArgs(args []string, flags runCmdFlags) (string, string, []string
 	script := args[0]
 	scriptArgs := args[1:]
 
-	return path, script, scriptArgs, nil
+	return flags.config.path, script, scriptArgs, nil
 }


### PR DESCRIPTION
## Summary

Getting config path from arguments is deprecated, so I remove related code and let config path be fetched from --config flag only.

## How was it tested?
