### PR TITLE
[RunScript] Add ctx parameter

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -41,7 +41,7 @@ type Devbox interface {
 	// the devbox environment.
 	Remove(ctx context.Context, pkgs ...string) error
 	RestartServices(ctx context.Context, services ...string) error
-	RunScript(scriptName string, scriptArgs []string) error
+	RunScript(ctx context.Context, scriptName string, scriptArgs []string) error
 	Services() (services.Services, error)
 	// Shell generates the devbox environment and launches nix-shell as a child process.
 	Shell(ctx context.Context) error

--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -80,7 +80,7 @@ func runScriptCmd(cmd *cobra.Command, args []string, flags runCmdFlags) error {
 		return redact.Errorf("error reading devbox.json: %w", err)
 	}
 
-	if err := box.RunScript(script, scriptArgs); err != nil {
+	if err := box.RunScript(cmd.Context(), script, scriptArgs); err != nil {
 		return redact.Errorf("error running command in Devbox: %w", err)
 	}
 	return nil

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -216,8 +216,8 @@ func (d *Devbox) Shell(ctx context.Context) error {
 	return shell.Run()
 }
 
-func (d *Devbox) RunScript(cmdName string, cmdArgs []string) error {
-	ctx, task := trace.NewTask(context.Background(), "devboxRun")
+func (d *Devbox) RunScript(ctx context.Context, cmdName string, cmdArgs []string) error {
+	ctx, task := trace.NewTask(ctx, "devboxRun")
 	defer task.End()
 
 	if err := d.ensurePackagesAreInstalled(ctx, ensure); err != nil {
@@ -478,7 +478,7 @@ func (d *Devbox) Services() (services.Services, error) {
 
 func (d *Devbox) StartServices(ctx context.Context, serviceNames ...string) error {
 	if !d.IsEnvEnabled() {
-		return d.RunScript("devbox", append([]string{"services", "start"}, serviceNames...))
+		return d.RunScript(ctx, "devbox", append([]string{"services", "start"}, serviceNames...))
 	}
 
 	if !services.ProcessManagerIsRunning(d.projectDir) {
@@ -520,7 +520,7 @@ func (d *Devbox) StopServices(ctx context.Context, allProjects bool, serviceName
 		if allProjects {
 			args = append(args, "--all-projects")
 		}
-		return d.RunScript("devbox", args)
+		return d.RunScript(ctx, "devbox", args)
 	}
 
 	if allProjects {
@@ -554,7 +554,7 @@ func (d *Devbox) StopServices(ctx context.Context, allProjects bool, serviceName
 
 func (d *Devbox) ListServices(ctx context.Context) error {
 	if !d.IsEnvEnabled() {
-		return d.RunScript("devbox", []string{"services", "ls"})
+		return d.RunScript(ctx, "devbox", []string{"services", "ls"})
 	}
 
 	svcSet, err := d.Services()
@@ -592,7 +592,7 @@ func (d *Devbox) ListServices(ctx context.Context) error {
 
 func (d *Devbox) RestartServices(ctx context.Context, serviceNames ...string) error {
 	if !d.IsEnvEnabled() {
-		return d.RunScript("devbox", append([]string{"services", "restart"}, serviceNames...))
+		return d.RunScript(ctx, "devbox", append([]string{"services", "restart"}, serviceNames...))
 	}
 
 	if !services.ProcessManagerIsRunning(d.projectDir) {
@@ -666,7 +666,7 @@ func (d *Devbox) StartProcessManager(
 		if background {
 			args = append(args, "--background")
 		}
-		return d.RunScript("devbox", args)
+		return d.RunScript(ctx, "devbox", args)
 	}
 
 	// Start the process manager


### PR DESCRIPTION
## Summary

Now that the implementation of `RunScript` is using `context.Background()`, I think it's better to pass the context.Context from `cmd.Context()`.

## How was it tested?

None