### PR TITLE
[sshshim] Add and pass ctx parameter for sshshim execution

### DIFF
--- a/internal/boxcli/midcobra/midcobra.go
+++ b/internal/boxcli/midcobra/midcobra.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 
 	"github.com/spf13/cobra"
+
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/ux"

--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
 	"go.jetpack.io/devbox/internal/boxcli/midcobra"
 	"go.jetpack.io/devbox/internal/cloud/openssh/sshshim"
 	"go.jetpack.io/devbox/internal/debug"
@@ -97,17 +98,18 @@ func Execute(ctx context.Context, args []string) int {
 }
 
 func Main() {
+	ctx := context.Background()
 	if strings.HasSuffix(os.Args[0], "ssh") ||
 		strings.HasSuffix(os.Args[0], "scp") {
-		code := sshshim.Execute(os.Args)
-		os.Exit(code)
+		os.Exit(sshshim.Execute(ctx, os.Args))
 	}
+
 	if len(os.Args) > 1 && os.Args[1] == "bug" {
 		telemetry.ReportErrors()
 		return
 	}
-	code := Execute(context.Background(), os.Args[1:])
-	os.Exit(code)
+
+	os.Exit(Execute(ctx, os.Args[1:]))
 }
 
 func listAllCommands(cmd *cobra.Command, indent string) {

--- a/internal/cloud/openssh/sshshim/command.go
+++ b/internal/cloud/openssh/sshshim/command.go
@@ -4,6 +4,7 @@
 package sshshim
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -11,27 +12,29 @@ import (
 	"go.jetpack.io/devbox/internal/telemetry"
 )
 
-func Execute(args []string) int {
+func Execute(ctx context.Context, args []string) int {
 	defer debug.Recover()
 	telemetry.Start(telemetry.AppSSHShim)
 	defer telemetry.Stop()
 
-	if err := execute(args); err != nil {
+	if err := execute(ctx, args); err != nil {
 		telemetry.Error(err, telemetry.Metadata{})
 		return 1
 	}
 	return 0
 }
 
-func execute(args []string) error {
+func execute(ctx context.Context, args []string) error {
 	EnableDebug() // Always enable for now.
 	debug.Log("os.Args: %v", args)
 
-	if alive, err := EnsureLiveVMOrTerminateMutagenSessions(args[1:]); err != nil {
+	alive, err := EnsureLiveVMOrTerminateMutagenSessions(ctx, args[1:])
+	if err != nil {
 		debug.Log("ensureLiveVMOrTerminateMutagenSessions error: %v", err)
 		fmt.Fprintf(os.Stderr, "%v", err)
 		return err
-	} else if !alive {
+	}
+	if !alive {
 		return nil
 	}
 
@@ -40,5 +43,6 @@ func execute(args []string) error {
 		fmt.Fprintf(os.Stderr, "%v", err)
 		return err
 	}
+
 	return nil
 }


### PR DESCRIPTION
## Summary

Title says it.

Now that `context.Context` is used, I think it's better to pass this parameter from the top instead of creating it when necessary.

## How was it tested?

None.