### PR TITLE
[shellenv] prepend to XDG_DATA_DIRS, instead of overwriting

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -812,6 +812,12 @@ func (d *Devbox) computeNixEnv(ctx context.Context, usePrintDevEnvCache bool) (m
 
 	d.setCommonHelperEnvVars(env)
 
+	// preserve the original XDG_DATA_DIRS by prepending to it
+	env["XDG_DATA_DIRS"] = JoinPathLists(
+		env["XDG_DATA_DIRS"],
+		os.Getenv("XDG_DATA_DIRS"),
+	)
+
 	return env, addHashToEnv(env)
 }
 


### PR DESCRIPTION
## Summary

This PR ensures we preserve the XDG_DATA_DIRS env-var by appending the original
value to the end of the new shellenv XDG_DATA_DIRS paths:

`XDG_DATA_DIR={shellenv-XDG_DATA_DIR}:{original-XDG_DATA_DIR}`

## How was it tested?

I have direnv enabled in my devbox repo
```
> cd ~/code/jetpack
> echo $XDG_DATA_DIRS
some /nix/store/.... path is printed

> cd devbox
# direnv kicks in

> echo $XDG_DATA_DIRS
the original XDG_DATA_DIRS is preserved
BEFORE: this would be empty

```
