### PR TITLE
[pure-shell] making sure nix is in path in pure mode

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -1188,8 +1188,9 @@ func (d *Devbox) convertEnvToMap(currentEnv []string) (map[string]string, error)
 			continue
 		}
 		// handling special cases to for pure shell
-		// Passing HOME USER and DISTPLAY for pure shell to leak through
+		// Passing HOME USER and DISPLAY for pure shell to leak through
 		// otherwise devbox binary won't work - this matches nix
+		// We include PATH to find the nix installation. It is cleaned for pure mode below
 		if !d.pure || key == "HOME" || key == "USER" || key == "DISPLAY" || key == "PATH" {
 			env[key] = val
 		}

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -761,15 +761,15 @@ func (d *Devbox) computeNixEnv(ctx context.Context, usePrintDevEnvCache bool) (m
 
 	currentEnvPath := env["PATH"]
 	if d.pure { // make nix available inside pure shell - necessary for devbox commands to work
-		nixBins, err := d.NixBins(ctx)
-		if err != nil {
-			return nil, err
-		}
+		// nixBins, err := d.NixBins(ctx)
+		// if err != nil {
+		// 	return nil, err
+		// }
 		fmt.Println("####")
-		fmt.Println(nixBins)
+		fmt.Println(env)
 		fmt.Println("####")
 
-		nixInPath, err := findNixInPATH(nixBins, env)
+		nixInPath, err := findNixInPATH(env)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -761,14 +761,11 @@ func (d *Devbox) computeNixEnv(ctx context.Context, usePrintDevEnvCache bool) (m
 
 	currentEnvPath := env["PATH"]
 	if d.pure { // make nix available inside pure shell - necessary for devbox commands to work
-		singleUserNixBin := fmt.Sprintf("%s/.nix-profile/bin", env["HOME"])
-		multiUserNixBin := "/nix/var/nix/profiles/default/bin"
-		// ~/.nix-profile/bin takes precedent because of this from Nix reference manual:
-		// "You generally wouldn’t have /nix/var/nix/profiles/some-profile/bin in your PATH.
-		// Rather, there is a symlink ~/.nix-profile that points to your current profile.
-		// This means that you should put ~/.nix-profile/bin in your PATH
-		// (and indeed, that’s what the initialisation script /nix/etc/profile.d/nix.sh does)."
-		currentEnvPath = fmt.Sprintf("%s:%s", singleUserNixBin, multiUserNixBin)
+		nixInPath, err := findNixInPATH(env)
+		if err != nil {
+			return nil, err
+		}
+		currentEnvPath = nixInPath
 	}
 	debug.Log("current environment PATH is: %s", currentEnvPath)
 	// Use the original path, if available. If not available, set it for future calls.

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -761,15 +761,15 @@ func (d *Devbox) computeNixEnv(ctx context.Context, usePrintDevEnvCache bool) (m
 	}
 
 	currentEnvPath := env["PATH"]
-	if d.pure {
-		// Finding nix executables in path and passing it through
-		// Needed for devbox commands inside pure shell to work
-		nixInPath, err := findNixInPATH(env)
-		if err != nil {
-			return nil, err
-		}
-		currentEnvPath = nixInPath
-	}
+	// if d.pure {
+	// 	// Finding nix executables in path and passing it through
+	// 	// Needed for devbox commands inside pure shell to work
+	// 	nixInPath, err := findNixInPATH(env)
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+	// 	currentEnvPath = nixInPath
+	// }
 
 	debug.Log("current environment PATH is: %s", currentEnvPath)
 	// Use the original path, if available. If not available, set it for future calls.

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -733,6 +733,12 @@ func (d *Devbox) StartProcessManager(
 func (d *Devbox) computeNixEnv(ctx context.Context, usePrintDevEnvCache bool) (map[string]string, error) {
 	defer trace.StartRegion(ctx, "computeNixEnv").End()
 
+	// making sure nix is installed before saving current env
+	if err := nix.EnsureNixInstalled(
+		d.writer, func() *bool { return lo.ToPtr(false) },
+	); err != nil {
+		return nil, err
+	}
 	// Append variables from current env if --pure is not passed
 	currentEnv := os.Environ()
 	env := make(map[string]string, len(currentEnv))

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -760,8 +760,15 @@ func (d *Devbox) computeNixEnv(ctx context.Context, usePrintDevEnvCache bool) (m
 	}
 
 	currentEnvPath := env["PATH"]
-	if d.pure { // make nix available inside pure shell - necessary for devbox add to work
-		currentEnvPath = "/nix/var/nix/profiles/default/bin"
+	if d.pure { // make nix available inside pure shell - necessary for devbox commands to work
+		singleUserNixBin := fmt.Sprintf("%s/.nix-profile/bin", env["HOME"])
+		multiUserNixBin := "/nix/var/nix/profiles/default/bin"
+		// ~/.nix-profile/bin takes precedent because of this from Nix reference manual:
+		// "You generally wouldn’t have /nix/var/nix/profiles/some-profile/bin in your PATH.
+		// Rather, there is a symlink ~/.nix-profile that points to your current profile.
+		// This means that you should put ~/.nix-profile/bin in your PATH
+		// (and indeed, that’s what the initialisation script /nix/etc/profile.d/nix.sh does)."
+		currentEnvPath = fmt.Sprintf("%s:%s", singleUserNixBin, multiUserNixBin)
 	}
 	debug.Log("current environment PATH is: %s", currentEnvPath)
 	// Use the original path, if available. If not available, set it for future calls.

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -761,15 +761,15 @@ func (d *Devbox) computeNixEnv(ctx context.Context, usePrintDevEnvCache bool) (m
 	}
 
 	currentEnvPath := env["PATH"]
-	// if d.pure {
-	// 	// Finding nix executables in path and passing it through
-	// 	// Needed for devbox commands inside pure shell to work
-	// 	nixInPath, err := findNixInPATH(env)
-	// 	if err != nil {
-	// 		return nil, err
-	// 	}
-	// 	currentEnvPath = nixInPath
-	// }
+	if d.pure {
+		// Finding nix executables in path and passing it through
+		// Needed for devbox commands inside pure shell to work
+		nixInPath, err := findNixInPATH(env)
+		if err != nil {
+			return nil, err
+		}
+		currentEnvPath = nixInPath
+	}
 
 	debug.Log("current environment PATH is: %s", currentEnvPath)
 	// Use the original path, if available. If not available, set it for future calls.

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -747,8 +747,17 @@ func (d *Devbox) computeNixEnv(ctx context.Context, usePrintDevEnvCache bool) (m
 		}
 		// Passing HOME USER and DISTPLAY for pure shell to leak through
 		// otherwise devbox binary won't work - this matches nix
-		if !d.pure || key == "HOME" || key == "USER" || key == "DISPLAY" {
-			env[key] = val
+		if !d.pure {
+			if key == "PATH" {
+				nixInPath, err := findNixInPATH(env)
+				if err != nil {
+					return nil, err
+				}
+				env[key] = nixInPath
+			}
+			if key == "HOME" || key == "USER" || key == "DISPLAY" {
+				env[key] = val
+			}
 		}
 	}
 	// check if contents of .envrc is old and print warning
@@ -760,21 +769,21 @@ func (d *Devbox) computeNixEnv(ctx context.Context, usePrintDevEnvCache bool) (m
 	}
 
 	currentEnvPath := env["PATH"]
-	if d.pure { // make nix available inside pure shell - necessary for devbox commands to work
-		// nixBins, err := d.NixBins(ctx)
-		// if err != nil {
-		// 	return nil, err
-		// }
-		fmt.Println("####")
-		fmt.Println(env)
-		fmt.Println("####")
+	// if d.pure { // make nix available inside pure shell - necessary for devbox commands to work
+	// 	// nixBins, err := d.NixBins(ctx)
+	// 	// if err != nil {
+	// 	// 	return nil, err
+	// 	// }
+	// 	fmt.Println("####")
+	// 	fmt.Println(env)
+	// 	fmt.Println("####")
 
-		nixInPath, err := findNixInPATH(env)
-		if err != nil {
-			return nil, err
-		}
-		currentEnvPath = nixInPath
-	}
+	// 	nixInPath, err := findNixInPATH(env)
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+	// 	currentEnvPath = nixInPath
+	// }
 	debug.Log("current environment PATH is: %s", currentEnvPath)
 	// Use the original path, if available. If not available, set it for future calls.
 	// See https://github.com/jetpack-io/devbox/issues/687

--- a/internal/impl/shell.go
+++ b/internal/impl/shell.go
@@ -427,5 +427,5 @@ func findNixInPATH(env map[string]string) (string, error) {
 	}
 
 	// did not find nix executable in PATH, return error
-	return "", errors.New("Could not find any nix executable in PATH. Make sure Nix is installed and in PATH, then try again.")
+	return "", errors.New("could not find any nix executable in PATH. Make sure Nix is installed and in PATH, then try again.")
 }

--- a/internal/impl/shell.go
+++ b/internal/impl/shell.go
@@ -412,12 +412,12 @@ func filterPathList(pathList string, keep func(string) bool) string {
 	return strings.Join(filtered, string(filepath.ListSeparator))
 }
 
-func findNixInPATH(env map[string]string) (string, error) {
+func findNixInPATH(bins []string, env map[string]string) (string, error) {
 	defaultSingleUserNixBin := fmt.Sprintf("%s/.nix-profile/bin", env["HOME"])
 	defaultMultiUserNixBin := "/nix/var/nix/profiles/default/bin"
 	xdgNixBin := xdg.StateSubpath("/nix/profile/bin")
-	pathElements := strings.Split(env["PATH"], ":")
-	for _, el := range pathElements {
+	// pathElements := strings.Split(env["PATH"], ":")
+	for _, el := range bins {
 		if el == xdgNixBin ||
 			el == defaultSingleUserNixBin ||
 			el == defaultMultiUserNixBin {

--- a/internal/impl/shell.go
+++ b/internal/impl/shell.go
@@ -411,3 +411,20 @@ func filterPathList(pathList string, keep func(string) bool) string {
 	}
 	return strings.Join(filtered, string(filepath.ListSeparator))
 }
+
+func findNixInPATH(env map[string]string) (string, error) {
+	defaultSingleUserNixBin := fmt.Sprintf("%s/.nix-profile/bin", env["HOME"])
+	defaultMultiUserNixBin := "/nix/var/nix/profiles/default/bin"
+	xdgNixBin := xdg.StateSubpath("/nix/profile/bin")
+	pathElements := strings.Split(env["PATH"], ":")
+	for _, el := range pathElements {
+		if el == xdgNixBin ||
+			el == defaultSingleUserNixBin ||
+			el == defaultMultiUserNixBin {
+			return el, nil
+		}
+	}
+
+	// did not find nix executable in PATH, return error
+	return "", errors.New("Could not find any nix executable in PATH. Make sure Nix is installed and in PATH, then try again.")
+}

--- a/internal/impl/shell.go
+++ b/internal/impl/shell.go
@@ -412,12 +412,13 @@ func filterPathList(pathList string, keep func(string) bool) string {
 	return strings.Join(filtered, string(filepath.ListSeparator))
 }
 
-func findNixInPATH(bins []string, env map[string]string) (string, error) {
+func findNixInPATH(env map[string]string) (string, error) {
 	defaultSingleUserNixBin := fmt.Sprintf("%s/.nix-profile/bin", env["HOME"])
 	defaultMultiUserNixBin := "/nix/var/nix/profiles/default/bin"
 	xdgNixBin := xdg.StateSubpath("/nix/profile/bin")
-	// pathElements := strings.Split(env["PATH"], ":")
-	for _, el := range bins {
+	pathElements := strings.Split(env["PATH"], ":")
+	debug.Log("path elements: %v", pathElements)
+	for _, el := range pathElements {
 		if el == xdgNixBin ||
 			el == defaultSingleUserNixBin ||
 			el == defaultMultiUserNixBin {

--- a/internal/impl/shell.go
+++ b/internal/impl/shell.go
@@ -427,5 +427,5 @@ func findNixInPATH(env map[string]string) (string, error) {
 	}
 
 	// did not find nix executable in PATH, return error
-	return "", errors.New("could not find any nix executable in PATH. Make sure Nix is installed and in PATH, then try again.")
+	return "", errors.New("could not find any nix executable in PATH. Make sure Nix is installed and in PATH, then try again")
 }

--- a/testscripts/run/pure.test.txt
+++ b/testscripts/run/pure.test.txt
@@ -1,0 +1,21 @@
+# Tests related to having devbox run in pure mode.
+
+env FOO=bar
+env FOO2=bar2
+
+exec devbox run --pure echo '$FOO'
+stdout 'baz'
+
+exec devbox run --pure echo '$FOO2'
+stdout ''
+
+exec devbox run --pure hello
+stdout 'Hello, world!'
+
+-- devbox.json --
+{
+  "packages": ["hello"],
+  "env": {
+    "FOO": "baz"
+  }
+}


### PR DESCRIPTION
## Summary
This is a follow up PR from as a result of [this discussion](https://github.com/jetpack-io/devbox/pull/1084#discussion_r1224750558). 
Note, xdg dirs don't keep any nix executables as far as I know. Single user and multi user nix installation put the nix executable in `~/.nix-profile/bin/` and `/nix/var/nix/profiles/default/bin` respectively.

Also added tests for devbox run pure mode. For `devbox shellenv`, pure mode doesn't really make sense to write tests for, and for `devbox shell` it's not possible to write testscript tests.


## How was it tested?
- in a single user nix installed env, run `./devbox shell --pure` 
- `devbox add which`
- `which nix` should point to `~/.nix-profile/bin/nix`
- in a multi-user nix, same test should point to `/nix/var/nix/profiles/default/bin/nix`
