### PR TITLE
chore: add more envs and functions

### DIFF
--- a/internal/envir/env.go
+++ b/internal/envir/env.go
@@ -13,9 +13,11 @@ const (
 	// DevboxLatestVersion is the latest version available of the devbox CLI binary.
 	// NOTE: it should NOT start with v (like 0.4.8)
 	DevboxLatestVersion  = "DEVBOX_LATEST_VERSION"
+	DevboxOGPathPrefix   = "DEVBOX_OG_PATH_"
 	DevboxRegion         = "DEVBOX_REGION"
+	DevboxRunCmd         = "DEVBOX_RUN_CMD"
 	DevboxSearchHost     = "DEVBOX_SEARCH_HOST"
-	DevboxShellEnabled   = "DEVBOX_SHELL_ENABLED"
+	devboxShellEnabled   = "DEVBOX_SHELL_ENABLED"
 	DevboxShellStartTime = "DEVBOX_SHELL_START_TIME"
 	DevboxVM             = "DEVBOX_VM"
 

--- a/internal/envir/util.go
+++ b/internal/envir/util.go
@@ -18,8 +18,12 @@ func IsDevboxCloud() bool {
 }
 
 func IsDevboxShellEnabled() bool {
-	inDevboxShell, _ := strconv.ParseBool(os.Getenv(DevboxShellEnabled))
+	inDevboxShell, _ := strconv.ParseBool(os.Getenv(devboxShellEnabled))
 	return inDevboxShell
+}
+
+func EnableDevboxShell(env map[string]string) {
+	env[devboxShellEnabled] = "1"
 }
 
 func DoNotTrack() bool {
@@ -57,4 +61,11 @@ func GetValueOrDefault(key, def string) string {
 	}
 
 	return val
+}
+
+func GetPath(env map[string]string) string {
+	if env == nil {
+		return ""
+	}
+	return env[Path]
 }

--- a/internal/impl/shell.go
+++ b/internal/impl/shell.go
@@ -266,7 +266,7 @@ func (s *DevboxShell) shellRCOverrides(shellrc string) (extraEnv map[string]stri
 	case shZsh:
 		extraEnv = map[string]string{"ZDOTDIR": shellescape.Quote(filepath.Dir(shellrc))}
 	case shKsh, shPosix:
-		extraEnv = map[string]string{"ENV": shellescape.Quote(shellrc)}
+		extraEnv = map[string]string{envir.Env: shellescape.Quote(shellrc)}
 	case shFish:
 		extraArgs = []string{"-C", ". " + shellrc}
 	}


### PR DESCRIPTION
## Summary

1. Add more envs: `DevboxRunCmd`, `DevboxOGPathPrefix`
2. Add function to set env `devboxShellEnabled` and get `PATH` values
3. use existing envs and functions

## How was it tested?
