### PR TITLE
[path] Add global path command

### DIFF
--- a/internal/boxcli/global.go
+++ b/internal/boxcli/global.go
@@ -25,6 +25,7 @@ func globalCmd() *cobra.Command {
 
 	addCommandAndHideConfigFlag(globalCmd, addCmd())
 	addCommandAndHideConfigFlag(globalCmd, installCmd())
+	addCommandAndHideConfigFlag(globalCmd, pathCmd())
 	addCommandAndHideConfigFlag(globalCmd, pullCmd())
 	addCommandAndHideConfigFlag(globalCmd, removeCmd())
 	addCommandAndHideConfigFlag(globalCmd, runCmd())

--- a/internal/boxcli/path.go
+++ b/internal/boxcli/path.go
@@ -1,0 +1,43 @@
+// Copyright 2023 Jetpack Technologies Inc and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package boxcli
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"go.jetpack.io/devbox/internal/nix"
+)
+
+type pathCmdFlags struct {
+	config     configFlags
+	nixProfile bool
+}
+
+func pathCmd() *cobra.Command {
+	flags := pathCmdFlags{}
+	cmd := &cobra.Command{
+		Use:     "path",
+		Short:   "Show path to [global] devbox config",
+		PreRunE: ensureNixInstalled,
+		Args:    cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if flags.nixProfile {
+				fmt.Println(filepath.Join(flags.config.path, nix.ProfilePath))
+			} else {
+				fmt.Println(flags.config.path)
+			}
+			return nil
+		},
+	}
+
+	flags.config.register(cmd)
+	cmd.Flags().BoolVarP(
+		&flags.nixProfile, "nix-profile", "n", false,
+		"Show path to nix profile created by devbox",
+	)
+
+	return cmd
+}

--- a/internal/boxcli/path.go
+++ b/internal/boxcli/path.go
@@ -5,15 +5,12 @@ package boxcli
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"go.jetpack.io/devbox/internal/nix"
 )
 
 type pathCmdFlags struct {
-	config     configFlags
-	nixProfile bool
+	config configFlags
 }
 
 func pathCmd() *cobra.Command {
@@ -24,20 +21,12 @@ func pathCmd() *cobra.Command {
 		PreRunE: ensureNixInstalled,
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if flags.nixProfile {
-				fmt.Println(filepath.Join(flags.config.path, nix.ProfilePath))
-			} else {
-				fmt.Println(flags.config.path)
-			}
+			fmt.Println(flags.config.path)
 			return nil
 		},
 	}
 
 	flags.config.register(cmd)
-	cmd.Flags().BoolVarP(
-		&flags.nixProfile, "nix-profile", "n", false,
-		"Show path to nix profile created by devbox",
-	)
 
 	return cmd
 }


### PR DESCRIPTION
## Summary

Inspired by https://github.com/jetpack-io/devbox/pull/1058

## How was it tested?

```bash
➜  devbox git:(landau/global-path) devbox global path
/Users/mike/.local/share/devbox/global/default
```