### PR TITLE
[docs] Correct direnv.md reference to `devbox generate direnv`

### DIFF
--- a/docs/app/docs/ide_configuration/direnv.md
+++ b/docs/app/docs/ide_configuration/direnv.md
@@ -34,7 +34,7 @@ or `direnv revoke` to stop.
 
 #### Existing Project
 
-For an existing project, you can add a `.envrc` file by running `devbox generate envrc`:
+For an existing project, you can add a `.envrc` file by running `devbox generate direnv`:
 
 ```bash
 ➜  devbox generate direnv


### PR DESCRIPTION
## Summary

Docs update. Docs refer to `devbox generate envrc` when it should be `devbox generate direnv`

## How was it tested?

Visually? 🤷 