### PR TITLE
ci: stub workflow for search index

### DIFF
--- a/.github/workflows/index-nixpkgs.yaml
+++ b/.github/workflows/index-nixpkgs.yaml
@@ -1,0 +1,14 @@
+name: Index nixpkgs-unstable
+run-name: Daily index update
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  check-channel:
+    name: Check for channel updates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch nixpkgs-unstable channel history
+        run: curl --silent --show-error --fail --proto '=https' --tlsv1.2 --location https://channels.nix.gsc.io/nixpkgs-unstable/history-v2


### PR DESCRIPTION
The workflow needs to exist on main so we can start iterating on it by invoking it manually.