### PR TITLE
[vscode extension] ensure directory exists for ssh keys

### DIFF
--- a/vscode-extension/src/openinvscode.ts
+++ b/vscode-extension/src/openinvscode.ts
@@ -106,7 +106,7 @@ async function setupSSHConfig(vmId: string, prKey: string) {
     });
 
     // save private key to file
-    const prkeyDir = `${process.env['HOME']}/.config/devbox/ssh/keys/`;
+    const prkeyDir = `${process.env['HOME']}/.config/devbox/ssh/keys`;
     await ensureDir(prkeyDir);
     const prkeyPath = `${prkeyDir}/${vmId}.vm.devbox-vms.internal`;
     try {

--- a/vscode-extension/src/openinvscode.ts
+++ b/vscode-extension/src/openinvscode.ts
@@ -4,7 +4,7 @@ import fetch from 'node-fetch';
 import { exec } from 'child_process';
 import * as FormData from 'form-data';
 import { Uri, commands, window } from 'vscode';
-import { chmod, open, writeFile } from 'fs/promises';
+import { chmod, mkdir, open, writeFile } from 'fs/promises';
 
 type VmInfo = {
     /* eslint-disable @typescript-eslint/naming-convention */
@@ -104,8 +104,11 @@ async function setupSSHConfig(vmId: string, prKey: string) {
         console.debug(`stdout: ${stdout}`);
         console.debug(`stderr: ${stderr}`);
     });
+
     // save private key to file
-    const prkeyPath = `${process.env['HOME']}/.config/devbox/ssh/keys/${vmId}.vm.devbox-vms.internal`;
+    const prkeyDir = `${process.env['HOME']}/.config/devbox/ssh/keys/`;
+    await ensureDir(prkeyDir);
+    const prkeyPath = `${prkeyDir}/${vmId}.vm.devbox-vms.internal`;
     try {
         const prKeydata = new Uint8Array(Buffer.from(prKey));
         const fileHandler = await open(prkeyPath, 'w');
@@ -128,5 +131,16 @@ function connectToRemote(username: string, vmId: string, workDir: string) {
         commands.executeCommand("vscode.openFolder", uriToOpen, false);
     } catch (err: any) {
         console.error('failed to connect to remote: ' + err);
+    }
+}
+
+async function ensureDir(dir: string) {
+    try {
+        await mkdir(dir, {recursive: true, mode: 0o700});
+    } catch (err: any) {
+        if (err.code !== 'EEXIST') {
+            console.error('Failed to setup ssh keys directory: ' + err);
+            throw (err);
+        }
     }
 }


### PR DESCRIPTION
## Summary

This fix ensures the ssh keys directory exists. Previously, the call to
`const fileHandler = await open(prkeyPath, 'w');`
would fail if the prKeyPath's directory did not exist.

## How was it tested?

Followed the Test Plan from https://github.com/jetpack-io/devbox/pull/804.

First: `rm -rf ~/.devbox/config/ssh/keys` to remove the "keys" folder.

- Open `vscode-extension` folder via `code vscode-extension`. 
- In vscode terminal: `yarn run pretest` to compile and lint the extension.
- For the debugger, we need a file to be open. I suggest `openinvscode.ts`. 
- Then click the icon on the left bar for "Run and Debug" and press the "Run and Debug" button in the left pane that opens. A new vscode window pops up. Ensure you have focus on it as "the last vscode window".
- Go to `devbox.sh` and open some repo in it. Click on "Open in Desktop" button
- This should open the repo in a new vscode window running the custom vscode-extension code.

Then check:
`ls -al ~/.devbox/config/ssh/keys` to see the key was saved 