### PR TITLE
Keep file mode the same as it is cleared

### DIFF
--- a/internal/boxcli/gen-docs.go
+++ b/internal/boxcli/gen-docs.go
@@ -10,6 +10,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
+
+	"go.jetpack.io/devbox/internal/fileutil"
 )
 
 func genDocsCmd() *cobra.Command {
@@ -30,15 +32,8 @@ func genDocsCmd() *cobra.Command {
 			// We clear out the existing directory so that the doc-pages for
 			// commands that have been deleted in the CLI will also be removed
 			// after we re-generate the docs below
-			err = os.RemoveAll(docsPath)
-			if err != nil {
-				return errors.WithStack(err)
-			}
-
-			// Ensure the directory exists
-			err = os.MkdirAll(docsPath, 0755)
-			if err != nil {
-				return errors.WithStack(err)
+			if err := fileutil.ClearDir(docsPath); err != nil {
+				return err
 			}
 
 			rootCmd := cmd

--- a/internal/fileutil/dir.go
+++ b/internal/fileutil/dir.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
+
 	"go.jetpack.io/devbox/internal/cmdutil"
 )
 
@@ -26,8 +27,14 @@ func CopyAll(src, dst string) error {
 }
 
 func ClearDir(dir string) error {
+	f, err := os.Stat(dir)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	mode := f.Mode()
+
 	if err := os.RemoveAll(dir); err != nil {
 		return errors.WithStack(err)
 	}
-	return errors.WithStack(os.MkdirAll(dir, 0755))
+	return errors.WithStack(os.MkdirAll(dir, mode))
 }

--- a/internal/pullbox/pullbox.go
+++ b/internal/pullbox/pullbox.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
+
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/pullbox/git"
 )


### PR DESCRIPTION
## Summary

1. Get the filemode of the directory before everything inside is deleted and use that mode for re-creation
2. Reuse the `ClearDir` in gen-docs

## How was it tested?
