### PR TITLE
[update] Fix update bug

### DIFF
--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"go.jetpack.io/devbox/internal/lock"
+	"go.jetpack.io/devbox/internal/searcher"
+	"go.jetpack.io/devbox/internal/ux"
 )
 
 func (d *Devbox) Update(ctx context.Context, pkgs ...string) error {
@@ -26,20 +28,24 @@ func (d *Devbox) Update(ctx context.Context, pkgs ...string) error {
 			continue
 		}
 		existing := d.lockfile.Packages[pkg]
-		newEntry, err := d.lockfile.ForceResolve(pkg)
+		newEntry, err := searcher.Client().Resolve(pkg)
 		if err != nil {
 			return err
 		}
 		if existing != nil && existing.Version != newEntry.Version {
 			fmt.Fprintf(d.writer, "Updating %s %s -> %s\n", pkg, existing.Version, newEntry.Version)
 			if err := d.removePackagesFromProfile(ctx, []string{pkg}); err != nil {
-				return err
+				// Warn but continue. TODO(landau): ensurePackagesAreInstalled should
+				// sync the profile so we don't need to do this manually.
+				ux.Fwarning(d.writer, "Failed to remove %s from profile: %s\n", pkg, err)
 			}
 		} else if existing == nil {
 			fmt.Fprintf(d.writer, "Resolved %s to %[1]s %[2]s\n", pkg, newEntry.Resolved)
 		} else {
 			fmt.Fprintf(d.writer, "Already up-to-date %s %s\n", pkg, existing.Version)
 		}
+		// Set the new entry after we've removed the old package from the profile
+		d.lockfile.Packages[pkg] = newEntry
 	}
 
 	// TODO(landau): Improve output


### PR DESCRIPTION
## Summary

Calling `removePackagesFromProfile` after forcing a resolve was causing an error because package doesn't exist in profile. Also, make update a little more forgiving, don't break if you can't remove pkg from profile.

## How was it tested?

* Hand changed devbox.lock to older version of go and older hash.
* deleted .devbox dir
* Ran `devbox install`
* Ran `devbox update`
* Observed new version of go installed, old one removed. No error.
