### PR TITLE
[bug fix] write devbox.lock file first, and then write local.lock

### DIFF
--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -191,12 +191,11 @@ func (d *Devbox) ensurePackagesAreInstalled(ctx context.Context, mode installMod
 		return err
 	}
 
-	if err = localLock.Update(); err != nil {
+	if err = d.lockfile.Save(); err != nil {
 		return err
 	}
 
-	// Update lockfile to ensure any newly resolved packages are saved to disk.
-	return d.lockfile.Save()
+	return localLock.Update()
 }
 
 func (d *Devbox) profilePath() (string, error) {


### PR DESCRIPTION
## Summary

Problem:
The local.lock file has an empty field for `lock_file_hash` on the first run.

This probably results in print-dev-env cache misses, and may cause some perf regressions.

Cause:
We were doing `localLock.Update()` first, which writes a hash of the `devbox.lock` file (which is currently empty).

Instead, we should first write the `devbox.lock` file and then the `.devbox/local.lock` file.



## How was it tested?

```
> cat devbox.json
{
  "packages": [
    "go@1.20",
    "actionlint@1.6.23"
  ],
  "shell": {
    "init_hook": null
  },
  "nixpkgs": {
    "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
  }
}⏎

# run a command to install packages
> devbox shellenv

```

BEFORE:
```
> cat .devbox/local.lock
{
  "config_hash": "d85415929c9f724a7e0aa2acdf2ecf3de219cc9562462fa94ce161f917112b0f",
  "devbox_version": "0.0.0-dev",
  "lock_file_hash": "",
  "nix_profile_manifest_hash": "9efe99415f34794f020246de1cebb5cd0a86a8c9102980d53235b49afd7b6b0a",
  "nix_print_dev_env_hash": "cf8009a62d97f724e3fbe3caf5df18241da854bfa416b15545015e876518b28a"
}⏎
```

AFTER:
```
> cat .devbox/local.lock
{
  "config_hash": "0b24ba518d49ccd3a84c7b85dd842e90fff19d6a865a6885a2219cce6de948e9",
  "devbox_version": "0.0.0-dev",
  "lock_file_hash": "223a022c8349d1aa0118d6b4e816716786ee44b0f9ea5183ce6bfa86e817afba",
  "nix_profile_manifest_hash": "9efe99415f34794f020246de1cebb5cd0a86a8c9102980d53235b49afd7b6b0a",
  "nix_print_dev_env_hash": "cf8009a62d97f724e3fbe3caf5df18241da854bfa416b15545015e876518b28a"
}⏎
```
