### PR TITLE
[envrc] run devbox install to ensure createWrappers is called

### DIFF
--- a/internal/impl/tmpl/envrcContent.tmpl
+++ b/internal/impl/tmpl/envrcContent.tmpl
@@ -1,5 +1,6 @@
 use_devbox() {
     watch_file devbox.json
     eval "$(devbox shellenv --init-hook)"
+    devbox install
 }
 use devbox


### PR DESCRIPTION
## Summary

Our `.envrc` today calls `shellenv` but that doesn't run `createWrappers`.

If the package's binary may change, then the .envrc environment will not get updated.

## How was it tested?

in `examples/flakes/php`, I did:
1. `devbox generate direnv`
2. `php -m | grep ds` which prints `ds`.
3. edit `examples/flakes/php/my-php-flake/flake.nix` to remove `ds` extension
4. re-run `php -m | grep ds`. This still prints `ds`.

Now, for the test steps:
- cd out of the direnv 
- re-enter the direnv-enabled directory (`examples/flakes/php`)
- re-run `php -m | grep ds`. 
BEFORE: This still prints `ds`.
AFTER: no `ds` is printed.

Note, in Step 4, ideally we would not print `ds` but for that to happen the direnv would need
to check local flake files for changes. Today, it just checks devbox.json for changes.
Not addressing in this PR (workaround: `cd` out and back in to the directory)
