### PR TITLE
Change caddy to run on non privileged ports

### DIFF
--- a/examples/servers/caddy/README.md
+++ b/examples/servers/caddy/README.md
@@ -4,13 +4,14 @@
 
 You can customize the config used by the caddy service by modifying the Caddyfile in devbox.d/caddy, or by changing the CADDY_CONFIG environment variable to point to a custom config. The custom config must be either JSON or Caddyfile format.
 
-After starting the service, you can test this example using `curl https://localhost:2020`
+After starting the service, you can test this example using `curl http://localhost:8080`
 
 ## Services
 
 * caddy
 
-Use `devbox services start|stop [service]` to interact with services
+Use `devbox run start` to start the caddy server.
+You can also use `devbox services start|stop [service]` to interact with services.
 
 ## This plugin creates the following helper files
 

--- a/examples/servers/caddy/README.md
+++ b/examples/servers/caddy/README.md
@@ -4,7 +4,7 @@
 
 You can customize the config used by the caddy service by modifying the Caddyfile in devbox.d/caddy, or by changing the CADDY_CONFIG environment variable to point to a custom config. The custom config must be either JSON or Caddyfile format.
 
-After starting the service, you can test this example using `curl http://localhost:8080`
+After starting the service, you can test this example using `curl http://localhost:8082`
 
 ## Services
 

--- a/examples/servers/caddy/devbox.d/caddy/Caddyfile
+++ b/examples/servers/caddy/devbox.d/caddy/Caddyfile
@@ -1,9 +1,15 @@
 # See https://caddyserver.com/docs/caddyfile for more details
+{
+	admin 0.0.0.0:2020
+	auto_https disable_certs
+	http_port 8800
+	https_port 4443
+}
 
-localhost:2020 {
-        root * {$CADDY_ROOT_DIR}
-        log {
-            output file {$CADDY_LOG_DIR}/caddy.log
-        }
-        file_server
+:8080 {
+	root * {$CADDY_ROOT_DIR}
+	log {
+		output file {$CADDY_LOG_DIR}/caddy.log
+	}
+	file_server
 }

--- a/examples/servers/caddy/devbox.d/caddy/Caddyfile
+++ b/examples/servers/caddy/devbox.d/caddy/Caddyfile
@@ -6,7 +6,7 @@
 	https_port 4443
 }
 
-:8080 {
+:8082 {
 	root * {$CADDY_ROOT_DIR}
 	log {
 		output file {$CADDY_LOG_DIR}/caddy.log

--- a/examples/servers/caddy/devbox.json
+++ b/examples/servers/caddy/devbox.json
@@ -3,6 +3,9 @@
     "caddy@latest"
   ],
   "shell": {
-    "init_hook": null
+    "init_hook": null,
+    "scripts": {
+      "start": "caddy run --config=devbox.d/caddy/Caddyfile"
+    }
   }
 }

--- a/examples/servers/caddy/devbox.lock
+++ b/examples/servers/caddy/devbox.lock
@@ -3,6 +3,7 @@
   "packages": {
     "caddy@latest": {
       "last_modified": "2023-05-01T16:53:22Z",
+      "plugin_version": "0.0.1",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#caddy",
       "version": "2.6.4"
     }

--- a/examples/servers/caddy/devbox.lock
+++ b/examples/servers/caddy/devbox.lock
@@ -3,7 +3,7 @@
   "packages": {
     "caddy@latest": {
       "last_modified": "2023-05-01T16:53:22Z",
-      "plugin_version": "0.0.1",
+      "plugin_version": "0.0.2",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#caddy",
       "version": "2.6.4"
     }

--- a/plugins/caddy.json
+++ b/plugins/caddy.json
@@ -1,6 +1,6 @@
 {
     "name": "caddy",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "readme": "You can customize the config used by the caddy service by modifying the Caddyfile in devbox.d/caddy, or by changing the CADDY_CONFIG environment variable to point to a custom config. The custom config must be either JSON or Caddyfile format.",
     "env": {
         "CADDY_CONFIG": "{{ .DevboxDir }}/Caddyfile",

--- a/plugins/caddy/Caddyfile
+++ b/plugins/caddy/Caddyfile
@@ -1,9 +1,15 @@
 # See https://caddyserver.com/docs/caddyfile for more details
+{
+	admin 0.0.0.0:2020
+	auto_https disable_certs
+	http_port 8800
+	https_port 4443
+}
 
-localhost:2020 {
-        root * {$CADDY_ROOT_DIR}
-        log {
-            output file {$CADDY_LOG_DIR}/caddy.log
-        }
-        file_server
+:8080 {
+	root * {$CADDY_ROOT_DIR}
+	log {
+		output file {$CADDY_LOG_DIR}/caddy.log
+	}
+	file_server
 }

--- a/plugins/caddy/Caddyfile
+++ b/plugins/caddy/Caddyfile
@@ -6,7 +6,7 @@
 	https_port 4443
 }
 
-:8080 {
+:8082 {
 	root * {$CADDY_ROOT_DIR}
 	log {
 		output file {$CADDY_LOG_DIR}/caddy.log

--- a/plugins/caddy/process-compose.yaml
+++ b/plugins/caddy/process-compose.yaml
@@ -2,7 +2,7 @@ version: "0.6"
 
 processes:
   caddy:
-    command: "caddy run --config=$CADDY_CONF"
+    command: "caddy run --config=$CADDY_CONFIG"
     availability:
       restart: on_failure
       max_restarts: 5


### PR DESCRIPTION
## Summary
Change caddy to run on non privileged ports. I added the following script to the caddy example:
- devbox run start

Since I have a global caddy running on port `2019` for the admin endpoint already, I need to run this caddy under a separate admin port.

## Issue I still need help with (resolved. See commit "fix process compose")
Running `devbox services up` has the following error
```
[caddy_1	] Error: loading initial config: loading new config: starting caddy administration endpoint: listen tcp 127.0.0.1:2019: bind: address already in use
```
Where as `devbox run start` is successful 🤷‍♀️ Are we doing something special with process compose? Seems like for some reason, it is loading some initial config, then reload it with the new config. And because the initial config has a port conflict, everything fails.

To reproduce, go to [https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/servers/caddy&branch=lucille--caddy-on-vm](https://devbox.sh/github.com/jetpack-io/devbox?folder=examples/servers/caddy&branch=lucille--caddy-on-vm)

## How was it tested?
devbox.sh