### PR TITLE
[scripts] Add bash shebang

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -928,6 +928,11 @@ func (d *Devbox) writeScriptFile(name string, body string) (err error) {
 		return errors.WithStack(err)
 	}
 
+	// add bash shebang if not present
+	if !strings.HasPrefix(body, "#!") {
+		body = "#!/bin/bash\n\n" + body
+	}
+
 	if featureflag.ScriptExitOnError.Enabled() {
 		body = fmt.Sprintf("set -e\n\n%s", body)
 	}


### PR DESCRIPTION
## Summary

Our scripts should always run as bash. 

Can we assume `/bin/bash` is always set?

## How was it tested?

`devbox run build`

inspected generated scripts.
