### PR TITLE
[add] Implemented devbox add granular package selection

### DIFF
--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -16,6 +16,7 @@ import (
 	"go.jetpack.io/devbox/internal/lockfile"
 	"go.jetpack.io/devbox/internal/nix"
 	"go.jetpack.io/devbox/internal/plugin"
+	"go.jetpack.io/devbox/internal/searcher"
 	"go.jetpack.io/devbox/internal/ux"
 	"go.jetpack.io/devbox/internal/wrapnix"
 	"golang.org/x/exp/slices"
@@ -29,6 +30,11 @@ func (d *Devbox) Add(ctx context.Context, pkgs ...string) error {
 	defer task.End()
 
 	pkgs = lo.Uniq(pkgs)
+
+	pkgs, err := searcher.GenLockedReferences(pkgs)
+	if err != nil {
+		return err
+	}
 
 	original := d.cfg.RawPackages
 	// Check packages are valid before adding.

--- a/internal/searcher/client.go
+++ b/internal/searcher/client.go
@@ -27,8 +27,12 @@ func NewClient() *client {
 	}
 }
 
-func (c *client) Search(query string) (*SearchResult, error) {
-	response, err := http.Get(c.endpoint + "?q=" + url.QueryEscape(query))
+func (c *client) Search(query, version string) (*SearchResult, error) {
+	response, err := http.Get(
+		c.endpoint +
+			"?q=" + url.QueryEscape(query) +
+			"&v=" + url.QueryEscape(version),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/searcher/client.go
+++ b/internal/searcher/client.go
@@ -27,12 +27,20 @@ func NewClient() *client {
 	}
 }
 
-func (c *client) Search(query, version string) (*SearchResult, error) {
-	response, err := http.Get(
+func (c *client) Search(query string) (*SearchResult, error) {
+	return execSearch(c.endpoint + "?q=" + url.QueryEscape(query))
+}
+
+func (c *client) SearchVersion(query, version string) (*SearchResult, error) {
+	return execSearch(
 		c.endpoint +
 			"?q=" + url.QueryEscape(query) +
 			"&v=" + url.QueryEscape(version),
 	)
+}
+
+func execSearch(url string) (*SearchResult, error) {
+	response, err := http.Get(url)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/searcher/model.go
+++ b/internal/searcher/model.go
@@ -24,6 +24,7 @@ type Metadata struct {
 }
 
 type SearchResult struct {
-	Metadata Metadata `json:"metadata"`
-	Results  []Result `json:"results"`
+	Metadata    Metadata `json:"metadata"`
+	Results     []Result `json:"results"`
+	Suggestions []Result `json:"suggestions"`
 }

--- a/internal/searcher/searcher.go
+++ b/internal/searcher/searcher.go
@@ -9,12 +9,13 @@ import (
 	"strings"
 
 	"github.com/samber/lo"
+	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/redact"
 )
 
 func SearchAndPrint(w io.Writer, query string) error {
 	c := NewClient()
-	result, err := c.Search(query)
+	result, err := c.Search(query, "" /*version*/)
 	if err != nil {
 		return redact.Errorf("error getting search results: %v", redact.Safe(err))
 	}
@@ -37,4 +38,40 @@ func SearchAndPrint(w io.Writer, query string) error {
 		fmt.Fprintf(w, "* %s (%s)\n", r.Name, strings.Join(versions, ", "))
 	}
 	return nil
+}
+
+func GenLockedReferences(pkgs []string) ([]string, error) {
+	c := NewClient()
+	references := []string{}
+	for _, pkg := range pkgs {
+		if name, version, found := strings.Cut(pkg, "@"); found {
+			result, err := c.Search(name, version)
+			if err != nil {
+				return nil, err
+			}
+			if len(result.Results) == 0 {
+				errorText := fmt.Sprintf("No results found for %q.", pkg)
+				if len(result.Suggestions) > 0 && len(result.Suggestions[0].Packages) > 0 {
+					versions := lo.Map(
+						result.Suggestions[0].Packages,
+						func(p *NixPackageInfo, _ int) string { return p.Version },
+					)
+					errorText += fmt.Sprintf(
+						" Available versions %s",
+						strings.Join(versions, ", "),
+					)
+				}
+				return nil, usererr.New(errorText + "\n")
+			}
+
+			references = append(references, fmt.Sprintf(
+				"github:NixOS/nixpkgs/%s#%s",
+				result.Results[0].Packages[0].NixpkgCommit,
+				result.Results[0].Packages[0].AttributePath,
+			))
+		} else {
+			references = append(references, pkg)
+		}
+	}
+	return references, nil
 }


### PR DESCRIPTION
## Summary

Stacked on https://github.com/jetpack-io/devbox/pull/916

This implements `devbox add pkg@version`. It stores the nix flake reference in the devbox.json but this is temporary. In a follow up we will implement a lock file that will store the reference instead.

## How was it tested?

```bash
devbox add php@8.1 # success
devbox add python39@3.9.167 
Error: No results found for "python39@3.9.167". Available versions 3.9.16, 3.9.1
devbox add python39@3.9.16 # success
devbox shell
(devbox) ➜  devbox git:(landau/version-add) ✗ python --version
Python 3.9.16
(devbox) ➜  devbox git:(landau/version-add) ✗ php --version
PHP 8.1.17 (cli) (built: Mar 22 2023 21:22:45) (NTS)
```

```bash
cat devbox.json
```

```json
{
  "packages": [
    "go_1_20",
    "golangci-lint",
    "actionlint",
    "github:NixOS/nixpkgs/242246ee1e58f54d2322227fc5eef53b4a616a31#php",
    "github:NixOS/nixpkgs/242246ee1e58f54d2322227fc5eef53b4a616a31#python39"
  ]
}
```
