### PR TITLE
[direnv] run init-hooks in envrc, and generate shell files prior to gen envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,7 +5,7 @@ use_devbox() {
     watch_file devbox.json
     if [ -f .devbox/gen/flake/flake.nix ]; then
         DEVBOX_SHELL_ENABLED_BACKUP=$DEVBOX_SHELL_ENABLED
-        eval $(devbox shell --print-env)
+        eval $(devbox shellenv --init-hook)
         export DEVBOX_SHELL_ENABLED=$DEVBOX_SHELL_ENABLED_BACKUP
     fi
 }

--- a/internal/boxcli/generate.go
+++ b/internal/boxcli/generate.go
@@ -90,8 +90,7 @@ func direnvCmd() *cobra.Command {
 		Short: "Generate a .envrc file that integrates direnv with this devbox project",
 		Long: "Generate a .envrc file that integrates direnv with this devbox project. " +
 			"Requires direnv to be installed.",
-		Args:    cobra.MaximumNArgs(0),
-		PreRunE: ensureNixInstalled,
+		Args: cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runGenerateCmd(cmd, flags)
 		},

--- a/internal/boxcli/generate.go
+++ b/internal/boxcli/generate.go
@@ -90,7 +90,8 @@ func direnvCmd() *cobra.Command {
 		Short: "Generate a .envrc file that integrates direnv with this devbox project",
 		Long: "Generate a .envrc file that integrates direnv with this devbox project. " +
 			"Requires direnv to be installed.",
-		Args: cobra.MaximumNArgs(0),
+		Args:    cobra.MaximumNArgs(0),
+		PreRunE: ensureNixInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runGenerateCmd(cmd, flags)
 		},

--- a/internal/boxcli/init.go
+++ b/internal/boxcli/init.go
@@ -16,8 +16,7 @@ func initCmd() *cobra.Command {
 		Long: "Initialize a directory as a devbox project. " +
 			"This will create an empty devbox.json in the current directory. " +
 			"You can then add packages using `devbox add`",
-		Args:    cobra.MaximumNArgs(1),
-		PreRunE: ensureNixInstalled,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runInitCmd(cmd, args)
 		},
@@ -37,5 +36,6 @@ func runInitCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
+
 	return errors.WithStack(box.GenerateEnvrc(false, "init"))
 }

--- a/internal/boxcli/init.go
+++ b/internal/boxcli/init.go
@@ -16,7 +16,8 @@ func initCmd() *cobra.Command {
 		Long: "Initialize a directory as a devbox project. " +
 			"This will create an empty devbox.json in the current directory. " +
 			"You can then add packages using `devbox add`",
-		Args: cobra.MaximumNArgs(1),
+		Args:    cobra.MaximumNArgs(1),
+		PreRunE: ensureNixInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runInitCmd(cmd, args)
 		},

--- a/internal/boxcli/setup.go
+++ b/internal/boxcli/setup.go
@@ -50,7 +50,7 @@ func runInstallNixCmd(cmd *cobra.Command) error {
 	return nix.Install(cmd.ErrOrStderr(), nixDaemonFlagVal(cmd))
 }
 
-func ensureNixInstalled(cmd *cobra.Command, args []string) error {
+func ensureNixInstalled(cmd *cobra.Command, _args []string) error {
 	if nix.BinaryInstalled() {
 		return nil
 	}

--- a/internal/boxcli/setup.go
+++ b/internal/boxcli/setup.go
@@ -4,14 +4,11 @@
 package boxcli
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/fatih/color"
-	"github.com/mattn/go-isatty"
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
-	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/nix"
 	"go.jetpack.io/devbox/internal/ux"
 )
@@ -51,43 +48,7 @@ func runInstallNixCmd(cmd *cobra.Command) error {
 }
 
 func ensureNixInstalled(cmd *cobra.Command, _args []string) error {
-	if nix.BinaryInstalled() {
-		return nil
-	}
-	if nix.DirExists() {
-		if err := nix.SourceNixEnv(); err != nil {
-			return err
-		} else if nix.BinaryInstalled() {
-			return nil
-		}
-
-		return usererr.New(
-			"We found a /nix directory but nix binary is not in your PATH and we " +
-				"were not able to find it in the usual locations. Your nix installation " +
-				"might be broken. If restarting your terminal or reinstalling nix " +
-				"doesn't work, please create an issue at " +
-				"https://github.com/jetpack-io/devbox/issues",
-		)
-	}
-
-	color.Yellow("\nNix is not installed. Devbox will attempt to install it.\n\n")
-
-	if isatty.IsTerminal(os.Stdout.Fd()) {
-		color.Yellow("Press enter to continue or ctrl-c to exit.\n")
-		fmt.Scanln()
-	}
-
-	if err := nix.Install(cmd.ErrOrStderr(), nixDaemonFlagVal(cmd)); err != nil {
-		return err
-	}
-
-	// Source again
-	if err := nix.SourceNixEnv(); err != nil {
-		return err
-	}
-
-	cmd.PrintErrln("Nix installed successfully. Devbox is ready to use!")
-	return nil
+	return nix.EnsureNixInstalled(cmd.ErrOrStderr(), nixDaemonFlagVal(cmd))
 }
 
 func nixDaemonFlagVal(cmd *cobra.Command) *bool {

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -371,6 +371,14 @@ func (d *Devbox) GenerateDockerfile(force bool) error {
 
 // GenerateEnvrc generates a .envrc file that makes direnv integration convenient
 func (d *Devbox) GenerateEnvrc(force bool, source string) error {
+	ctx, task := trace.NewTask(context.Background(), "devboxGenerateEnvrc")
+	defer task.End()
+
+	// generate all shell files to ensure we can refer to them in the .envrc script
+	if err := d.ensurePackagesAreInstalled(ctx, ensure); err != nil {
+		return err
+	}
+
 	envrcfilePath := filepath.Join(d.projectDir, ".envrc")
 	filesExist := fileutil.Exists(envrcfilePath)
 	if !force && filesExist {

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -374,11 +374,6 @@ func (d *Devbox) GenerateEnvrc(force bool, source string) error {
 	ctx, task := trace.NewTask(context.Background(), "devboxGenerateEnvrc")
 	defer task.End()
 
-	// generate all shell files to ensure we can refer to them in the .envrc script
-	if err := d.ensurePackagesAreInstalled(ctx, ensure); err != nil {
-		return err
-	}
-
 	envrcfilePath := filepath.Join(d.projectDir, ".envrc")
 	filesExist := fileutil.Exists(envrcfilePath)
 	if !force && filesExist {
@@ -402,20 +397,27 @@ func (d *Devbox) GenerateEnvrc(force bool, source string) error {
 			}
 		}
 
+		if strings.ToLower(result) == "y" || !isInteractiveMode || source == "generate" {
+			nixDaemon := false
+			if err := nix.EnsureNixInstalled(d.writer, &nixDaemon); err != nil {
+				return err
+			}
+
+			// generate all shell files to ensure we can refer to them in the .envrc script
+			if err := d.ensurePackagesAreInstalled(ctx, ensure); err != nil {
+				return err
+			}
+
+			// .envrc file creation
+			err := generate.CreateEnvrc(tmplFS, d.projectDir)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+		}
+
 		if strings.ToLower(result) == "y" || !isInteractiveMode {
-			// .envrc file creation
-			err := generate.CreateEnvrc(tmplFS, d.projectDir)
-			if err != nil {
-				return errors.WithStack(err)
-			}
 			cmd := exec.Command("direnv", "allow")
-			err = cmd.Run()
-			if err != nil {
-				return errors.WithStack(err)
-			}
-		} else if source == "generate" {
-			// .envrc file creation
-			err := generate.CreateEnvrc(tmplFS, d.projectDir)
+			err := cmd.Run()
 			if err != nil {
 				return errors.WithStack(err)
 			}

--- a/internal/impl/tmpl/envrc.tmpl
+++ b/internal/impl/tmpl/envrc.tmpl
@@ -5,7 +5,7 @@ use_devbox() {
     watch_file devbox.json
     if [ -f .devbox/gen/flake/flake.nix ]; then
         DEVBOX_SHELL_ENABLED_BACKUP=$DEVBOX_SHELL_ENABLED
-        eval $(devbox shell --print-env)
+        eval $(devbox shellenv --init-hook)
         export DEVBOX_SHELL_ENABLED=$DEVBOX_SHELL_ENABLED_BACKUP
     fi
 }


### PR DESCRIPTION
## Summary

Two changes:

1. Run `shellenv --init-hook` to ensure correctness. There will be a small perf hit if the init-hooks are very slow, but we are biasing towards correctness over perf.
  - To improve the perf, we can distinguish a generic init hook versus shell-specific init hook, later on.

2. Ensure packages are installed and shell files are generated. This is important because we check for existence of `.devbox/gen/flake/flake.nix` prior to running `devbox shellenv --init-hook`.
  - since this requires `nix`, we add `ensureNixInstalled` to `devbox init` and `devbox generate direnv` commands.
  - I refactored to call `ensureNixInstalled` from within `GenerateEnvrc` so that we don't block `devbox init` if envrc is not required.

## How was it tested?

```
# clear .devbox directory and nix profile contained therein
> rm -rf .devbox

# generate a new .envrc
> devbox generate direnv --force
# observe output ensuring packages are installed

# go outside the directory and check my global `go` path
> cd ..
> which go

# confirm `go` path is now from the /nix/store
> cd devbox
> which go
```
