### PR TITLE
[vscode extension] bump version and add to CHANGELOG

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "devbox" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.0.7]
+
+- Fixed a bug for `Open in VSCode` that ensures the directory in which
+  we save the VM's ssh key does exist.
+
 ## [0.0.6]
 
 - Fixed a small bug connecting to a remote environment.

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "devbox",
   "displayName": "devbox by jetpack.io",
   "description": "devbox integration for VSCode",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "icon": "assets/icon.png",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Inspired by #903

## How was it tested?

Not tested.

Will release via manually running https://github.com/jetpack-io/devbox/actions/workflows/vscode-ext-release.yaml
