### PR TITLE
[cleanup] remove --use-cached-print-dev-env from shellenv

### DIFF
--- a/internal/boxcli/shellenv.go
+++ b/internal/boxcli/shellenv.go
@@ -12,11 +12,10 @@ import (
 )
 
 type shellEnvCmdFlags struct {
-	config               configFlags
-	runInitHook          bool
-	install              bool
-	useCachedPrintDevEnv bool
-	pure                 bool
+	config      configFlags
+	runInitHook bool
+	install     bool
+	pure        bool
 }
 
 func shellEnvCmd() *cobra.Command {
@@ -45,15 +44,6 @@ func shellEnvCmd() *cobra.Command {
 	command.Flags().BoolVar(
 		&flags.pure, "pure", false, "If this flag is specified, devbox creates an isolated environment inheriting almost no variables from the current environment. A few variables, in particular HOME, USER and DISPLAY, are retained.")
 
-	// This is no longer used. Remove after 0.4.8 is released.
-	command.Flags().BoolVar(
-		&flags.useCachedPrintDevEnv,
-		"use-cached-print-dev-env",
-		false,
-		"[internal - not meant for general usage] Use the cached nix print-dev-env environment instead of the current environment",
-	)
-	// This is used by bin wrappers and not meant for end users.
-	command.Flag("use-cached-print-dev-env").Hidden = true
 	flags.config.register(command)
 
 	command.AddCommand(shellEnvOnlyPathWithoutWrappersCmd())


### PR DESCRIPTION
## Summary

This flag used to be used by bin-wrappers, but has been removed as of 0.4.8

cc @mikeland86

## How was it tested?

compiles
