### PR TITLE
[global] Remove global only functions, make global reuse local code

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -19,7 +19,6 @@ type Devbox interface {
 	// environment. It validates that the Nix packages exist, and install them.
 	// Adding duplicate packages is a no-op.
 	Add(ctx context.Context, pkgs ...string) error
-	AddGlobal(pkgs ...string) error
 	Config() *impl.Config
 	ProjectDir() string
 	// Generate creates the directory of Nix files and the Dockerfile that define
@@ -29,15 +28,15 @@ type Devbox interface {
 	GenerateDockerfile(force bool) error
 	GenerateEnvrcFile(force bool) error
 	Info(pkg string, markdown bool) error
+	IsEnvEnabled() bool
 	ListScripts() []string
 	PrintEnv(ctx context.Context, includeHooks bool) (string, error)
 	PrintGlobalList() error
 	PrintEnvrcContent(w io.Writer) error
-	PullGlobal(path string) error
+	PullGlobal(ctx context.Context, path string) error
 	// Remove removes Nix packages from the config so that it no longer exists in
 	// the devbox environment.
 	Remove(ctx context.Context, pkgs ...string) error
-	RemoveGlobal(pkgs ...string) error
 	RestartServices(ctx context.Context, services ...string) error
 	RunScript(scriptName string, scriptArgs []string) error
 	Services() (services.Services, error)

--- a/internal/boxcli/install.go
+++ b/internal/boxcli/install.go
@@ -14,10 +14,8 @@ import (
 func installCmd() *cobra.Command {
 	flags := runCmdFlags{}
 	command := &cobra.Command{
-		Use:   "install",
-		Short: "Install all packages mentioned in devbox.json",
-		Long: "Start a new devbox shell and installs all packages mentioned in devbox.json in current directory or" +
-			"a directory specified via --config. \n\n Then exits the shell when packages are done installing.\n\n ",
+		Use:     "install",
+		Short:   "Install all packages mentioned in devbox.json",
 		Args:    cobra.MaximumNArgs(0),
 		PreRunE: ensureNixInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/boxcli/shellenv.go
+++ b/internal/boxcli/shellenv.go
@@ -29,6 +29,7 @@ func shellEnvCmd() *cobra.Command {
 				return err
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), s)
+			fmt.Fprintln(cmd.OutOrStdout(), "hash -r")
 			return nil
 		},
 	}

--- a/internal/impl/envvars.go
+++ b/internal/impl/envvars.go
@@ -5,6 +5,7 @@ package impl
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 )
@@ -80,4 +81,11 @@ func markEnvsAsSetByDevbox(envs ...map[string]string) {
 			env[devboxSetPrefix+key] = "1"
 		}
 	}
+}
+
+// IsEnvEnabled checks if the devbox environment is enabled. We use the ogPathKey
+// as a proxy for this. This allows us to differentiate between global and
+// individual project shells.
+func (d *Devbox) IsEnvEnabled() bool {
+	return os.Getenv(d.ogPathKey()) != ""
 }

--- a/internal/impl/global.go
+++ b/internal/impl/global.go
@@ -4,6 +4,7 @@
 package impl
 
 import (
+	"context"
 	"fmt"
 	"io/fs"
 	"net/url"
@@ -14,8 +15,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
 
-	"go.jetpack.io/devbox/internal/nix"
-	"go.jetpack.io/devbox/internal/ux"
 	"go.jetpack.io/devbox/internal/xdg"
 )
 
@@ -30,89 +29,12 @@ and restart your shell to fix this:
 // In the future we will support multiple global profiles
 const currentGlobalProfile = "default"
 
-func (d *Devbox) AddGlobal(pkgs ...string) error {
-	pkgs = lo.Uniq(pkgs)
-
-	// validate all packages exist. Don't install anything if any are missing
-	for _, pkg := range pkgs {
-		found, err := nix.PkgExists(pkg, d.lockfile)
-		if err != nil {
-			return err
-		}
-		if !found {
-			return nix.ErrPackageNotFound
-		}
-	}
-	profilePath, err := GlobalNixProfilePath()
-	if err != nil {
-		return err
-	}
-
-	var added []string
-	total := len(pkgs)
-	for idx, pkg := range pkgs {
-		stepNum := idx + 1
-		stepMsg := fmt.Sprintf("[%d/%d] %s", stepNum, total, pkg)
-		err = nix.ProfileInstall(&nix.ProfileInstallArgs{
-			CustomStepMessage: stepMsg,
-			Lockfile:          d.lockfile,
-			Package:           pkg,
-			ProfilePath:       profilePath,
-			Writer:            d.writer,
-		})
-		if err != nil {
-			fmt.Fprintf(d.writer, "Error installing %s: %s", pkg, err)
-		} else {
-			added = append(added, pkg)
-		}
-	}
-	if len(added) == 0 && err != nil {
-		return err
-	}
-	d.cfg.Packages = lo.Uniq(append(d.cfg.Packages, added...))
-	if err := d.saveCfg(); err != nil {
-		return err
-	}
-	d.ensureDevboxGlobalShellenvEnabled()
-	return nil
-}
-
-func (d *Devbox) RemoveGlobal(pkgs ...string) error {
-	pkgs = lo.Uniq(pkgs)
-	if _, missing := lo.Difference(d.cfg.Packages, pkgs); len(missing) > 0 {
-		ux.Fwarning(
-			d.writer,
-			"the following packages were not found in your global devbox.json: %s\n",
-			strings.Join(missing, ", "),
-		)
-	}
-	var removed []string
-	profilePath, err := GlobalNixProfilePath()
-	if err != nil {
-		return err
-	}
-	for _, pkg := range lo.Intersect(d.cfg.Packages, pkgs) {
-		if err := nix.ProfileRemove(profilePath, pkg, d.lockfile); err != nil {
-			if errors.Is(err, nix.ErrPackageNotInstalled) {
-				removed = append(removed, pkg)
-			} else {
-				fmt.Fprintf(d.writer, "Error removing %s: %s", pkg, err)
-			}
-		} else {
-			fmt.Fprintf(d.writer, "%s was removed\n", pkg)
-			removed = append(removed, pkg)
-		}
-	}
-	d.cfg.Packages, _ = lo.Difference(d.cfg.Packages, removed)
-	return d.saveCfg()
-}
-
-func (d *Devbox) PullGlobal(path string) error {
+func (d *Devbox) PullGlobal(ctx context.Context, path string) error {
 	u, err := url.Parse(path)
 	if err == nil && u.Scheme != "" {
-		return d.pullGlobalFromURL(u)
+		return d.pullGlobalFromURL(ctx, u)
 	}
-	return d.pullGlobalFromPath(path)
+	return d.pullGlobalFromPath(ctx, path)
 }
 
 func (d *Devbox) PrintGlobalList() error {
@@ -122,25 +44,25 @@ func (d *Devbox) PrintGlobalList() error {
 	return nil
 }
 
-func (d *Devbox) pullGlobalFromURL(u *url.URL) error {
+func (d *Devbox) pullGlobalFromURL(ctx context.Context, u *url.URL) error {
 	fmt.Fprintf(d.writer, "Pulling global config from %s\n", u)
 	cfg, err := readConfigFromURL(u)
 	if err != nil {
 		return err
 	}
-	return d.addFromPull(cfg)
+	return d.addFromPull(ctx, cfg)
 }
 
-func (d *Devbox) pullGlobalFromPath(path string) error {
+func (d *Devbox) pullGlobalFromPath(ctx context.Context, path string) error {
 	fmt.Fprintf(d.writer, "Pulling global config from %s\n", path)
 	cfg, err := readConfig(path)
 	if err != nil {
 		return err
 	}
-	return d.addFromPull(cfg)
+	return d.addFromPull(ctx, cfg)
 }
 
-func (d *Devbox) addFromPull(pullCfg *Config) error {
+func (d *Devbox) addFromPull(ctx context.Context, pullCfg *Config) error {
 	diff, _ := lo.Difference(pullCfg.Packages, d.cfg.Packages)
 	if len(diff) == 0 {
 		fmt.Fprint(d.writer, "No new packages to install\n")
@@ -151,7 +73,7 @@ func (d *Devbox) addFromPull(pullCfg *Config) error {
 		"Installing the following packages: %s\n",
 		strings.Join(diff, ", "),
 	)
-	return d.AddGlobal(diff...)
+	return d.Add(ctx, diff...)
 }
 
 func GlobalDataPath() (string, error) {
@@ -160,30 +82,22 @@ func GlobalDataPath() (string, error) {
 		return "", errors.WithStack(err)
 	}
 
-	nixProfilePath := filepath.Join(path, "profile")
+	nixProfilePath := filepath.Join(path)
 	currentPath := xdg.DataSubpath("devbox/global/current")
 
 	// For now default is always current. In the future we will support multiple
-	// and allow user to switch.
+	// and allow user to switch. Remove any existing symlink and create a new one
+	// because previous versions of devbox may have created a symlink to a different
+	// profile.
+	existing, _ := os.Readlink(currentPath)
+	if existing != nixProfilePath {
+		_ = os.Remove(currentPath)
+	}
+
 	err := os.Symlink(nixProfilePath, currentPath)
 	if err != nil && !errors.Is(err, fs.ErrExist) {
 		return "", errors.WithStack(err)
 	}
 
 	return path, nil
-}
-
-func GlobalNixProfilePath() (string, error) {
-	path, err := GlobalDataPath()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(path, "profile"), nil
-}
-
-// Checks if the global has been shellenv'd and warns the user if not
-func (d *Devbox) ensureDevboxGlobalShellenvEnabled() {
-	if os.Getenv(d.ogPathKey()) == "" {
-		ux.Fwarning(d.writer, warningNotInPath)
-	}
 }

--- a/internal/impl/global.go
+++ b/internal/impl/global.go
@@ -18,14 +18,6 @@ import (
 	"go.jetpack.io/devbox/internal/xdg"
 )
 
-var warningNotInPath = `the devbox global profile is not in your $PATH.
-
-Add the following line to your shell's rcfile (e.g., ~/.bashrc or ~/.zshrc)
-and restart your shell to fix this:
-
-	eval "$(devbox global shellenv)"
-`
-
 // In the future we will support multiple global profiles
 const currentGlobalProfile = "default"
 


### PR DESCRIPTION
## Summary

This PR is in preparation for adding more global commands (update, etc) and to allow `global pull` to download additional data.

It simplifies how global works by removing global only code-paths and reusing projects code-paths where possible. (it removes 3 lines for every line it adds :) )

It turns the global parent command into an alias for `--config [global-path]` which let's us make any command global fairly easily.

One semi-significant change this makes is that the global nix profile is changing. It was previously stored in `~/.local/share/devbox/global/default/profile`  (which is at the same level as the devbox.json). It is now stored in the more familiar `~/.local/share/devbox/global/default/.devbox/nix/profile/default` which is the same as regular projects. This should not affect existing users, but it will leave some profile files hanging around. We could write a follow up to clean them up.

## How was it tested?

```bash
devbox global ls
devbox global add hello
hello
devbox global rm hello
```
