### PR TITLE
[update] Silence update notice for devbox-global-shellenv and development-devbox

### DIFF
--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"go.jetpack.io/devbox/internal/build"
 
 	"go.jetpack.io/devbox/internal/boxcli/midcobra"
 	"go.jetpack.io/devbox/internal/cloud/openssh/sshshim"
@@ -34,7 +35,15 @@ func RootCmd() *cobra.Command {
 		Use:   "devbox",
 		Short: "Instant, easy, predictable development environments",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			vercheck.CheckVersion(cmd.ErrOrStderr())
+			// Skip CheckVersion for `devbox global shellenv` because users will include that
+			// command in their shellrc files, and we don't want to bother them everytime they
+			// open their terminals.
+			//
+			// Skip CheckVersion for engineers building devbox during development.
+			if !strings.HasPrefix(cmd.CommandPath(), "devbox global shellenv") &&
+				!build.IsDev {
+				vercheck.CheckVersion(cmd.ErrOrStderr())
+			}
 			if flags.quiet {
 				cmd.SetErr(io.Discard)
 			}

--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -35,6 +35,10 @@ func RootCmd() *cobra.Command {
 		Use:   "devbox",
 		Short: "Instant, easy, predictable development environments",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if flags.quiet {
+				cmd.SetErr(io.Discard)
+			}
+
 			// Skip CheckVersion for `devbox global shellenv` because users will include that
 			// command in their shellrc files, and we don't want to bother them everytime they
 			// open their terminals.
@@ -43,9 +47,6 @@ func RootCmd() *cobra.Command {
 			if !strings.HasPrefix(cmd.CommandPath(), "devbox global shellenv") &&
 				!build.IsDev {
 				vercheck.CheckVersion(cmd.ErrOrStderr())
-			}
-			if flags.quiet {
-				cmd.SetErr(io.Discard)
 			}
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary

For `devbox global shellenv` which may be used in the user's shellrc file, its
not ideal to show the update notice everytime the user opens their shell (likely
for a non-devbox purpose).

For devbox engineers, we need not see the notice everytime we execute a devbox command
during development.

## How was it tested?

Added `fmt.Fprintf(os.Stderr, "version was checked")` in `boxcli/root.go` just prior
to calling `vercheck.BuildVersion`. Then did `devbox global shellenv 1> /dev/null`,
and saw that "version was checked" was not printed. As a sanity test, verified
that it was printed for `devbox shellenv 1> /dev/null`.

Also ran `devbox run build` and saw that the notice was not printed since I'd built
the `devbox` originally with the code of this PR.
