### PR TITLE
feat: add list to devbox run if no args are given

### DIFF
--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -4,6 +4,8 @@
 package boxcli
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"go.jetpack.io/devbox"
@@ -28,7 +30,6 @@ func runCmd() *cobra.Command {
 		Example: "\nRun a command directly:\n\n  devbox add cowsay\n  devbox run cowsay hello\n  " +
 			"devbox run -- cowsay -d hello\n\nRun a script (defined as `\"moo\": \"cowsay moo\"`) " +
 			"in your devbox.json:\n\n  devbox run moo",
-		Args:    cobra.MinimumNArgs(1),
 		PreRunE: ensureNixInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runScriptCmd(cmd, args, flags)
@@ -53,6 +54,18 @@ func listScripts(cmd *cobra.Command, flags runCmdFlags) []string {
 }
 
 func runScriptCmd(cmd *cobra.Command, args []string, flags runCmdFlags) error {
+	if len(args) == 0 {
+		scripts := listScripts(cmd, flags)
+		if len(scripts) == 0 {
+			return redact.Errorf("no scripts defined in devbox.json")
+		}
+		fmt.Println("Available scripts:")
+		for _, p := range scripts {
+			fmt.Printf("* %s\n", p)
+		}
+		return nil
+	}
+
 	path, script, scriptArgs, err := parseScriptArgs(args, flags)
 	if err != nil {
 		return redact.Errorf("error parsing script arguments: %w", err)

--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -57,7 +57,8 @@ func runScriptCmd(cmd *cobra.Command, args []string, flags runCmdFlags) error {
 	if len(args) == 0 {
 		scripts := listScripts(cmd, flags)
 		if len(scripts) == 0 {
-			return redact.Errorf("no scripts defined in devbox.json")
+			fmt.Fprintln(cmd.OutOrStdout(), "no scripts defined in devbox.json")
+			return nil
 		}
 		fmt.Fprintln(cmd.OutOrStdout(), "Available scripts:")
 		for _, p := range scripts {

--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -59,9 +59,9 @@ func runScriptCmd(cmd *cobra.Command, args []string, flags runCmdFlags) error {
 		if len(scripts) == 0 {
 			return redact.Errorf("no scripts defined in devbox.json")
 		}
-		fmt.Println("Available scripts:")
+		fmt.Fprintln(cmd.OutOrStdout(), "Available scripts:")
 		for _, p := range scripts {
-			fmt.Printf("* %s\n", p)
+			fmt.Fprintf(cmd.OutOrStdout(), "* %s\n", p)
 		}
 		return nil
 	}


### PR DESCRIPTION
## Summary
If merged this change will print available scripts if no arguments are given on the `devbox run` command.

## How was it tested?
Trivial change, tested with CLI.