### PR TITLE
[versioned] Deal with packages that don't build on system

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -152,7 +152,11 @@ func (d *Devbox) NixPkgsCommitHash() string {
 
 func (d *Devbox) ShellPlan() (*plansdk.ShellPlan, error) {
 	shellPlan := planner.GetShellPlan(d.projectDir, d.packages())
-	shellPlan.FlakeInputs = d.flakeInputs()
+	var err error
+	shellPlan.FlakeInputs, err = d.flakeInputs()
+	if err != nil {
+		return nil, err
+	}
 
 	nixpkgsInfo := plansdk.GetNixpkgsInfo(d.cfg.Nixpkgs.Commit)
 

--- a/internal/impl/flakes.go
+++ b/internal/impl/flakes.go
@@ -14,13 +14,13 @@ import (
 // created by devbox. We map packages to the correct flake and attribute path
 // and group flakes by URL to avoid duplication. All inputs should be locked
 // i.e. have a commit hash and always resolve to the same package/version.
-func (d *Devbox) flakeInputs() []*plansdk.FlakeInput {
+func (d *Devbox) flakeInputs() ([]*plansdk.FlakeInput, error) {
 	inputs := map[string]*plansdk.FlakeInput{}
 	for _, p := range d.packages() {
 		pkg := nix.InputFromString(p, d.lockfile)
 		AttributePath, err := pkg.PackageAttributePath()
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 		if input, ok := inputs[pkg.URLForInput()]; !ok {
 			inputs[pkg.URLForInput()] = &plansdk.FlakeInput{
@@ -35,5 +35,5 @@ func (d *Devbox) flakeInputs() []*plansdk.FlakeInput {
 		}
 	}
 
-	return lo.Values(inputs)
+	return lo.Values(inputs), nil
 }

--- a/internal/nix/search.go
+++ b/internal/nix/search.go
@@ -67,16 +67,23 @@ func parseSearchResults(data []byte) map[string]*Info {
 	return infos
 }
 
-// pkgExistsForAnySystem is a bit slow. Only use it if there's already been
-// an error and we want to provide a better error message.
+// pkgExistsForAnySystem is a bit slow (~600ms). Only use it if there's already
+// been an error and we want to provide a better error message.
 func pkgExistsForAnySystem(pkg string) bool {
 	systems := []string{
+		// Check most common systems first.
+		"x86_64-linux",
+		"x86_64-darwin",
 		"aarch64-linux",
+		"aarch64-darwin",
+
+		"armv5tel-linux",
 		"armv6l-linux",
 		"armv7l-linux",
 		"i686-linux",
-		"x86_64-darwin",
-		"x86_64-linux",
+		"mipsel-linux",
+		"powerpc64le-linux",
+		"riscv64-linux",
 	}
 	for _, system := range systems {
 		if len(searchSystem(pkg, system)) > 0 {

--- a/internal/nix/search.go
+++ b/internal/nix/search.go
@@ -1,0 +1,103 @@
+package nix
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/pkg/errors"
+	"github.com/samber/lo"
+	"go.jetpack.io/devbox/internal/debug"
+	"go.jetpack.io/devbox/internal/lock"
+)
+
+var ErrPackageNotFound = errors.New("package not found")
+var ErrPackageNotInstalled = errors.New("package not installed")
+
+func PkgExists(pkg string, lock *lock.File) (bool, error) {
+	return InputFromString(pkg, lock).validateExists()
+}
+
+type Info struct {
+	// attribute key is different in flakes vs legacy so we should only use it
+	// if we know exactly which version we are using
+	attributeKey string
+	PName        string
+	Version      string
+}
+
+func (i *Info) String() string {
+	return fmt.Sprintf("%s-%s", i.PName, i.Version)
+}
+
+func PkgInfo(nixpkgsCommit, pkg string) *Info {
+	exactPackage := fmt.Sprintf("%s#%s", FlakeNixpkgs(nixpkgsCommit), pkg)
+	if nixpkgsCommit == "" {
+		exactPackage = fmt.Sprintf("nixpkgs#%s", pkg)
+	}
+
+	results := search(exactPackage)
+	if len(results) == 0 {
+		return nil
+	}
+	// we should only have one result
+	return lo.Values(results)[0]
+}
+
+func search(url string) map[string]*Info {
+	return searchSystem(url, "")
+}
+
+func parseSearchResults(data []byte) map[string]*Info {
+	var results map[string]map[string]any
+	err := json.Unmarshal(data, &results)
+	if err != nil {
+		panic(err)
+	}
+	infos := map[string]*Info{}
+	for key, result := range results {
+		infos[key] = &Info{
+			attributeKey: key,
+			PName:        result["pname"].(string),
+			Version:      result["version"].(string),
+		}
+
+	}
+	return infos
+}
+
+// pkgExistsForAnySystem is a bit slow. Only use it if there's already been
+// an error and we want to provide a better error message.
+func pkgExistsForAnySystem(pkg string) bool {
+	systems := []string{
+		"aarch64-linux",
+		"armv6l-linux",
+		"armv7l-linux",
+		"i686-linux",
+		"x86_64-darwin",
+		"x86_64-linux",
+	}
+	for _, system := range systems {
+		if len(searchSystem(pkg, system)) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func searchSystem(url string, system string) map[string]*Info {
+	cmd := exec.Command("nix", "search", "--json", url)
+	cmd.Args = append(cmd.Args, ExperimentalFlags()...)
+	if system != "" {
+		cmd.Args = append(cmd.Args, "--system", system)
+	}
+	cmd.Stderr = os.Stderr
+	debug.Log("running command: %s\n", cmd)
+	out, err := cmd.Output()
+	if err != nil {
+		// for now, assume all errors are invalid packages.
+		return nil
+	}
+	return parseSearchResults(out)
+}


### PR DESCRIPTION
## Summary

Fixes a few bugs:

* Remove panic
* If package can't be found for current system, search on all systems so we can return better error message.
* Don't automatically write to disk when resolving lockfile packages. That way if there's an error we don't leave the lockfile in a bad state.

## How was it tested?

### package that exists but not for my system

```bash
➜  devbox git:(landau/fix-panic) ✗ devbox add ripgrep@12
There was an error installing nix packages: ripgrep@12. Packages were not added to devbox.json

Error: Package "ripgrep@12" was found, but we're unable to build it for your system. You may need to choose another version or write a custom flake.
```

### package that doesn't exist

```bash
➜  devbox git:(landau/fix-panic) ✗ devbox add foobar1@8

Error: foobar1@8: package not found

To search for packages use https://search.nixos.org/packages
```

### regular versioned install:

```bash
devbox add php@8
```

### Regular install:

```bash
devbox add php
```

### Manual add

* Edited devbox.json and added `php@8` and confirmed lockfile was updated after `devbox run`