### PR TITLE
bring back shell.nix

### DIFF
--- a/internal/impl/generate.go
+++ b/internal/impl/generate.go
@@ -24,11 +24,22 @@ import (
 //go:embed tmpl/*
 var tmplFS embed.FS
 
+var shellFiles = []string{"shell.nix"}
+
 func (d *Devbox) generateShellFiles() error {
 
 	plan, err := d.ShellPlan()
 	if err != nil {
 		return err
+	}
+
+	outPath := filepath.Join(d.projectDir, ".devbox/gen")
+
+	for _, file := range shellFiles {
+		err := writeFromTemplate(outPath, plan, file)
+		if err != nil {
+			return errors.WithStack(err)
+		}
 	}
 
 	// Gitignore file is added to the .devbox directory
@@ -37,7 +48,6 @@ func (d *Devbox) generateShellFiles() error {
 		return errors.WithStack(err)
 	}
 
-	outPath := filepath.Join(d.projectDir, ".devbox/gen")
 	err = makeFlakeFile(outPath, plan)
 	if err != nil {
 		return errors.WithStack(err)

--- a/internal/impl/tmpl/shell.nix.tmpl
+++ b/internal/impl/tmpl/shell.nix.tmpl
@@ -1,0 +1,21 @@
+let
+  pkgs = import
+    (fetchTarball {
+      url = "{{ .NixpkgsInfo.URL }}";
+      {{- if .NixpkgsInfo.Sha256 }}
+      sha256 = "{{ .NixpkgsInfo.Sha256 }}";
+      {{- end }}
+    })
+    { };
+  {{- range .Definitions}}
+    {{.}}
+  {{ end }}
+in
+with pkgs;
+mkShell {
+  packages = [
+    {{- range .DevPackages}}
+      {{.}}
+    {{- end }}
+  ];
+}


### PR DESCRIPTION
## Summary

We can bring back the `shell.nix` file to ensure older .envrc files work.

## How was it tested?

did `devbox shell` and saw that `.devbox/gen/shell.nix` exists.
```
❯ cat .devbox/gen/shell.nix
let
  pkgs = import
    (fetchTarball {
      url = "https://github.com/nixos/nixpkgs/archive/3364b5b117f65fe1ce65a3cdd5612a078a3b31e3.tar.gz";
    })
    { };
in
with pkgs;
mkShell {
  packages = [
      go_1_20
      golangci-lint
      actionlint
  ];
}
```

