### PR TITLE
[tests] global-add should not fail if global-bins-not-in-path and add testscript unit tests for add and global-add

### DIFF
--- a/internal/boxcli/global.go
+++ b/internal/boxcli/global.go
@@ -103,8 +103,9 @@ func globalPullCmd() *cobra.Command {
 func globalShellenvCmd() *cobra.Command {
 	flags := shellEnvCmdFlags{}
 	command := &cobra.Command{
-		Use:   "shellenv",
-		Short: "Print shell commands that add global Devbox packages to your PATH",
+		Use:     "shellenv",
+		Short:   "Print shell commands that add global Devbox packages to your PATH",
+		PreRunE: ensureNixInstalled,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return shellenvGlobalCmdFunc(cmd, flags.runInitHook)
 		},

--- a/internal/impl/global.go
+++ b/internal/impl/global.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
 
-	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/env"
 	"go.jetpack.io/devbox/internal/nix"
 	"go.jetpack.io/devbox/internal/planner/plansdk"
@@ -22,13 +21,13 @@ import (
 	"go.jetpack.io/devbox/internal/xdg"
 )
 
-var warningNotInPath = usererr.NewWarning(`the devbox global profile is not in your $PATH.
+var warningNotInPath = `the devbox global profile is not in your $PATH.
 
 Add the following line to your shell's rcfile (e.g., ~/.bashrc or ~/.zshrc)
 and restart your shell to fix this:
 
 	eval "$(devbox global shellenv)"
-`)
+`
 
 // In the future we will support multiple global profiles
 const currentGlobalProfile = "default"
@@ -80,7 +79,7 @@ func (d *Devbox) AddGlobal(pkgs ...string) error {
 	if err := d.saveCfg(); err != nil {
 		return err
 	}
-	return ensureGlobalProfileInPath()
+	return d.ensureGlobalProfileInPath()
 }
 
 func (d *Devbox) RemoveGlobal(pkgs ...string) error {
@@ -195,13 +194,13 @@ func globalBinPath() (string, error) {
 }
 
 // Checks if the global profile is in the path
-func ensureGlobalProfileInPath() error {
+func (d *Devbox) ensureGlobalProfileInPath() error {
 	binPath, err := globalBinPath()
 	if err != nil {
 		return err
 	}
 	if !strings.Contains(os.Getenv(env.Path), binPath) {
-		return warningNotInPath
+		ux.Fwarning(d.writer, warningNotInPath)
 	}
 	return nil
 }

--- a/testscripts/add/add.test.txt
+++ b/testscripts/add/add.test.txt
@@ -1,0 +1,18 @@
+# Testscript for exercising adding packages
+
+exec devbox init
+
+! exec rg --version
+! exec vim --version
+exec devbox add ripgrep vim
+
+exec devbox shellenv
+source.path
+exec rg --version
+exec vim --version
+
+-- devbox.json --
+{
+  "packages": [
+  ]
+}

--- a/testscripts/add/global_add.test.txt
+++ b/testscripts/add/global_add.test.txt
@@ -1,0 +1,16 @@
+# Testscript for exercising adding packages
+
+! exec rg --version
+! exec vim --version
+exec devbox global add ripgrep vim
+
+exec devbox global shellenv
+source.path
+exec rg --version
+exec vim --version
+
+-- devbox.json --
+{
+  "packages": [
+  ]
+}


### PR DESCRIPTION
## Summary

Makes a couple of fixes:
1. `devbox global add` should avoid returning an error status code if devbox-global-bin-path is not in PATH. We should instead print a warning, and return a 0 code.
2. `devbox global shellenv` should call `ensureNixInstalled` to find `nix` if not in `PATH`.

Adds basic test cases for multiple packages for `devbox add` and `devbox global add`

## How was it tested?

`go test -v -run TestScripts/add\.test ./testscripts/...`
`go test -v -run TestScripts/global_add\.test ./testscripts/...`
