### PR TITLE
[easy][bugs] Fix 2 package input bugs

### DIFF
--- a/internal/nix/input.go
+++ b/internal/nix/input.go
@@ -137,7 +137,7 @@ func (i *Input) PackageAttributePath() (string, error) {
 				strings.Join(lo.Keys(infos), ", ")
 		}
 		return "", usererr.New(
-			"Flake \"%s\" is ambiguous. %s",
+			"Package \"%s\" is ambiguous. %s",
 			i.String(),
 			outputs,
 		)

--- a/internal/nix/input_test.go
+++ b/internal/nix/input_test.go
@@ -29,16 +29,16 @@ func TestInput(t *testing.T) {
 		{
 			pkg:                "path:path/to/my-flake#my-package",
 			isFlake:            true,
-			name:               "my-flake-c7758d",
-			urlWithoutFragment: "path://" + filepath.Join(projectDir, "path/to/my-flake"),
-			urlForInput:        "path://" + filepath.Join(projectDir, "path/to/my-flake"),
+			name:               "my-flake-eaedce",
+			urlWithoutFragment: "path:" + filepath.Join(projectDir, "path/to/my-flake"),
+			urlForInput:        "path:" + filepath.Join(projectDir, "path/to/my-flake"),
 		},
 		{
 			pkg:                "path:.#my-package",
 			isFlake:            true,
-			name:               "my-project-744eaa",
-			urlWithoutFragment: "path://" + projectDir,
-			urlForInput:        "path://" + projectDir,
+			name:               "my-project-bbeb05",
+			urlWithoutFragment: "path:" + projectDir,
+			urlForInput:        "path:" + projectDir,
 		},
 		{
 			pkg:                "path:/tmp/my-project/path/to/my-flake#my-package",


### PR DESCRIPTION
## Summary

Fixes 2 bugs:

* Avoid triple slashes that can make comparing urls break when adding flakes (this was affecting correct removal of profile packages and also detecting that they were already installed)
* Fix package validation for non-versioned packages (They should use nix search instead of new search service)

## How was it tested?

* `devbox add sqlite3`  showed error and was not added to devbox.json
* In examples/flake/php added and removed packages and confirmed profile remained in sync. 
