### PR TITLE
doc: Fix typo in zig.md

### DIFF
--- a/docs/app/docs/devbox_examples/languages/zig.md
+++ b/docs/app/docs/devbox_examples/languages/zig.md
@@ -8,7 +8,7 @@ Zig projects can be run in Devbox by adding Zig and Nimble to your project.
 
 [![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/development/development/zig/zig-hello-world)
 
-## Adding Go to your Project
+## Adding Zig to your Project
 
 `devbox add zig`, or add the following to your `devbox.json`
 


### PR DESCRIPTION
There were copy paste leftovers from go.md.

## Summary

## How was it tested?
