### PR TITLE
[refactor] Move config to own package. Don't warn if overwriting defa…

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -61,7 +61,7 @@ func Open(dir string, writer io.Writer) (Devbox, error) {
 
 // InitConfig creates a default devbox config file if one doesn't already exist.
 func InitConfig(dir string, writer io.Writer) (bool, error) {
-	return devconfig.InitConfig(dir, writer)
+	return devconfig.Init(dir, writer)
 }
 
 func GlobalDataPath() (string, error) {

--- a/devbox.go
+++ b/devbox.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"io"
 
+	"go.jetpack.io/devbox/internal/devconfig"
 	"go.jetpack.io/devbox/internal/impl"
 	"go.jetpack.io/devbox/internal/planner/plansdk"
 	"go.jetpack.io/devbox/internal/services"
@@ -19,7 +20,7 @@ type Devbox interface {
 	// environment. It validates that the Nix packages exist, and install them.
 	// Adding duplicate packages is a no-op.
 	Add(ctx context.Context, pkgs ...string) error
-	Config() *impl.Config
+	Config() *devconfig.Config
 	ProjectDir() string
 	// Generate creates the directory of Nix files and the Dockerfile that define
 	// the devbox environment.
@@ -60,7 +61,7 @@ func Open(dir string, writer io.Writer) (Devbox, error) {
 
 // InitConfig creates a default devbox config file if one doesn't already exist.
 func InitConfig(dir string, writer io.Writer) (bool, error) {
-	return impl.InitConfig(dir, writer)
+	return devconfig.InitConfig(dir, writer)
 }
 
 func GlobalDataPath() (string, error) {

--- a/internal/boxcli/global.go
+++ b/internal/boxcli/global.go
@@ -112,9 +112,10 @@ func pullGlobalCmdFunc(
 		if err = survey.AskOne(prompt, &overwrite); err != nil {
 			return errors.WithStack(err)
 		}
-		if overwrite {
-			err = box.PullGlobal(cmd.Context(), overwrite, args[0])
+		if !overwrite {
+			return nil
 		}
+		err = box.PullGlobal(cmd.Context(), overwrite, args[0])
 	}
 	if err != nil {
 		return err

--- a/internal/devconfig/config.go
+++ b/internal/devconfig/config.go
@@ -1,13 +1,12 @@
 // Copyright 2023 Jetpack Technologies Inc and contributors. All rights reserved.
 // Use of this source code is governed by the license in the LICENSE file.
 
-package impl
+package devconfig
 
 import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -16,11 +15,11 @@ import (
 
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/cuecfg"
-	"go.jetpack.io/devbox/internal/debug"
-	"go.jetpack.io/devbox/internal/fileutil"
 	"go.jetpack.io/devbox/internal/impl/shellcmd"
 	"go.jetpack.io/devbox/internal/planner/plansdk"
 )
+
+const DefaultName = "devbox.json"
 
 // Config defines a devbox environment as JSON.
 type Config struct {
@@ -59,7 +58,7 @@ type Stage struct {
 	Command string `cue:"string" json:"command"`
 }
 
-func defaultConfig() *Config {
+func DefaultConfig() *Config {
 	return &Config{
 		Shell: &shellConfig{
 			Scripts: map[string]*shellcmd.Commands{
@@ -78,6 +77,12 @@ func defaultConfig() *Config {
 
 func (c *Config) Hash() (string, error) {
 	return cuecfg.Hash(c)
+}
+
+func (c *Config) Equals(other *Config) bool {
+	hash1, _ := c.Hash()
+	hash2, _ := other.Hash()
+	return hash1 == hash2
 }
 
 func (c *Config) NixPkgsCommitHash() string {
@@ -101,13 +106,19 @@ func (c *Config) InitHook() *shellcmd.Commands {
 	return c.Shell.InitHook
 }
 
+// SaveTo writes the config to a file.
+func (c *Config) SaveTo(path string) error {
+	cfgPath := filepath.Join(path, DefaultName)
+	return cuecfg.WriteFile(cfgPath, c)
+}
+
 func readConfig(path string) (*Config, error) {
 	cfg := &Config{}
 	return cfg, errors.WithStack(cuecfg.ParseFile(path, cfg))
 }
 
-// ReadConfig reads a devbox config file, and validates it.
-func ReadConfig(path string) (*Config, error) {
+// Load reads a devbox config file, and validates it.
+func Load(path string) (*Config, error) {
 	cfg, err := readConfig(path)
 	if err != nil {
 		return nil, err
@@ -115,7 +126,7 @@ func ReadConfig(path string) (*Config, error) {
 	return cfg, validateConfig(cfg)
 }
 
-func readConfigFromURL(url *url.URL) (*Config, error) {
+func LoadConfigFromURL(url *url.URL) (*Config, error) {
 	res, err := http.Get(url.String())
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -142,96 +153,9 @@ func WriteConfig(path string, cfg *Config) error {
 	return cuecfg.WriteFile(path, cfg)
 }
 
-// findProjectDir walks up the directory tree looking for a devbox.json
-// and upon finding it, will return the directory-path.
-//
-// If it doesn't find any devbox.json, then an error is returned.
-func findProjectDir(path string) (string, error) {
-	debug.Log("findProjectDir: path is %s\n", path)
-
-	// Sanitize the directory and use the absolute path as canonical form
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return "", errors.WithStack(err)
-	}
-
-	// If the path  is specified, then we check directly for a config.
-	// Otherwise, we search the parent directories.
-	if path != "" {
-		return findProjectDirAtPath(absPath)
-	}
-	return findProjectDirFromParentDirSearch("/" /*root*/, absPath)
-}
-
-func findProjectDirAtPath(absPath string) (string, error) {
-	fi, err := os.Stat(absPath)
-	if err != nil {
-		return "", err
-	}
-
-	switch mode := fi.Mode(); {
-	case mode.IsDir():
-		if !fileutil.Exists(filepath.Join(absPath, configFilename)) {
-			return "", missingConfigError(absPath, false /*didCheckParents*/)
-		}
-		return absPath, nil
-	default: // assumes 'file' i.e. mode.IsRegular()
-		if !fileutil.Exists(filepath.Clean(absPath)) {
-			return "", missingConfigError(absPath, false /*didCheckParents*/)
-		}
-		// we return a directory from this function
-		return filepath.Dir(absPath), nil
-	}
-}
-
-func findProjectDirFromParentDirSearch(root string, absPath string) (string, error) {
-	cur := absPath
-	// Search parent directories for a devbox.json
-	for cur != root {
-		debug.Log("finding %s in dir: %s\n", configFilename, cur)
-		if fileutil.Exists(filepath.Join(cur, configFilename)) {
-			return cur, nil
-		}
-		cur = filepath.Dir(cur)
-	}
-	if fileutil.Exists(filepath.Join(cur, configFilename)) {
-		return cur, nil
-	}
-	return "", missingConfigError(absPath, true /*didCheckParents*/)
-}
-
-func missingConfigError(path string, didCheckParents bool) error {
-	var workingDir string
-	wd, err := os.Getwd()
-	if err == nil {
-		workingDir = wd
-	}
-	// We try to prettify the `path` before printing
-	if path == "." || path == "" || workingDir == path {
-		path = "this directory"
-	} else {
-		// Instead of a long absolute directory, print the relative directory
-
-		// if an error occurs, then just use `path`
-		if workingDir != "" {
-			relDir, err := filepath.Rel(workingDir, path)
-			if err == nil {
-				path = relDir
-			}
-		}
-	}
-
-	parentDirCheckAddendum := ""
-	if didCheckParents {
-		parentDirCheckAddendum = ", or any parent directories"
-	}
-
-	return usererr.New("No devbox.json found in %s%s. Did you run `devbox init` yet?", path, parentDirCheckAddendum)
-}
-
 func validateConfig(cfg *Config) error {
 	fns := []func(cfg *Config) error{
-		validateNixpkg,
+		ValidateNixpkg,
 		validateScripts,
 	}
 
@@ -252,16 +176,18 @@ func validateScripts(cfg *Config) error {
 			return errors.New("cannot have script with empty name in devbox.json")
 		}
 		if whitespace.MatchString(k) {
-			return errors.Errorf("cannot have script name with whitespace in devbox.json: %s", k)
+			return errors.Errorf(
+				"cannot have script name with whitespace in devbox.json: %s", k)
 		}
 		if strings.TrimSpace(scripts[k].String()) == "" {
-			return errors.Errorf("cannot have an empty script body in devbox.json: %s", k)
+			return errors.Errorf(
+				"cannot have an empty script body in devbox.json: %s", k)
 		}
 	}
 	return nil
 }
 
-func validateNixpkg(cfg *Config) error {
+func ValidateNixpkg(cfg *Config) error {
 	hash := cfg.NixPkgsCommitHash()
 	if hash == "" {
 		return nil

--- a/internal/devconfig/config.go
+++ b/internal/devconfig/config.go
@@ -60,6 +60,7 @@ type Stage struct {
 
 func DefaultConfig() *Config {
 	return &Config{
+		Packages: []string{}, // initialize to empty slice instead of nil for consistent marshalling
 		Shell: &shellConfig{
 			Scripts: map[string]*shellcmd.Commands{
 				"test": {
@@ -141,7 +142,10 @@ func LoadConfigFromURL(url *url.URL) (*Config, error) {
 	if !cuecfg.IsSupportedExtension(ext) {
 		ext = ".json"
 	}
-	return cfg, cuecfg.Unmarshal(data, ext, cfg)
+	if err = cuecfg.Unmarshal(data, ext, cfg); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return cfg, validateConfig(cfg)
 }
 
 // WriteConfig saves a devbox config file.

--- a/internal/devconfig/init.go
+++ b/internal/devconfig/init.go
@@ -14,7 +14,7 @@ import (
 	"go.jetpack.io/devbox/internal/initrec"
 )
 
-func InitConfig(dir string, writer io.Writer) (created bool, err error) {
+func Init(dir string, writer io.Writer) (created bool, err error) {
 	cfgPath := filepath.Join(dir, DefaultName)
 
 	config := DefaultConfig()

--- a/internal/devconfig/init.go
+++ b/internal/devconfig/init.go
@@ -1,0 +1,37 @@
+// Copyright 2023 Jetpack Technologies Inc and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package devconfig
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/fatih/color"
+	"go.jetpack.io/devbox/internal/cuecfg"
+	"go.jetpack.io/devbox/internal/initrec"
+)
+
+func InitConfig(dir string, writer io.Writer) (created bool, err error) {
+	cfgPath := filepath.Join(dir, DefaultName)
+
+	config := DefaultConfig()
+
+	// package suggestion
+	pkgsToSuggest, err := initrec.Get(dir)
+	if err != nil {
+		return false, err
+	}
+	if len(pkgsToSuggest) > 0 {
+		s := fmt.Sprintf("devbox add %s", strings.Join(pkgsToSuggest, " "))
+		fmt.Fprintf(
+			writer,
+			"We detected extra packages you may need. To install them, run `%s`\n",
+			color.HiYellowString(s),
+		)
+	}
+
+	return cuecfg.InitFile(cfgPath, config)
+}

--- a/internal/impl/devbox_test.go
+++ b/internal/impl/devbox_test.go
@@ -63,7 +63,7 @@ func (n *testNix) PrintDevEnv(ctx context.Context, args *nix.PrintDevEnvArgs) (*
 
 func TestComputeNixEnv(t *testing.T) {
 	path := t.TempDir()
-	_, err := devconfig.InitConfig(path, os.Stdout)
+	_, err := devconfig.Init(path, os.Stdout)
 	require.NoError(t, err, "InitConfig should not fail")
 	d, err := Open(path, os.Stdout)
 	require.NoError(t, err, "Open should not fail")
@@ -76,7 +76,7 @@ func TestComputeNixEnv(t *testing.T) {
 
 func TestComputeNixPathIsIdempotent(t *testing.T) {
 	dir := t.TempDir()
-	_, err := devconfig.InitConfig(dir, os.Stdout)
+	_, err := devconfig.Init(dir, os.Stdout)
 	require.NoError(t, err, "InitConfig should not fail")
 	devbox, err := Open(dir, os.Stdout)
 	require.NoError(t, err, "Open should not fail")
@@ -102,7 +102,7 @@ func TestComputeNixPathIsIdempotent(t *testing.T) {
 
 func TestComputeNixPathWhenRemoving(t *testing.T) {
 	dir := t.TempDir()
-	_, err := devconfig.InitConfig(dir, os.Stdout)
+	_, err := devconfig.Init(dir, os.Stdout)
 	require.NoError(t, err, "InitConfig should not fail")
 	devbox, err := Open(dir, os.Stdout)
 	require.NoError(t, err, "Open should not fail")

--- a/internal/impl/devbox_test.go
+++ b/internal/impl/devbox_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.jetpack.io/devbox/internal/devconfig"
 	"go.jetpack.io/devbox/internal/envir"
 	"go.jetpack.io/devbox/internal/nix"
 )
@@ -62,7 +63,7 @@ func (n *testNix) PrintDevEnv(ctx context.Context, args *nix.PrintDevEnvArgs) (*
 
 func TestComputeNixEnv(t *testing.T) {
 	path := t.TempDir()
-	_, err := InitConfig(path, os.Stdout)
+	_, err := devconfig.InitConfig(path, os.Stdout)
 	require.NoError(t, err, "InitConfig should not fail")
 	d, err := Open(path, os.Stdout)
 	require.NoError(t, err, "Open should not fail")
@@ -75,7 +76,7 @@ func TestComputeNixEnv(t *testing.T) {
 
 func TestComputeNixPathIsIdempotent(t *testing.T) {
 	dir := t.TempDir()
-	_, err := InitConfig(dir, os.Stdout)
+	_, err := devconfig.InitConfig(dir, os.Stdout)
 	require.NoError(t, err, "InitConfig should not fail")
 	devbox, err := Open(dir, os.Stdout)
 	require.NoError(t, err, "Open should not fail")
@@ -101,7 +102,7 @@ func TestComputeNixPathIsIdempotent(t *testing.T) {
 
 func TestComputeNixPathWhenRemoving(t *testing.T) {
 	dir := t.TempDir()
-	_, err := InitConfig(dir, os.Stdout)
+	_, err := devconfig.InitConfig(dir, os.Stdout)
 	require.NoError(t, err, "InitConfig should not fail")
 	devbox, err := Open(dir, os.Stdout)
 	require.NoError(t, err, "Open should not fail")

--- a/internal/impl/dir.go
+++ b/internal/impl/dir.go
@@ -1,0 +1,109 @@
+// Copyright 2023 Jetpack Technologies Inc and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package impl
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/internal/boxcli/usererr"
+	"go.jetpack.io/devbox/internal/debug"
+	"go.jetpack.io/devbox/internal/devconfig"
+	"go.jetpack.io/devbox/internal/fileutil"
+)
+
+// findProjectDir walks up the directory tree looking for a devbox.json
+// and upon finding it, will return the directory-path.
+//
+// If it doesn't find any devbox.json, then an error is returned.
+func findProjectDir(path string) (string, error) {
+	debug.Log("findProjectDir: path is %s\n", path)
+
+	// Sanitize the directory and use the absolute path as canonical form
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	// If the path  is specified, then we check directly for a config.
+	// Otherwise, we search the parent directories.
+	if path != "" {
+		return findProjectDirAtPath(absPath)
+	}
+	return findProjectDirFromParentDirSearch("/" /*root*/, absPath)
+}
+
+func findProjectDirAtPath(absPath string) (string, error) {
+	fi, err := os.Stat(absPath)
+	if err != nil {
+		return "", err
+	}
+
+	switch mode := fi.Mode(); {
+	case mode.IsDir():
+		if !fileutil.Exists(filepath.Join(absPath, devconfig.DefaultName)) {
+			return "", missingConfigError(absPath, false /*didCheckParents*/)
+		}
+		return absPath, nil
+	default: // assumes 'file' i.e. mode.IsRegular()
+		if !fileutil.Exists(filepath.Clean(absPath)) {
+			return "", missingConfigError(absPath, false /*didCheckParents*/)
+		}
+		// we return a directory from this function
+		return filepath.Dir(absPath), nil
+	}
+}
+
+func findProjectDirFromParentDirSearch(
+	root string,
+	absPath string,
+) (string, error) {
+	cur := absPath
+	// Search parent directories for a devbox.json
+	for cur != root {
+		debug.Log("finding %s in dir: %s\n", devconfig.DefaultName, cur)
+		if fileutil.Exists(filepath.Join(cur, devconfig.DefaultName)) {
+			return cur, nil
+		}
+		cur = filepath.Dir(cur)
+	}
+	if fileutil.Exists(filepath.Join(cur, devconfig.DefaultName)) {
+		return cur, nil
+	}
+	return "", missingConfigError(absPath, true /*didCheckParents*/)
+}
+
+func missingConfigError(path string, didCheckParents bool) error {
+	var workingDir string
+	wd, err := os.Getwd()
+	if err == nil {
+		workingDir = wd
+	}
+	// We try to prettify the `path` before printing
+	if path == "." || path == "" || workingDir == path {
+		path = "this directory"
+	} else {
+		// Instead of a long absolute directory, print the relative directory
+
+		// if an error occurs, then just use `path`
+		if workingDir != "" {
+			relDir, err := filepath.Rel(workingDir, path)
+			if err == nil {
+				path = relDir
+			}
+		}
+	}
+
+	parentDirCheckAddendum := ""
+	if didCheckParents {
+		parentDirCheckAddendum = ", or any parent directories"
+	}
+
+	return usererr.New(
+		"No devbox.json found in %s%s. Did you run `devbox init` yet?",
+		path,
+		parentDirCheckAddendum,
+	)
+}

--- a/internal/impl/dir_test.go
+++ b/internal/impl/dir_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.jetpack.io/devbox/internal/devconfig"
 )
 
 func TestFindProjectDirFromParentDirSearch(t *testing.T) {
@@ -52,7 +53,7 @@ func TestFindProjectDirFromParentDirSearch(t *testing.T) {
 			err = os.MkdirAll(filepath.Join(root, testCase.allDirs), 0777)
 			assert.NoError(err)
 
-			absProjectPath, err := filepath.Abs(filepath.Join(root, testCase.projectDir, configFilename))
+			absProjectPath, err := filepath.Abs(filepath.Join(root, testCase.projectDir, devconfig.DefaultName))
 			assert.NoError(err)
 			err = os.WriteFile(absProjectPath, []byte("{}"), 0666)
 			assert.NoError(err)
@@ -96,14 +97,14 @@ func TestFindParentDirAtPath(t *testing.T) {
 			name:        "flag_path_is_file_has_config",
 			allDirs:     "a/b/c",
 			projectDir:  "a/b",
-			flagPath:    "a/b/" + configFilename,
+			flagPath:    "a/b/" + devconfig.DefaultName,
 			expectError: false,
 		},
 		{
 			name:        "flag_path_is_file_missing_config",
 			allDirs:     "a/b/c",
 			projectDir:  "", // missing config
-			flagPath:    "a/b/" + configFilename,
+			flagPath:    "a/b/" + devconfig.DefaultName,
 			expectError: true,
 		},
 	}
@@ -120,7 +121,7 @@ func TestFindParentDirAtPath(t *testing.T) {
 
 			var absProjectPath string
 			if testCase.projectDir != "" {
-				absProjectPath, err = filepath.Abs(filepath.Join(root, testCase.projectDir, configFilename))
+				absProjectPath, err = filepath.Abs(filepath.Join(root, testCase.projectDir, devconfig.DefaultName))
 				assert.NoError(err)
 				err = os.WriteFile(absProjectPath, []byte("{}"), 0666)
 				assert.NoError(err)
@@ -152,8 +153,8 @@ func TestNixpkgsValidation(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			err := validateNixpkg(&Config{
-				Nixpkgs: &NixpkgsConfig{
+			err := devconfig.ValidateNixpkg(&devconfig.Config{
+				Nixpkgs: &devconfig.NixpkgsConfig{
 					Commit: testCase.commit,
 				},
 			})

--- a/internal/impl/global.go
+++ b/internal/impl/global.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
 
+	"go.jetpack.io/devbox/internal/devconfig"
 	"go.jetpack.io/devbox/internal/pullbox"
 	"go.jetpack.io/devbox/internal/xdg"
 )
@@ -55,11 +56,15 @@ func (d *Devbox) pullGlobalFromURL(
 			configURL,
 			d.ProjectDir(),
 		)
-		return puller.DownloadAndExtract(overwrite, configURL.String(), d.projectDir)
+		return puller.DownloadAndExtract(
+			overwrite,
+			configURL.String(),
+			d.projectDir,
+		)
 	} else if err != nil {
 		return err
 	}
-	cfg, err := readConfigFromURL(configURL)
+	cfg, err := devconfig.LoadConfigFromURL(configURL)
 	if err != nil {
 		return err
 	}
@@ -68,15 +73,15 @@ func (d *Devbox) pullGlobalFromURL(
 
 func (d *Devbox) pullGlobalFromPath(ctx context.Context, path string) error {
 	fmt.Fprintf(d.writer, "Pulling global config from %s\n", path)
-	cfg, err := readConfig(path)
+	cfg, err := devconfig.Load(path)
 	if err != nil {
 		return err
 	}
 	return d.addFromPull(ctx, cfg)
 }
 
-func (d *Devbox) addFromPull(ctx context.Context, pullCfg *Config) error {
-	diff, _ := lo.Difference(pullCfg.Packages, d.cfg.Packages)
+func (d *Devbox) addFromPull(ctx context.Context, cfg *devconfig.Config) error {
+	diff, _ := lo.Difference(cfg.Packages, d.cfg.Packages)
 	if len(diff) == 0 {
 		fmt.Fprint(d.writer, "No new packages to install\n")
 		return nil
@@ -100,8 +105,8 @@ func GlobalDataPath() (string, error) {
 
 	// For now default is always current. In the future we will support multiple
 	// and allow user to switch. Remove any existing symlink and create a new one
-	// because previous versions of devbox may have created a symlink to a different
-	// profile.
+	// because previous versions of devbox may have created a symlink to a
+	// different profile.
 	existing, _ := os.Readlink(currentPath)
 	if existing != nixProfilePath {
 		_ = os.Remove(currentPath)

--- a/internal/pullbox/tar.go
+++ b/internal/pullbox/tar.go
@@ -59,9 +59,9 @@ func (p *pullbox) copy(overwrite bool, src, dst string) error {
 
 	if !overwrite {
 		for _, srcFile := range srcFiles {
-			// Only show error if file exists and is not a non-modified config
-			_, err := os.Stat(filepath.Join(dst, srcFile.Name()))
-			if err == nil && !isModifiedConfig(srcFile.Name()) {
+			dstPath := filepath.Join(dst, srcFile.Name())
+			// Only show error if file exists and is a modified config
+			if _, err := os.Stat(dstPath); err == nil && isModifiedConfig(dstPath) {
 				return fs.ErrExist
 			}
 		}

--- a/internal/pullbox/tar.go
+++ b/internal/pullbox/tar.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 
 	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/internal/devconfig"
 )
 
 // extract decompresses a tar file and saves it to a tmp directory
@@ -58,7 +59,9 @@ func (p *pullbox) copy(overwrite bool, src, dst string) error {
 
 	if !overwrite {
 		for _, srcFile := range srcFiles {
-			if _, err := os.Stat(filepath.Join(dst, srcFile.Name())); err == nil {
+			// Only show error if file exists and is not a non-modified config
+			_, err := os.Stat(filepath.Join(dst, srcFile.Name()))
+			if err == nil && !isModifiedConfig(srcFile.Name()) {
 				return fs.ErrExist
 			}
 		}
@@ -71,4 +74,15 @@ func (p *pullbox) copy(overwrite bool, src, dst string) error {
 		}
 	}
 	return nil
+}
+
+func isModifiedConfig(path string) bool {
+	if filepath.Base(path) == devconfig.DefaultName {
+		cfg, err := devconfig.Load(path)
+		if err != nil {
+			return false
+		}
+		return !cfg.Equals(devconfig.DefaultConfig())
+	}
+	return false
 }

--- a/testscripts/testrunner/examplesrunner.go
+++ b/testscripts/testrunner/examplesrunner.go
@@ -14,8 +14,8 @@ import (
 	"github.com/rogpeppe/go-internal/testscript"
 
 	"go.jetpack.io/devbox/internal/debug"
+	"go.jetpack.io/devbox/internal/devconfig"
 	"go.jetpack.io/devbox/internal/envir"
-	"go.jetpack.io/devbox/internal/impl"
 )
 
 // xdgStateHomeDir is the home directory for devbox state. We store symlinks to
@@ -42,7 +42,7 @@ func RunExamplesTestscripts(t *testing.T, examplesDir string) {
 		}
 
 		configPath := filepath.Join(path, "devbox.json")
-		config, err := impl.ReadConfig(configPath)
+		config, err := devconfig.Load(configPath)
 		if err != nil {
 			// skip directories that do not have a devbox.json defined
 			if errors.Is(err, fs.ErrNotExist) {


### PR DESCRIPTION
## Summary

Stacked on https://github.com/jetpack-io/devbox/pull/1043

This is mostly a straight refactor. Just moved everything to new package, renamed a few methods/constants if it made sense.

Only added functionality is `isModifiedConfig` in pullbox that doesn't return error if config that is being overwritten is a default config. (we need this because configs are created automatically so we always get the prompt even if it's empty)

## How was it tested?

Ran `devbox global pull https://fleekgen.fly.dev/high` with global directory:

* Empty
* Only with unmodified config
* Only with modified config
* With other files.
