### PR TITLE
[dockerfile] Copying local flakes in dockerfile

### DIFF
--- a/internal/boxcli/generate/devcontainer_util.go
+++ b/internal/boxcli/generate/devcontainer_util.go
@@ -38,10 +38,11 @@ type vscode struct {
 
 type dockerfileData struct {
 	IsDevcontainer bool
+	LocalFlakeDirs []string
 }
 
 // CreateDockerfile creates a Dockerfile in path and writes devcontainerDockerfile.tmpl's content into it
-func CreateDockerfile(tmplFS embed.FS, path string, isDevcontainer bool) error {
+func CreateDockerfile(tmplFS embed.FS, path string, localFlakeDirs []string, isDevcontainer bool) error {
 	// create dockerfile
 	file, err := os.Create(filepath.Join(path, "Dockerfile"))
 	if err != nil {
@@ -52,7 +53,10 @@ func CreateDockerfile(tmplFS embed.FS, path string, isDevcontainer bool) error {
 	tmplName := "devcontainerDockerfile.tmpl"
 	t := template.Must(template.ParseFS(tmplFS, "tmpl/"+tmplName))
 	// write content into file
-	return t.Execute(file, &dockerfileData{IsDevcontainer: isDevcontainer})
+	return t.Execute(file, &dockerfileData{
+		IsDevcontainer: isDevcontainer,
+		LocalFlakeDirs: localFlakeDirs,
+	})
 }
 
 // CreateDevcontainer creates a devcontainer.json in path and writes getDevcontainerContent's output into it

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -392,7 +392,7 @@ func (d *Devbox) GenerateDevcontainer(force bool) error {
 			redact.Safe(filepath.Base(devContainerPath)), err)
 	}
 	// generate dockerfile
-	err = generate.CreateDockerfile(tmplFS, devContainerPath, true /* isDevcontainer */)
+	err = generate.CreateDockerfile(tmplFS, devContainerPath, d.getLocalFlakesDirs(), true /* isDevcontainer */)
 	if err != nil {
 		return redact.Errorf("error generating dev container Dockerfile in <project>/%s: %w",
 			redact.Safe(filepath.Base(devContainerPath)), err)
@@ -419,7 +419,7 @@ func (d *Devbox) GenerateDockerfile(force bool) error {
 	}
 
 	// generate dockerfile
-	return errors.WithStack(generate.CreateDockerfile(tmplFS, d.projectDir, false /* isDevcontainer */))
+	return errors.WithStack(generate.CreateDockerfile(tmplFS, d.projectDir, d.getLocalFlakesDirs(), false /* isDevcontainer */))
 }
 
 func PrintEnvrcContent(w io.Writer) error {

--- a/internal/impl/flakes.go
+++ b/internal/impl/flakes.go
@@ -53,7 +53,7 @@ func (d *Devbox) flakeInputs() ([]*plansdk.FlakeInput, error) {
 	return goutil.PickByKeysSorted(inputs, order), nil
 }
 
-// getLocalFlakesDirs searches pacakges and returns list of directories
+// getLocalFlakesDirs searches packages and returns list of directories
 // of local flakes that are mentioned in config.
 // e.g., path:./my-flake#packageName -> ./my-flakes
 func (d *Devbox) getLocalFlakesDirs() []string {

--- a/internal/impl/flakes.go
+++ b/internal/impl/flakes.go
@@ -4,6 +4,8 @@
 package impl
 
 import (
+	"strings"
+
 	"github.com/samber/lo"
 
 	"go.jetpack.io/devbox/internal/goutil"
@@ -49,4 +51,22 @@ func (d *Devbox) flakeInputs() ([]*plansdk.FlakeInput, error) {
 	}
 
 	return goutil.PickByKeysSorted(inputs, order), nil
+}
+
+// getLocalFlakesDirs searches pacakges and returns list of directories
+// of local flakes that are mentioned in config.
+// e.g., path:./my-flake#packageName -> ./my-flakes
+func (d *Devbox) getLocalFlakesDirs() []string {
+	localFlakeDirs := []string{}
+
+	// searching through installed packages to get location of local flakes
+	for _, pkg := range d.Packages() {
+		// filtering local flakes packages
+		if strings.HasPrefix(pkg, "path:") {
+			pkgDirAndName, _ := strings.CutPrefix(pkg, "path:")
+			pkgDir := strings.Split(pkgDirAndName, "#")[0]
+			localFlakeDirs = append(localFlakeDirs, pkgDir)
+		}
+	}
+	return localFlakeDirs
 }

--- a/internal/impl/tmpl/devcontainerDockerfile.tmpl
+++ b/internal/impl/tmpl/devcontainerDockerfile.tmpl
@@ -26,6 +26,12 @@ ENV PATH="/home/${DEVBOX_USER}/.nix-profile/bin:/home/${DEVBOX_USER}/.devbox/nix
 WORKDIR /code
 RUN sudo chown $DEVBOX_USER:root /code
 COPY devbox.json devbox.json
+{{if len .LocalFlakeDirs}}
+# Step 6: Copying local flakes directories
+{{- end}}
+{{range $i, $element := .LocalFlakeDirs -}}
+COPY {{$element}} {{$element}}
+{{end}}
 RUN devbox install
 {{if .IsDevcontainer}}
 RUN devbox shellenv --init-hook >> ~/.profile


### PR DESCRIPTION
## Summary
This PR addresses the issue in generated dockerfiles by `devbox generate dockerfile` and `devbox generate devcontainer` in which packages mentioned as local flakes are not copied over in dockerfile and user has to manually do that.
Addresses: #1051 

## How was it tested?
- compile
- add a local flake (example: https://github.com/NixOS/templates/blob/master/go-hello/) 
- add local flake to devbox
- ./devbox generate dockerfile
- check the contents of generated dockerfile and confirm there is a Step 6 comment and COPY commands for each local flake.