### PR TITLE
[testscripts] augment php testscrpt to remove and re-add a php-extension

### DIFF
--- a/testscripts/languages/php.test.txt
+++ b/testscripts/languages/php.test.txt
@@ -1,6 +1,14 @@
 exec devbox run -- php index.php
 stdout 'done\n'
 
+exec devbox rm php81Extensions.ds
+exec devbox run -- php index.php
+stdout 'ds extension is not enabled'
+
+exec devbox add php81Extensions.ds
+exec devbox run -- php index.php
+stdout 'done\n'
+
 -- devbox.json --
 {
   "packages": [


### PR DESCRIPTION
## Summary

When reviewing #1000, I found myself wanting to ensure the test plan of #648 was used.

So, I added it to testscripts. It works :)

## How was it tested?

`go test -run TestScripts/php ./testscripts/...`
