### PR TITLE
[shellenv] preserve original XDG_DATA_DIRS during shellenv-ception

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -739,9 +739,8 @@ func (d *Devbox) computeNixEnv(ctx context.Context, usePrintDevEnvCache bool) (m
 	originalXdgDataDirs, ok := env[d.ogXdgDataDirsKey()]
 	if !ok {
 		// if the env does not have XDG_DATA_DIRS then currentXdgDataDirs is empty string
-		currentXdgDataDirs, _ := env["XDG_DATA_DIRS"]
-		env[d.ogXdgDataDirsKey()] = currentXdgDataDirs
-		originalXdgDataDirs = currentXdgDataDirs
+		originalXdgDataDirs = env["XDG_DATA_DIRS"]
+		env[d.ogXdgDataDirsKey()] = originalXdgDataDirs
 	}
 
 	vaf, err := d.nix.PrintDevEnv(ctx, &nix.PrintDevEnvArgs{

--- a/internal/impl/shell_test.go
+++ b/internal/impl/shell_test.go
@@ -107,31 +107,31 @@ If the new shellrc is correct, you can update the golden file with:
 
 func TestCleanEnvPath(t *testing.T) {
 	tests := []struct {
-		name       string
-		inPath     string
-		joinedPath string
+		name    string
+		inPath  string
+		outPath string
 	}{
 		{
-			name:       "NoEmptyPaths",
-			inPath:     "/usr/local/bin::",
-			joinedPath: "/usr/local/bin",
+			name:    "NoEmptyPaths",
+			inPath:  "/usr/local/bin::",
+			outPath: "/usr/local/bin",
 		},
 		{
-			name:       "NoRelativePaths",
-			inPath:     "/usr/local/bin:/usr/bin:../test:/bin:/usr/sbin:/sbin:.:..",
-			joinedPath: "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+			name:    "NoRelativePaths",
+			inPath:  "/usr/local/bin:/usr/bin:../test:/bin:/usr/sbin:/sbin:.:..",
+			outPath: "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
 		},
 		{
-			name:       "WithDuplicatedPaths",
-			inPath:     "/usr/bin/first:/usr/bin/second:/usr/bin/first",
-			joinedPath: "/usr/bin/first:/usr/bin/second",
+			name:    "WithDuplicatedPaths",
+			inPath:  "/usr/bin/first:/usr/bin/second:/usr/bin/first",
+			outPath: "/usr/bin/first:/usr/bin/second",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got := JoinPathLists(test.inPath)
-			if got != test.joinedPath {
-				t.Errorf("Got incorrect cleaned path.\ngot:  %s\nwant: %s", got, test.joinedPath)
+			if got != test.outPath {
+				t.Errorf("Got incorrect cleaned path.\ngot:  %s\nwant: %s", got, test.outPath)
 			}
 		})
 	}

--- a/internal/impl/shell_test.go
+++ b/internal/impl/shell_test.go
@@ -107,26 +107,31 @@ If the new shellrc is correct, you can update the golden file with:
 
 func TestCleanEnvPath(t *testing.T) {
 	tests := []struct {
-		name    string
-		inPath  string
-		outPath string
+		name       string
+		inPath     string
+		joinedPath string
 	}{
 		{
-			name:    "NoEmptyPaths",
-			inPath:  "/usr/local/bin::",
-			outPath: "/usr/local/bin",
+			name:       "NoEmptyPaths",
+			inPath:     "/usr/local/bin::",
+			joinedPath: "/usr/local/bin",
 		},
 		{
-			name:    "NoRelativePaths",
-			inPath:  "/usr/local/bin:/usr/bin:../test:/bin:/usr/sbin:/sbin:.:..",
-			outPath: "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+			name:       "NoRelativePaths",
+			inPath:     "/usr/local/bin:/usr/bin:../test:/bin:/usr/sbin:/sbin:.:..",
+			joinedPath: "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+		},
+		{
+			name:       "WithDuplicatedPaths",
+			inPath:     "/usr/bin/first:/usr/bin/second:/usr/bin/first",
+			joinedPath: "/usr/bin/first:/usr/bin/second",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got := JoinPathLists(test.inPath)
-			if got != test.outPath {
-				t.Errorf("Got incorrect cleaned PATH.\ngot:  %s\nwant: %s", got, test.outPath)
+			if got != test.joinedPath {
+				t.Errorf("Got incorrect cleaned path.\ngot:  %s\nwant: %s", got, test.joinedPath)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

shellenv-ception is when we run shellenv within an already enabled shellenv environment.

We would like to preserve idempotency of XDG_DATA_DIRS for shellenv-ception, so 
that we don't recursively keep prepending to the shellenv-enabled XDG_DATA_DIRS
and instead we prepend to the original XDG_DATA_DIRS.

## How was it tested?

same as #1041
