### PR TITLE
[direnv] ensure shellenv --init-hooks also runs plugin hooks

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -30,7 +30,7 @@ type Devbox interface {
 	GenerateEnvrc(force bool, source string) error
 	Info(pkg string, markdown bool) error
 	ListScripts() []string
-	PrintEnv(ctx context.Context, useCache bool) (string, error)
+	PrintEnv(ctx context.Context, useCache bool, includeHooks bool) (string, error)
 	PrintGlobalList() error
 	PullGlobal(path string) error
 	// Remove removes Nix packages from the config so that it no longer exists in

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -48,7 +48,7 @@ func runShellCmd(cmd *cobra.Command, flags shellCmdFlags) error {
 	}
 
 	if flags.PrintEnv {
-		script, err := box.PrintEnv(cmd.Context(), false /*useCachedPrintDevEnv*/)
+		script, err := box.PrintEnv(cmd.Context(), false /*useCachedPrintDevEnv*/, true /*includeHooks*/)
 		if err != nil {
 			return err
 		}

--- a/internal/boxcli/shellenv.go
+++ b/internal/boxcli/shellenv.go
@@ -54,14 +54,9 @@ func shellEnvFunc(cmd *cobra.Command, flags shellEnvCmdFlags) (string, error) {
 		return "", err
 	}
 
-	envStr, err := box.PrintEnv(cmd.Context(), flags.useCachedPrintDevEnv)
+	envStr, err := box.PrintEnv(cmd.Context(), flags.useCachedPrintDevEnv, flags.runInitHook)
 	if err != nil {
 		return "", err
-	}
-
-	if flags.runInitHook {
-		initHookStr := box.Config().Shell.InitHook.String()
-		return fmt.Sprintf("%s\n%s", envStr, initHookStr), nil
 	}
 
 	return envStr, nil

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -285,7 +285,7 @@ func (d *Devbox) PrintEnv(ctx context.Context, useCache bool, includeHooks bool)
 
 	if includeHooks {
 		hooksStr := ". " + d.scriptPath(hooksFilename)
-		envStr = fmt.Sprintf("%s\n%s", hooksStr, envStr)
+		envStr = fmt.Sprintf("%s\n%s", envStr, hooksStr)
 	}
 
 	return envStr, nil

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -259,7 +259,7 @@ func (d *Devbox) ListScripts() []string {
 	return keys
 }
 
-func (d *Devbox) PrintEnv(ctx context.Context, useCache bool) (string, error) {
+func (d *Devbox) PrintEnv(ctx context.Context, useCache bool, includeHooks bool) (string, error) {
 	ctx, task := trace.NewTask(ctx, "devboxPrintEnv")
 	defer task.End()
 
@@ -281,7 +281,14 @@ func (d *Devbox) PrintEnv(ctx context.Context, useCache bool) (string, error) {
 		return "", err
 	}
 
-	return exportify(envs), nil
+	envStr := exportify(envs)
+
+	if includeHooks {
+		hooksStr := ". " + d.scriptPath(hooksFilename)
+		envStr = fmt.Sprintf("%s\n%s", hooksStr, envStr)
+	}
+
+	return envStr, nil
 }
 
 func (d *Devbox) ShellEnvHash(ctx context.Context) (string, error) {


### PR DESCRIPTION
## Summary

We want the `--init-hooks` flag to run both shell init hooks and plugin hooks
of packages

## How was it tested?

Need to check with @lagoja for a good repro case.

Did a sanity test that the local `devbox` repo works fine.

re-generated the `examples/cloud_development/temporal` .envrc. Upon entering the directory it sourced the python virtualenv without errors.
