### PR TITLE
[direnv] Added warning for old envrc content

### DIFF
--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -48,7 +48,7 @@ func Exists(path string) bool {
 }
 
 // Contains checks if a given file at 'path' contains the 'substring'
-func Contains(path string, substring string) (bool, error) {
+func FileContains(path string, substring string) (bool, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return false, err

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -5,6 +5,7 @@ package fileutil
 
 import (
 	"os"
+	"strings"
 )
 
 // TODO: publish as it's own shared package that other binaries can use.
@@ -44,4 +45,13 @@ func IsFile(path string) bool {
 func Exists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// Contains checks if a given file at 'path' contains the 'substring'
+func Contains(path string, substring string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	return strings.Contains(string(data), substring), nil
 }

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -47,7 +47,7 @@ func Exists(path string) bool {
 	return err == nil
 }
 
-// Contains checks if a given file at 'path' contains the 'substring'
+// FileContains checks if a given file at 'path' contains the 'substring'
 func FileContains(path string, substring string) (bool, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime/trace"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"text/template"
@@ -1014,11 +1015,18 @@ func (d *Devbox) findPackageByName(name string) (string, error) {
 }
 
 func (d *Devbox) checkOldEnvrc() error {
+	envrcPath := filepath.Join(d.ProjectDir(), ".envrc")
+	noUpdate, err := strconv.ParseBool(os.Getenv("DEVBOX_NO_ENVRC_UPDATE"))
+	if err != nil {
+		return err
+	}
 	// check if user has an old version of envrc
-	if fileutil.Exists(".envrc") && os.Getenv("DEVBOX_NO_ENVRC_UPDATE") != "1" {
-		// fmt.Println("inside general if")
-		isNewEnvrc, err := fileutil.FileContains(".envrc", "eval \"$(devbox generate direnv --print-envrc)\"")
-		if err != nil && !errors.Is(err, os.ErrNotExist) {
+	if fileutil.Exists(".envrc") && !noUpdate {
+		isNewEnvrc, err := fileutil.FileContains(
+			envrcPath,
+			"eval \"$(devbox generate direnv --print-envrc)\"",
+		)
+		if err != nil {
 			return err
 		}
 		if !isNewEnvrc {

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -1018,7 +1018,9 @@ func (d *Devbox) checkOldEnvrc() error {
 	envrcPath := filepath.Join(d.ProjectDir(), ".envrc")
 	noUpdate, err := strconv.ParseBool(os.Getenv("DEVBOX_NO_ENVRC_UPDATE"))
 	if err != nil {
-		return err
+		// DEVBOX_NO_ENVRC_UPDATE is either not set or invalid
+		// so we consider it the same as false
+		noUpdate = false
 	}
 	// check if user has an old version of envrc
 	if fileutil.Exists(".envrc") && !noUpdate {


### PR DESCRIPTION
## Summary
Checks for old .envrc file if all following is true:
- usePrintDevEnvCache is false
- .envrc file exists
- DEVBOX_NO_ENVRC_UPDATE env variable is not set to 1

Then checks if the .envrc file contains the 1 line that we have in new .envrc file:
```eval "$(devbox generate direnv --print-envrc)"```

if the file doesn't contain this line it prints out a warning.

## How was it tested?
- compile
- prepend path to compiled binary to PATH
- create an empty dir
- `devbox init`
- `touch .envrc` (don't run `devbox generate direnv`)
- copy the following to .envrc
```
eval "$(../devbox/dist/devbox generate direnv --print-envrc)"
```
replace `../devbox/dist/devbox` with a relative path to the compiled devbox binary

- then run `direnv allow` or run `devbox shell`
- it should show the warning about the content of your envrc being old.
NOTE: subsequent cd ins and out or devbox shells won't show the warning because of `usePrintDevEnvCache`