### PR TITLE
[perf] move ensureNixpkgsPrefetched outside nix.ProfileInstall for-loops

### DIFF
--- a/internal/impl/global.go
+++ b/internal/impl/global.go
@@ -55,6 +55,10 @@ func (d *Devbox) AddGlobal(pkgs ...string) error {
 		return err
 	}
 
+	if err := nix.EnsureNixpkgsPrefetched(d.writer, d.cfg.Nixpkgs.Commit); err != nil {
+		return err
+	}
+
 	total := len(pkgs)
 	for idx, pkg := range pkgs {
 		stepNum := idx + 1

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -222,6 +222,10 @@ func (d *Devbox) addPackagesToProfile(ctx context.Context, mode installMode) err
 		return err
 	}
 
+	if err := nix.EnsureNixpkgsPrefetched(d.writer, d.cfg.Nixpkgs.Commit); err != nil {
+		return err
+	}
+
 	total := len(pkgs)
 	for idx, pkg := range pkgs {
 		stepNum := idx + 1

--- a/internal/impl/util.go
+++ b/internal/impl/util.go
@@ -30,6 +30,10 @@ func (d *Devbox) addDevboxUtilityPackage(pkg string) error {
 		return err
 	}
 
+	if err := nix.EnsureNixpkgsPrefetched(d.writer, d.cfg.Nixpkgs.Commit); err != nil {
+		return err
+	}
+
 	return nix.ProfileInstall(&nix.ProfileInstallArgs{
 		NixpkgsCommit: nixpkgsUtilityCommit,
 		Package:       pkg,

--- a/internal/nix/nixpkgs.go
+++ b/internal/nix/nixpkgs.go
@@ -16,6 +16,12 @@ import (
 	"go.jetpack.io/devbox/internal/xdg"
 )
 
+// EnsureNixpkgsPrefetched ensures that the nixpkgs registry is downloaded
+// Having this public is a temporary hack for a perf win, until we refactor NixProfileInstall.
+func EnsureNixpkgsPrefetched(w io.Writer, commit string) error {
+	return ensureNixpkgsPrefetched(w, commit)
+}
+
 // ensureNixpkgsPrefetched runs the prefetch step to download the flake of the registry
 func ensureNixpkgsPrefetched(w io.Writer, commit string) error {
 	// Look up the cached map of commitHash:nixStoreLocation

--- a/internal/nix/profile.go
+++ b/internal/nix/profile.go
@@ -242,10 +242,9 @@ type ProfileInstallArgs struct {
 }
 
 // ProfileInstall calls nix profile install with default profile
+// Note: for better UX callers should invoke nix.EnsureNixpkgsPrefetched
+// before calling this function. We'll refactor this API soon.
 func ProfileInstall(args *ProfileInstallArgs) error {
-	if err := ensureNixpkgsPrefetched(args.Writer, args.NixpkgsCommit); err != nil {
-		return err
-	}
 	stepMsg := args.Package
 	if args.CustomStepMessage != "" {
 		stepMsg = args.CustomStepMessage


### PR DESCRIPTION
## Summary

I tried refactoring the nix.ProfileInstall callers to make it work for multiple
packages, but it is a bit challenging because:
1. local installs via `devbox add`: these need to fail-fast as soon as the first package fails
2. global installs: these need to continue trying to install for all

I'll send a PR that does that but sending this first.

## How was it tested?
