### PR TITLE
[version] part 1: update command for devbox and launcher updates

### DIFF
--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -33,7 +33,7 @@ func RootCmd() *cobra.Command {
 		Use:   "devbox",
 		Short: "Instant, easy, predictable development environments",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			vercheck.CheckLauncherVersion(cmd.ErrOrStderr())
+			vercheck.CheckVersion(cmd.ErrOrStderr())
 			if flags.quiet {
 				cmd.SetErr(io.Discard)
 			}

--- a/internal/boxcli/version.go
+++ b/internal/boxcli/version.go
@@ -5,6 +5,7 @@ package boxcli
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 
 	"github.com/spf13/cobra"
@@ -56,6 +57,7 @@ func versionCmdFunc(cmd *cobra.Command, _ []string, flags versionFlags) error {
 		fmt.Fprintf(w, "Commit:      %v\n", v.Commit)
 		fmt.Fprintf(w, "Commit Time: %v\n", v.CommitDate)
 		fmt.Fprintf(w, "Go Version:  %v\n", v.GoVersion)
+		fmt.Fprintf(w, "Launcher:    %v\n", v.LauncherVersion)
 	} else {
 		fmt.Fprintf(w, "%v\n", v.Version)
 	}
@@ -63,12 +65,13 @@ func versionCmdFunc(cmd *cobra.Command, _ []string, flags versionFlags) error {
 }
 
 type versionInfo struct {
-	Version      string
-	IsPrerelease bool
-	Platform     string
-	Commit       string
-	CommitDate   string
-	GoVersion    string
+	Version         string
+	IsPrerelease    bool
+	Platform        string
+	Commit          string
+	CommitDate      string
+	GoVersion       string
+	LauncherVersion string
 }
 
 func getVersionInfo() *versionInfo {
@@ -78,6 +81,8 @@ func getVersionInfo() *versionInfo {
 		Commit:     build.Commit,
 		CommitDate: build.CommitDate,
 		GoVersion:  runtime.Version(),
+		// Change to env.LauncherVersion. Not doing so to minimize merge conflicts.
+		LauncherVersion: os.Getenv("LAUNCHER_VERSION"),
 	}
 
 	return v

--- a/internal/vercheck/vercheck_test.go
+++ b/internal/vercheck/vercheck_test.go
@@ -1,0 +1,78 @@
+package vercheck
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCheckVersion(t *testing.T) {
+
+	t.Run("no_devbox_cloud", func(t *testing.T) {
+		// if devbox cloud
+		t.Setenv("DEVBOX_REGION", "true")
+		buf := new(bytes.Buffer)
+		CheckVersion(buf)
+		if buf.String() != "" {
+			t.Errorf("expected empty string, got %q", buf.String())
+		}
+		t.Setenv("DEVBOX_REGION", "")
+	})
+
+	// no envir.LauncherVersion or latest-version env var
+	t.Run("no_launcher_version_or_latest_version", func(t *testing.T) {
+		t.Setenv("LAUNCHER_VERSION", "")
+		t.Setenv(envDevboxLatestVersion, "")
+		buf := new(bytes.Buffer)
+		CheckVersion(buf)
+		if buf.String() != "" {
+			t.Errorf("expected empty string, got %q", buf.String())
+		}
+	})
+
+	t.Run("launcher_version_outdated", func(t *testing.T) {
+		// set older launcher version
+		t.Setenv("LAUNCHER_VERSION", "v0.1.0")
+
+		buf := new(bytes.Buffer)
+		CheckVersion(buf)
+		if !strings.Contains(buf.String(), "New launcher available") {
+			t.Errorf("expected notice about new launcher version, got %q", buf.String())
+		}
+	})
+
+	t.Run("binary_version_outdated", func(t *testing.T) {
+		// set the launcher version so that it is not outdated
+		t.Setenv("LAUNCHER_VERSION", strings.TrimPrefix(expectedLauncherVersion, "v"))
+
+		// set the latest version to be greater the current binary version
+		t.Setenv(envDevboxLatestVersion, "0.4.9")
+
+		// mock the existing binary version
+		currentDevboxVersion = "v0.4.8"
+
+		buf := new(bytes.Buffer)
+		CheckVersion(buf)
+		if !strings.Contains(buf.String(), "New devbox available") {
+			t.Errorf("expected notice about new devbox version, got %q", buf.String())
+		}
+	})
+
+	t.Run("all_versions_up_to_date", func(t *testing.T) {
+
+		// set the launcher version so that it is not outdated
+		t.Setenv("LAUNCHER_VERSION", strings.TrimPrefix(expectedLauncherVersion, "v"))
+
+		// mock the existing binary version
+		currentDevboxVersion = "v0.4.8"
+
+		// set the latest version to the same as the current binary version
+		t.Setenv(envDevboxLatestVersion, "0.4.8")
+
+		buf := new(bytes.Buffer)
+		CheckVersion(buf)
+		if buf.String() != "" {
+			t.Errorf("expected empty string, got %q", buf.String())
+		}
+	})
+}


### PR DESCRIPTION
## Summary

**Motivation:**
We want to disable auto-update for devbox CLIs. This will minimize unexpected interruptions for our users.

To do so, we are going to do the following:

1. Update `launch.sh` file in `axiom` repo to write new versions to `{XDG_CACHE_HOME}/devbox/available-version`. https://github.com/jetpack-io/axiom/pull/3150
2. Change `devbox version update` to update the launcher (if needed) and else, update the CLI binary. (this PR).
3. Change the `vercheck.CheckVersion` that runs in `boxcli/root.go` on every command to check if the launcher or CLI binary versions are out-of-date, and to print a notice if so. (reviewed in #966, but merged into this PR)

We will cherry-pick ~these two PRs~ this PR for the next release so auto-update stops for users.

**Implementation:**
This PR enables `jetpack version update` to:

1. Update the launcher: We detect if the launcher version is outdated, and update it, if needed. This also updates the devbox CLI binary as a side-effect. This requires `sudo` so we only do it, if necessary.

2. Update just the devbox CLI binary: If the launcher is up-to-date, then we update just the devbox CLI binary.

3. Remove dependency on new code like `env` package to minimize cherry-picking merge conflicts.

TODO:
- [x] confirm that we can switch the `devbox version` operation after an update to `StdOut`. I feel this is better so user is informed about the new version.
cc @mikeland86 for the above question.


Will only land this after the launch.sh file is updated in https://github.com/jetpack-io/axiom/pull/3150 

## How was it tested?

Did some basic testing:

hardcoded `true` to ensure `selfUpdateLauncher` runs, and did `devbox version update`:

<img width="742" alt="Screenshot 2023-05-01 at 8 57 46 PM" src="https://user-images.githubusercontent.com/676452/235576315-03069599-a469-4f3a-90c2-cc6a58ec648a.png">


regular `devbox version update`
<img width="332" alt="Screenshot 2023-05-01 at 8 48 20 PM" src="https://user-images.githubusercontent.com/676452/235575369-f2a70299-4a3a-4b41-80ec-ecedb730ad0b.png">
