### PR TITLE
[wrappers] shellenv should not create bin wrappers

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -29,6 +29,7 @@ type Devbox interface {
 	GenerateDockerfile(force bool) error
 	GenerateEnvrcFile(force bool) error
 	Info(pkg string, markdown bool) error
+	Install(ctx context.Context) error
 	IsEnvEnabled() bool
 	ListScripts() []string
 	PrintEnv(ctx context.Context, includeHooks bool) (string, error)

--- a/internal/boxcli/install.go
+++ b/internal/boxcli/install.go
@@ -34,8 +34,7 @@ func installCmdFunc(cmd *cobra.Command, flags runCmdFlags) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	_, err = box.PrintEnv(cmd.Context(), false /* run init hooks */)
-	if err != nil {
+	if err = box.Install(cmd.Context()); err != nil {
 		return errors.WithStack(err)
 	}
 	fmt.Fprintln(cmd.ErrOrStderr(), "Finished installing packages.")

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -262,6 +262,16 @@ func (d *Devbox) RunScript(cmdName string, cmdArgs []string) error {
 	return nix.RunScript(d.projectDir, strings.Join(cmdWithArgs, " "), env)
 }
 
+// Install ensures that all the packages in the config are installed and
+// creates all wrappers, but does not run init hooks. It is used to power
+// devbox install cli command.
+func (d *Devbox) Install(ctx context.Context) error {
+	if _, err := d.PrintEnv(ctx, false /* run init hooks */); err != nil {
+		return err
+	}
+	return wrapnix.CreateWrappers(ctx, d)
+}
+
 func (d *Devbox) ListScripts() []string {
 	keys := make([]string, len(d.cfg.Scripts()))
 	i := 0
@@ -282,10 +292,6 @@ func (d *Devbox) PrintEnv(ctx context.Context, includeHooks bool) (string, error
 
 	envs, err := d.nixEnv(ctx)
 	if err != nil {
-		return "", err
-	}
-
-	if err := wrapnix.CreateWrappers(ctx, d); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/jetpack-io/devbox/issues/1073

The underlying cause of https://github.com/jetpack-io/devbox/issues/1073 is that we were creating bin wrappers in shellenv which can get called a lot (and in parallel) this was leading to race conditions.

We should still try to limit shellenv calls (because they slow things down), but this fixes the race condition.

cc: @bketelsen 

## How was it tested?

Since I could not repro race condition, I created a setup that simulated it:

* Wrote some testing code that would save a file to /tmp every time create wrappers is called.
* Setup the environment to call a bin wrapper for every command
* Before change, saw new /tmp file being created on every command.
* After change, no new /tmp file was getting created.
* Tested `devbox install` for sanity.
