### PR TITLE
[workaround] add PGHOST at top-level env

### DIFF
--- a/examples/stacks/lapp-stack/devbox.json
+++ b/examples/stacks/lapp-stack/devbox.json
@@ -7,7 +7,8 @@
     "apache@2.4"
   ],
   "env": {
-    "PGPORT": "5432"
+    "PGPORT": "5432",
+    "PGHOST": "/tmp/devbox/lapp"
   },
   "shell": {
     "scripts": {
@@ -19,7 +20,6 @@
       "init_db": "initdb",
       "run_test": [
         "mkdir -p /tmp/devbox/lapp",
-        "export PGHOST=/tmp/devbox/lapp",
         "initdb",
         "devbox services start",
         "echo 'sleep 1 second for the postgres server to initialize.' && sleep 1",

--- a/examples/stacks/lepp-stack/devbox.json
+++ b/examples/stacks/lepp-stack/devbox.json
@@ -7,7 +7,8 @@
         "nginx@1.24"
     ],
     "env": {
-        "PGPORT": "5433"
+        "PGPORT": "5433",
+        "PGHOST": "/tmp/devbox/lepp"
     },
     "shell": {
         "scripts": {
@@ -19,7 +20,6 @@
             ],
             "run_test": [
                 "mkdir -p /tmp/devbox/lepp",
-                "export PGHOST=/tmp/devbox/lepp",
                 "initdb",
                 "devbox services up -b",
                 "echo 'sleep 2 second for the postgres server to initialize.' && sleep 2",


### PR DESCRIPTION
## Summary

This simple fix moves the `export PGHOST` in the lapp-stack and lepp-stack examples to the `env` field of the devbox.jsons

Upside:
1. Much simpler fix compared to #1158 , and more maintainable.

Downside:
1. These are reused as templates for users, and are not the ideal code. 

I'm inclined to land this for now, and figure out a better solution without adding the bash code of #1158 

## How was it tested?
