### PR TITLE
[devbox] add .envrc file to repo

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,16 @@
+# Automatically sets up your devbox environment whenever you cd into this
+# directory via our direnv integration:
+
+use_devbox() {
+    watch_file devbox.json
+    if [ -f .devbox/gen/shell.nix ]; then
+        DEVBOX_SHELL_ENABLED_BACKUP=$DEVBOX_SHELL_ENABLED
+        use nix .devbox/gen/shell.nix
+        eval $(devbox shell --print-env)
+        export DEVBOX_SHELL_ENABLED=$DEVBOX_SHELL_ENABLED_BACKUP
+    fi
+}
+use devbox
+
+# check out https://www.jetpack.io/devbox/docs/ide_configuration/direnv/
+# for more details


### PR DESCRIPTION
## Summary

- enable us to use direnv in the repo


## How was it tested?

enabled direnv as per: https://direnv.net/docs/hook.html


verified via:
```
~/code/jetpack on ☁️  (us-east-2) on ☁️  savil.srivastava@jetpack.io
❯ cd devbox
direnv: loading ~/code/jetpack/devbox/.envrc
direnv: using devbox
direnv: using nix .devbox/gen/shell.nix
direnv: ([/usr/local/bin/direnv export zsh]) is taking a while to execute. Use CTRL-C to give up.
this path will be fetched (1.05 MiB download, 6.52 MiB unpacked):
  /nix/store/vsm70r60gfg7bkzcyybm932qfc3cirl9-bash-interactive-5.2-p15
copying path '/nix/store/vsm70r60gfg7bkzcyybm932qfc3cirl9-bash-interactive-5.2-p15' from 'https://cache.nixos.org'...
direnv: export +AR +AS +CC +CONFIG_SHELL +CXX +DEVBOX_OG_PATH +DEVBOX_SHELL_ENABLED +GETTEXTDATADIRS +HOST_PATH +IN_NIX_SHELL +LD +LD_DYLD_PATH +LD_LIBRARY_PATH +LIBRARY_PATH +MACOSX_DEPLOYMENT_TARGET +NIX_BINTOOLS +NIX_BINTOOLS_WRAPPER_TARGET_HOST_x86_64_apple_darwin +NIX_BUILD_CORES +NIX_BUILD_TOP +NIX_CC +NIX_CC_WRAPPER_TARGET_HOST_x86_64_apple_darwin +NIX_CFLAGS_COMPILE +NIX_COREFOUNDATION_RPATH +NIX_DONT_SET_RPATH +NIX_DONT_SET_RPATH_FOR_BUILD +NIX_ENFORCE_NO_NATIVE +NIX_HARDENING_ENABLE +NIX_IGNORE_LD_THROUGH_GCC +NIX_LDFLAGS +NIX_NO_SELF_RPATH +NIX_STORE +NM +PATH_LOCALE +RANLIB +SIZE +SOURCE_DATE_EPOCH +STRINGS +STRIP +TEMP +TEMPDIR +TMP +XDG_DATA_DIRS +__DEVBOX_SHELLENV_HASH +__ETC_PROFILE_NIX_SOURCED +__darwinAllowLocalNetworking +__impureHostDeps +__propagatedImpureHostDeps +__propagatedSandboxProfile +__sandboxProfile +__structuredAttrs +buildInputs +buildPhase +builder +cmakeFlags +configureFlags +depsBuildBuild +depsBuildBuildPropagated +depsBuildTarget +depsBuildTargetPropagated +depsHostHost +depsHostHostPropagated +depsTargetTarget +depsTargetTargetPropagated +doCheck +doInstallCheck +dontAddDisableDepTrack +mesonFlags +name +nativeBuildInputs +out +outputs +patches +phases +preferLocalBuild +propagatedBuildInputs +propagatedNativeBuildInputs +shell +shellHook +stdenv +strictDeps +system ~PATH ~TMPDIR

❯ cd ..
direnv: unloading
```
