### PR TITLE
[wrappers] Improve wrappers in multi-project env

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -305,7 +305,12 @@ func (d *Devbox) ShellEnvHash(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	return envs[devboxShellEnvHashVarName], nil
+	return envs[d.ShellEnvHashKey()], nil
+}
+
+func (d *Devbox) ShellEnvHashKey() string {
+	// Don't make this a const so we don't use it by itself accidentally
+	return "__DEVBOX_SHELLENV_HASH_" + d.projectDirHash()
 }
 
 func (d *Devbox) Info(pkg string, markdown bool) error {
@@ -827,7 +832,7 @@ func (d *Devbox) computeNixEnv(ctx context.Context, usePrintDevEnvCache bool) (m
 		os.Getenv("XDG_DATA_DIRS"),
 	)
 
-	return env, addHashToEnv(env)
+	return env, d.addHashToEnv(env)
 }
 
 var nixEnvCache map[string]string
@@ -1113,10 +1118,10 @@ func (d *Devbox) projectDirHash() string {
 	return hash
 }
 
-func addHashToEnv(env map[string]string) error {
+func (d *Devbox) addHashToEnv(env map[string]string) error {
 	hash, err := cuecfg.Hash(env)
 	if err == nil {
-		env[devboxShellEnvHashVarName] = hash
+		env[d.ShellEnvHashKey()] = hash
 	}
 	return err
 }

--- a/internal/impl/envvars.go
+++ b/internal/impl/envvars.go
@@ -11,7 +11,6 @@ import (
 )
 
 const devboxSetPrefix = "__DEVBOX_SET_"
-const devboxShellEnvHashVarName = "__DEVBOX_SHELLENV_HASH"
 
 func mapToPairs(m map[string]string) []string {
 	pairs := []string{}

--- a/internal/wrapnix/wrapper.sh.tmpl
+++ b/internal/wrapnix/wrapper.sh.tmpl
@@ -14,14 +14,14 @@ fi
 {{- end }}
 
 {{/*
-We use __DEVBOX_SHELLENV_HASH to avoid re-sourcing shellenv. Since wrappers
+We use ShellEnvHashKey to avoid re-sourcing shellenv. Since wrappers
 call other wrappers and potentially modify the environment, we don't want the
 environment to get re-written.
 
 DO_NOT_TRACK=1 can be removed once we optimize segment to queue events.
 */ -}}
 
-if [[ "$__DEVBOX_SHELLENV_HASH" != "{{ .ShellEnvHash }}" ]]; then
+if [[ "${{ .ShellEnvHashKey }}" != "{{ .ShellEnvHash }}" ]]; then
 eval "$(DO_NOT_TRACK=1 devbox shellenv -c {{ .ProjectDir }})"
 fi
 


### PR DESCRIPTION
## Summary

This is a possible cause of https://github.com/jetpack-io/devbox/issues/881#issuecomment-1565764159

bin wrappers belong to a specific project so we should not have a single global hash.

## How was it tested?

`devbox shell`
called binaries, inspected wrappers
`devbox add curl`
called binaries, inspected wrappers
