### PR TITLE
[CICD] stream go test output, and turn off DEVBOX_DEBUG for example tests

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -23,6 +23,9 @@ on:
         type: boolean
       run-mac-tests:
         type: boolean
+      # run the example tests with DEVBOX_DEBUG=1
+      example-debug:
+        type: boolean
 
 permissions:
   contents: read
@@ -117,11 +120,14 @@ jobs:
           nix-build-user-count: 4
       - name: Run tests
         env:
+          # For example tests, we default to non-debug mode since the debug output is less useful than for unit testscripts.
+          # But we allow overriding via inputs.example-debug
+          DEVBOX_DEBUG: ${{ (!matrix.run-example-tests || inputs.example-debug) && '1' || '0' }}
           DEVBOX_EXAMPLE_TESTS: ${{ matrix.run-example-tests }}
           # Used in `go test -timeout` flag. Needs a value that time.ParseDuration can parse.
           DEVBOX_GOLANG_TEST_TIMEOUT: "${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && '35m' || '15m' }}"
         run: |
-          go test -timeout $DEVBOX_GOLANG_TEST_TIMEOUT ./...
+          go test -v -timeout $DEVBOX_GOLANG_TEST_TIMEOUT ./...
 
   auto-nix-install: # ensure Devbox installs nix and works properly after installation.
     strategy:


### PR DESCRIPTION
## Summary

The current test output when the macos tests timeout is not helpful. We don't know
if any of the specific example tests is taking longer:
https://github.com/jetpack-io/devbox/actions/runs/4685049031/jobs/8301872973

In this PR:
1. set `go test -v`. This should stream the output as the tests run. It also has 
the benefit of printing a summary of which testscripts passed versus failed (tho 
not useful for timeouts). I use this always locally when running these example testscripts.

2. turn off DEVBOX_DEBUG for example testscripts. The devbox-internal logging is
less useful for examples testscripts, and makes it hard to follow where in the examples's `run_test` the script
is failing or getting stuck on. 

DEVBOX_DEBUG _is_ useful for other unit tests so left it on for those.

## How was it tested?

buildkite run, will inspect.
