### PR TITLE
[release] also release to stable-channel's S3 bucket

### DIFF
--- a/.github/workflows/cli-post-release.yml
+++ b/.github/workflows/cli-post-release.yml
@@ -25,3 +25,4 @@ jobs:
           tmp_file=$(mktemp)
           echo "${{ github.ref_name }}" > $tmp_file
           aws s3 cp $tmp_file s3://releases.jetpack.io/devbox/latest/version
+          aws s3 cp $tmp_file s3://releases.jetpack.io/devbox/stable/version


### PR DESCRIPTION
## Summary

We want to introduce a "stable" channel, as part of turning off auto-update.
As a first step, we'll begin publishing to the `stable` bucket in S3, in addition to the existing `latest`.

Once we deploy the new launcher and binary that turns off auto-updating, we'll drop `latest` from this github action.

## How was it tested?

have not tested. Do I need to pre-create the S3 bucket?


