### PR TITLE
[easy][wrappers] Ensure wrappers use correct project dir

### DIFF
--- a/internal/wrapnix/wrapper.go
+++ b/internal/wrapnix/wrapper.go
@@ -57,6 +57,7 @@ func CreateWrappers(ctx context.Context, devbox devboxer) error {
 			BashPath:     bashPath,
 			Command:      service.Start,
 			Env:          service.Env,
+			ProjectDir:   devbox.ProjectDir(),
 			ShellEnvHash: shellEnvHash,
 			destPath:     filepath.Join(destPath, service.StartName()),
 		}); err != nil {
@@ -66,6 +67,7 @@ func CreateWrappers(ctx context.Context, devbox devboxer) error {
 			BashPath:     bashPath,
 			Command:      service.Stop,
 			Env:          service.Env,
+			ProjectDir:   devbox.ProjectDir(),
 			ShellEnvHash: shellEnvHash,
 			destPath:     filepath.Join(destPath, service.StopName()),
 		}); err != nil {
@@ -82,6 +84,7 @@ func CreateWrappers(ctx context.Context, devbox devboxer) error {
 		if err = createWrapper(&createWrapperArgs{
 			BashPath:     bashPath,
 			Command:      bin,
+			ProjectDir:   devbox.ProjectDir(),
 			ShellEnvHash: shellEnvHash,
 			destPath:     filepath.Join(destPath, filepath.Base(bin)),
 		}); err != nil {
@@ -96,6 +99,7 @@ type createWrapperArgs struct {
 	BashPath     string
 	Command      string
 	Env          map[string]string
+	ProjectDir   string
 	ShellEnvHash string
 
 	destPath string

--- a/internal/wrapnix/wrapper.sh.tmpl
+++ b/internal/wrapnix/wrapper.sh.tmpl
@@ -22,7 +22,7 @@ DO_NOT_TRACK=1 can be removed once we optimize segment to queue events.
 */ -}}
 
 if [[ "$__DEVBOX_SHELLENV_HASH" != "{{ .ShellEnvHash }}" ]]; then
-eval "$(DO_NOT_TRACK=1 devbox shellenv)"
+eval "$(DO_NOT_TRACK=1 devbox shellenv -c {{ .ProjectDir }})"
 fi
 
 exec {{ .Command }} "$@"


### PR DESCRIPTION
## Summary

We're relying on binaries getting called within the same directory hierarchy where the original devbox.json lives but this can break down in the following cases:

* global
* Multiple devbox.json within the hirarchy
* if you navigate outisde the directory with the devbox.json

## How was it tested?

```bash
devbox shell
devbox add hello # to change the env hash
cd ~/
go version
```

Also tested global:

```
eval "$(devbox global shellenv)"
devbox global add hello  # to change the env hash
go version
```
