### PR TITLE
[cleanup] Simplify code by removing printDevEnv cache and version file

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -30,7 +30,7 @@ type Devbox interface {
 	GenerateEnvrc(force bool, source string) error
 	Info(pkg string, markdown bool) error
 	ListScripts() []string
-	PrintEnv(ctx context.Context, useCache bool, includeHooks bool) (string, error)
+	PrintEnv(ctx context.Context, includeHooks bool) (string, error)
 	PrintGlobalList() error
 	PullGlobal(path string) error
 	// Remove removes Nix packages from the config so that it no longer exists in

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -48,7 +48,7 @@ func runShellCmd(cmd *cobra.Command, flags shellCmdFlags) error {
 	}
 
 	if flags.PrintEnv {
-		script, err := box.PrintEnv(cmd.Context(), false /*useCachedPrintDevEnv*/, true /*includeHooks*/)
+		script, err := box.PrintEnv(cmd.Context(), true /*includeHooks*/)
 		if err != nil {
 			return err
 		}

--- a/internal/boxcli/shellenv.go
+++ b/internal/boxcli/shellenv.go
@@ -36,6 +36,7 @@ func shellEnvCmd() *cobra.Command {
 	command.Flags().BoolVar(
 		&flags.runInitHook, "init-hook", false, "runs init hook after exporting shell environment")
 
+	// This is no longer used. Remove after 0.4.8 is released.
 	command.Flags().BoolVar(
 		&flags.useCachedPrintDevEnv,
 		"use-cached-print-dev-env",
@@ -54,7 +55,7 @@ func shellEnvFunc(cmd *cobra.Command, flags shellEnvCmdFlags) (string, error) {
 		return "", err
 	}
 
-	envStr, err := box.PrintEnv(cmd.Context(), flags.useCachedPrintDevEnv, flags.runInitHook)
+	envStr, err := box.PrintEnv(cmd.Context(), flags.runInitHook)
 	if err != nil {
 		return "", err
 	}

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -263,6 +263,16 @@ func (d *Devbox) PrintEnv(ctx context.Context, includeHooks bool) (string, error
 	ctx, task := trace.NewTask(ctx, "devboxPrintEnv")
 	defer task.End()
 
+	if lock, err := lockfile.Local(d); err != nil {
+		return "", err
+	} else if upToDate, err := lock.IsUpToDate(); err != nil {
+		return "", err
+	} else if !upToDate {
+		if err := d.Generate(); err != nil {
+			return "", err
+		}
+	}
+
 	envs, err := d.nixEnv(ctx)
 	if err != nil {
 		return "", err

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -259,24 +259,11 @@ func (d *Devbox) ListScripts() []string {
 	return keys
 }
 
-func (d *Devbox) PrintEnv(ctx context.Context, useCache bool, includeHooks bool) (string, error) {
+func (d *Devbox) PrintEnv(ctx context.Context, includeHooks bool) (string, error) {
 	ctx, task := trace.NewTask(ctx, "devboxPrintEnv")
 	defer task.End()
 
-	// generate in case user has old .devbox dir and is missing any files.
-	if !d.isDotDevboxVersionCurrent() {
-		if err := d.Generate(); err != nil {
-			return "", err
-		}
-	}
-
-	var envs map[string]string
-	var err error
-	if useCache {
-		envs, err = d.nixEnvWithPrintDevEnvCache(ctx)
-	} else {
-		envs, err = d.nixEnv(ctx)
-	}
+	envs, err := d.nixEnv(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -817,7 +804,6 @@ func (d *Devbox) computeNixEnv(
 }
 
 var nixEnvCache map[string]string
-var nixEnvWithPrintDevEnvCache map[string]string
 
 // nixEnv is a wrapper around computeNixEnv that caches the result.
 // Note that this is in-memory cache of the final environment, and not the same
@@ -839,26 +825,6 @@ func (d *Devbox) nixEnv(ctx context.Context) (map[string]string, error) {
 		nixEnvCache, err = d.computeNixEnv(ctx, usePrintDevEnvCache)
 	}
 	return nixEnvCache, err
-}
-
-func (d *Devbox) nixEnvWithPrintDevEnvCache(
-	ctx context.Context,
-) (map[string]string, error) {
-	var err error
-
-	// minor optimization. If we've already computed the non-cache version, use
-	// that instead.
-	if nixEnvCache != nil {
-		nixEnvWithPrintDevEnvCache = nixEnvCache
-	}
-
-	if nixEnvWithPrintDevEnvCache == nil {
-		nixEnvWithPrintDevEnvCache, err = d.computeNixEnv(
-			ctx,
-			true, /*usePrintDevEnvCache*/
-		)
-	}
-	return nixEnvWithPrintDevEnvCache, err
 }
 
 // writeScriptsToFiles writes scripts defined in devbox.json into files inside .devbox/gen/scripts.

--- a/internal/impl/generate.go
+++ b/internal/impl/generate.go
@@ -15,7 +15,6 @@ import (
 	"text/template"
 
 	"github.com/pkg/errors"
-	"go.jetpack.io/devbox/internal/build"
 	"go.jetpack.io/devbox/internal/cuecfg"
 	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/planner/plansdk"
@@ -56,15 +55,7 @@ func (d *Devbox) generateShellFiles() error {
 		}
 	}
 
-	if err := d.writeScriptsToFiles(); err != nil {
-		return err
-	}
-
-	return os.WriteFile(
-		filepath.Join(d.projectDir, ".devbox/version"),
-		[]byte(build.Version),
-		0644,
-	)
+	return d.writeScriptsToFiles()
 }
 
 // Cache and buffers for generating templated files.
@@ -211,13 +202,4 @@ func isProjectInGitRepo(dir string) bool {
 	// We reached the fs-root dir, climbed the highest mountain and
 	// we still haven't found what we're looking for.
 	return false
-}
-
-func (d *Devbox) isDotDevboxVersionCurrent() bool {
-	b, err := os.ReadFile(filepath.Join(d.projectDir, ".devbox/version"))
-	if err != nil {
-		return false
-	}
-
-	return strings.TrimSpace(string(b)) == build.Version
 }

--- a/internal/lockfile/local.go
+++ b/internal/lockfile/local.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"go.jetpack.io/devbox/internal/build"
 	"go.jetpack.io/devbox/internal/cuecfg"
 	"go.jetpack.io/devbox/internal/nix"
 )
@@ -17,6 +18,7 @@ import (
 type localLockFile struct {
 	project                devboxProject
 	ConfigHash             string `json:"config_hash"`
+	DevboxVersion          string `json:"devbox_version"`
 	NixProfileManifestHash string `json:"nix_profile_manifest_hash"`
 	NixPrintDevEnvHash     string `json:"nix_print_dev_env_hash"`
 }
@@ -24,7 +26,8 @@ type localLockFile struct {
 func (l *localLockFile) equals(other *localLockFile) bool {
 	return l.ConfigHash == other.ConfigHash &&
 		l.NixProfileManifestHash == other.NixProfileManifestHash &&
-		l.NixPrintDevEnvHash == other.NixPrintDevEnvHash
+		l.NixPrintDevEnvHash == other.NixPrintDevEnvHash &&
+		l.DevboxVersion == other.DevboxVersion
 }
 
 func (l *localLockFile) IsUpToDate() (bool, error) {
@@ -81,6 +84,7 @@ func forProject(project devboxProject) (*localLockFile, error) {
 	newLock := &localLockFile{
 		project:                project,
 		ConfigHash:             configHash,
+		DevboxVersion:          build.Version,
 		NixProfileManifestHash: nixHash,
 		NixPrintDevEnvHash:     printDevEnvCacheHash,
 	}

--- a/internal/wrapnix/wrapper.sh.tmpl
+++ b/internal/wrapnix/wrapper.sh.tmpl
@@ -22,7 +22,7 @@ DO_NOT_TRACK=1 can be removed once we optimize segment to queue events.
 */ -}}
 
 if [[ "$__DEVBOX_SHELLENV_HASH" != "{{ .ShellEnvHash }}" ]]; then
-eval "$(DO_NOT_TRACK=1 devbox shellenv --use-cached-print-dev-env)"
+eval "$(DO_NOT_TRACK=1 devbox shellenv)"
 fi
 
 {{ .Command }} "$@"


### PR DESCRIPTION
## Summary

This simplifies print dev env code paths by removing the explicit cache and instead just relying on local.lock to decide if cache is OK to use. It also removes the `version` file and stores data in cache instead.

## How was it tested?

```bash
devbox shell
time go version
devbox add hello
time go version 
time go hello
```

