### PR TITLE
nixstore: search packages by attribute path

### DIFF
--- a/internal/nix/nixstore/indexpkgs.nix
+++ b/internal/nix/nixstore/indexpkgs.nix
@@ -105,6 +105,14 @@ let
     */
     paths = [ ];
 
+    /* The full store path of the package.
+
+       Examples:
+         /nix/store/mzd0lvp4lqs5pkds7vihn68hspq50859-go-1.20.1
+         /nix/store/b1kk0rp0yw1742rd88ql4379c2cmcqh2-zig-0.10.1
+    */
+    out = unsafeDiscardStringContext drv.outPath;
+
     # The remaining attributes are all optional.
     ${if drv ? meta.mainProgram then "program" else null} = drv.meta.mainProgram;
     ${if drv ? meta.description then "summary" else null} = drv.meta.description;

--- a/internal/nix/nixstore/nixstore.go
+++ b/internal/nix/nixstore/nixstore.go
@@ -89,7 +89,9 @@ func (r *Root) Package(name string) (*Package, error) {
 
 func (r *Root) PackageAttrPath(attr string) (*Package, error) {
 	if pkgByAttrPath == nil {
-		buildSearchIndex()
+		if err := buildSearchIndex(); err != nil {
+			return nil, err
+		}
 	}
 	storePath := pkgByAttrPath[attr].Out
 	if storePath == "" {

--- a/internal/nix/nixstore/nixstore.go
+++ b/internal/nix/nixstore/nixstore.go
@@ -87,6 +87,21 @@ func (r *Root) Package(name string) (*Package, error) {
 	return pkg, r.resolveDeps(pkg)
 }
 
+func (r *Root) PackageAttrPath(attr string) (*Package, error) {
+	if pkgByAttrPath == nil {
+		buildSearchIndex()
+	}
+	storePath := pkgByAttrPath[attr].Out
+	if storePath == "" {
+		return nil, errors.New("package not found")
+	}
+
+	// The store path from the search index will be the absolute path
+	// with a /nix/store/ prefix. We need to get the base name for
+	// r.Package.
+	return r.Package(filepath.Base(storePath))
+}
+
 // indexPkg returns a [Package] with the given store name, adding it to the
 // index if necessary. It assumes that the name is valid and in <hash>-<name>
 // format.

--- a/internal/nix/nixstore/nixstore_test.go
+++ b/internal/nix/nixstore/nixstore_test.go
@@ -55,7 +55,11 @@ func TestInstall(t *testing.T) {
 	if err != nil {
 		t.Fatalf("got error for remote Nix store %s: %v", storeURL, err)
 	}
-	pkg, err := remoteStore.Package("b1kk0rp0yw1742rd88ql4379c2cmcqh2-zig-0.10.1")
+	zigPkg, err := remoteStore.Package("b1kk0rp0yw1742rd88ql4379c2cmcqh2-zig-0.10.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	goPkg, err := remoteStore.PackageAttrPath("go_1_19")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +68,11 @@ func TestInstall(t *testing.T) {
 	if err != nil {
 		t.Fatalf("got error for local Nix store %s: %v", storePath, err)
 	}
-	err = localStore.Install(pkg)
+	err = localStore.Install(zigPkg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = localStore.Install(goPkg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/nix/nixstore/search.go
+++ b/internal/nix/nixstore/search.go
@@ -1,0 +1,55 @@
+package nixstore
+
+import (
+	"bytes"
+	"compress/gzip"
+	_ "embed"
+	"encoding/json"
+	"io"
+	"path"
+)
+
+//go:embed packages.json.gz
+var packagesJSON []byte
+
+var pkgByAttrPath map[string]indexedPackage
+
+type indexedPackage struct {
+	Out   string
+	Paths []string
+}
+
+func buildSearchIndex() error {
+	index := struct {
+		Packages map[string]indexedPackage
+	}{}
+	r, err := gzip.NewReader(bytes.NewReader(packagesJSON))
+	if err != nil {
+		return err
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	if err := r.Close(); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, &index); err != nil {
+		return err
+	}
+
+	pkgByAttrPath = make(map[string]indexedPackage, len(index.Packages))
+	for _, info := range index.Packages {
+		for _, attrPath := range info.Paths {
+			pkgByAttrPath[attrPath] = info
+		}
+	}
+	return nil
+}
+
+func SearchExact(attrPath string) (string, error) {
+	if pkgByAttrPath == nil {
+		buildSearchIndex()
+	}
+	return path.Base(pkgByAttrPath[attrPath].Out), nil
+}

--- a/internal/nix/nixstore/search.go
+++ b/internal/nix/nixstore/search.go
@@ -6,7 +6,6 @@ import (
 	_ "embed"
 	"encoding/json"
 	"io"
-	"path"
 )
 
 //go:embed packages.json.gz
@@ -45,11 +44,4 @@ func buildSearchIndex() error {
 		}
 	}
 	return nil
-}
-
-func SearchExact(attrPath string) (string, error) {
-	if pkgByAttrPath == nil {
-		buildSearchIndex()
-	}
-	return path.Base(pkgByAttrPath[attrPath].Out), nil
 }


### PR DESCRIPTION
Depends on #896.

---

This is a hack to get a rudimentary package search (by attribute path) working natively in Devbox. For example, to install Go 1.19:

```go
remoteStore, _ := Remote("https://cache.nixos.org")
remotePkg, _ := remoteStore.PackageAttrPath("go_1_19")

localStore, _ := Local("/nix/store")
localStore.Install(remotePkg)
```

The attribute path lookup relies on embedding a gzipped JSON index of all nixpkgs at commit 3fb8eedc450. This file adds 4.7 MiB to the size of the Devbox binary. Ideally this index would be downloaded as-needed instead.