### PR TITLE
[source] Fix direnv

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -284,7 +284,7 @@ func (d *Devbox) PrintEnv(ctx context.Context, useCache bool, includeHooks bool)
 	envStr := exportify(envs)
 
 	if includeHooks {
-		hooksStr := ". " + d.scriptPath(hooksFilename)
+		hooksStr := "; . " + d.scriptPath(hooksFilename)
 		envStr = fmt.Sprintf("%s\n%s", envStr, hooksStr)
 	}
 


### PR DESCRIPTION
## Summary

On older versions we are missing quotes in `.envrc`, this makes sure it is compatible.

## How was it tested?

direnv
