### PR TITLE
Fix template create when ssh key is not setup

### DIFF
--- a/internal/templates/template.go
+++ b/internal/templates/template.go
@@ -31,7 +31,7 @@ func Init(w io.Writer, template, dir string) error {
 		return errors.WithStack(err)
 	}
 	cmd := exec.Command(
-		"git", "clone", "git@github.com:jetpack-io/devbox.git", tmp,
+		"git", "clone", "https://github.com/jetpack-io/devbox.git", tmp,
 	)
 	fmt.Fprintf(w, "%s\n", cmd)
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
## Summary
For users and Dockerfile that has no ssh key setup, we need to clone by https

## How was it tested?
devbox run build
devbox create --template apache