### PR TITLE
[devcontainer] Add GPG to dockerfile template

### DIFF
--- a/internal/impl/tmpl/devcontainerDockerfile.tmpl
+++ b/internal/impl/tmpl/devcontainerDockerfile.tmpl
@@ -2,7 +2,7 @@ FROM debian:stable-slim
 
 # Step 1: Installing dependencies
 RUN apt-get update
-RUN apt-get -y install bash binutils git xz-utils wget sudo
+RUN apt-get -y install bash binutils git{{if .IsDevcontainer}} gnupg2{{- end}} xz-utils wget sudo
 
 # Step 2: Setting up devbox user
 ENV DEVBOX_USER=devbox


### PR DESCRIPTION
## Summary

This change installs GPG (via the `gnupg2` package) in the dev container for the purposes of GPG commit-signing.

Fixes #1110

## How was it tested?

- [Install GPG locally](https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials#_sharing-gpg-keys)
- [Set up GPG commit-signing](https://docs.github.com/en/authentication/managing-commit-signature-verification) (i.e. generate a key and tell Git about it)
- devbox init
- devbox generate devcontainer
- cmd + shift + p and select "Rebuild and Reopen in Container"
- [Make a signed commit](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- Enter the password for your GPG key
- Assert that the commit is created successfully
