### PR TITLE
[plugins] Improve how we determine package name in plugins

### DIFF
--- a/internal/impl/flakes.go
+++ b/internal/impl/flakes.go
@@ -30,7 +30,7 @@ func (d *Devbox) flakeInputs() ([]*plansdk.FlakeInput, error) {
 	// if this is behavior we want for user plugins. We may need to add an optional
 	// priority field to the config.
 	for _, pkg := range append(pluginPackages, userPackages...) {
-		AttributePath, err := pkg.PackageAttributePath()
+		AttributePath, err := pkg.FullPackageAttributePath()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/nix/input.go
+++ b/internal/nix/input.go
@@ -100,7 +100,7 @@ func (i *Input) URLForInstall() (string, error) {
 		}
 		return entry.Resolved, nil
 	}
-	attrPath, err := i.PackageAttributePath()
+	attrPath, err := i.FullPackageAttributePath()
 	if err != nil {
 		return "", err
 	}
@@ -135,11 +135,25 @@ func (i *Input) normalizedDevboxPackageReference() (string, error) {
 	return "", nil
 }
 
-// PackageAttributePath returns the attribute path for a package. It is not
+// PackageAttributePath returns the short attribute path for a package which
+// does not include packages/legacyPackages or the system name.
+func (i *Input) PackageAttributePath() (string, error) {
+	if i.IsDevboxPackage() {
+		entry, err := i.lockfile.Resolve(i.String())
+		if err != nil {
+			return "", err
+		}
+		_, fragment, _ := strings.Cut(entry.Resolved, "#")
+		return fragment, nil
+	}
+	return i.Fragment, nil
+}
+
+// FullPackageAttributePath returns the attribute path for a package. It is not
 // always normalized which means it should not be used to compare packages.
 // During happy paths (devbox packages and nix flakes that contains a fragment)
 // it is much faster than NormalizedPackageAttributePath
-func (i *Input) PackageAttributePath() (string, error) {
+func (i *Input) FullPackageAttributePath() (string, error) {
 	if i.IsDevboxPackage() {
 		reference, err := i.normalizedDevboxPackageReference()
 		if err != nil {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -150,13 +150,18 @@ func (m *Manager) createFile(
 		return err
 	}
 
+	attributePath, err := pkg.PackageAttributePath()
+	if err != nil {
+		return err
+	}
+
 	var buf bytes.Buffer
 	if err = tmpl.Execute(&buf, map[string]any{
 		"DevboxConfigDir":      m.ProjectDir(),
 		"DevboxDir":            filepath.Join(m.ProjectDir(), devboxDirName, name),
 		"DevboxDirRoot":        filepath.Join(m.ProjectDir(), devboxDirName),
 		"DevboxProfileDefault": filepath.Join(m.ProjectDir(), nix.ProfilePath),
-		"PackageName":          name,
+		"PackageAttributePath": attributePath,
 		"Packages":             m.Packages(),
 		"System":               system,
 		"URLForInput":          pkg.URLForInput(),

--- a/plugins/haskell/flake.nix
+++ b/plugins/haskell/flake.nix
@@ -7,9 +7,9 @@
 
   outputs = { self, nixpkgs }:
     let
-      version = builtins.elemAt (builtins.match "^haskell\.compiler\.(.*)$" "{{ .PackageName }}") 0;
+      version = builtins.elemAt (builtins.match "^haskell\.compiler\.(.*)$" "{{ .PackageAttributePath }}") 0;
       
-      ghcWithPackages = if "{{ .PackageName }}" == "ghc" 
+      ghcWithPackages = if "{{ .PackageAttributePath }}" == "ghc" 
         then nixpkgs.legacyPackages.{{ .System }}.pkgs.haskellPackages.ghcWithPackages
         else nixpkgs.legacyPackages.{{ .System }}.pkgs.haskell.packages.${version}.ghcWithPackages;
 

--- a/plugins/mariadb/flake.nix
+++ b/plugins/mariadb/flake.nix
@@ -10,7 +10,7 @@
       mariadb-bin =  nixpkgs.legacyPackages.{{.System}}.symlinkJoin {
 
         name = "mariadb-wrapped";
-        paths = [nixpkgs.legacyPackages.{{ .System }}.{{.PackageName}}];
+        paths = [nixpkgs.legacyPackages.{{ .System }}.{{.PackageAttributePath}}];
         nativeBuildInputs = [ nixpkgs.legacyPackages.{{.System}}.makeWrapper];
         postBuild = ''
 

--- a/plugins/php/flake.nix
+++ b/plugins/php/flake.nix
@@ -13,7 +13,7 @@
         {{- end }}
       ]);
 
-      php = nixpkgs.legacyPackages.{{ .System }}.php.withExtensions (
+      php = nixpkgs.legacyPackages.{{ .System }}.{{ .PackageAttributePath }}.withExtensions (
         { enabled, all }: enabled ++ (with all; 
           map (ext: all.${ext}) extensions
         )


### PR DESCRIPTION
## Summary

This improves plugins by using attribute path instead of canonical name.

for example, in `php@8.2` the attribute path is `php82` and not `php`. Previously we were using canonical name which may not be the correct version. (and may not even exist).

## How was it tested?

Since existing PHP example had canonical name that matches attribute name, I changed the php version to `PHP@8.2` and the inspected generated `php/flake.nix`. Also did `devbox run "php -b | grep imagick" to verify plugin worked.
