### PR TITLE
[devcontainer] Added shellenv to dockerfile template

### DIFF
--- a/internal/boxcli/generate/devcontainer_util.go
+++ b/internal/boxcli/generate/devcontainer_util.go
@@ -36,8 +36,12 @@ type vscode struct {
 	Extensions []string `json:"extensions"`
 }
 
+type dockerfileData struct {
+	IsDevcontainer bool
+}
+
 // CreateDockerfile creates a Dockerfile in path and writes devcontainerDockerfile.tmpl's content into it
-func CreateDockerfile(tmplFS embed.FS, path string) error {
+func CreateDockerfile(tmplFS embed.FS, path string, isDevcontainer bool) error {
 	// create dockerfile
 	file, err := os.Create(filepath.Join(path, "Dockerfile"))
 	if err != nil {
@@ -48,7 +52,7 @@ func CreateDockerfile(tmplFS embed.FS, path string) error {
 	tmplName := "devcontainerDockerfile.tmpl"
 	t := template.Must(template.ParseFS(tmplFS, "tmpl/"+tmplName))
 	// write content into file
-	return t.Execute(file, nil)
+	return t.Execute(file, &dockerfileData{IsDevcontainer: isDevcontainer})
 }
 
 // CreateDevcontainer creates a devcontainer.json in path and writes getDevcontainerContent's output into it

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -365,7 +365,7 @@ func (d *Devbox) GenerateDevcontainer(force bool) error {
 			redact.Safe(filepath.Base(devContainerPath)), err)
 	}
 	// generate dockerfile
-	err = generate.CreateDockerfile(tmplFS, devContainerPath)
+	err = generate.CreateDockerfile(tmplFS, devContainerPath, true /* isDevcontainer */)
 	if err != nil {
 		return redact.Errorf("error generating dev container Dockerfile in <project>/%s: %w",
 			redact.Safe(filepath.Base(devContainerPath)), err)
@@ -392,7 +392,7 @@ func (d *Devbox) GenerateDockerfile(force bool) error {
 	}
 
 	// generate dockerfile
-	return errors.WithStack(generate.CreateDockerfile(tmplFS, d.projectDir))
+	return errors.WithStack(generate.CreateDockerfile(tmplFS, d.projectDir, false /* isDevcontainer */))
 }
 
 func (d *Devbox) PrintEnvrcContent(w io.Writer) error {

--- a/internal/impl/tmpl/devcontainerDockerfile.tmpl
+++ b/internal/impl/tmpl/devcontainerDockerfile.tmpl
@@ -27,5 +27,8 @@ WORKDIR /code
 RUN sudo chown $DEVBOX_USER:root /code
 COPY devbox.json devbox.json
 RUN devbox install
+{{if .IsDevcontainer}}
 RUN devbox shellenv --init-hook >> ~/.profile
+{{- else}}
 CMD ["devbox", "shell"]
+{{- end}}

--- a/internal/impl/tmpl/devcontainerDockerfile.tmpl
+++ b/internal/impl/tmpl/devcontainerDockerfile.tmpl
@@ -27,4 +27,5 @@ WORKDIR /code
 RUN sudo chown $DEVBOX_USER:root /code
 COPY devbox.json devbox.json
 RUN devbox install
+devbox shellenv --init-hook >> ~/.profile
 CMD ["devbox", "shell"]

--- a/internal/impl/tmpl/devcontainerDockerfile.tmpl
+++ b/internal/impl/tmpl/devcontainerDockerfile.tmpl
@@ -27,5 +27,5 @@ WORKDIR /code
 RUN sudo chown $DEVBOX_USER:root /code
 COPY devbox.json devbox.json
 RUN devbox install
-devbox shellenv --init-hook >> ~/.profile
+RUN devbox shellenv --init-hook >> ~/.profile
 CMD ["devbox", "shell"]


### PR DESCRIPTION
## Summary
title says it.
fixes #1028 

## How was it tested?
- devbox init
- devbox add terraform
- devbox generate devcontainer
- add a file in `.vscode/tasks.json` and put the following json in it:
```
 {
    "version": "2.0.0",
    "tasks": [
        {
            "label": "terraform version",
            "type": "shell",
            "command": "terraform version"
        }
    ]
}
```

- `cmd + shift + p` and select "Rebuild and Reopen in Container"
- `cmd + shift + p` and select "Run Task" 
- Choose terraform task to run
- Assert that the output shows terraform version is printed in output