### PR TITLE
[devbox global] Added devbox global install command

### DIFF
--- a/internal/boxcli/global.go
+++ b/internal/boxcli/global.go
@@ -152,6 +152,7 @@ func installGlobalCmdFunc(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
+	fmt.Fprintln(cmd.ErrOrStderr(), "Finished installing packages.")
 	return nil
 }
 

--- a/internal/boxcli/global.go
+++ b/internal/boxcli/global.go
@@ -22,6 +22,7 @@ func globalCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(globalAddCmd())
+	cmd.AddCommand(globalInstallCmd())
 	cmd.AddCommand(globalListCmd())
 	cmd.AddCommand(globalPullCmd())
 	cmd.AddCommand(globalRemoveCmd())
@@ -114,6 +115,15 @@ func globalShellenvCmd() *cobra.Command {
 	return command
 }
 
+func globalInstallCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "install",
+		Short:   "Installs packages defined in global devbox.json",
+		PreRunE: ensureNixInstalled,
+		RunE:    installGlobalCmdFunc,
+	}
+}
+
 func addGlobalCmdFunc(cmd *cobra.Command, args []string) error {
 	path, err := ensureGlobalConfig(cmd)
 	if err != nil {
@@ -126,6 +136,23 @@ func addGlobalCmdFunc(cmd *cobra.Command, args []string) error {
 	}
 
 	return box.AddGlobal(args...)
+}
+
+func installGlobalCmdFunc(cmd *cobra.Command, args []string) error {
+	path, err := ensureGlobalConfig(cmd)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	box, err := devbox.Open(path, cmd.ErrOrStderr())
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	_, err = box.PrintEnv(cmd.Context(), false /* run init hooks */)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
 }
 
 func removeGlobalCmdFunc(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary
Pretty much title says it.

This is using the same concept as `devbox global shellenv` except it doesn't output the computed environment.
Since we check and install packages in shellenv, we can reuse the same logic for devbox install.

- Also updated `devbox install` implementation to be the same as `devbox global install`

## How was it tested?
- compile
- edit the global devbox.json (`~/.local/share/devbox/global/default/devbox.json`) and add packages to it
- ./devbox global install