### PR TITLE
[update] call createWrappers

### DIFF
--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"go.jetpack.io/devbox/internal/lock"
+	"go.jetpack.io/devbox/internal/wrapnix"
 )
 
 func (d *Devbox) Update(ctx context.Context, pkgs ...string) error {
@@ -43,5 +44,9 @@ func (d *Devbox) Update(ctx context.Context, pkgs ...string) error {
 	}
 
 	// TODO(landau): Improve output
-	return d.ensurePackagesAreInstalled(ctx, ensure)
+	if err := d.ensurePackagesAreInstalled(ctx, ensure); err != nil {
+		return err
+	}
+
+	return wrapnix.CreateWrappers(ctx, d)
 }


### PR DESCRIPTION
## Summary

`devbox update` should ensure the wrappers point to the latest binaries of any updated packages.

## How was it tested?

- take a devbox.json having go@1.20 package  (such as the devbox-repo!)
- do `devbox shell` 
- confirm go version 1.20 via `go version`
- manually set a package to go@1.19
- do `devbox update`
- run `go version` and see the updated version

BEFORE: would continue to show `go 1.20` version
AFTER: shows `go 1.19` version