### PR TITLE
Change error message for devbox add when a package is not found

### DIFF
--- a/internal/boxcli/add.go
+++ b/internal/boxcli/add.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
+	"go.jetpack.io/devbox/internal/nix"
 )
 
 const toSearchForPackages = "To search for packages, use the `devbox search` command"
@@ -36,7 +37,7 @@ func addCmd() *cobra.Command {
 				return nil
 			}
 			err := addCmdFunc(cmd, args, flags)
-			if err != nil {
+			if errors.Is(err, nix.ErrPackageNotFound) {
 				return usererr.New("%s\n\n%s", err, toSearchForPackages)
 			}
 			return err

--- a/internal/boxcli/add.go
+++ b/internal/boxcli/add.go
@@ -10,10 +10,9 @@ import (
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
-	"go.jetpack.io/devbox/internal/nix"
 )
 
-const toSearchForPackages = "To search for packages use https://search.nixos.org/packages"
+const toSearchForPackages = "To search for packages, use the `devbox search` command"
 
 type addCmdFlags struct {
 	config configFlags
@@ -37,7 +36,7 @@ func addCmd() *cobra.Command {
 				return nil
 			}
 			err := addCmdFunc(cmd, args, flags)
-			if errors.Is(err, nix.ErrPackageNotFound) {
+			if err != nil {
 				return usererr.New("%s\n\n%s", err, toSearchForPackages)
 			}
 			return err

--- a/internal/searcher/client.go
+++ b/internal/searcher/client.go
@@ -14,6 +14,7 @@ import (
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/envir"
 	"go.jetpack.io/devbox/internal/lock"
+	"go.jetpack.io/devbox/internal/nix"
 )
 
 const searchAPIEndpoint = "https://search.devbox.sh"
@@ -60,7 +61,7 @@ func (c *client) Resolve(pkg string) (*lock.Package, error) {
 		return nil, err
 	}
 	if len(result.Results) == 0 {
-		return nil, usererr.New("No results found for %q.", pkg)
+		return nil, nix.ErrPackageNotFound
 	}
 	return &lock.Package{
 		LastModified: result.Results[0].Packages[0].Date,


### PR DESCRIPTION
## Summary
Change error message for devbox add when a package is not found. To repro:
`devbox add hellow@latest`

Original output:
```
Error: No results found for "hellow@latest".
```

New output:
```
Error: No results found for "hellow@latest".

To search for packages, use the `devbox search` command
```

## How was it tested?
```
devbox run build
devbox add hellow@latest
```