### PR TITLE
Revert "[bin wrappers] add --omit-wrappers-from-path to shellenv to prevent a binary from invoking a wrapped-binary. (#1151)"

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -33,7 +33,7 @@ type Devbox interface {
 	Install(ctx context.Context) error
 	IsEnvEnabled() bool
 	ListScripts() []string
-	PrintEnv(opts *devopt.PrintEnv) (string, error)
+	PrintEnv(ctx context.Context, includeHooks bool) (string, error)
 	PrintGlobalList() error
 	Pull(ctx context.Context, overwrite bool, path string) error
 	Push(url string) error

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -59,12 +59,7 @@ func runShellCmd(cmd *cobra.Command, flags shellCmdFlags) error {
 	if flags.printEnv {
 		// false for includeHooks is because init hooks is not compatible with .envrc files generated
 		// by versions older than 0.4.6
-		opts := &devopt.PrintEnv{
-			Ctx:                  cmd.Context(),
-			IncludeHooks:         false,
-			OmitWrappersFromPath: false,
-		}
-		script, err := box.PrintEnv(opts)
+		script, err := box.PrintEnv(cmd.Context(), false /*includeHooks*/)
 		if err != nil {
 			return err
 		}

--- a/internal/boxcli/shellenv.go
+++ b/internal/boxcli/shellenv.go
@@ -13,11 +13,10 @@ import (
 
 type shellEnvCmdFlags struct {
 	config               configFlags
-	install              bool
-	omitWrappersFromPath bool
-	pure                 bool
 	runInitHook          bool
+	install              bool
 	useCachedPrintDevEnv bool
+	pure                 bool
 }
 
 func shellEnvCmd() *cobra.Command {
@@ -45,12 +44,6 @@ func shellEnvCmd() *cobra.Command {
 
 	command.Flags().BoolVar(
 		&flags.pure, "pure", false, "If this flag is specified, devbox creates an isolated environment inheriting almost no variables from the current environment. A few variables, in particular HOME, USER and DISPLAY, are retained.")
-
-	// This flag is to be used by our generated bin-wrappers shell script.
-	command.Flags().BoolVar(
-		&flags.omitWrappersFromPath, "omit-wrappers-from-path", false, "If this flag is specified, "+
-			"the PATH from shellenv will not include the binary wrappers")
-	command.Flag("omit-wrappers-from-path").Hidden = true
 
 	// This is no longer used. Remove after 0.4.8 is released.
 	command.Flags().BoolVar(
@@ -81,12 +74,7 @@ func shellEnvFunc(cmd *cobra.Command, flags shellEnvCmdFlags) (string, error) {
 		}
 	}
 
-	opts := &devopt.PrintEnv{
-		Ctx:                  cmd.Context(),
-		IncludeHooks:         flags.runInitHook,
-		OmitWrappersFromPath: flags.omitWrappersFromPath,
-	}
-	envStr, err := box.PrintEnv(opts)
+	envStr, err := box.PrintEnv(cmd.Context(), flags.runInitHook)
 	if err != nil {
 		return "", err
 	}

--- a/internal/impl/devopt/devboxopts.go
+++ b/internal/impl/devopt/devboxopts.go
@@ -1,19 +1,10 @@
 package devopt
 
-import (
-	"context"
-	"io"
-)
+import "io"
 
 type Opts struct {
 	Dir            string
 	Pure           bool
 	IgnoreWarnings bool
 	Writer         io.Writer
-}
-
-type PrintEnv struct {
-	Ctx                  context.Context
-	IncludeHooks         bool
-	OmitWrappersFromPath bool
 }

--- a/internal/wrapnix/wrapper.go
+++ b/internal/wrapnix/wrapper.go
@@ -34,6 +34,11 @@ var wrapperTemplate = template.Must(template.New("wrapper").Parse(wrapper))
 
 // CreateWrappers creates wrappers for all the executables in nix paths
 func CreateWrappers(ctx context.Context, devbox devboxer) error {
+	shellEnvHash, err := devbox.ShellEnvHash(ctx)
+	if err != nil {
+		return err
+	}
+
 	services, err := devbox.Services()
 	if err != nil {
 		return err
@@ -49,20 +54,22 @@ func CreateWrappers(ctx context.Context, devbox devboxer) error {
 	bashPath := cmdutil.GetPathOrDefault("bash", "/bin/bash")
 	for _, service := range services {
 		if err = createWrapper(&createWrapperArgs{
-			devboxer: devbox,
-			BashPath: bashPath,
-			Command:  service.Start,
-			Env:      service.Env,
-			destPath: filepath.Join(destPath, service.StartName()),
+			devboxer:     devbox,
+			BashPath:     bashPath,
+			Command:      service.Start,
+			Env:          service.Env,
+			ShellEnvHash: shellEnvHash,
+			destPath:     filepath.Join(destPath, service.StartName()),
 		}); err != nil {
 			return err
 		}
 		if err = createWrapper(&createWrapperArgs{
-			devboxer: devbox,
-			BashPath: bashPath,
-			Command:  service.Stop,
-			Env:      service.Env,
-			destPath: filepath.Join(destPath, service.StopName()),
+			devboxer:     devbox,
+			BashPath:     bashPath,
+			Command:      service.Stop,
+			Env:          service.Env,
+			ShellEnvHash: shellEnvHash,
+			destPath:     filepath.Join(destPath, service.StopName()),
 		}); err != nil {
 			return err
 		}
@@ -75,10 +82,11 @@ func CreateWrappers(ctx context.Context, devbox devboxer) error {
 
 	for _, bin := range bins {
 		if err = createWrapper(&createWrapperArgs{
-			devboxer: devbox,
-			BashPath: bashPath,
-			Command:  bin,
-			destPath: filepath.Join(destPath, filepath.Base(bin)),
+			devboxer:     devbox,
+			BashPath:     bashPath,
+			Command:      bin,
+			ShellEnvHash: shellEnvHash,
+			destPath:     filepath.Join(destPath, filepath.Base(bin)),
 		}); err != nil {
 			return errors.WithStack(err)
 		}
@@ -92,9 +100,10 @@ func CreateWrappers(ctx context.Context, devbox devboxer) error {
 
 type createWrapperArgs struct {
 	devboxer
-	BashPath string
-	Command  string
-	Env      map[string]string
+	BashPath     string
+	Command      string
+	Env          map[string]string
+	ShellEnvHash string
 
 	destPath string
 }

--- a/internal/wrapnix/wrapper.sh.tmpl
+++ b/internal/wrapnix/wrapper.sh.tmpl
@@ -14,23 +14,19 @@ fi
 {{- end }}
 
 {{/*
+We use ShellEnvHashKey to prevent doing shellenv if the correct environment is
+already set. (perf optimization)
 
 We use the guard to prevent infinite loop if something in shellenv causes 
 another wrapped binary to be called. The guard is specific to this project so shellenv
 could still cause another project's shellenv to be called.
-Note, this guard can likely be removed since we use --omit-wrappers-from-path=true below,
-but leaving in to minimize change.
 
 DO_NOT_TRACK=1 can be removed once we optimize segment to queue events.
-
---omit-wrappers-from-path so that we do not invoke other bin-wrappers from
-this bin-wrapper. Instead, we directly invoke the binary from the nix store, which
-should be in PATH.
 */ -}}
 
-if [[ -z "${{ .ShellEnvHashKey }}_GUARD" ]]; then
+if [[ "${{ .ShellEnvHashKey }}" != "{{ .ShellEnvHash }}" ]] && [[ -z "${{ .ShellEnvHashKey }}_GUARD" ]]; then
 export {{ .ShellEnvHashKey }}_GUARD=true
-eval "$(DO_NOT_TRACK=1 devbox shellenv --omit-wrappers-from-path=true -c {{ .ProjectDir }})"
+eval "$(DO_NOT_TRACK=1 devbox shellenv -c {{ .ProjectDir }})"
 fi
 
 exec {{ .Command }} "$@"


### PR DESCRIPTION
## Summary

Reverting due to regression:
Within a devbox script if any environment variable has been exported, and
if a devbox-plugin also sets that env-var, then the devbox-plugin env-var
will be set for the wrapped-binary.

Specifically, in the `lapp-stack/devbox.json`, we have:
```
      "run_test": [
        "mkdir -p /tmp/devbox/lapp",
        "export PGHOST=/tmp/devbox/lapp",
        "initdb",
```

but the PGHOST that `initdb` sees is a different value i.e. the one set by the devbox plugin.

In the code being reverted, the wrapped-bin's bash script would always invoke
`eval $(devbox shellenv --omit-wrappers-from-path=true)` in order to omit wrappers
from PATH. A side-effect is that the PGHOST would also get overridden.


## How was it tested?

no testing done.
straight revert, tests should pass.
