### PR TITLE
[fileutil] move paths to fileutil

### DIFF
--- a/internal/cloud/mutagen/install.go
+++ b/internal/cloud/mutagen/install.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 
 	"github.com/cavaliergopher/grab/v3"
+
 	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/fileutil"
 )

--- a/internal/cloud/mutagen/wrapper.go
+++ b/internal/cloud/mutagen/wrapper.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pkg/errors"
 
 	"go.jetpack.io/devbox/internal/debug"
-	"go.jetpack.io/devbox/internal/xdg"
+	"go.jetpack.io/devbox/internal/fileutil"
 )
 
 func Create(spec *SessionSpec) error {
@@ -218,7 +218,7 @@ func envAsKeyValueStrings(userEnv map[string]string) []string {
 }
 
 func ensureMutagen() string {
-	installPath := xdg.CacheSubpath("mutagen/bin/mutagen")
+	installPath := fileutil.MutagenBinaryFile
 	err := InstallMutagenOnce(installPath)
 	if err != nil {
 		panic(err)

--- a/internal/fileutil/path.go
+++ b/internal/fileutil/path.go
@@ -1,0 +1,66 @@
+// Copyright 2023 Jetpack Technologies Inc and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+
+	"go.jetpack.io/devbox/internal/xdg"
+)
+
+// file path
+var (
+	BashConfigFile = rcfilePath(".bashrc") // default: ~/.bashrc
+	KshConfigFile  = rcfilePath(".kshrc")  // default: ~/.kshrc
+	ZshConfigFile  = rcfilePath(".zshrc")  // default: ~/.zshrc
+
+	CurrentVersionFile = filepath.Join(CacheDir, "current-version") // default: ~/.cache/devbox/current-version
+	NixpkgsCommitFile  = filepath.Join(CacheDir, "nixpkgs.json")    // default: ~/.cache/devbox/nixpkgs.json
+	MutagenBinaryFile  = xdg.CacheSubpath("mutagen/bin/mutagen")    // default: ~/.cache/mutagen/bin/mutagen
+
+	FishConfigFile = xdg.ConfigSubpath("fish/config.fish") // default: ~/.config/fish/config.fish
+
+	GlobalProcessComposeJSONFile = filepath.Join(GlobalDataDir, "process-compose.json") // default: ~/.local/share/devbox/global/process-compose.json
+
+)
+
+// dir path
+var (
+	CacheDir           = xdg.CacheSubpath("devbox")           // default: ~/.cache/devbox
+	NixCacheForTestDir = xdg.CacheSubpath("devbox-tests/nix") // default: ~/.cache/devbox-tests/nix
+
+	dataDir                 = xdg.DataSubpath("devbox")                         // default: ~/.local/share/devbox
+	GlobalDataDir           = filepath.Join(dataDir, "global")                  // default: ~/.local/share/devbox/global
+	CurrentGlobalProfileDir = filepath.Join(GlobalDataDir, "default")           // default:  ~/.local/share/devbox/global/default (will support multiple global profiles)
+	GlobalNixProfileDir     = filepath.Join(CurrentGlobalProfileDir, "profile") // default:  ~/.local/share/devbox/global/default/profile
+	UtilityDataDir          = filepath.Join(dataDir, "util")                    // default: ~/.local/share/devbox/util
+	UtilityNixProfileDir    = filepath.Join(UtilityDataDir, "profile")          // default: ~/.local/share/devbox/util/profile
+	UtilityBinaryDir        = filepath.Join(UtilityNixProfileDir, "bin")        // default: ~/.local/share/devbox/util/profile/bin
+
+	StateDir       = xdg.StateSubpath("devbox")                            // default: ~/.local/state/devbox
+	ErrorBufferDir = xdg.StateSubpath(filepath.FromSlash("devbox/sentry")) // default: ~/.local/state/devbox/sentry
+)
+
+// rcfilePath returns the absolute path for a rcfile, which is usually in the
+// user's home directory. It doesn't guarantee that the file exists.
+func rcfilePath(basename string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, basename)
+}
+
+func EnsureFile(path string) error {
+	if IsFile(path) {
+		return nil
+	}
+	dir := filepath.Dir(path)
+	return os.MkdirAll(dir, 0755)
+}
+
+func EnsureDir(dir string) (string, error) {
+	return dir, os.MkdirAll(dir, 0755)
+}

--- a/internal/impl/global.go
+++ b/internal/impl/global.go
@@ -7,16 +7,15 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
 
+	"go.jetpack.io/devbox/internal/fileutil"
 	"go.jetpack.io/devbox/internal/nix"
 	"go.jetpack.io/devbox/internal/planner/plansdk"
 	"go.jetpack.io/devbox/internal/ux"
-	"go.jetpack.io/devbox/internal/xdg"
 )
 
 var warningNotInPath = `the devbox global profile is not in your $PATH.
@@ -26,9 +25,6 @@ and restart your shell to fix this:
 
 	eval "$(devbox global shellenv)"
 `
-
-// In the future we will support multiple global profiles
-const currentGlobalProfile = "default"
 
 func (d *Devbox) AddGlobal(pkgs ...string) error {
 	pkgs = lo.Uniq(pkgs)
@@ -161,16 +157,13 @@ func (d *Devbox) addFromPull(pullCfg *Config) error {
 }
 
 func GlobalDataPath() (string, error) {
-	path := xdg.DataSubpath(filepath.Join("devbox/global", currentGlobalProfile))
-	return path, errors.WithStack(os.MkdirAll(path, 0755))
+	path, err := fileutil.EnsureDir(fileutil.CurrentGlobalProfileDir)
+	return path, errors.WithStack(err)
 }
 
 func GlobalNixProfilePath() (string, error) {
-	path, err := GlobalDataPath()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(path, "profile"), nil
+	path, err := fileutil.EnsureDir(fileutil.GlobalNixProfileDir)
+	return path, errors.WithStack(err)
 }
 
 // Checks if the global has been shellenv'd and warns the user if not

--- a/internal/impl/shell.go
+++ b/internal/impl/shell.go
@@ -19,8 +19,8 @@ import (
 
 	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/envir"
+	"go.jetpack.io/devbox/internal/fileutil"
 	"go.jetpack.io/devbox/internal/nix"
-	"go.jetpack.io/devbox/internal/xdg"
 )
 
 //go:embed shellrc.tmpl
@@ -137,16 +137,16 @@ func initShellBinaryFields(path string) *DevboxShell {
 	switch base {
 	case "bash":
 		shell.name = shBash
-		shell.userShellrcPath = rcfilePath(".bashrc")
+		shell.userShellrcPath = fileutil.BashConfigFile
 	case "zsh":
 		shell.name = shZsh
-		shell.userShellrcPath = rcfilePath(".zshrc")
+		shell.userShellrcPath = fileutil.ZshConfigFile
 	case "ksh":
 		shell.name = shKsh
-		shell.userShellrcPath = rcfilePath(".kshrc")
+		shell.userShellrcPath = fileutil.KshConfigFile
 	case "fish":
 		shell.name = shFish
-		shell.userShellrcPath = fishConfig()
+		shell.userShellrcPath = fileutil.FishConfigFile
 	case "dash", "ash", "shell":
 		shell.name = shPosix
 		shell.userShellrcPath = os.Getenv(envir.Env)
@@ -197,20 +197,6 @@ func WithShellStartTime(time string) ShellOption {
 	return func(s *DevboxShell) {
 		s.shellStartTime = time
 	}
-}
-
-// rcfilePath returns the absolute path for an rcfile, which is usually in the
-// user's home directory. It doesn't guarantee that the file exists.
-func rcfilePath(basename string) string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-	return filepath.Join(home, basename)
-}
-
-func fishConfig() string {
-	return xdg.ConfigSubpath("fish/config.fish")
 }
 
 func (s *DevboxShell) Run() error {

--- a/internal/plugin/symlink.go
+++ b/internal/plugin/symlink.go
@@ -13,8 +13,9 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
+
+	"go.jetpack.io/devbox/internal/fileutil"
 	"go.jetpack.io/devbox/internal/ux"
-	"go.jetpack.io/devbox/internal/xdg"
 )
 
 // Create and return a path of a symlink to the virtenv directory.
@@ -43,7 +44,7 @@ func createVirtenvSymlink(w io.Writer, projectDir string) (string, error) {
 		ux.Fwarning(w, "Virtenv's symlink (%s) in XDG_STATE_HOME (%s) "+
 			"is longer than 104 characters. If a plugin you are using uses a unix-socket, then "+
 			"it may not work. Consider changing XDG_STATE_HOME to a shorter path for devbox.",
-			symlinkPath, xdg.StateSubpath("devbox"))
+			symlinkPath, fileutil.StateDir)
 	}
 
 	// Ensure the symlink path's directory exists
@@ -88,5 +89,5 @@ func virtenvSymlinkPath(projectDir string) (string, error) {
 	// This disambiguates devbox/virtenv directories for different projects.
 	linkName := fmt.Sprintf("v-%s", hashed)
 
-	return filepath.Join(xdg.StateSubpath("devbox"), linkName), nil
+	return filepath.Join(fileutil.StateDir, linkName), nil
 }

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -19,7 +18,7 @@ import (
 
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/cuecfg"
-	"go.jetpack.io/devbox/internal/xdg"
+	"go.jetpack.io/devbox/internal/fileutil"
 )
 
 const (
@@ -63,8 +62,8 @@ func newGlobalProcessComposeConfig() *globalProcessComposeConfig {
 }
 
 func globalProcessComposeJSONPath() (string, error) {
-	path := xdg.DataSubpath(filepath.Join("devbox", "global"))
-	return filepath.Join(path, "process-compose.json"), errors.WithStack(os.MkdirAll(path, 0755))
+	path := fileutil.GlobalProcessComposeJSONFile
+	return path, errors.WithStack(fileutil.EnsureFile(path))
 }
 
 func readGlobalProcessComposeJSON(file *os.File) *globalProcessComposeConfig {

--- a/internal/vercheck/vercheck.go
+++ b/internal/vercheck/vercheck.go
@@ -10,7 +10,6 @@ import (
 	"io/fs"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/fatih/color"
@@ -21,8 +20,8 @@ import (
 	"go.jetpack.io/devbox/internal/build"
 	"go.jetpack.io/devbox/internal/cmdutil"
 	"go.jetpack.io/devbox/internal/envir"
+	"go.jetpack.io/devbox/internal/fileutil"
 	"go.jetpack.io/devbox/internal/ux"
-	"go.jetpack.io/devbox/internal/xdg"
 )
 
 // Keep this in-sync with latest version in launch.sh.
@@ -238,7 +237,7 @@ func removeCurrentVersionFile() error {
 	// If the version is newer, then the launcher updates.
 	//
 	// Note: keep this in sync with launch.sh code
-	currentVersionFilePath := filepath.Join(xdg.CacheSubpath("devbox"), "current-version")
+	currentVersionFilePath := fileutil.CurrentVersionFile
 
 	if err := os.Remove(currentVersionFilePath); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return usererr.WithLoggedUserMessage(

--- a/testscripts/testrunner/setupenv.go
+++ b/testscripts/testrunner/setupenv.go
@@ -1,3 +1,6 @@
+// Copyright 2023 Jetpack Technologies Inc and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
 package testrunner
 
 import (
@@ -9,7 +12,7 @@ import (
 	"github.com/rogpeppe/go-internal/testscript"
 
 	"go.jetpack.io/devbox/internal/envir"
-	"go.jetpack.io/devbox/internal/xdg"
+	"go.jetpack.io/devbox/internal/fileutil"
 )
 
 func setupTestEnv(t *testing.T, envs *testscript.Env) error {
@@ -61,14 +64,9 @@ func setupCacheHome(envs *testscript.Env) error {
 	// nixpkgs every time.
 	// Here we create a shared location for nix's cache, and symlink from
 	// the test's working directory.
-	err = os.MkdirAll(xdg.CacheSubpath("devbox-tests/nix"), 0755) // Ensure dir exists.
+	err = os.MkdirAll(fileutil.NixCacheForTestDir, 0755) // Ensure dir exists.
 	if err != nil {
 		return err
 	}
-	err = os.Symlink(xdg.CacheSubpath("devbox-tests/nix"), filepath.Join(cacheHome, "nix"))
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return os.Symlink(fileutil.NixCacheForTestDir, filepath.Join(cacheHome, "nix"))
 }


### PR DESCRIPTION
## Summary

1. Move paths from different packages to `fileutil`
2. Add default values as comments for every path
3. Distinguish file paths and dir paths with different suffixes
4. Add functions to ensure dirs exist

## How was it tested?
