### PR TITLE
[easy][global] Don't show eval message if already shellenved

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -712,9 +712,9 @@ func (d *Devbox) computeNixEnv(ctx context.Context, usePrintDevEnvCache bool) (m
 	// We add the project dir hash to ensure that we don't have conflicts
 	// between different projects (including global)
 	// (moving a project would change the hash and that's fine)
-	originalPath, ok := env["DEVBOX_OG_PATH_"+d.projectDirHash()]
+	originalPath, ok := env[d.ogPathKey()]
 	if !ok {
-		env["DEVBOX_OG_PATH_"+d.projectDirHash()] = currentEnvPath
+		env[d.ogPathKey()] = currentEnvPath
 		originalPath = currentEnvPath
 	}
 
@@ -831,6 +831,10 @@ func (d *Devbox) nixEnv(ctx context.Context) (map[string]string, error) {
 		nixEnvCache, err = d.computeNixEnv(ctx, usePrintDevEnvCache)
 	}
 	return nixEnvCache, err
+}
+
+func (d *Devbox) ogPathKey() string {
+	return "DEVBOX_OG_PATH_" + d.projectDirHash()
 }
 
 // writeScriptsToFiles writes scripts defined in devbox.json into files inside .devbox/gen/scripts.
@@ -1038,7 +1042,7 @@ func (d *Devbox) NixBins(ctx context.Context) ([]string, error) {
 }
 
 func (d *Devbox) projectDirHash() string {
-	hash, _ := cuecfg.Hash(d.cfg)
+	hash, _ := cuecfg.Hash(d.projectDir)
 	return hash
 }
 

--- a/internal/impl/global.go
+++ b/internal/impl/global.go
@@ -73,7 +73,7 @@ func (d *Devbox) AddGlobal(pkgs ...string) error {
 	if err := d.saveCfg(); err != nil {
 		return err
 	}
-	d.ensureGlobalProfileInPath()
+	d.ensureDevboxGlobalShellenvEnabled()
 	return nil
 }
 
@@ -174,7 +174,7 @@ func GlobalNixProfilePath() (string, error) {
 }
 
 // Checks if the global has been shellenv'd and warns the user if not
-func (d *Devbox) ensureGlobalProfileInPath() {
+func (d *Devbox) ensureDevboxGlobalShellenvEnabled() {
 	if os.Getenv(d.ogPathKey()) == "" {
 		ux.Fwarning(d.writer, warningNotInPath)
 	}

--- a/internal/impl/global.go
+++ b/internal/impl/global.go
@@ -5,7 +5,6 @@ package impl
 
 import (
 	"fmt"
-	"io/fs"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -14,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
 
-	"go.jetpack.io/devbox/internal/env"
 	"go.jetpack.io/devbox/internal/nix"
 	"go.jetpack.io/devbox/internal/planner/plansdk"
 	"go.jetpack.io/devbox/internal/ux"
@@ -75,7 +73,8 @@ func (d *Devbox) AddGlobal(pkgs ...string) error {
 	if err := d.saveCfg(); err != nil {
 		return err
 	}
-	return d.ensureGlobalProfileInPath()
+	d.ensureGlobalProfileInPath()
+	return nil
 }
 
 func (d *Devbox) RemoveGlobal(pkgs ...string) error {
@@ -174,29 +173,9 @@ func GlobalNixProfilePath() (string, error) {
 	return filepath.Join(path, "profile"), nil
 }
 
-func globalBinPath() (string, error) {
-	nixProfilePath, err := GlobalNixProfilePath()
-	if err != nil {
-		return "", err
-	}
-	currentPath := xdg.DataSubpath("devbox/global/current")
-	// For now default is always current. In the future we will support multiple
-	// and allow user to switch.
-	err = os.Symlink(nixProfilePath, currentPath)
-	if err != nil && !errors.Is(err, fs.ErrExist) {
-		return "", errors.WithStack(err)
-	}
-	return filepath.Join(currentPath, "bin"), nil
-}
-
-// Checks if the global profile is in the path
-func (d *Devbox) ensureGlobalProfileInPath() error {
-	binPath, err := globalBinPath()
-	if err != nil {
-		return err
-	}
-	if !strings.Contains(os.Getenv(env.Path), binPath) {
+// Checks if the global has been shellenv'd and warns the user if not
+func (d *Devbox) ensureGlobalProfileInPath() {
+	if os.Getenv(d.ogPathKey()) == "" {
 		ux.Fwarning(d.writer, warningNotInPath)
 	}
-	return nil
 }


### PR DESCRIPTION
## Summary

Two fixes:

* We were computing the wrong hash for projectDir. (using config contents instead). We want it to be stable even when adding packages so dir is the correct one.
* In devbox global we were showing the shellenv warning even when user had already shellenved.

## How was it tested?

`devbox global add hello`
