### PR TITLE
[cleanup] update checks for exist errors and not exist errors

### DIFF
--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,6 +18,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
+
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/cloud/fly"
 	"go.jetpack.io/devbox/internal/cloud/mutagen"
@@ -526,7 +528,7 @@ func gitIgnorePaths(projectDir string) ([]string, error) {
 
 	fpath := filepath.Join(projectDir, ".gitignore")
 	if _, err := os.Stat(fpath); err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return result, nil
 		}
 		return nil, errors.WithStack(err)
@@ -581,7 +583,7 @@ func ensureProjectDirIsNotSensitive(dir string) error {
 		// (and potentially syncing all the code to devbox-cloud)
 		_, err := os.Stat(filepath.Join(dir, ".git"))
 		if err != nil {
-			if os.IsNotExist(err) {
+			if errors.Is(err, fs.ErrNotExist) {
 				return usererr.New(
 					"Found a config (devbox.json) file at %s, "+
 						"but since it is a sensitive directory we require it to be part of a git repository "+

--- a/internal/cloud/openssh/config.go
+++ b/internal/cloud/openssh/config.go
@@ -213,7 +213,7 @@ func containsDevboxInclude(r io.Reader) bool {
 
 // move to a file utility
 func EnsureDirExists(path string, perm fs.FileMode, chmod bool) error {
-	if err := os.Mkdir(path, perm); err != nil && !errors.Is(err, os.ErrExist) {
+	if err := os.Mkdir(path, perm); err != nil && !errors.Is(err, fs.ErrExist) {
 		return errors.WithStack(err)
 	}
 	if chmod {
@@ -301,7 +301,7 @@ type atomicEdit struct {
 func editFile(path string, perm os.FileMode) (*atomicEdit, error) {
 	// editFile will be nil when creating a new file.
 	editFile, err := os.Open(path)
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, errors.WithStack(err)
 	}
 

--- a/internal/cloud/openssh/sshshim/generate.go
+++ b/internal/cloud/openssh/sshshim/generate.go
@@ -1,10 +1,12 @@
 package sshshim
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
+
 	"go.jetpack.io/devbox/internal/cloud/mutagenbox"
 	"go.jetpack.io/devbox/internal/cloud/openssh"
 )
@@ -37,12 +39,13 @@ func Setup() error {
 }
 
 func makeSymlink(from string, target string) error {
-	if err := os.Remove(from); err != nil && !os.IsNotExist(err) {
+	err := os.Remove(from)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return errors.WithStack(err)
 	}
 
-	err := os.Symlink(target, from)
-	if os.IsExist(err) {
+	err = os.Symlink(target, from)
+	if errors.Is(err, fs.ErrExist) {
 		err = nil
 	}
 	return errors.WithStack(err)

--- a/internal/cuecfg/cuecfg.go
+++ b/internal/cuecfg/cuecfg.go
@@ -4,6 +4,7 @@
 package cuecfg
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -53,7 +54,7 @@ func InitFile(path string, valuePtr any) (bool, error) {
 		// TODO: should we read and write again, in case the schema needs updating?
 		return false, nil
 	}
-	if errors.Is(err, os.ErrNotExist) {
+	if errors.Is(err, fs.ErrNotExist) {
 		// File does not exist, create a new one:
 		return true, WriteFile(path, valuePtr)
 	}

--- a/internal/cuecfg/hash.go
+++ b/internal/cuecfg/hash.go
@@ -3,12 +3,14 @@ package cuecfg
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
+	"io/fs"
 	"os"
 )
 
 func FileHash(path string) (string, error) {
 	data, err := os.ReadFile(path)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return "", err
 	}
 	hash := sha256.Sum256(data)

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -39,11 +39,6 @@ func IsFile(path string) bool {
 }
 
 func Exists(path string) bool {
-	err := TryExists(path)
-	return err == nil
-}
-
-func TryExists(path string) error {
 	_, err := os.Stat(path)
-	return err
+	return err == nil
 }

--- a/internal/fileutil/untar.go
+++ b/internal/fileutil/untar.go
@@ -14,7 +14,7 @@ import (
 )
 
 func Untar(archive io.Reader, destPath string) error {
-	err := TryExists(destPath)
+	_, err := os.Stat(destPath)
 	if err != nil {
 		return err
 	}

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1043,7 +1044,7 @@ func (d *Devbox) setCommonHelperEnvVars(env map[string]string) {
 	env["LIBRARY_PATH"] = filepath.Join(d.projectDir, nix.ProfilePath, "lib") + ":" + env["LIBRARY_PATH"]
 }
 
-// nix bins returns the paths to all the nix binaries that are installed by
+// NixBins returns the paths to all the nix binaries that are installed by
 // the flake. If there are conflicts, it returns the first one it finds of a
 // give name. This matches how nix flakes behaves if there are conflicts in
 // buildInputs
@@ -1057,7 +1058,7 @@ func (d *Devbox) NixBins(ctx context.Context) ([]string, error) {
 	bins := map[string]string{}
 	for _, dir := range dirs {
 		binPath := filepath.Join(dir, "bin")
-		if _, err = os.Stat(binPath); os.IsNotExist(err) {
+		if _, err = os.Stat(binPath); errors.Is(err, fs.ErrNotExist) {
 			continue
 		}
 		files, err := os.ReadDir(binPath)

--- a/internal/impl/generate.go
+++ b/internal/impl/generate.go
@@ -15,6 +15,7 @@ import (
 	"text/template"
 
 	"github.com/pkg/errors"
+
 	"go.jetpack.io/devbox/internal/cuecfg"
 	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/planner/plansdk"
@@ -106,7 +107,7 @@ func writeFromTemplate(path string, plan any, tmplName string) error {
 		perm    = fs.FileMode(0644)
 	)
 	outFile, err := os.OpenFile(outPath, flag, perm)
-	if errors.Is(err, os.ErrNotExist) {
+	if errors.Is(err, fs.ErrNotExist) {
 		if err := os.MkdirAll(path, 0755); err != nil {
 			return errors.WithStack(err)
 		}
@@ -202,7 +203,7 @@ func isProjectInGitRepo(dir string) bool {
 			// Found a .git
 			return true
 		}
-		if !os.IsNotExist(err) {
+		if !errors.Is(err, fs.ErrNotExist) {
 			// An error means we will not find a git repo so return false
 			return false
 		}

--- a/internal/impl/global.go
+++ b/internal/impl/global.go
@@ -5,6 +5,7 @@ package impl
 
 import (
 	"fmt"
+	"io/fs"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -185,7 +186,8 @@ func globalBinPath() (string, error) {
 	currentPath := xdg.DataSubpath("devbox/global/current")
 	// For now default is always current. In the future we will support multiple
 	// and allow user to switch.
-	if err := os.Symlink(nixProfilePath, currentPath); err != nil && !os.IsExist(err) {
+	err = os.Symlink(nixProfilePath, currentPath)
+	if err != nil && !errors.Is(err, fs.ErrExist) {
 		return "", errors.WithStack(err)
 	}
 	return filepath.Join(currentPath, "bin"), nil

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -3,6 +3,7 @@ package impl
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -325,7 +326,7 @@ func resetProfileDirForFlakes(profileDir string) (err error) {
 	}()
 
 	dir, err := filepath.EvalSymlinks(profileDir)
-	if errors.Is(err, os.ErrNotExist) {
+	if errors.Is(err, fs.ErrNotExist) {
 		return nil
 	}
 	if err != nil {
@@ -334,7 +335,7 @@ func resetProfileDirForFlakes(profileDir string) (err error) {
 
 	// older nix profiles have a manifest.nix file present
 	_, err = os.Stat(filepath.Join(dir, "manifest.nix"))
-	if errors.Is(err, os.ErrNotExist) {
+	if errors.Is(err, fs.ErrNotExist) {
 		return nil
 	}
 	if err != nil {

--- a/internal/impl/shell.go
+++ b/internal/impl/shell.go
@@ -347,10 +347,12 @@ func (s *DevboxShell) linkShellStartupFiles(shellSettingsDir string) {
 		filenames := []string{".zshenv", ".zprofile", ".zlogin"}
 		for _, filename := range filenames {
 			fileOld := filepath.Join(filepath.Dir(s.userShellrcPath), filename)
-			if _, err := os.Stat(fileOld); errors.Is(err, fs.ErrNotExist) {
+			_, err := os.Stat(fileOld)
+			if errors.Is(err, fs.ErrNotExist) {
 				// this file may not be relevant for the user's setup.
 				continue
-			} else if err != nil {
+			}
+			if err != nil {
 				debug.Log("os.Stat error for %s is %v", fileOld, err)
 			}
 

--- a/internal/impl/shell_test.go
+++ b/internal/impl/shell_test.go
@@ -3,6 +3,7 @@ package impl
 import (
 	"errors"
 	"flag"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,7 +47,7 @@ func testWriteDevboxShellrc(t *testing.T, testdirs []string) {
 		test.hooksFilePath = scriptPath(projectDir, hooksFilename)
 
 		test.shellrcPath = filepath.Join(path, "shellrc")
-		if _, err := os.Stat(test.shellrcPath); errors.Is(err, os.ErrNotExist) {
+		if _, err := os.Stat(test.shellrcPath); errors.Is(err, fs.ErrNotExist) {
 			test.shellrcPath = ""
 		}
 		test.goldShellrcPath = filepath.Join(path, "shellrc.golden")

--- a/internal/impl/util.go
+++ b/internal/impl/util.go
@@ -1,10 +1,12 @@
 package impl
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
+
 	"go.jetpack.io/devbox/internal/nix"
 	"go.jetpack.io/devbox/internal/xdg"
 )
@@ -43,7 +45,8 @@ func utilityLookPath(binName string) (string, error) {
 		return "", err
 	}
 	absPath := filepath.Join(binPath, binName)
-	if _, err := os.Stat(absPath); os.IsNotExist(err) {
+	_, err = os.Stat(absPath)
+	if errors.Is(err, fs.ErrNotExist) {
 		return "", err
 	}
 	return absPath, nil

--- a/internal/lockfile/local.go
+++ b/internal/lockfile/local.go
@@ -2,7 +2,7 @@ package lockfile
 
 import (
 	"errors"
-	"os"
+	"io/fs"
 	"path/filepath"
 
 	"go.jetpack.io/devbox/internal/build"
@@ -57,7 +57,7 @@ type devboxProject interface {
 func Local(project devboxProject) (*localLockFile, error) {
 	lockFile := &localLockFile{project: project}
 	err := cuecfg.ParseFile(localLockFilePath(project), lockFile)
-	if errors.Is(err, os.ErrNotExist) {
+	if errors.Is(err, fs.ErrNotExist) {
 		return lockFile, nil
 	}
 	if err != nil {

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -122,7 +123,7 @@ func PrintDevEnv(ctx context.Context, args *PrintDevEnvArgs) (*printDevEnvOut, e
 			if err := json.Unmarshal(data, &out); err != nil {
 				return nil, errors.WithStack(err)
 			}
-		} else if !errors.Is(err, os.ErrNotExist) {
+		} else if !errors.Is(err, fs.ErrNotExist) {
 			return nil, errors.WithStack(err)
 		}
 	}

--- a/internal/nix/nixpkgs.go
+++ b/internal/nix/nixpkgs.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
+
 	"go.jetpack.io/devbox/internal/fileutil"
 	"go.jetpack.io/devbox/internal/xdg"
 )
@@ -87,7 +88,8 @@ func saveToNixpkgsCommitFile(commit string, commitToLocation map[string]string) 
 
 	// Ensure the nixpkgs commit file path exists so we can write an update to it
 	path := nixpkgsCommitFilePath()
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil && !errors.Is(err, fs.ErrExist) {
+	err = os.MkdirAll(filepath.Dir(path), 0755)
+	if err != nil && !errors.Is(err, fs.ErrExist) {
 		return errors.WithStack(err)
 	}
 

--- a/internal/nix/profile.go
+++ b/internal/nix/profile.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,6 +14,8 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/pkg/errors"
+
 	"go.jetpack.io/devbox/internal/cuecfg"
 	"go.jetpack.io/devbox/internal/redact"
 )
@@ -322,9 +325,10 @@ type manifest struct {
 
 func readManifest(profilePath string) (manifest, error) {
 	data, err := os.ReadFile(filepath.Join(profilePath, "manifest.json"))
-	if os.IsNotExist(err) {
+	if errors.Is(err, fs.ErrNotExist) {
 		return manifest{}, nil
-	} else if err != nil {
+	}
+	if err != nil {
 		return manifest{}, err
 	}
 

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -216,5 +216,5 @@ func (m *Manager) shouldCreateFile(filePath string) bool {
 	}
 	_, err := os.Stat(filePath)
 	// File doesn't exist, so we should create it.
-	return os.IsNotExist(err)
+	return errors.Is(err, fs.ErrNotExist)
 }

--- a/internal/plugin/rm.go
+++ b/internal/plugin/rm.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -18,7 +19,7 @@ func Remove(projectDir string, pkgs []string) error {
 
 func RemoveInvalidSymlinks(projectDir string) error {
 	binPath := filepath.Join(projectDir, VirtenvBinPath)
-	if _, err := os.Stat(binPath); errors.Is(err, os.ErrNotExist) {
+	if _, err := os.Stat(binPath); errors.Is(err, fs.ErrNotExist) {
 		return nil
 	}
 	dirEntry, err := os.ReadDir(binPath)
@@ -27,7 +28,7 @@ func RemoveInvalidSymlinks(projectDir string) error {
 	}
 	for _, entry := range dirEntry {
 		_, err := os.Stat(filepath.Join(projectDir, VirtenvBinPath, entry.Name()))
-		if errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, fs.ErrNotExist) {
 			os.Remove(filepath.Join(projectDir, VirtenvBinPath, entry.Name()))
 		}
 	}

--- a/internal/plugin/symlink.go
+++ b/internal/plugin/symlink.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -49,7 +50,7 @@ func createVirtenvSymlink(w io.Writer, projectDir string) (string, error) {
 
 	// Create the symlink
 	virtenvPath := filepath.Join(projectDir, VirtenvPath)
-	if err := os.Symlink(virtenvPath, symlinkPath); err != nil && !errors.Is(err, os.ErrExist) {
+	if err := os.Symlink(virtenvPath, symlinkPath); err != nil && !errors.Is(err, fs.ErrExist) {
 		return "", errors.WithStack(err)
 	}
 	return symlinkPath, nil

--- a/internal/services/status.go
+++ b/internal/services/status.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -93,7 +94,7 @@ func initCloudDir(projectDir, hostID string) error {
 	_ = os.MkdirAll(filepath.Join(cloudDirPath, hostID), 0755)
 	gitignorePath := filepath.Join(cloudDirPath, ".gitignore")
 	_, err := os.Stat(gitignorePath)
-	if !os.IsNotExist(err) {
+	if !errors.Is(err, fs.ErrNotExist) {
 		return nil
 	}
 	return errors.WithStack(os.WriteFile(gitignorePath, []byte("*"), 0644))
@@ -130,7 +131,8 @@ func updateServiceStatusOnRemote(projectDir string, s *ServiceStatus) error {
 }
 
 func readServiceStatus(path string) (*ServiceStatus, error) {
-	if _, err := os.Stat(path); os.IsNotExist(err) {
+	_, err := os.Stat(path)
+	if errors.Is(err, fs.ErrNotExist) {
 		return nil, nil
 	}
 

--- a/internal/telemetry/sentry.go
+++ b/internal/telemetry/sentry.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path"
@@ -252,7 +253,7 @@ func bufferEvent(event *sentry.Event) {
 
 	file := filepath.Join(errorBufferDir, string(event.EventID)+".json")
 	err = os.WriteFile(file, data, 0600)
-	if errors.Is(err, os.ErrNotExist) {
+	if errors.Is(err, fs.ErrNotExist) {
 		// XDG specifies perms 0700.
 		if err := os.MkdirAll(errorBufferDir, 0700); err != nil {
 			return

--- a/internal/wrapnix/wrapper.go
+++ b/internal/wrapnix/wrapper.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -110,7 +111,7 @@ func createWrapper(args *createWrapperArgs) error {
 // will contain the union of both. We need to do the same.
 func createSymlinksForSupportDirs(projectDir string) error {
 	profilePath := filepath.Join(projectDir, nix.ProfilePath)
-	if _, err := os.Stat(profilePath); errors.Is(err, os.ErrNotExist) {
+	if _, err := os.Stat(profilePath); errors.Is(err, fs.ErrNotExist) {
 		return nil
 	}
 

--- a/testscripts/testrunner/examplesrunner.go
+++ b/testscripts/testrunner/examplesrunner.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rogpeppe/go-internal/testscript"
+
 	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/impl"
 )
@@ -25,13 +26,13 @@ const xdgStateHomeDir = "/tmp/devbox-example-testscripts"
 
 // RunExamplesTestscripts generates testscripts for each example devbox-project.
 func RunExamplesTestscripts(t *testing.T, examplesDir string) {
-
 	// ensure the state home dir for devbox exists
-	if err := os.MkdirAll(xdgStateHomeDir, 0700); err != nil && !errors.Is(err, fs.ErrNotExist) {
+	err := os.MkdirAll(xdgStateHomeDir, 0700)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		t.Error(err)
 	}
 
-	err := filepath.WalkDir(examplesDir, func(path string, entry os.DirEntry, err error) error {
+	err = filepath.WalkDir(examplesDir, func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

`os.Isxxx` predates errors.Is. It only supports errors returned by the os package. New code should use `errors.Is`.

1. replace `os.IsNotExist(err)` with `errors.Is(err, fs.ErrNotExist)`
2. replace `os.IsExist(err)` with `errors.Is(err, fs.ErrExist)`


## How was it tested?
