### PR TITLE
[CICD] Fix pre-release job and create new edge release process.

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -7,13 +7,13 @@ on:
   # Build/Release on demand
   workflow_dispatch:
     inputs:
-      update_nightly:
-        description: "Update nightly?"
+      update_weekly:
+        description: "Update weekly?"
         required: false
         default: false
         type: boolean
   schedule:
-    - cron: "0 0 * * *" # Nightly
+    - cron: "45 8 * * 4" # Weekly pre-release on Thursdays.
   push:
     tags:
       - "*" # Tags that trigger a new release version
@@ -23,31 +23,31 @@ permissions:
   pull-requests: read
   id-token: write # Needed for aws-actions/configure-aws-credentials@v1
 
-env:
-  NIGHTLY_TAG: 0.0.0-nightly
-
 jobs:
   tests:
     uses: ./.github/workflows/cli-tests.yaml
     with:
       run-mac-tests: true
 
-  nightly:
+  weekly:
     runs-on: ubuntu-latest
     environment: release
     # needs: tests
-    if: ${{ inputs.update_nightly || github.event.schedule }}
+    if: ${{ inputs.update_weekly || github.event.schedule }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Needed by goreleaser to browse history.
-      - name: Set nightly tag
+      - name: Determine weekly tag
+        # This tag is semver and works with semver.Compare
+        run: echo "WEEKLY_TAG=$(date +%Y.%U)" >> $GITHUB_ENV
+      - name: Set weekly tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          custom_tag: ${{ env.NIGHTLY_TAG }}
+          custom_tag: ${{ env.WEEKLY_TAG }}
           tag_prefix: ""
       - name: Set up go
         uses: actions/setup-go@v4
@@ -72,15 +72,13 @@ jobs:
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
         with:
           environment: development
-          # TODO: Add hash or date.
-          version:  ${{ env.NIGHTLY_TAG }}
+          version:  ${{ env.WEEKLY_TAG }}
       - name: Publish snapshot release to GitHub
         uses: softprops/action-gh-release@v1
         with:
           prerelease: true
           fail_on_unmatched_files: true
-          tag_name: ${{ env.NIGHTLY_TAG }}
-          name: nightly
+          tag_name: ${{ env.WEEKLY_TAG }}
           files: |
             dist/checksums.txt
             dist/*.tar.gz

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -33,7 +33,7 @@ jobs:
   prerelease:
     runs-on: ubuntu-latest
     environment: release
-    needs: tests
+    # needs: tests
     if: ${{ inputs.is_prerelease || github.event.schedule }}
     steps:
       - name: Checkout source code

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -32,7 +32,7 @@ jobs:
   edge:
     runs-on: ubuntu-latest
     environment: release
-    needs: tests
+    # needs: tests
     if: ${{ inputs.create_edge_release || github.event.schedule }}
     steps:
       - name: Checkout source code

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -82,6 +82,16 @@ jobs:
           files: |
             dist/checksums.txt
             dist/*.tar.gz
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: us-west-2
+      - name: Update weekly version in s3
+        run: |
+          tmp_file=$(mktemp)
+          echo "${{ env.WEEKLY_TAG }}" > $tmp_file
+          aws s3 cp $tmp_file s3://releases.jetpack.io/devbox/weekly/version
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -32,7 +32,7 @@ jobs:
   weekly:
     runs-on: ubuntu-latest
     environment: release
-    # needs: tests
+    needs: tests
     if: ${{ inputs.update_weekly || github.event.schedule }}
     steps:
       - name: Checkout source code

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -7,13 +7,13 @@ on:
   # Build/Release on demand
   workflow_dispatch:
     inputs:
-      create_alpha_release:
-        description: "Create alpha release?"
+      create_edge_release:
+        description: "Create edge release?"
         required: false
         default: false
         type: boolean
   schedule:
-    - cron: "45 8 * * 4" # Create alpha weekly on Thursdays.
+    - cron: "45 8 * * 4" # Create edge weekly on Thursdays.
   push:
     tags:
       - "*" # Tags that trigger a new release version
@@ -29,25 +29,25 @@ jobs:
     with:
       run-mac-tests: true
 
-  alpha:
+  edge:
     runs-on: ubuntu-latest
     environment: release
     needs: tests
-    if: ${{ inputs.create_alpha_release || github.event.schedule }}
+    if: ${{ inputs.create_edge_release || github.event.schedule }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Needed by goreleaser to browse history.
-      - name: Determine alpha tag
+      - name: Determine edge tag
         # This tag is semver and works with semver.Compare
-        run: echo "ALPHA_TAG=0.0.0-alpha.$(date +%Y-%m-%d)" >> $GITHUB_ENV
-      - name: Set alpha tag
+        run: echo "EDGE_TAG=0.0.0-edge.$(date +%Y-%m-%d)" >> $GITHUB_ENV
+      - name: Set edge tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          custom_tag: ${{ env.ALPHA_TAG }}
+          custom_tag: ${{ env.EDGE_TAG }}
           tag_prefix: ""
       - name: Set up go
         uses: actions/setup-go@v4
@@ -72,13 +72,13 @@ jobs:
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
         with:
           environment: development
-          version:  ${{ env.ALPHA_TAG }}
+          version:  ${{ env.EDGE_TAG }}
       - name: Publish snapshot release to GitHub
         uses: softprops/action-gh-release@v1
         with:
           prerelease: true
           fail_on_unmatched_files: true
-          tag_name: ${{ env.ALPHA_TAG }}
+          tag_name: ${{ env.EDGE_TAG }}
           files: |
             dist/checksums.txt
             dist/*.tar.gz
@@ -87,11 +87,11 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}
           aws-region: us-west-2
-      - name: Update alpha version in s3
+      - name: Update edge version in s3
         run: |
           tmp_file=$(mktemp)
-          echo "${{ env.ALPHA_TAG }}" > $tmp_file
-          aws s3 cp $tmp_file s3://releases.jetpack.io/devbox/alpha/version
+          echo "${{ env.EDGE_TAG }}" > $tmp_file
+          aws s3 cp $tmp_file s3://releases.jetpack.io/devbox/edge/version
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -41,7 +41,7 @@ jobs:
           fetch-depth: 0 # Needed by goreleaser to browse history.
       - name: Determine weekly tag
         # This tag is semver and works with semver.Compare
-        run: echo "WEEKLY_TAG=$(date +%Y.%U)" >> $GITHUB_ENV
+        run: echo "WEEKLY_TAG=0.0.0-weekly.$(date +%Y.%U)" >> $GITHUB_ENV
       - name: Set weekly tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.1

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -7,13 +7,13 @@ on:
   # Build/Release on demand
   workflow_dispatch:
     inputs:
-      update_weekly:
-        description: "Update weekly?"
+      create_alpha_release:
+        description: "Create alpha release?"
         required: false
         default: false
         type: boolean
   schedule:
-    - cron: "45 8 * * 4" # Weekly pre-release on Thursdays.
+    - cron: "45 8 * * 4" # Create alpha weekly on Thursdays.
   push:
     tags:
       - "*" # Tags that trigger a new release version
@@ -29,25 +29,25 @@ jobs:
     with:
       run-mac-tests: true
 
-  weekly:
+  alpha:
     runs-on: ubuntu-latest
     environment: release
     needs: tests
-    if: ${{ inputs.update_weekly || github.event.schedule }}
+    if: ${{ inputs.create_alpha_release || github.event.schedule }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Needed by goreleaser to browse history.
-      - name: Determine weekly tag
+      - name: Determine alpha tag
         # This tag is semver and works with semver.Compare
-        run: echo "WEEKLY_TAG=0.0.0-weekly.$(date +%Y.%U)" >> $GITHUB_ENV
-      - name: Set weekly tag
+        run: echo "ALPHA_TAG=0.0.0-alpha.$(date +%Y-%m-%d)" >> $GITHUB_ENV
+      - name: Set alpha tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          custom_tag: ${{ env.WEEKLY_TAG }}
+          custom_tag: ${{ env.ALPHA_TAG }}
           tag_prefix: ""
       - name: Set up go
         uses: actions/setup-go@v4
@@ -72,13 +72,13 @@ jobs:
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
         with:
           environment: development
-          version:  ${{ env.WEEKLY_TAG }}
+          version:  ${{ env.ALPHA_TAG }}
       - name: Publish snapshot release to GitHub
         uses: softprops/action-gh-release@v1
         with:
           prerelease: true
           fail_on_unmatched_files: true
-          tag_name: ${{ env.WEEKLY_TAG }}
+          tag_name: ${{ env.ALPHA_TAG }}
           files: |
             dist/checksums.txt
             dist/*.tar.gz
@@ -87,11 +87,11 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}
           aws-region: us-west-2
-      - name: Update weekly version in s3
+      - name: Update alpha version in s3
         run: |
           tmp_file=$(mktemp)
-          echo "${{ env.WEEKLY_TAG }}" > $tmp_file
-          aws s3 cp $tmp_file s3://releases.jetpack.io/devbox/weekly/version
+          echo "${{ env.ALPHA_TAG }}" > $tmp_file
+          aws s3 cp $tmp_file s3://releases.jetpack.io/devbox/alpha/version
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -7,13 +7,13 @@ on:
   # Build/Release on demand
   workflow_dispatch:
     inputs:
-      is_prerelease:
-        description: "Pre-release?"
+      update_nightly:
+        description: "Update nightly?"
         required: false
         default: false
         type: boolean
   schedule:
-    - cron: "45 8 * * 4" # Weekly pre-release on Thursdays.
+    - cron: "0 0 * * *" # Nightly
   push:
     tags:
       - "*" # Tags that trigger a new release version
@@ -23,6 +23,8 @@ permissions:
   pull-requests: read
   id-token: write # Needed for aws-actions/configure-aws-credentials@v1
 
+env:
+  NIGHTLY_TAG: 0.0.0-nightly
 
 jobs:
   tests:
@@ -30,16 +32,23 @@ jobs:
     with:
       run-mac-tests: true
 
-  prerelease:
+  nightly:
     runs-on: ubuntu-latest
     environment: release
     # needs: tests
-    if: ${{ inputs.is_prerelease || github.event.schedule }}
+    if: ${{ inputs.update_nightly || github.event.schedule }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Needed by goreleaser to browse history.
+      - name: Set nightly tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ env.NIGHTLY_TAG }}
+          tag_prefix: ""
       - name: Set up go
         uses: actions/setup-go@v4
         with:
@@ -55,10 +64,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TELEMETRY_KEY: ${{ secrets.TELEMETRY_KEY }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-      - name: Determine snapshot tag
-        run: |
-          TAG=$(ls dist/*_linux_386.tar.gz | cut -d '_' -f 2 | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+-dev')
-          echo "release_tag=$TAG" >> $GITHUB_ENV
       - name: Create Sentry release
         uses: getsentry/action-release@v1
         env:
@@ -67,16 +72,19 @@ jobs:
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
         with:
           environment: development
-          version: ${{ env.release_tag }}
+          # TODO: Add hash or date.
+          version:  ${{ env.NIGHTLY_TAG }}
       - name: Publish snapshot release to GitHub
         uses: softprops/action-gh-release@v1
         with:
           prerelease: true
           fail_on_unmatched_files: true
-          tag_name: ${{ env.release_tag }}
+          tag_name: ${{ env.NIGHTLY_TAG }}
+          name: nightly
           files: |
             dist/checksums.txt
             dist/*.tar.gz
+
   release:
     runs-on: ubuntu-latest
     environment: release

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -63,8 +63,8 @@ jobs:
         uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
         with:
           environment: development
           version: ${{ env.release_tag }}

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -77,6 +77,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           prerelease: true
+          body: $(git log --pretty=oneline $(git describe --tags --abbrev=0 --match '0.0.0-edge*')..HEAD)
           fail_on_unmatched_files: true
           tag_name: ${{ env.EDGE_TAG }}
           files: |

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -73,11 +73,14 @@ jobs:
         with:
           environment: development
           version:  ${{ env.EDGE_TAG }}
+      - name: Create release body
+        run: echo "BODY=$(git log --pretty=oneline $(git describe --tags --abbrev=0 --match '0.0.0-edge*')..HEAD)" >> $GITHUB_OUTPUT
+        id: body
       - name: Publish snapshot release to GitHub
         uses: softprops/action-gh-release@v1
         with:
           prerelease: true
-          body: $(git log --pretty=oneline $(git describe --tags --abbrev=0 --match '0.0.0-edge*')..HEAD)
+          body: ${{ steps.body.outputs.BODY }}
           fail_on_unmatched_files: true
           tag_name: ${{ env.EDGE_TAG }}
           files: |

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -32,7 +32,7 @@ jobs:
   edge:
     runs-on: ubuntu-latest
     environment: release
-    # needs: tests
+    needs: tests
     if: ${{ inputs.create_edge_release || github.event.schedule }}
     steps:
       - name: Checkout source code

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,7 @@ archives:
       - no-files-will-match-* # Glob that does not match to create archive with only binaries.
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 snapshot:
-  name_template: "{{ incpatch .Version }}-dev"
+  name_template: "{{ .Env.NIGHTLY_TAG }}"
 checksum:
   name_template: "checksums.txt"
   algorithm: sha256

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,7 @@ archives:
       - no-files-will-match-* # Glob that does not match to create archive with only binaries.
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 snapshot:
-  name_template: "{{ .Env.ALPHA_TAG }}"
+  name_template: "{{ .Env.EDGE_TAG }}"
 checksum:
   name_template: "checksums.txt"
   algorithm: sha256

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,7 @@ archives:
       - no-files-will-match-* # Glob that does not match to create archive with only binaries.
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 snapshot:
-  name_template: "{{ .Env.WEEKLY_TAG }}"
+  name_template: "{{ .Env.ALPHA_TAG }}"
 checksum:
   name_template: "checksums.txt"
   algorithm: sha256

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,7 @@ archives:
       - no-files-will-match-* # Glob that does not match to create archive with only binaries.
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 snapshot:
-  name_template: "{{ .Env.NIGHTLY_TAG }}"
+  name_template: "{{ .Env.WEEKLY_TAG }}"
 checksum:
   name_template: "checksums.txt"
   algorithm: sha256


### PR DESCRIPTION
## Summary

This needed some changes for it to work again. Changes:

* Renamed to alpha
* Create a new tag of the form `ALPHA_TAG=0.0.0-alpha.$(date +%Y-%m-%d)` This tag is semver.
* Run goreleaser --snapshot with this tag as version.
* Create/update github release with same name as tag.

This almost works with new CLI launcher. It has a regex that is not completely accurate so it complains that a version ending in `.2023-01-1` is not valid.

## How was it tested?

Github actions
