### PR TITLE
[direnv] change default hooks for shell --print-env

### DIFF
--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -48,6 +48,8 @@ func runShellCmd(cmd *cobra.Command, flags shellCmdFlags) error {
 	}
 
 	if flags.PrintEnv {
+		// false for includeHooks is because init hooks is not compatible with .envrc files generated
+		// by versions older than 0.4.6
 		script, err := box.PrintEnv(cmd.Context(), false /*useCachedPrintDevEnv*/, false /*includeHooks*/)
 		if err != nil {
 			return err

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -48,7 +48,7 @@ func runShellCmd(cmd *cobra.Command, flags shellCmdFlags) error {
 	}
 
 	if flags.PrintEnv {
-		script, err := box.PrintEnv(cmd.Context(), false /*useCachedPrintDevEnv*/, true /*includeHooks*/)
+		script, err := box.PrintEnv(cmd.Context(), false /*useCachedPrintDevEnv*/, false /*includeHooks*/)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary
title says it

## How was it tested?
- `devbox shell --print-env`
- confirm output does not contain `. /path/to/.hooks.sh`