### PR TITLE
[examples tests] insert one second sleep for services to initialize

### DIFF
--- a/examples/stacks/lapp-stack/devbox.json
+++ b/examples/stacks/lapp-stack/devbox.json
@@ -18,8 +18,9 @@
                 "psql devbox_lapp < setup_postgres_db.sql"
             ],
             "run_test": [
-                "initdb",
+                "devbox run init_db",
                 "devbox services start",
+                "echo 'sleep 1 second for the postgres server to initialize.' && sleep 1",
                 "devbox run create_db",
                 "curl localhost:$HTTPD_PORT",
                 "devbox services stop"

--- a/examples/stacks/lepp-stack/devbox.json
+++ b/examples/stacks/lepp-stack/devbox.json
@@ -18,8 +18,9 @@
                 "psql devbox_lepp < setup_postgres_db.sql"
             ],
             "run_test": [
-                "initdb",
+                "devbox run init_db",
                 "devbox services start",
+                "echo 'sleep 1 second for the postgres server to initialize.' && sleep 1",
                 "devbox run create_db",
                 "curl localhost:8089",
                 "devbox services stop"


### PR DESCRIPTION
## Summary

The lepp-stack test was sporadically failing with unable to find the working postgres socket.

I think but not 100% this could be because the `devbox services start` completes but postgres
may take a short while to fully initialize before it is ready. So, here I inject
a one second sleep to hopefully let postgres be ready.


## How was it tested?

`DEVBOX_EXAMPLE_TESTS=1 DEVBOX_DEBUG=0 go test -v -count 1 -run TestExamples/stacks_l ./testscripts/...`
