### PR TITLE
Replace current process instead of spawning a new one.

### DIFF
--- a/internal/wrapnix/wrapper.sh.tmpl
+++ b/internal/wrapnix/wrapper.sh.tmpl
@@ -25,4 +25,4 @@ if [[ "$__DEVBOX_SHELLENV_HASH" != "{{ .ShellEnvHash }}" ]]; then
 eval "$(DO_NOT_TRACK=1 devbox shellenv)"
 fi
 
-{{ .Command }} "$@"
+exec {{ .Command }} "$@"


### PR DESCRIPTION
## Summary

Without exec, the wrapper script spawns a new process and the new process might not receive a signal sent to the wrapper script's pid. With exec, the wrapper process is replaced by the new process and the pid stays the same.

Example (without exec):

1. Supervisord starts process X which has been wrapped.
2. X wrapper script's pid is 10
3. X's wrapper script starts actual X with pid 11
4. Supervisord attempts to stop X on pid 10 by sending SIGTERM
5. X's wrapper script is terminated
6. Actual X is still running because it never received the signal

## How was it tested?

By editing the files locally.