### PR TITLE
[CICD] Don't run example tests on mac

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -94,6 +94,8 @@ jobs:
             os: "${{ inputs.run-mac-tests && 'dummy' || 'macos-latest' }}"
           - is-main: true
             run-example-tests: false
+          - run-example-tests: true
+            os: macos-latest
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && 37 || 20 }}
     steps:


### PR DESCRIPTION
## Summary

Until we figure out a caching strategy we should disable example tests on macs.

## How was it tested?

CICD
