### PR TITLE
chore: use constants defined in envir in version check

### DIFF
--- a/internal/boxcli/version.go
+++ b/internal/boxcli/version.go
@@ -9,7 +9,9 @@ import (
 	"runtime"
 
 	"github.com/spf13/cobra"
+
 	"go.jetpack.io/devbox/internal/build"
+	"go.jetpack.io/devbox/internal/envir"
 	"go.jetpack.io/devbox/internal/vercheck"
 )
 
@@ -76,13 +78,12 @@ type versionInfo struct {
 
 func getVersionInfo() *versionInfo {
 	v := &versionInfo{
-		Version:    build.Version,
-		Platform:   fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH),
-		Commit:     build.Commit,
-		CommitDate: build.CommitDate,
-		GoVersion:  runtime.Version(),
-		// Change to env.LauncherVersion. Not doing so to minimize merge conflicts.
-		LauncherVersion: os.Getenv("LAUNCHER_VERSION"),
+		Version:         build.Version,
+		Platform:        fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH),
+		Commit:          build.Commit,
+		CommitDate:      build.CommitDate,
+		GoVersion:       runtime.Version(),
+		LauncherVersion: os.Getenv(envir.LauncherVersion),
 	}
 
 	return v

--- a/internal/envir/env.go
+++ b/internal/envir/env.go
@@ -10,13 +10,17 @@ const (
 	DevboxFeaturePrefix      = "DEVBOX_FEATURE_"
 	DevboxGateway            = "DEVBOX_GATEWAY"
 	DevboxDoNotUpgradeConfig = "DEVBOX_DONT_UPGRADE_CONFIG"
-	DevboxRegion             = "DEVBOX_REGION"
-	DevboxSearchHost         = "DEVBOX_SEARCH_HOST"
-	DevboxShellEnabled       = "DEVBOX_SHELL_ENABLED"
-	DevboxShellStartTime     = "DEVBOX_SHELL_START_TIME"
-	DevboxVM                 = "DEVBOX_VM"
+	// DevboxLatestVersion is the latest version available of the devbox CLI binary.
+	// NOTE: it should NOT start with v (like 0.4.8)
+	DevboxLatestVersion  = "DEVBOX_LATEST_VERSION"
+	DevboxRegion         = "DEVBOX_REGION"
+	DevboxSearchHost     = "DEVBOX_SEARCH_HOST"
+	DevboxShellEnabled   = "DEVBOX_SHELL_ENABLED"
+	DevboxShellStartTime = "DEVBOX_SHELL_START_TIME"
+	DevboxVM             = "DEVBOX_VM"
 
 	LauncherVersion = "LAUNCHER_VERSION"
+	LauncherPath    = "LAUNCHER_PATH"
 
 	SSHTTY = "SSH_TTY"
 

--- a/internal/envir/util.go
+++ b/internal/envir/util.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 )
 
-func IsCLICloudShell() bool {
+func IsCLICloudShell() bool { // TODO: not used any more
 	cliCloudShell, _ := strconv.ParseBool(os.Getenv(devboxCLICloudShell))
 	return cliCloudShell
 }

--- a/internal/vercheck/vercheck.go
+++ b/internal/vercheck/vercheck.go
@@ -20,31 +20,28 @@ import (
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/build"
 	"go.jetpack.io/devbox/internal/cmdutil"
+	"go.jetpack.io/devbox/internal/envir"
 	"go.jetpack.io/devbox/internal/ux"
 	"go.jetpack.io/devbox/internal/xdg"
 )
 
-// Keep this in-sync with latest version in launch.sh. If this version is newer
-// than the version in launch.sh, we'll print a notice.
+// Keep this in-sync with latest version in launch.sh.
+// If this version is newer than the version in launch.sh, we'll print a notice.
 const expectedLauncherVersion = "v0.2.0"
 
 // currentDevboxVersion is the version of the devbox CLI binary that is currently running.
-// We use this variable so we can mock it in tests.
+// We use this variable so that we can mock it in tests.
 var currentDevboxVersion = build.Version
-
-// envDevboxLatestVersion is the latest version available of the devbox CLI binary.
-// Change to env.DevboxLatestVersion. Not doing so to minimize merge conflicts.
-var envDevboxLatestVersion = "DEVBOX_LATEST_VERSION"
 
 // CheckVersion checks the launcher and binary versions and prints a notice if
 // they are out of date.
 func CheckVersion(w io.Writer) {
 
-	// Replace with envir.IsDevboxCloud(). Not doing so to minimize merge conflicts.
-	if os.Getenv("DEVBOX_REGION") != "" {
+	if envir.IsDevboxCloud() {
 		return
 	}
 
+	// check launcher version
 	launcherNotice := launcherVersionNotice()
 	if launcherNotice != "" {
 		// TODO: use ux.FNotice
@@ -53,6 +50,7 @@ func CheckVersion(w io.Writer) {
 		// fallthrough to alert the user about a new Devbox CLI binary being possibly available
 	}
 
+	// check devbox CLI version
 	devboxNotice := devboxVersionNotice()
 	if devboxNotice != "" {
 		// TODO: use ux.FNotice
@@ -139,7 +137,7 @@ type updatedVersions struct {
 // devbox versions.
 func triggerUpdate(stdErr io.Writer) (*updatedVersions, error) {
 
-	exePath := os.Getenv("LAUNCHER_PATH")
+	exePath := os.Getenv(envir.LauncherPath)
 	if exePath == "" {
 		ux.Fwarning(stdErr, "expected LAUNCHER_PATH to be set. Defaulting to \"devbox\".")
 		exePath = "devbox"
@@ -227,8 +225,7 @@ func isNewDevboxAvailable() bool {
 // currentLauncherAvailable returns launcher's version if it is
 // available, or empty string if it is not.
 func currentLauncherVersion() string {
-	// Change to envir.LauncherVersion. Not doing so to minimize merge-conflicts.
-	launcherVersion := os.Getenv("LAUNCHER_VERSION")
+	launcherVersion := os.Getenv(envir.LauncherVersion)
 	if launcherVersion == "" {
 		return ""
 	}
@@ -265,7 +262,7 @@ func semverCompare(ver1, ver2 string) int {
 
 // latestVersion returns the latest version available for the binary.
 func latestVersion() string {
-	version := os.Getenv(envDevboxLatestVersion)
+	version := os.Getenv(envir.DevboxLatestVersion)
 	if version == "" {
 		return ""
 	}

--- a/internal/vercheck/vercheck_test.go
+++ b/internal/vercheck/vercheck_test.go
@@ -1,28 +1,33 @@
+// Copyright 2023 Jetpack Technologies Inc and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
 package vercheck
 
 import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"go.jetpack.io/devbox/internal/envir"
 )
 
 func TestCheckVersion(t *testing.T) {
 
 	t.Run("no_devbox_cloud", func(t *testing.T) {
 		// if devbox cloud
-		t.Setenv("DEVBOX_REGION", "true")
+		t.Setenv(envir.DevboxRegion, "true")
 		buf := new(bytes.Buffer)
 		CheckVersion(buf)
 		if buf.String() != "" {
 			t.Errorf("expected empty string, got %q", buf.String())
 		}
-		t.Setenv("DEVBOX_REGION", "")
+		t.Setenv(envir.DevboxRegion, "")
 	})
 
-	// no envir.LauncherVersion or latest-version env var
+	// no launcher version or latest-version env var
 	t.Run("no_launcher_version_or_latest_version", func(t *testing.T) {
-		t.Setenv("LAUNCHER_VERSION", "")
-		t.Setenv(envDevboxLatestVersion, "")
+		t.Setenv(envir.LauncherVersion, "")
+		t.Setenv(envir.DevboxLatestVersion, "")
 		buf := new(bytes.Buffer)
 		CheckVersion(buf)
 		if buf.String() != "" {
@@ -32,7 +37,7 @@ func TestCheckVersion(t *testing.T) {
 
 	t.Run("launcher_version_outdated", func(t *testing.T) {
 		// set older launcher version
-		t.Setenv("LAUNCHER_VERSION", "v0.1.0")
+		t.Setenv(envir.LauncherVersion, "v0.1.0")
 
 		buf := new(bytes.Buffer)
 		CheckVersion(buf)
@@ -43,10 +48,10 @@ func TestCheckVersion(t *testing.T) {
 
 	t.Run("binary_version_outdated", func(t *testing.T) {
 		// set the launcher version so that it is not outdated
-		t.Setenv("LAUNCHER_VERSION", strings.TrimPrefix(expectedLauncherVersion, "v"))
+		t.Setenv(envir.LauncherVersion, strings.TrimPrefix(expectedLauncherVersion, "v"))
 
 		// set the latest version to be greater the current binary version
-		t.Setenv(envDevboxLatestVersion, "0.4.9")
+		t.Setenv(envir.DevboxLatestVersion, "0.4.9")
 
 		// mock the existing binary version
 		currentDevboxVersion = "v0.4.8"
@@ -61,13 +66,13 @@ func TestCheckVersion(t *testing.T) {
 	t.Run("all_versions_up_to_date", func(t *testing.T) {
 
 		// set the launcher version so that it is not outdated
-		t.Setenv("LAUNCHER_VERSION", strings.TrimPrefix(expectedLauncherVersion, "v"))
+		t.Setenv(envir.LauncherVersion, strings.TrimPrefix(expectedLauncherVersion, "v"))
 
 		// mock the existing binary version
 		currentDevboxVersion = "v0.4.8"
 
 		// set the latest version to the same as the current binary version
-		t.Setenv(envDevboxLatestVersion, "0.4.8")
+		t.Setenv(envir.DevboxLatestVersion, "0.4.8")
 
 		buf := new(bytes.Buffer)
 		CheckVersion(buf)


### PR DESCRIPTION
## Summary

1. replace constants with existing envir constants
2. add new envir constants

## How was it tested?
