### PR TITLE
[cicd] Simplify go CICD cache

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -53,7 +53,6 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: ./go.mod
-          cache: true
       - name: Build snapshot with goreleaser
         uses: goreleaser/goreleaser-action@v3
         with:
@@ -112,7 +111,6 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: ./go.mod
-          cache: false
       - name: Create Sentry release
         uses: getsentry/action-release@v1
         env:

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -60,19 +60,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: ./go.mod
-      - name: Get current time
-        uses: josStorer/get-current-time@v2.0.2
-        id: current-time
-      - name: Mount golangci-lint cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/golangci-lint
-            ~/.cache/go-build
-            ~/go/pkg
-          key: golangci-lint-cache-${{ runner.os }}-${{ steps.current-time.outputs.day }}
-          restore-keys: |
-            golangci-lint-cache-${{ runner.os }}-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.4.0
         with:
@@ -103,7 +90,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: ./go.mod
-          cache: true
       - name: Build devbox
         run: go install ./cmd/devbox
       - name: Install additional shells (dash, zsh)
@@ -141,7 +127,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: ./go.mod
-          cache: true
       - name: Build devbox
         run: go install ./cmd/devbox
       - name: Install nix and devbox packages


### PR DESCRIPTION
## Summary

We were double caching in some places. 

I remove `cache: true` because this is default in v4 go action.

@loreto any reason cache was disabled for release?

## How was it tested?

CICD
