### PR TITLE
nixstore: implement package install

### DIFF
--- a/internal/nix/nixstore/nixstore_test.go
+++ b/internal/nix/nixstore/nixstore_test.go
@@ -44,6 +44,32 @@ func TestRemote(t *testing.T) {
 	checkDependencies(t, pkg, unmarshalNixPathInfoOutput(t, pkg))
 }
 
+func TestInstall(t *testing.T) {
+	storePath := os.Getenv("DEVBOX_TEST_NIX_STORE")
+	if storePath == "" {
+		t.Skip("set DEVBOX_TEST_NIX_STORE to a local Nix store path to run this test")
+	}
+
+	storeURL := "https://cache.nixos.org"
+	remoteStore, err := Remote(storeURL)
+	if err != nil {
+		t.Fatalf("got error for remote Nix store %s: %v", storeURL, err)
+	}
+	pkg, err := remoteStore.Package("b1kk0rp0yw1742rd88ql4379c2cmcqh2-zig-0.10.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	localStore, err := Local(storePath)
+	if err != nil {
+		t.Fatalf("got error for local Nix store %s: %v", storePath, err)
+	}
+	err = localStore.Install(pkg)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func checkDependencies(t *testing.T, got *Package, nixPathInfos map[string][]string) {
 	t.Helper()
 


### PR DESCRIPTION
Depends on #892.

---

This allows a `nixstore.Root` to install packages to the store without calling Nix directly:

```go
remoteStore, _ := Remote("https://cache.nixos.org")
remotePkg, _ := remoteStore.Package("b1kk0rp0yw1742rd88ql4379c2cmcqh2-zig-0.10.1")

localStore, _ := Local("/nix/store")
localStore.Install(remotePkg)
```

```sh
$ /nix/store/b1kk0rp0yw1742rd88ql4379c2cmcqh2-zig-0.10.1/bin/zig build-exe hello.zig
$ ./hello
Hello, world!
```

This has a caveat that the installed package isn't registered with the Nix database. This will cause Nix to think the path is invalid. This can be fixed by manually registering the path:

	$ printf "/nix/store/b1kk0rp0yw1742rd88ql4379c2cmcqh2-zig-0.10.1\n\n0\n" | sudo nix-store --register-validity

This implies that Devbox would need two modes to run with/without Nix:

1. With a Nix install - Devbox puts the packages in a temp directory and then runs `nix store add-path` instead of putting the package in the store directly.
2. Without a Nix install - just assume ownership of /nix/store