### PR TITLE
[update] Show warning for legacy packages and fix with update

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -34,7 +34,6 @@ type Devbox interface {
 	ListScripts() []string
 	PrintEnv(ctx context.Context, includeHooks bool) (string, error)
 	PrintGlobalList() error
-	PrintEnvrcContent(w io.Writer) error
 	Pull(ctx context.Context, overwrite bool, path string) error
 	Push(url string) error
 	// Remove removes Nix packages from the config so that it no longer exists in
@@ -58,7 +57,11 @@ type Devbox interface {
 
 // Open opens a devbox by reading the config file in dir.
 func Open(dir string, writer io.Writer) (Devbox, error) {
-	return impl.Open(dir, writer)
+	return impl.Open(dir, writer, true)
+}
+
+func OpenWithoutWarnings(dir string, writer io.Writer) (Devbox, error) {
+	return impl.Open(dir, writer, false)
 }
 
 // InitConfig creates a default devbox config file if one doesn't already exist.
@@ -68,4 +71,8 @@ func InitConfig(dir string, writer io.Writer) (bool, error) {
 
 func GlobalDataPath() (string, error) {
 	return impl.GlobalDataPath()
+}
+
+func PrintEnvrcContent(w io.Writer) error {
+	return impl.PrintEnvrcContent(w)
 }

--- a/internal/boxcli/featureflag/autolatest.go
+++ b/internal/boxcli/featureflag/autolatest.go
@@ -1,3 +1,0 @@
-package featureflag
-
-var AutoLatest = enabled("AUTO_LATEST")

--- a/internal/boxcli/generate.go
+++ b/internal/boxcli/generate.go
@@ -92,7 +92,7 @@ func direnvCmd() *cobra.Command {
 			"Requires direnv to be installed.",
 		Args: cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runGenerateCmd(cmd, flags)
+			return runGenerateDirenvCmd(cmd, flags)
 		},
 	}
 	command.Flags().BoolVarP(
@@ -140,11 +140,19 @@ func runGenerateCmd(cmd *cobra.Command, flags *generateCmdFlags) error {
 		return box.GenerateDevcontainer(flags.force)
 	case "dockerfile":
 		return box.GenerateDockerfile(flags.force)
-	case "direnv":
-		if flags.printEnvrcContent {
-			return box.PrintEnvrcContent(cmd.OutOrStdout())
-		}
-		return box.GenerateEnvrcFile(flags.force)
 	}
 	return nil
+}
+
+func runGenerateDirenvCmd(cmd *cobra.Command, flags *generateCmdFlags) error {
+	if flags.printEnvrcContent {
+		return devbox.PrintEnvrcContent(cmd.OutOrStdout())
+	}
+
+	box, err := devbox.Open(flags.config.path, cmd.ErrOrStderr())
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return box.GenerateEnvrcFile(flags.force)
 }

--- a/internal/boxcli/midcobra/telemetry.go
+++ b/internal/boxcli/midcobra/telemetry.go
@@ -222,7 +222,7 @@ func getPackagesAndCommitHash(c *cobra.Command) ([]string, string) {
 		path = configFlag.Value.String()
 	}
 
-	box, err := devbox.Open(path, os.Stdout)
+	box, err := devbox.OpenWithoutWarnings(path, os.Stdout)
 	if err != nil {
 		return []string{}, ""
 	}

--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -44,7 +44,7 @@ func runCmd() *cobra.Command {
 }
 
 func listScripts(cmd *cobra.Command, flags runCmdFlags) []string {
-	box, err := devbox.Open(flags.config.path, cmd.ErrOrStderr())
+	box, err := devbox.OpenWithoutWarnings(flags.config.path, cmd.ErrOrStderr())
 	if err != nil {
 		debug.Log("failed to open devbox: %v", err)
 		return nil

--- a/internal/boxcli/shellenv.go
+++ b/internal/boxcli/shellenv.go
@@ -13,6 +13,7 @@ import (
 type shellEnvCmdFlags struct {
 	config               configFlags
 	runInitHook          bool
+	install              bool
 	useCachedPrintDevEnv bool
 }
 
@@ -36,6 +37,8 @@ func shellEnvCmd() *cobra.Command {
 
 	command.Flags().BoolVar(
 		&flags.runInitHook, "init-hook", false, "runs init hook after exporting shell environment")
+	command.Flags().BoolVar(
+		&flags.install, "install", false, "install packages before exporting shell environment")
 
 	// This is no longer used. Remove after 0.4.8 is released.
 	command.Flags().BoolVar(
@@ -54,6 +57,12 @@ func shellEnvFunc(cmd *cobra.Command, flags shellEnvCmdFlags) (string, error) {
 	box, err := devbox.Open(flags.config.path, cmd.ErrOrStderr())
 	if err != nil {
 		return "", err
+	}
+
+	if flags.install {
+		if err := box.Install(cmd.Context()); err != nil {
+			return "", err
+		}
 	}
 
 	envStr, err := box.PrintEnv(cmd.Context(), flags.runInitHook)

--- a/internal/boxcli/update.go
+++ b/internal/boxcli/update.go
@@ -22,7 +22,8 @@ func updateCmd() *cobra.Command {
 		Short: "Update packages in your devbox",
 		Long: "Update one, many, or all packages in your devbox. " +
 			"If no packages are specified, all packages will be updated. " +
-			"Only update versioned packages (e.g. `python@3.11`), not packages that are pinned to a nix channel (e.g. `python3`)",
+			"Legacy non-versioned packages will be converted to @latest versioned " +
+			"packages resolved to their current version.",
 		PreRunE: ensureNixInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return updateCmdFunc(cmd, args, flags)

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -72,7 +72,7 @@ type Devbox struct {
 
 var legacyPackagesWarningHasBeenShown = false
 
-func Open(path string, writer io.Writer) (*Devbox, error) {
+func Open(path string, writer io.Writer, showWarnings bool) (*Devbox, error) {
 	projectDir, err := findProjectDir(path)
 	if err != nil {
 		return nil, err
@@ -101,7 +101,9 @@ func Open(path string, writer io.Writer) (*Devbox, error) {
 	)
 	box.lockfile = lock
 
-	if box.HasDeprecatedPackages() && !legacyPackagesWarningHasBeenShown {
+	if showWarnings &&
+		!legacyPackagesWarningHasBeenShown &&
+		box.HasDeprecatedPackages() {
 		legacyPackagesWarningHasBeenShown = true
 		ux.Fwarning(
 			os.Stderr, // Always stderr. box.writer should probably always be err.
@@ -407,7 +409,7 @@ func (d *Devbox) GenerateDockerfile(force bool) error {
 	return errors.WithStack(generate.CreateDockerfile(tmplFS, d.projectDir, false /* isDevcontainer */))
 }
 
-func (d *Devbox) PrintEnvrcContent(w io.Writer) error {
+func PrintEnvrcContent(w io.Writer) error {
 	tmplName := "envrcContent.tmpl"
 	t := template.Must(template.ParseFS(tmplFS, "tmpl/"+tmplName))
 	// write content into file

--- a/internal/impl/devbox_test.go
+++ b/internal/impl/devbox_test.go
@@ -41,7 +41,7 @@ func testShellPlan(t *testing.T, testPath string) {
 		t.Setenv(envir.XDGDataHome, "/tmp/devbox")
 		assert := assert.New(t)
 
-		_, err := Open(baseDir, os.Stdout)
+		_, err := Open(baseDir, os.Stdout, true)
 		assert.NoErrorf(err, "%s should be a valid devbox project", baseDir)
 	})
 }
@@ -65,7 +65,7 @@ func TestComputeNixEnv(t *testing.T) {
 	path := t.TempDir()
 	_, err := devconfig.Init(path, os.Stdout)
 	require.NoError(t, err, "InitConfig should not fail")
-	d, err := Open(path, os.Stdout)
+	d, err := Open(path, os.Stdout, true)
 	require.NoError(t, err, "Open should not fail")
 	d.nix = &testNix{}
 	ctx := context.Background()
@@ -78,7 +78,7 @@ func TestComputeNixPathIsIdempotent(t *testing.T) {
 	dir := t.TempDir()
 	_, err := devconfig.Init(dir, os.Stdout)
 	require.NoError(t, err, "InitConfig should not fail")
-	devbox, err := Open(dir, os.Stdout)
+	devbox, err := Open(dir, os.Stdout, true)
 	require.NoError(t, err, "Open should not fail")
 	devbox.nix = &testNix{"/tmp/my/path"}
 	ctx := context.Background()
@@ -104,7 +104,7 @@ func TestComputeNixPathWhenRemoving(t *testing.T) {
 	dir := t.TempDir()
 	_, err := devconfig.Init(dir, os.Stdout)
 	require.NoError(t, err, "InitConfig should not fail")
-	devbox, err := Open(dir, os.Stdout)
+	devbox, err := Open(dir, os.Stdout, true)
 	require.NoError(t, err, "Open should not fail")
 	devbox.nix = &testNix{"/tmp/my/path"}
 	ctx := context.Background()

--- a/internal/impl/tmpl/envrcContent.tmpl
+++ b/internal/impl/tmpl/envrcContent.tmpl
@@ -1,6 +1,5 @@
 use_devbox() {
     watch_file devbox.json
-    eval "$(devbox shellenv --init-hook)"
-    devbox install
+    eval "$(devbox shellenv --init-hook --install)"
 }
 use devbox

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -28,7 +28,11 @@ func (d *Devbox) Update(ctx context.Context, pkgs ...string) error {
 			if err := d.Remove(ctx, pkg.Raw); err != nil {
 				return err
 			}
-			d.lockfile.ResolveToCurrentNixpkgCommitHash(pkg.LegacyToVersioned())
+			if err := d.lockfile.ResolveToCurrentNixpkgCommitHash(
+				pkg.LegacyToVersioned(),
+			); err != nil {
+				return err
+			}
 			if err := d.Add(ctx, pkg.LegacyToVersioned()); err != nil {
 				return err
 			}

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"go.jetpack.io/devbox/internal/lock"
+	"go.jetpack.io/devbox/internal/nix"
 )
 
 func (d *Devbox) Update(ctx context.Context, pkgs ...string) error {
@@ -20,19 +21,33 @@ func (d *Devbox) Update(ctx context.Context, pkgs ...string) error {
 		pkgsToUpdate = d.Packages()
 	}
 
-	for _, pkg := range pkgsToUpdate {
-		if !lock.IsVersionedPackage(pkg) {
+	inputs := nix.InputsFromStrings(pkgsToUpdate, d.lockfile)
+	for _, pkg := range inputs {
+		if pkg.IsLegacy() {
+			fmt.Fprintf(d.writer, "Updating %s -> %s\n", pkg.Raw, pkg.LegacyToVersioned())
+			if err := d.Remove(ctx, pkg.Raw); err != nil {
+				return err
+			}
+			d.lockfile.ResolveToCurrentNixpkgCommitHash(pkg.LegacyToVersioned())
+			if err := d.Add(ctx, pkg.LegacyToVersioned()); err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, pkg := range inputs {
+		if !lock.IsVersionedPackage(pkg.Raw) {
 			fmt.Fprintf(d.writer, "Skipping %s because it is not a versioned package\n", pkg)
 			continue
 		}
-		existing := d.lockfile.Packages[pkg]
-		newEntry, err := d.lockfile.ForceResolve(pkg)
+		existing := d.lockfile.Packages[pkg.Raw]
+		newEntry, err := d.lockfile.ForceResolve(pkg.Raw)
 		if err != nil {
 			return err
 		}
 		if existing != nil && existing.Version != newEntry.Version {
 			fmt.Fprintf(d.writer, "Updating %s %s -> %s\n", pkg, existing.Version, newEntry.Version)
-			if err := d.removePackagesFromProfile(ctx, []string{pkg}); err != nil {
+			if err := d.removePackagesFromProfile(ctx, []string{pkg.Raw}); err != nil {
 				return err
 			}
 		} else if existing == nil {

--- a/internal/lock/lockfile.go
+++ b/internal/lock/lockfile.go
@@ -93,6 +93,17 @@ func (l *File) ForceResolve(pkg string) (*Package, error) {
 	return l.Resolve(pkg)
 }
 
+func (l *File) ResolveToCurrentNixpkgCommitHash(pkg string) error {
+	name, version, found := strings.Cut(pkg, "@")
+	if found && version != "latest" {
+		return errors.New(
+			"only allowed version is @latest. Otherwise we can't guarantee the " +
+				"version will resolve")
+	}
+	l.Packages[pkg] = &Package{Resolved: l.LegacyNixpkgsPath(name)}
+	return nil
+}
+
 func (l *File) Save() error {
 	// Never write lockfile if versioned packages is not enabled
 	if !featureflag.LockFile.Enabled() {

--- a/internal/nix/input.go
+++ b/internal/nix/input.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/samber/lo"
 
-	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/cuecfg"
 	"go.jetpack.io/devbox/internal/lock"
@@ -295,10 +294,21 @@ func (i *Input) CanonicalName() string {
 }
 
 func (i *Input) Versioned() string {
-	if featureflag.AutoLatest.Enabled() && i.IsDevboxPackage() && !i.isVersioned() {
+	if i.IsDevboxPackage() && !i.isVersioned() {
 		return i.Raw + "@latest"
 	}
 	return i.Raw
+}
+
+func (i *Input) IsLegacy() bool {
+	return i.IsDevboxPackage() && !i.isVersioned()
+}
+
+func (i *Input) LegacyToVersioned() string {
+	if !i.IsLegacy() {
+		return i.Raw
+	}
+	return i.Raw + "@latest"
 }
 
 func (i *Input) EnsureNixpkgsPrefetched(w io.Writer) error {

--- a/internal/nix/input.go
+++ b/internal/nix/input.go
@@ -84,7 +84,7 @@ func (i *Input) InputName() string {
 
 func (i *Input) URLForInput() string {
 	if i.IsDevboxPackage() {
-		entry, err := i.lockfile.Resolve(i.String())
+		entry, err := i.lockfile.Resolve(i.Raw)
 		if err != nil {
 			panic(err)
 			// TODO(landau): handle error
@@ -97,7 +97,7 @@ func (i *Input) URLForInput() string {
 
 func (i *Input) URLForInstall() (string, error) {
 	if i.IsDevboxPackage() {
-		entry, err := i.lockfile.Resolve(i.String())
+		entry, err := i.lockfile.Resolve(i.Raw)
 		if err != nil {
 			return "", err
 		}
@@ -117,7 +117,7 @@ func (i *Input) normalizedDevboxPackageReference() (string, error) {
 
 	path := ""
 	if i.isVersioned() {
-		entry, err := i.lockfile.Resolve(i.String())
+		entry, err := i.lockfile.Resolve(i.Raw)
 		if err != nil {
 			return "", err
 		}
@@ -142,7 +142,7 @@ func (i *Input) normalizedDevboxPackageReference() (string, error) {
 // does not include packages/legacyPackages or the system name.
 func (i *Input) PackageAttributePath() (string, error) {
 	if i.IsDevboxPackage() {
-		entry, err := i.lockfile.Resolve(i.String())
+		entry, err := i.lockfile.Resolve(i.Raw)
 		if err != nil {
 			return "", err
 		}
@@ -174,7 +174,7 @@ func (i *Input) FullPackageAttributePath() (string, error) {
 func (i *Input) NormalizedPackageAttributePath() (string, error) {
 	var query string
 	if i.isVersioned() {
-		entry, err := i.lockfile.Resolve(i.String())
+		entry, err := i.lockfile.Resolve(i.Raw)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
## Summary

Add warning if devbox.json contains legacy packages. Fix them with update command. Update will turn legacy packages to `<pkg>@latest` and resolve them to current hash. This guarantees version will not change. If they run update again, it will update to newest version.

## How was it tested?

<img width="840" alt="image" src="https://github.com/jetpack-io/devbox/assets/544948/fe612548-356a-4ed5-810a-78a3942913d1">

```bash
# modified devbox.json to have `curl` package.
devbox update
```

Inspected devbox.json and devbox.lock and verified it was now `curl@latest` 
