### PR TITLE
[run] escape quotes in arguments

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -263,6 +263,11 @@ func (d *Devbox) RunScript(ctx context.Context, cmdName string, cmdArgs []string
 		return err
 	}
 
+	// wrap the arg in double-quotes, and escape any double-quotes inside it
+	for idx, arg := range cmdArgs {
+		cmdArgs[idx] = strconv.Quote(arg)
+	}
+
 	var cmdWithArgs []string
 	if _, ok := d.cfg.Scripts()[cmdName]; ok {
 		// it's a script, so replace the command with the script file's path.

--- a/testscripts/run/quote_escaping.test.txt
+++ b/testscripts/run/quote_escaping.test.txt
@@ -1,0 +1,12 @@
+# ensure that we escape the arguments to `devbox run`
+
+exec devbox init
+exec devbox run -- echo 'this is a "hello world"'
+stdout 'this is a "hello world"'
+
+env FOO=bar
+exec devbox run echo '$FOO'
+stdout 'bar'
+
+exec devbox run echo "$FOO"
+stdout 'bar'


### PR DESCRIPTION
## Summary

Implementing a narrow fix for #1137
We wrap each command arg in double-quotes and escape any double-quotes within.

Fixes #1137

## How was it tested?

Added testscript unit test

from issue:
```
> devbox run -- jq -r '.shell.scripts | keys | join(" ")' devbox.json
build build-linux build-linux-amd64 code lint test
```

Also, this now matches:
```
> echo 'hello "world"'
hello "world"

> devbox run -- echo 'hello "world"'
hello "world"
```
previously:
```
> devbox run -- echo 'hello "world"'
hello world
```
