### PR TITLE
chore: correct package comment and tweak OSExpandEnvMap

### DIFF
--- a/internal/conf/doc.go
+++ b/internal/conf/doc.go
@@ -1,3 +1,3 @@
-// package conf is future home of the config (devbox.json) management code.
+// Package conf is future home of the config (devbox.json) management code.
 // it will merge exiting plugin and impl/config.go code.
 package conf

--- a/internal/conf/env.go
+++ b/internal/conf/env.go
@@ -4,22 +4,19 @@ import (
 	"os"
 )
 
-func OSExpandEnvMap(
-	env map[string]string,
-	projectDir string,
-	existingEnv map[string]string,
-) map[string]string {
+func OSExpandEnvMap(env, existingEnv map[string]string, projectDir string) map[string]string {
 	mapperfunc := func(value string) string {
 		// Special variables that should return correct value
 		switch value {
 		case "PWD":
 			return projectDir
 		}
-		// check if referenced variables exists in computed environment
-		if v, ok := existingEnv[value]; ok {
-			return v
+
+		// in case existingEnv is nil
+		if existingEnv == nil {
+			return ""
 		}
-		return ""
+		return existingEnv[value]
 	}
 
 	res := map[string]string{}

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -978,7 +978,7 @@ func (d *Devbox) globalCommitHash() string {
 // allow env variables from outside the shell to be referenced so
 // no leaked variables are caused by this function.
 func (d *Devbox) configEnvs(computedEnv map[string]string) map[string]string {
-	return conf.OSExpandEnvMap(d.cfg.Env, d.ProjectDir(), computedEnv)
+	return conf.OSExpandEnvMap(d.cfg.Env, computedEnv, d.ProjectDir())
 }
 
 // Move to a utility package?

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -11,6 +11,7 @@ import (
 	"text/template"
 
 	"github.com/pkg/errors"
+
 	"go.jetpack.io/devbox/internal/conf"
 	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/impl/shellcmd"
@@ -145,7 +146,7 @@ func Env(
 			env[k] = v
 		}
 	}
-	return conf.OSExpandEnvMap(env, projectDir, computedEnv), nil
+	return conf.OSExpandEnvMap(env, computedEnv, projectDir), nil
 }
 
 func buildConfig(pkg, projectDir, content string) (*config, error) {


### PR DESCRIPTION
## Summary

1. correct package comment
2. adjust `OSExpandEnvMap`'s parameters order
3. use `nil` check for `existingEnv` to replace `if v, ok := existingEnv[value]; ok { ... }` because non-existing key's value are `""`

## How was it tested?
