### PR TITLE
[shellenv] filter out buildInput paths from PATH

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -841,6 +841,11 @@ func (d *Devbox) computeNixEnv(ctx context.Context, usePrintDevEnvCache bool) (m
 	nixEnvPath := env["PATH"]
 	debug.Log("PATH after plugins and config is: %s", nixEnvPath)
 
+	nixEnvPath = filterPathList(nixEnvPath, func(path string) bool {
+		return !strings.HasPrefix(path, "/nix/store")
+	})
+	debug.Log("PATH after removing /nix/store paths is: %s", nixEnvPath)
+
 	env["PATH"] = JoinPathLists(nixEnvPath, originalPath)
 	debug.Log("computed environment PATH is: %s", env["PATH"])
 

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -841,6 +841,10 @@ func (d *Devbox) computeNixEnv(ctx context.Context, usePrintDevEnvCache bool) (m
 	nixEnvPath := env["PATH"]
 	debug.Log("PATH after plugins and config is: %s", nixEnvPath)
 
+	// We filter out nix store paths so that if a user removes a package from their devbox
+	// it no longer is available in their environment. This is needed because nix may keep
+	// packages around if they are used somewhere else or if the user hasn't triggered
+	// garbage collection.
 	nixEnvPath = filterPathList(nixEnvPath, func(path string) bool {
 		return !strings.HasPrefix(path, "/nix/store")
 	})

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -849,7 +849,8 @@ func (d *Devbox) computeNixEnv(ctx context.Context, usePrintDevEnvCache bool) (m
 		for _, input := range buildInputs {
 			// input is of the form: /nix/store/<hash>-<package-name>-<version>
 			// path is of the form: /nix/store/<hash>-<package-name>-<version>/bin
-			if strings.HasPrefix(path, input) {
+			if strings.TrimSpace(input) != "" && strings.HasPrefix(path, input) {
+				debug.Log("returning false for path %s and input %s\n", path, input)
 				return false
 			}
 		}

--- a/internal/impl/devbox_test.go
+++ b/internal/impl/devbox_test.go
@@ -126,5 +126,5 @@ func TestComputeNixPathWhenRemoving(t *testing.T) {
 	path2 := env["PATH"]
 	assert.NotContains(t, path2, "/tmp/my/path", "path should not contain /tmp/my/path")
 
-	assert.NotEqual(t, path, path2, "path should be the same")
+	assert.NotEqual(t, path, path2, "path should not be the same")
 }

--- a/internal/impl/shell.go
+++ b/internal/impl/shell.go
@@ -399,3 +399,13 @@ func JoinPathLists(pathLists ...string) string {
 	}
 	return strings.Join(cleaned, string(filepath.ListSeparator))
 }
+
+func filterPathList(pathList string, keep func(string) bool) string {
+	filtered := []string{}
+	for _, path := range filepath.SplitList(pathList) {
+		if keep(path) {
+			filtered = append(filtered, path)
+		}
+	}
+	return strings.Join(filtered, string(filepath.ListSeparator))
+}

--- a/testscripts/run/path.test.txt
+++ b/testscripts/run/path.test.txt
@@ -12,10 +12,11 @@ exec devbox run echo '$PATH'
 ! stdout '/some//dirty/../clean/path'
 stdout '/some/clean/path'
 
-# Path contains path to installed nix packages
-stdout '-which-'
+# Path contains path to installed nix packages in the wrappers and nix profile
+stdout '.devbox/virtenv/.wrappers/bin'
+stdout '.devbox/nix/profile/default/bin'
 
 # Verify PATH is set in correct order: virtual env path nix packages, host path.
-path.order '-which-' 'some/clean/path'
+path.order '.devbox/virtenv/.wrappers/bin' '/some/clean/path'
 
 # TODO: verify that bashrc file prepends do not prepend before nix paths.


### PR DESCRIPTION
## Summary

**problem**
Doing `devbox rm <package>` within a devbox shell will usually still have the package's binary accessible in PATH. This is confusing and unexpected.

**cause**

In shellenv's `PATH`, we now have 3 sources of paths:
1. `.devbox/virtenv/.wrappers/bin`
2. `.devbox/nix/profile/default/bin`
3. `/nix/store/<hash>-<package>-<version>/bin`

When we do `devbox rm <package>`, the first two (wrappers and profile bins) are removed, but the `/nix/store` remains in PATH. 

The user would have to do `eval $(devbox shellenv)` to remove it. But that is not a good UX.

**background context**

Heres’ why we need/don’t need each one:
1. bin-wrapper dir: is our path for binaries. Binaries here are wrapped to ensure the correct environment is sourced. “Support files” are also sym linked here to ensure that binaries that require relative dependencies work as well (e.g. mariadb)
2. profile bin path: This is a fallback hack for certain edge cases (e.g. curl). If a package uses propagateBuildInputs then we may not correctly create a bin wrapper for it. Currently we use $buildInputs to determine binaries that need to be wrapped, but this does not contain propagated inputs, only explicit inputs. 
3. nix store paths: these are included by nix from `nix print-dev-env`. We've never removed them, but need to ensure nothing breaks.

Thanks to @mikeland86 for explaining this. I've copy-pasted this from a chat conversation.


**this PR**
This PR removes from PATH the subset of `/nix/store` paths that belong to the buildInputs, during `shellenv`. 


Fixes #1060 

TODO:
- [x] do more extensive testing

## How was it tested?

```
> devbox add stress
> devbox shell
(devbox)> which stress
# printed wrappers/bin path
(devbox)> devbox rm stress
(devbox)> which stress
# empty
# BEFORE: this would print the /nix/store path
```

- [x] ensure testscripts pass.
