### PR TITLE
Hide devbox cloud cli command for now in favor of devbox.sh

### DIFF
--- a/internal/boxcli/cloud.go
+++ b/internal/boxcli/cloud.go
@@ -29,6 +29,7 @@ func cloudCmd() *cobra.Command {
 		Long: "Remote development environments on the cloud. All cloud commands " +
 			"are currently in developer preview and may have some rough edges. " +
 			"Please report any issues to https://github.com/jetpack-io/devbox/issues",
+		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},


### PR DESCRIPTION
## Summary
Hide devbox cloud cli command for now as we decided that devbox.sh will be the primary way to create a vm, and a user can ssh into that vm directly with local credentials

## How was it tested?
devbox run build
devbox help