### PR TITLE
[examples] drop binutils from java examples

### DIFF
--- a/examples/development/java/gradle/hello-world/devbox.json
+++ b/examples/development/java/gradle/hello-world/devbox.json
@@ -1,8 +1,7 @@
 {
     "packages": [
         "gradle",
-        "jdk",
-        "binutils"
+        "jdk"
     ],
     "shell": {
         "init_hook": null,

--- a/examples/development/java/maven/hello-world/devbox.json
+++ b/examples/development/java/maven/hello-world/devbox.json
@@ -1,8 +1,7 @@
 {
     "packages": [
         "maven",
-        "jdk",
-        "binutils"
+        "jdk"
     ],
     "shell": {
         "init_hook": null,


### PR DESCRIPTION
## Summary

I think these were added when @mohsenari was developing these examples to 
work inside a alpine Dockerfile. Usually, binutils is not needed and can be sourced
from the regular OS.

## How was it tested?
```
DEVBOX_EXAMPLE_TESTS=1 go test -v -run TestExamples/development_java  ./testscripts/...
```

