### PR TITLE
cli-post-release.yml: freeze latest channel

### DIFF
--- a/.github/workflows/cli-post-release.yml
+++ b/.github/workflows/cli-post-release.yml
@@ -24,5 +24,4 @@ jobs:
         run: |
           tmp_file=$(mktemp)
           echo "${{ github.ref_name }}" > $tmp_file
-          aws s3 cp $tmp_file s3://releases.jetpack.io/devbox/latest/version
           aws s3 cp $tmp_file s3://releases.jetpack.io/devbox/stable/version


### PR DESCRIPTION
This is so that users who are on the old launcher (pre version `0.2.0`) do not get auto-updated.

Stop updating latest channel, only stable gets updated.

## Summary

## How was it tested?
