### PR TITLE
[packages] fix error check in pendingPackagesForInstallation

### DIFF
--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -335,7 +335,10 @@ func (d *Devbox) pendingPackagesForInstallation(ctx context.Context) ([]string, 
 			ProfileDir: profileDir,
 		})
 		if err != nil {
-			pending = append(pending, input.Raw)
+			if errors.Is(err, nix.ErrPackageNotFound) {
+				pending = append(pending, input.Raw)
+			}
+			return nil, err
 		}
 	}
 	return pending, nil

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -335,10 +335,10 @@ func (d *Devbox) pendingPackagesForInstallation(ctx context.Context) ([]string, 
 			ProfileDir: profileDir,
 		})
 		if err != nil {
-			if errors.Is(err, nix.ErrPackageNotFound) {
-				pending = append(pending, input.Raw)
+			if !errors.Is(err, nix.ErrPackageNotFound) {
+				return nil, err
 			}
-			return nil, err
+			pending = append(pending, input.Raw)
 		}
 	}
 	return pending, nil


### PR DESCRIPTION
## Summary

The if-condition was ignoring genuine errors

## How was it tested?

```
> rm -rf <project>/.devbox
> cd <project>
# has direnv-enabled, and so this installed the packages that were pending
```