### PR TITLE
[bugs] Fix shell.nix bug and ensure current symlink

### DIFF
--- a/internal/impl/tmpl/shell.nix.tmpl
+++ b/internal/impl/tmpl/shell.nix.tmpl
@@ -1,7 +1,7 @@
 let
   pkgs = import
     (fetchTarball {
-      url = "{{ .NixpkgsInfo.URL }}";
+      url = "{{ .NixpkgsInfo.TarURL }}";
     })
     { };
   {{- range .Definitions}}

--- a/internal/planner/plansdk/plansdk.go
+++ b/internal/planner/plansdk/plansdk.go
@@ -85,7 +85,8 @@ func WelcomeMessage(s string) string {
 // TODO: We can probably get rid of this once we remove the haskell and php
 // planners
 type NixpkgsInfo struct {
-	URL string
+	URL    string
+	TarURL string
 }
 
 // The commit hash for nixpkgs-unstable on 2023-01-25 from status.nixos.org
@@ -100,6 +101,8 @@ func GetNixpkgsInfo(commitHash string) *NixpkgsInfo {
 	}
 	return &NixpkgsInfo{
 		URL: fmt.Sprintf("github:NixOS/nixpkgs/%s", commitHash),
+		// legacy, used for shell.nix (which is no longer used, but some direnv users still need it)
+		TarURL: fmt.Sprintf("https://github.com/nixos/nixpkgs/archive/%s.tar.gz", commitHash),
 	}
 }
 

--- a/internal/planner/plansdk/plansdk.go
+++ b/internal/planner/plansdk/plansdk.go
@@ -93,14 +93,12 @@ type NixpkgsInfo struct {
 const DefaultNixpkgsCommit = "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
 
 func GetNixpkgsInfo(commitHash string) *NixpkgsInfo {
-	mirror := nixpkgsMirrorURL(commitHash)
-	if mirror != "" {
-		return &NixpkgsInfo{
-			URL: mirror,
-		}
+	url := fmt.Sprintf("github:NixOS/nixpkgs/%s", commitHash)
+	if mirror := nixpkgsMirrorURL(commitHash); mirror != "" {
+		url = mirror
 	}
 	return &NixpkgsInfo{
-		URL: fmt.Sprintf("github:NixOS/nixpkgs/%s", commitHash),
+		URL: url,
 		// legacy, used for shell.nix (which is no longer used, but some direnv users still need it)
 		TarURL: fmt.Sprintf("https://github.com/nixos/nixpkgs/archive/%s.tar.gz", commitHash),
 	}


### PR DESCRIPTION
## Summary

Fixes 2 unrelated bugs:

* Create current symlink if needed. This has no user impact, but is causing devbox cloud to break. It is also needed for future multi-profile support.
* Ensure shell.nix works by including correct URL in fetchTarball. This affects direnv users that have a legacy .envrc file. New/updated users are unaffected. Fixes https://github.com/jetpack-io/devbox/issues/1010

cc: @Lagoja 

## How was it tested?

* Deleted current symlink, and saw it being recreated.
* `nix-shell .devbox/gen/shell.nix`
