### PR TITLE
impl: semicolon at the end of env string commands

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -285,7 +285,7 @@ func (d *Devbox) PrintEnv(ctx context.Context, useCache bool, includeHooks bool)
 
 	if includeHooks {
 		hooksStr := ". " + d.scriptPath(hooksFilename)
-		envStr = fmt.Sprintf("%s\n%s", envStr, hooksStr)
+		envStr = fmt.Sprintf("%s\n%s;\n", envStr, hooksStr)
 	}
 
 	return envStr, nil

--- a/internal/impl/envvars.go
+++ b/internal/impl/envvars.go
@@ -52,7 +52,7 @@ func exportify(vars map[string]string) string {
 			}
 			strb.WriteRune(r)
 		}
-		strb.WriteString("\"\n")
+		strb.WriteString("\";\n")
 	}
 	return strings.TrimSpace(strb.String())
 }

--- a/internal/impl/testdata/shellrc/basic/shellrc.golden
+++ b/internal/impl/testdata/shellrc/basic/shellrc.golden
@@ -2,10 +2,10 @@
 
 # Begin Devbox Post-init Hook
 
-export quote="they said, \"lasers\""
-export simple="value"
-export space="quote me"
-export special="\$\`\"\\"
+export quote="they said, \"lasers\"";
+export simple="value";
+export space="quote me";
+export special="\$\`\"\\";
 
 # Prepend to the prompt to make it clear we're in a devbox shell.
 export PS1="(devbox) $PS1"


### PR DESCRIPTION
## Summary

This hardens the `devbox shellenv --init-hook` command so that it works without quotes.

## How was it tested?

Did the following for `zsh`, `bash`, and `fish`:

- `eval "$(direnv hook ...)"`
- `cd devbox`
- edit .envrc to not quote the eval
- `cd ..; cd devbox`