### PR TITLE
[cicd] bump timeouts for cli-tests

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -92,7 +92,7 @@ jobs:
           - is-main: true
             run-example-tests: false
     runs-on: ${{ matrix.os }}
-    timeout-minutes: ${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && 30 || 15 }}
+    timeout-minutes: ${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && 35 || 20 }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -92,7 +92,7 @@ jobs:
           - is-main: true
             run-example-tests: false
     runs-on: ${{ matrix.os }}
-    timeout-minutes: ${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && 35 || 20 }}
+    timeout-minutes: ${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && 37 || 20 }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -119,7 +119,7 @@ jobs:
         env:
           DEVBOX_EXAMPLE_TESTS: ${{ matrix.run-example-tests }}
           # Used in `go test -timeout` flag. Needs a value that time.ParseDuration can parse.
-          DEVBOX_GOLANG_TEST_TIMEOUT: "${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && '30m' || '15m' }}"
+          DEVBOX_GOLANG_TEST_TIMEOUT: "${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && '35m' || '15m' }}"
         run: |
           go test -timeout $DEVBOX_GOLANG_TEST_TIMEOUT ./...
 


### PR DESCRIPTION
## Summary

The test-step `cli-test` timeout needs to be bigger than the `go test --timeout` value
since we run other steps prior to it.

Also bumped the go test timeout, just to be safe.

Obviously, this is not a long term solution. We need a way of caching the nix packages,
but in the meantime prefer to have the Github Actions be Green.

## How was it tested?

buildkite run should be green
