### PR TITLE
[push] Simplify git clone for push

### DIFF
--- a/internal/boxcli/push.go
+++ b/internal/boxcli/push.go
@@ -6,6 +6,7 @@ package boxcli
 import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
 	"go.jetpack.io/devbox"
 )
 

--- a/internal/fileutil/dir.go
+++ b/internal/fileutil/dir.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
+
 	"go.jetpack.io/devbox/internal/cmdutil"
 )
 
@@ -30,4 +31,9 @@ func ClearDir(dir string) error {
 		return errors.WithStack(err)
 	}
 	return errors.WithStack(os.MkdirAll(dir, 0755))
+}
+
+func CreateDevboxTempDir() (string, error) {
+	tmpDir, err := os.MkdirTemp("", "devbox")
+	return tmpDir, errors.WithStack(err)
 }

--- a/internal/pullbox/config.go
+++ b/internal/pullbox/config.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/internal/cuecfg"
 	"go.jetpack.io/devbox/internal/devconfig"
+	"go.jetpack.io/devbox/internal/fileutil"
 )
 
 func (p *pullbox) IsTextDevboxConfig() bool {
@@ -33,9 +33,9 @@ func (p *pullbox) pullTextDevboxConfig() error {
 		return err
 	}
 
-	tmpDir, err := os.MkdirTemp("", "devbox")
+	tmpDir, err := fileutil.CreateDevboxTempDir()
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 	if err = cfg.SaveTo(tmpDir); err != nil {
 		return err

--- a/internal/pullbox/git/git.go
+++ b/internal/pullbox/git/git.go
@@ -19,7 +19,7 @@ func CloneToTmp(repo string) (string, error) {
 	}
 
 	if err := clone(repo, tmpDir); err != nil {
-		return "", errors.WithStack(err)
+		return "", err
 	}
 	return tmpDir, nil
 }

--- a/internal/pullbox/git/git.go
+++ b/internal/pullbox/git/git.go
@@ -4,18 +4,20 @@
 package git
 
 import (
-	"os"
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"go.jetpack.io/devbox/internal/cmdutil"
+	"go.jetpack.io/devbox/internal/fileutil"
 )
 
 func CloneToTmp(repo string) (string, error) {
-	tmpDir, err := os.MkdirTemp("", "devbox")
+	tmpDir, err := fileutil.CreateDevboxTempDir()
 	if err != nil {
-		return "", errors.WithStack(err)
+		return "", err
 	}
+
 	if err := clone(repo, tmpDir); err != nil {
 		return "", errors.WithStack(err)
 	}


### PR DESCRIPTION
## Summary

1. clone `.git` only for push (See https://stackoverflow.com/questions/38999901/clone-only-the-git-directory-of-a-git-repo for more information)
2. add `CreateDevboxTempDIr` to `fileutil` and reuse it in more cases

## How was it tested?
