### PR TITLE
[direnv] add quotations around devbox-shellenv-init-hook call

### DIFF
--- a/internal/impl/tmpl/envrc.tmpl
+++ b/internal/impl/tmpl/envrc.tmpl
@@ -5,7 +5,7 @@ use_devbox() {
     watch_file devbox.json
     if [ -f .devbox/gen/flake/flake.nix ]; then
         DEVBOX_SHELL_ENABLED_BACKUP=$DEVBOX_SHELL_ENABLED
-        eval $(devbox shellenv --init-hook)
+        eval "$(devbox shellenv --init-hook)"
         export DEVBOX_SHELL_ENABLED=$DEVBOX_SHELL_ENABLED_BACKUP
     fi
 }


### PR DESCRIPTION
## Summary

@lagoja is reporting an error of the form:
```
./.envrc:8: go: command not found
```

In our generated code we have `eval $(devbox shellenv --init-hook)`.

The error is occuring because bash is executing the `devbox shellenv --init-hook` prior
to doing the eval. Any `$(<bash command>)` within the output of `devbox shellenv`
will also be eagerly evaluated (via bash command substituion) prior to the
final `eval`.

With the change: we add quotations around the $(devbox shellenv --init-hook)` so
that the `eval` operation will execute the `devbox shellenv --init-hook`. And `eval`
each line in the output as it goes.

This way, a line in our init-hook like `export GOROOT="(go env GOROOT)"` will have access to the `go`
binary prior to `go env GOROOT` being executed (presumably a prior line adds the
`go` binary to `PATH`).

## How was it tested?

1. removed `go` from my zshrc `PATH`.
2. did `rm .envrc` and `direnv revoke .` to reset.
3. `devbox generate direnv` and `direnv allow .`
4. `cd ..` to exit directory and `cd devbox` to enter directory 

BEFORE: saw error above
AFTER: no error seen
