### PR TITLE
[perf] Improve how we determine attribute path

### DIFF
--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -277,15 +277,19 @@ func (d *Devbox) removePackagesFromProfile(ctx context.Context, pkgs []string) e
 		return err
 	}
 
-	for _, pkg := range pkgs {
+	for _, input := range nix.InputsFromStrings(pkgs, d.lockfile) {
 		index, err := nix.ProfileListIndex(&nix.ProfileListIndexArgs{
 			Lockfile:   d.lockfile,
 			Writer:     d.writer,
-			Pkg:        pkg,
+			Input:      input,
 			ProfileDir: profileDir,
 		})
 		if err != nil {
-			ux.Ferror(d.writer, "Package %s not found in profile. Skipping.\n", pkg)
+			ux.Ferror(
+				d.writer,
+				"Package %s not found in profile. Skipping.\n",
+				input.Raw,
+			)
 			continue
 		}
 
@@ -322,16 +326,16 @@ func (d *Devbox) pendingPackagesForInstallation(ctx context.Context) ([]string, 
 	if err != nil {
 		return nil, err
 	}
-	for _, pkg := range d.Packages() {
+	for _, input := range d.packagesAsInputs() {
 		_, err := nix.ProfileListIndex(&nix.ProfileListIndexArgs{
 			List:       list,
 			Lockfile:   d.lockfile,
 			Writer:     d.writer,
-			Pkg:        pkg,
+			Input:      input,
 			ProfileDir: profileDir,
 		})
 		if err != nil {
-			pending = append(pending, pkg)
+			pending = append(pending, input.Raw)
 		}
 	}
 	return pending, nil


### PR DESCRIPTION
## Summary

This makes 2 improvements to our use of attribute paths which was causing performance issues:

**Improve ProfileListIndex:**

ProfileListIndex will attempt to find an exact match in unlocked profile references. (See `normalizedDevboxPackageReference`. This short circuits having to loop through all profile list items and having to compute normalized attribute paths for each.

**Split PackageAttributePath:**

Split `PackageAttributePath` into `NormalizedPackageAttributePath` and a faster new `PackageAttributePath`. When computing attribute paths we would always use nix search to ensure the attribute path is normalized. This is helpful for comparing 2 distinct attribute paths that point to same package (e.g. `flake` and `flake#default` are likely the same). The downside is that search is slow. (about 100ms per search). So what we do is when using devbox packages, we assume they resolve to nixpkgs and therefore we can reconstruct the exact attribute path (`legacyPackages.<system>.<pkg>`) without using search.

Some additional improvements:

* Currently local/remote flakes still need to use search. This affects our plugins. We could cache the search results to make them faster.

## How was it tested?

Created devbox.json with 20 packages and stuff got super slow. After these changes, it reduces non-installation time during `devbox add` from  40-60 seconds to about 2s. 
