### PR TITLE
[update] Implement devbox update

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -49,6 +49,8 @@ type Devbox interface {
 	StartServices(ctx context.Context, services ...string) error
 	StopServices(ctx context.Context, allProjects bool, services ...string) error
 	ListServices(ctx context.Context) error
+
+	Update(ctx context.Context, pkgs ...string) error
 }
 
 // Open opens a devbox by reading the config file in dir.

--- a/devbox.json
+++ b/devbox.json
@@ -1,8 +1,8 @@
 {
   "packages": [
-    "go_1_20",
-    "golangci-lint",
-    "actionlint"
+    "go@1.20",
+    "actionlint@1.6.23",
+    "golangci-lint@1.52.2"
   ],
   "env": {
     "PATH": "$PATH:$PWD/dist"

--- a/devbox.lock
+++ b/devbox.lock
@@ -2,17 +2,17 @@
   "lockfile_version": "1",
   "packages": {
     "actionlint@1.6.23": {
-      "last_modified": "",
+      "last_modified": "2023-03-31T22:52:29Z",
       "resolved": "github:NixOS/nixpkgs/242246ee1e58f54d2322227fc5eef53b4a616a31#actionlint",
       "version": "1.6.23"
     },
     "go@1.20": {
-      "last_modified": "",
+      "last_modified": "2023-03-31T22:52:29Z",
       "resolved": "github:NixOS/nixpkgs/242246ee1e58f54d2322227fc5eef53b4a616a31#go",
       "version": "1.20.2"
     },
     "golangci-lint@1.52.2": {
-      "last_modified": "",
+      "last_modified": "2023-03-31T22:52:29Z",
       "resolved": "github:NixOS/nixpkgs/242246ee1e58f54d2322227fc5eef53b4a616a31#golangci-lint",
       "version": "1.52.2"
     }

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,20 +1,20 @@
 {
   "lockfile_version": "1",
   "packages": {
-    "actionlint": {
+    "actionlint@1.6.23": {
       "last_modified": "",
-      "resolved": "github:NixOS/nixpkgs/3364b5b117f65fe1ce65a3cdd5612a078a3b31e3#actionlint",
-      "version": ""
+      "resolved": "github:NixOS/nixpkgs/242246ee1e58f54d2322227fc5eef53b4a616a31#actionlint",
+      "version": "1.6.23"
     },
-    "go_1_20": {
+    "go@1.20": {
       "last_modified": "",
-      "resolved": "github:NixOS/nixpkgs/3364b5b117f65fe1ce65a3cdd5612a078a3b31e3#go_1_20",
-      "version": ""
+      "resolved": "github:NixOS/nixpkgs/242246ee1e58f54d2322227fc5eef53b4a616a31#go",
+      "version": "1.20.2"
     },
-    "golangci-lint": {
+    "golangci-lint@1.52.2": {
       "last_modified": "",
-      "resolved": "github:NixOS/nixpkgs/3364b5b117f65fe1ce65a3cdd5612a078a3b31e3#golangci-lint",
-      "version": ""
+      "resolved": "github:NixOS/nixpkgs/242246ee1e58f54d2322227fc5eef53b4a616a31#golangci-lint",
+      "version": "1.52.2"
     }
   }
 }

--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -61,6 +61,7 @@ func RootCmd() *cobra.Command {
 	command.AddCommand(setupCmd())
 	command.AddCommand(shellCmd())
 	command.AddCommand(shellEnvCmd())
+	command.AddCommand(updateCmd())
 	command.AddCommand(versionCmd())
 	// Preview commands
 	command.AddCommand(cloudCmd())

--- a/internal/boxcli/update.go
+++ b/internal/boxcli/update.go
@@ -18,15 +18,13 @@ func updateCmd() *cobra.Command {
 
 	command := &cobra.Command{
 		Use:   "update [pkg]...",
-		Short: "Updates one, many, or all packages in your devbox",
-		Long: "Updates one, many, or all packages in your devbox. If no " +
-			"packages are specified, all packages will be updated. Only updates " +
-			"versioned packages (e.g. `python@3.11`), not packages that are " +
-			"pinned to a nix channel (e.g. `python3`)",
+		Short: "Updates packages in your devbox",
+		Long: "Updates one, many, or all packages in your devbox. " +
+			"If no packages are specified, all packages will be updated. " +
+			"Only updates versioned packages (e.g. `python@3.11`), not packages that are pinned to a nix channel (e.g. `python3`)",
 		PreRunE: ensureNixInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return updateCmdFunc(cmd, args, flags)
-
 		},
 	}
 

--- a/internal/boxcli/update.go
+++ b/internal/boxcli/update.go
@@ -1,0 +1,48 @@
+// Copyright 2023 Jetpack Technologies Inc and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package boxcli
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"go.jetpack.io/devbox"
+)
+
+type updateCmdFlags struct {
+	config configFlags
+}
+
+func updateCmd() *cobra.Command {
+	flags := &updateCmdFlags{}
+
+	command := &cobra.Command{
+		Use:   "update [pkg]...",
+		Short: "Updates one, many, or all packages in your devbox",
+		Long: "Updates one, many, or all packages in your devbox. If no " +
+			"packages are specified, all packages will be updated. Only updates " +
+			"versioned packages (e.g. `python@3.11`), not packages that are " +
+			"pinned to a nix channel (e.g. `python3`)",
+		PreRunE: ensureNixInstalled,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return updateCmdFunc(cmd, args, flags)
+
+		},
+	}
+
+	flags.config.register(command)
+	return command
+}
+
+func updateCmdFunc(
+	cmd *cobra.Command,
+	args []string,
+	flags *updateCmdFlags,
+) error {
+	box, err := devbox.Open(flags.config.path, cmd.ErrOrStderr())
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return box.Update(cmd.Context(), args...)
+}

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -150,6 +150,19 @@ func (d *Devbox) ShellPlan() (*plansdk.ShellPlan, error) {
 	shellPlan.FlakeInputs = d.flakeInputs()
 
 	nixpkgsInfo := plansdk.GetNixpkgsInfo(d.cfg.Nixpkgs.Commit)
+
+	// This is an optimization. If there are no dev packages (which we only use
+	// for php/haskell planners) we can use nixpkgs from one of the flakes.
+	// That saves us from downloading nixpkgs an additional time for mkShell.
+	if len(shellPlan.DevPackages) == 0 {
+		for _, input := range shellPlan.FlakeInputs {
+			if input.IsNixpkgs() {
+				nixpkgsInfo = plansdk.GetNixpkgsInfo(input.HashFromNixPkgsURL())
+				break
+			}
+		}
+	}
+
 	shellPlan.NixpkgsInfo = nixpkgsInfo
 
 	return shellPlan, nil
@@ -940,6 +953,23 @@ func (d *Devbox) nixFlakesFilePath() string {
 // packages returns the list of packages to be installed in the nix shell.
 func (d *Devbox) packages() []string {
 	return d.cfg.Packages
+}
+
+func (d *Devbox) findPackageByName(name string) (string, error) {
+	results := []string{}
+	for _, pkg := range d.cfg.Packages {
+		i := nix.InputFromString(pkg, d.lockfile)
+		if i.String() == name || i.CanonicalName() == name {
+			results = append(results, pkg)
+		}
+	}
+	if len(results) > 1 {
+		return "", usererr.New(
+			"found multiple packages with name %s: %s", name, results)
+	} else if len(results) == 0 {
+		return "", usererr.New("no package found with name %s", name)
+	}
+	return results[0], nil
 }
 
 // configEnvs takes the computed env variables (nix + plugin) and adds env

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -965,8 +965,12 @@ func (d *Devbox) findPackageByName(name string) (string, error) {
 	}
 	if len(results) > 1 {
 		return "", usererr.New(
-			"found multiple packages with name %s: %s", name, results)
-	} else if len(results) == 0 {
+			"found multiple packages with name %s: %s. Please specify version",
+			name,
+			results,
+		)
+	}
+	if len(results) == 0 {
 		return "", usererr.New("no package found with name %s", name)
 	}
 	return results[0], nil

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -1,0 +1,46 @@
+package impl
+
+import (
+	"context"
+	"fmt"
+)
+
+func (d *Devbox) Update(ctx context.Context, pkgs ...string) error {
+	pkgsToUpdate := []string{}
+	if len(pkgs) == 0 {
+		pkgsToUpdate = append([]string(nil), d.packages()...)
+	} else {
+		for _, pkg := range pkgs {
+			found, err := d.findPackageByName(pkg)
+			if err != nil {
+				return err
+			}
+			pkgsToUpdate = append(pkgsToUpdate, found)
+		}
+	}
+
+	for _, pkg := range pkgsToUpdate {
+		if !d.lockfile.IsVersionedPackage(pkg) {
+			fmt.Fprintf(d.writer, "Skipping %s because it is not a versioned package\n", pkg)
+			continue
+		}
+		existing := d.lockfile.Entry(pkg)
+		newEntry, err := d.lockfile.ForceResolve(pkg)
+		if err != nil {
+			return err
+		}
+		if existing != nil && existing.Version != newEntry.Version {
+			fmt.Fprintf(d.writer, "Updating %s %s -> %s\n", pkg, existing.Version, newEntry.Version)
+			if err := d.removePackagesFromProfile(ctx, []string{pkg}); err != nil {
+				return err
+			}
+		} else if existing == nil {
+			fmt.Fprintf(d.writer, "Resolved %s to %[1]s %[2]s\n", pkg, newEntry.Resolved)
+		} else {
+			fmt.Fprintf(d.writer, "Already up-to-date %s %s\n", pkg, existing.Version)
+		}
+	}
+
+	// TODO(landau): Improve output
+	return d.ensurePackagesAreInstalled(ctx, ensure)
+}

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -3,24 +3,25 @@ package impl
 import (
 	"context"
 	"fmt"
+
+	"go.jetpack.io/devbox/internal/lock"
 )
 
 func (d *Devbox) Update(ctx context.Context, pkgs ...string) error {
-	pkgsToUpdate := []string{}
-	if len(pkgs) == 0 {
-		pkgsToUpdate = append([]string(nil), d.packages()...)
-	} else {
-		for _, pkg := range pkgs {
-			found, err := d.findPackageByName(pkg)
-			if err != nil {
-				return err
-			}
-			pkgsToUpdate = append(pkgsToUpdate, found)
+	var pkgsToUpdate []string
+	for _, pkg := range pkgs {
+		found, err := d.findPackageByName(pkg)
+		if err != nil {
+			return err
 		}
+		pkgsToUpdate = append(pkgsToUpdate, found)
+	}
+	if len(pkgsToUpdate) == 0 {
+		pkgsToUpdate = d.packages()
 	}
 
 	for _, pkg := range pkgsToUpdate {
-		if !d.lockfile.IsVersionedPackage(pkg) {
+		if !lock.IsVersionedPackage(pkg) {
 			fmt.Fprintf(d.writer, "Skipping %s because it is not a versioned package\n", pkg)
 			continue
 		}

--- a/internal/lock/lockfile.go
+++ b/internal/lock/lockfile.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/fs"
 	"path/filepath"
+	"strings"
 
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/cuecfg"
@@ -50,7 +51,7 @@ func GetFile(project devboxProject, resolver resolver) (*File, error) {
 
 func (l *File) Add(pkgs ...string) error {
 	for _, p := range pkgs {
-		if l.IsVersionedPackage(p) {
+		if IsVersionedPackage(p) {
 			if _, err := l.Resolve(p); err != nil {
 				return err
 			}
@@ -70,7 +71,7 @@ func (l *File) Resolve(pkg string) (*Package, error) {
 	if entry, ok := l.Packages[pkg]; !ok || entry.Resolved == "" {
 		var locked *Package
 		var err error
-		if l.IsVersionedPackage(pkg) {
+		if IsVersionedPackage(pkg) {
 			locked, err = l.resolver.Resolve(pkg)
 			if err != nil {
 				return nil, err
@@ -111,6 +112,11 @@ func (l *File) Update() error {
 	}
 
 	return cuecfg.WriteFile(lockFilePath(l), l)
+}
+
+func IsVersionedPackage(pkg string) bool {
+	name, version, found := strings.Cut(pkg, "@")
+	return found && name != "" && version != ""
 }
 
 func lockFilePath(project devboxProject) string {

--- a/internal/lock/lockfile.go
+++ b/internal/lock/lockfile.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io/fs"
 	"path/filepath"
-	"strings"
 
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/cuecfg"
@@ -21,8 +20,8 @@ type File struct {
 	devboxProject
 	resolver
 
-	LockFileVersion string             `json:"lockfile_version"`
-	Packages        map[string]Package `json:"packages"`
+	LockFileVersion string              `json:"lockfile_version"`
+	Packages        map[string]*Package `json:"packages"`
 }
 
 type Package struct {
@@ -37,7 +36,7 @@ func GetFile(project devboxProject, resolver resolver) (*File, error) {
 		resolver:      resolver,
 
 		LockFileVersion: lockFileVersion,
-		Packages:        map[string]Package{},
+		Packages:        map[string]*Package{},
 	}
 	err := cuecfg.ParseFile(lockFilePath(project), lockFile)
 	if errors.Is(err, fs.ErrNotExist) {
@@ -67,15 +66,14 @@ func (l *File) Remove(pkgs ...string) error {
 	return l.Update()
 }
 
-func (l *File) Resolve(pkg string) (string, error) {
-	if _, ok := l.Packages[pkg]; !ok {
+func (l *File) Resolve(pkg string) (*Package, error) {
+	if entry, ok := l.Packages[pkg]; !ok || entry.Resolved == "" {
 		var locked *Package
 		var err error
 		if l.IsVersionedPackage(pkg) {
-			name, version, _ := strings.Cut(pkg, "@")
-			locked, err = l.resolver.Resolve(name, version)
+			locked, err = l.resolver.Resolve(pkg)
 			if err != nil {
-				return "", err
+				return nil, err
 			}
 		} else {
 			// These are legacy packages without a version. Resolve to nixpkgs with
@@ -88,13 +86,22 @@ func (l *File) Resolve(pkg string) (string, error) {
 				),
 			}
 		}
-		l.Packages[pkg] = *locked
+		l.Packages[pkg] = locked
 		if err := l.Update(); err != nil {
-			return "", err
+			return nil, err
 		}
 	}
 
-	return l.Packages[pkg].Resolved, nil
+	return l.Packages[pkg], nil
+}
+
+func (l *File) ForceResolve(pkg string) (*Package, error) {
+	delete(l.Packages, pkg)
+	return l.Resolve(pkg)
+}
+
+func (l *File) Entry(pkg string) *Package {
+	return l.Packages[pkg]
 }
 
 func (l *File) Update() error {

--- a/internal/lock/resolvers.go
+++ b/internal/lock/resolvers.go
@@ -10,7 +10,6 @@ type devboxProject interface {
 }
 
 type resolver interface {
-	IsVersionedPackage(pkg string) bool
 	Resolve(pkg string) (*Package, error)
 }
 

--- a/internal/lock/resolvers.go
+++ b/internal/lock/resolvers.go
@@ -11,10 +11,10 @@ type devboxProject interface {
 
 type resolver interface {
 	IsVersionedPackage(pkg string) bool
-	Resolve(pkg, version string) (*Package, error)
+	Resolve(pkg string) (*Package, error)
 }
 
 type Locker interface {
 	devboxProject
-	Resolve(pkg string) (string, error)
+	resolver
 }

--- a/internal/nix/input.go
+++ b/internal/nix/input.go
@@ -69,12 +69,12 @@ func (i *Input) Name() string {
 
 func (i *Input) URLForInput() string {
 	if i.IsDevboxPackage() {
-		resolved, err := i.lockfile.Resolve(i.String())
+		entry, err := i.lockfile.Resolve(i.String())
 		if err != nil {
 			panic(err)
 			// TODO(landau): handle error
 		}
-		withoutFragment, _, _ := strings.Cut(resolved, "#")
+		withoutFragment, _, _ := strings.Cut(entry.Resolved, "#")
 		return withoutFragment
 	}
 	return i.urlWithoutFragment()
@@ -82,7 +82,11 @@ func (i *Input) URLForInput() string {
 
 func (i *Input) URLForInstall() (string, error) {
 	if i.IsDevboxPackage() {
-		return i.lockfile.Resolve(i.String())
+		entry, err := i.lockfile.Resolve(i.String())
+		if err != nil {
+			return "", err
+		}
+		return entry.Resolved, nil
 	}
 	attrPath, err := i.PackageAttributePath()
 	if err != nil {
@@ -97,11 +101,11 @@ func (i *Input) URLForInstall() (string, error) {
 func (i *Input) PackageAttributePath() (string, error) {
 	var infos map[string]*Info
 	if i.IsDevboxPackage() {
-		path, err := i.lockfile.Resolve(i.String())
+		entry, err := i.lockfile.Resolve(i.String())
 		if err != nil {
 			return "", err
 		}
-		infos = search(path)
+		infos = search(entry.Resolved)
 	} else {
 		infos = search(i.String())
 	}
@@ -158,7 +162,7 @@ func (i *Input) hash() string {
 
 func (i *Input) validateExists() (bool, error) {
 	if i.IsDevboxPackage() {
-		return searcher.Exists(i.canonicalName(), i.version())
+		return searcher.Exists(i.CanonicalName(), i.version())
 	}
 	info, err := i.PackageAttributePath()
 	return info != "", err
@@ -185,9 +189,9 @@ func (i *Input) equals(other *Input) bool {
 	return name == otherName
 }
 
-// canonicalName returns the name of the package without the version
+// CanonicalName returns the name of the package without the version
 // it only applies to devbox packages
-func (i *Input) canonicalName() string {
+func (i *Input) CanonicalName() string {
 	if !i.IsDevboxPackage() {
 		return ""
 	}

--- a/internal/nix/input.go
+++ b/internal/nix/input.go
@@ -162,7 +162,11 @@ func (i *Input) hash() string {
 
 func (i *Input) validateExists() (bool, error) {
 	if i.IsDevboxPackage() {
-		return searcher.Exists(i.CanonicalName(), i.version())
+		version := i.version()
+		if version == "" && i.isVersioned() {
+			return false, usererr.New("No version specified for %q.", i.Path)
+		}
+		return searcher.Exists(i.CanonicalName(), version)
 	}
 	info, err := i.PackageAttributePath()
 	return info != "", err
@@ -207,6 +211,10 @@ func (i *Input) version() string {
 	}
 	_, version, _ := strings.Cut(i.Path, "@")
 	return version
+}
+
+func (i *Input) isVersioned() bool {
+	return i.IsDevboxPackage() && strings.Contains(i.Path, "@")
 }
 
 func (i *Input) hashFromNiPkgsURL() string {

--- a/internal/nix/input_test.go
+++ b/internal/nix/input_test.go
@@ -118,24 +118,21 @@ func (l *lockfile) ProjectDir() string {
 	return l.projectDir
 }
 
-func (l *lockfile) IsVersionedPackage(pkg string) bool {
-	name, version, found := strings.Cut(pkg, "@")
-	return found && name != "" && version != ""
-}
-
 func (lockfile) Resolve(pkg string) (*lock.Package, error) {
-	if strings.Contains(pkg, "path:") {
+	switch {
+	case strings.Contains(pkg, "path:"):
 		return &lock.Package{Resolved: pkg}, nil
-	} else if strings.Contains(pkg, "github:") {
+	case strings.Contains(pkg, "github:"):
 		return &lock.Package{Resolved: pkg}, nil
+	default:
+		return &lock.Package{
+			Resolved: fmt.Sprintf(
+				"github:NixOS/nixpkgs/%s#%s",
+				nixCommitHash,
+				pkg,
+			),
+		}, nil
 	}
-	return &lock.Package{
-		Resolved: fmt.Sprintf(
-			"github:NixOS/nixpkgs/%s#%s",
-			nixCommitHash,
-			pkg,
-		),
-	}, nil
 }
 
 func testInputFromString(s, projectDir string) *testInput {

--- a/internal/nix/input_test.go
+++ b/internal/nix/input_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/samber/lo"
+	"go.jetpack.io/devbox/internal/lock"
 )
 
 const nixCommitHash = "hsdafkhsdafhas"
@@ -117,17 +118,24 @@ func (l *lockfile) ProjectDir() string {
 	return l.projectDir
 }
 
-func (lockfile) Resolve(pkg string) (string, error) {
+func (l *lockfile) IsVersionedPackage(pkg string) bool {
+	name, version, found := strings.Cut(pkg, "@")
+	return found && name != "" && version != ""
+}
+
+func (lockfile) Resolve(pkg string) (*lock.Package, error) {
 	if strings.Contains(pkg, "path:") {
-		return pkg, nil
+		return &lock.Package{Resolved: pkg}, nil
 	} else if strings.Contains(pkg, "github:") {
-		return pkg, nil
+		return &lock.Package{Resolved: pkg}, nil
 	}
-	return fmt.Sprintf(
-		"github:NixOS/nixpkgs/%s#%s",
-		nixCommitHash,
-		pkg,
-	), nil
+	return &lock.Package{
+		Resolved: fmt.Sprintf(
+			"github:NixOS/nixpkgs/%s#%s",
+			nixCommitHash,
+			pkg,
+		),
+	}, nil
 }
 
 func testInputFromString(s, projectDir string) *testInput {

--- a/internal/nix/profile.go
+++ b/internal/nix/profile.go
@@ -233,7 +233,7 @@ func ProfileInstall(args *ProfileInstallArgs) error {
 		"--priority", nextPriority(args.ProfilePath),
 		urlForInstall,
 	)
-	cmd.Env = AllowUnfreeEnv()
+	cmd.Env = allowUnfreeEnv()
 	cmd.Args = append(cmd.Args, ExperimentalFlags()...)
 	cmd.Args = append(cmd.Args, args.ExtraFlags...)
 
@@ -265,7 +265,7 @@ func ProfileRemove(profilePath, nixpkgsCommit, pkg string) error {
 		"--impure", // for NIXPKGS_ALLOW_UNFREE
 		info.attributeKey,
 	)
-	cmd.Env = AllowUnfreeEnv()
+	cmd.Env = allowUnfreeEnv()
 	cmd.Args = append(cmd.Args, ExperimentalFlags()...)
 	out, err := cmd.CombinedOutput()
 	if bytes.Contains(out, []byte("does not match any packages")) {
@@ -277,7 +277,7 @@ func ProfileRemove(profilePath, nixpkgsCommit, pkg string) error {
 	return nil
 }
 
-func AllowUnfreeEnv() []string {
+func allowUnfreeEnv() []string {
 	return append(os.Environ(), "NIXPKGS_ALLOW_UNFREE=1")
 }
 

--- a/internal/planner/plansdk/flake.go
+++ b/internal/planner/plansdk/flake.go
@@ -23,6 +23,13 @@ func (f *FlakeInput) IsNixpkgs() bool {
 	return nix.IsGithubNixpkgsURL(f.URL)
 }
 
+func (f *FlakeInput) HashFromNixPkgsURL() string {
+	if !f.IsNixpkgs() {
+		return ""
+	}
+	return nix.HashFromNixPkgsURL(f.URL)
+}
+
 func (f *FlakeInput) URLWithCaching() string {
 	if !f.IsNixpkgs() {
 		return f.URL

--- a/internal/searcher/client.go
+++ b/internal/searcher/client.go
@@ -57,12 +57,15 @@ func (c *client) SearchVersion(query, version string) (*SearchResult, error) {
 
 func (c *client) Resolve(pkg string) (*lock.Package, error) {
 	name, version, _ := strings.Cut(pkg, "@")
+	if version == "" {
+		return nil, usererr.New("No version specified for %q.", name)
+	}
 	result, err := c.SearchVersion(name, version)
 	if err != nil {
 		return nil, err
 	}
 	if len(result.Results) == 0 {
-		return nil, usererr.New("No results found for %q.", name)
+		return nil, usererr.New("No results found for %q.", pkg)
 	}
 	return &lock.Package{
 		LastModified: result.Results[0].Packages[0].Date,
@@ -73,11 +76,6 @@ func (c *client) Resolve(pkg string) (*lock.Package, error) {
 		),
 		Version: result.Results[0].Packages[0].Version,
 	}, nil
-}
-
-func (c *client) IsVersionedPackage(pkg string) bool {
-	name, version, found := strings.Cut(pkg, "@")
-	return found && name != "" && version != ""
 }
 
 func execSearch(url string) (*SearchResult, error) {

--- a/internal/searcher/client.go
+++ b/internal/searcher/client.go
@@ -55,13 +55,14 @@ func (c *client) SearchVersion(query, version string) (*SearchResult, error) {
 	)
 }
 
-func (c *client) Resolve(pkg, version string) (*lock.Package, error) {
-	result, err := c.SearchVersion(pkg, version)
+func (c *client) Resolve(pkg string) (*lock.Package, error) {
+	name, version, _ := strings.Cut(pkg, "@")
+	result, err := c.SearchVersion(name, version)
 	if err != nil {
 		return nil, err
 	}
 	if len(result.Results) == 0 {
-		return nil, usererr.New("No results found for %q.", pkg)
+		return nil, usererr.New("No results found for %q.", name)
 	}
 	return &lock.Package{
 		LastModified: result.Results[0].Packages[0].Date,


### PR DESCRIPTION
## Summary

Implements `devbox update [pkg]...`

It basically just re-resolves version. If there's a new version that satisfies constraints, it installs it and removes the previous one.

Other improvements:

* implemented `findPackageByName` which allows us to use `devbox update go` instead of `devbox update go@1.20`. In follow up we can also use this for `devbox rm` 
* flake.nix optimization: If there are no dev packages (this is a legacy planner concept that is almost never used) and we add at least one nixpkgs flake input, we use that input for mkShell. This avoids having to download an additional nixpkgs.


## How was it tested?

* Manually modified lockfile to point to older versions and ran `devbox update` and `devbox update go`
* Inspected flake.nix 
* Inspected nix profile
