### PR TITLE
wrappers] ensure bin-wrappers invoke other binaries and not bin-wrappers

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -33,7 +33,7 @@ type Devbox interface {
 	Install(ctx context.Context) error
 	IsEnvEnabled() bool
 	ListScripts() []string
-	PrintEnv(ctx context.Context, includeHooks bool) (string, error)
+	PrintEnv(opts *devopt.PrintEnv) (string, error)
 	PrintGlobalList() error
 	Pull(ctx context.Context, overwrite bool, path string) error
 	Push(url string) error

--- a/examples/stacks/lapp-stack/devbox.json
+++ b/examples/stacks/lapp-stack/devbox.json
@@ -19,7 +19,8 @@
       "init_db": "initdb",
       "run_test": [
         "mkdir -p /tmp/devbox/lapp",
-        "PGHOST=/tmp/devbox/lapp initdb",
+        "export PGHOST=/tmp/devbox/lapp",
+        "initdb",
         "devbox services start",
         "echo 'sleep 1 second for the postgres server to initialize.' && sleep 1",
         "dropdb --if-exists devbox_lapp",

--- a/examples/stacks/lapp-stack/devbox.json
+++ b/examples/stacks/lapp-stack/devbox.json
@@ -19,8 +19,7 @@
       "init_db": "initdb",
       "run_test": [
         "mkdir -p /tmp/devbox/lapp",
-        "export PGHOST=/tmp/devbox/lapp",
-        "initdb",
+        "PGHOST=/tmp/devbox/lapp initdb",
         "devbox services start",
         "echo 'sleep 1 second for the postgres server to initialize.' && sleep 1",
         "dropdb --if-exists devbox_lapp",

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -59,7 +59,7 @@ func runShellCmd(cmd *cobra.Command, flags shellCmdFlags) error {
 	if flags.printEnv {
 		// false for includeHooks is because init hooks is not compatible with .envrc files generated
 		// by versions older than 0.4.6
-		script, err := box.PrintEnv(cmd.Context(), false /*includeHooks*/)
+		script, err := box.PrintEnv(&devopt.PrintEnv{Ctx: cmd.Context()})
 		if err != nil {
 			return err
 		}

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -293,7 +293,7 @@ func (d *Devbox) RunScript(ctx context.Context, cmdName string, cmdArgs []string
 // creates all wrappers, but does not run init hooks. It is used to power
 // devbox install cli command.
 func (d *Devbox) Install(ctx context.Context) error {
-	if _, err := d.PrintEnv(ctx, false /* run init hooks */); err != nil {
+	if _, err := d.PrintEnv(&devopt.PrintEnv{Ctx: ctx}); err != nil {
 		return err
 	}
 	return wrapnix.CreateWrappers(ctx, d)
@@ -309,8 +309,8 @@ func (d *Devbox) ListScripts() []string {
 	return keys
 }
 
-func (d *Devbox) PrintEnv(ctx context.Context, includeHooks bool) (string, error) {
-	ctx, task := trace.NewTask(ctx, "devboxPrintEnv")
+func (d *Devbox) PrintEnv(opts *devopt.PrintEnv) (string, error) {
+	ctx, task := trace.NewTask(opts.Ctx, "devboxPrintEnv")
 	defer task.End()
 
 	if err := d.ensurePackagesAreInstalled(ctx, ensure); err != nil {
@@ -322,9 +322,23 @@ func (d *Devbox) PrintEnv(ctx context.Context, includeHooks bool) (string, error
 		return "", err
 	}
 
+	if opts.OnlyPathWithoutWrappers {
+		path := []string{}
+		for _, p := range strings.Split(envs["PATH"], string(filepath.ListSeparator)) {
+			if !strings.Contains(p, plugin.WrapperPath) {
+				path = append(path, p)
+			}
+		}
+
+		// reset envs to be PATH only!
+		envs = map[string]string{
+			"PATH": strings.Join(path, string(filepath.ListSeparator)),
+		}
+	}
+
 	envStr := exportify(envs)
 
-	if includeHooks {
+	if opts.IncludeHooks {
 		hooksStr := ". " + d.scriptPath(hooksFilename)
 		envStr = fmt.Sprintf("%s\n%s;\n", envStr, hooksStr)
 	}

--- a/internal/impl/devopt/devboxopts.go
+++ b/internal/impl/devopt/devboxopts.go
@@ -1,10 +1,19 @@
 package devopt
 
-import "io"
+import (
+	"context"
+	"io"
+)
 
 type Opts struct {
 	Dir            string
 	Pure           bool
 	IgnoreWarnings bool
 	Writer         io.Writer
+}
+
+type PrintEnv struct {
+	Ctx                     context.Context
+	IncludeHooks            bool
+	OnlyPathWithoutWrappers bool
 }

--- a/internal/wrapnix/wrapper.sh.tmpl
+++ b/internal/wrapnix/wrapper.sh.tmpl
@@ -29,4 +29,9 @@ export {{ .ShellEnvHashKey }}_GUARD=true
 eval "$(DO_NOT_TRACK=1 devbox shellenv -c {{ .ProjectDir }})"
 fi
 
+# So that we do not invoke other bin-wrappers from
+# this bin-wrapper. Instead, we directly invoke the binary from the nix store, which
+# should be in PATH.
+eval "$(devbox shellenv only-path-without-wrappers)"
+
 exec {{ .Command }} "$@"


### PR DESCRIPTION
## Summary

This is an alternate to #1151 (see explanation in #1159)

In this approach, the wrapped-binary always calls:
`eval $(devbox shellenv only-path-without-wrappers)` 
to ensure that the PATH is set without the `wrappers/bin` directory.

In contrast to #1151, we do not always set any other environment variables

Fixes #1142

## How was it tested?

issue from #1142 is fixed:
```
> devbox run -- iex -S mix
* creating .nix-mix/archives/hex-2.0.6
* creating .nix-mix/elixir/1-14/rebar3
Resolving Hex dependencies...
Resolution completed in 0.016s
Unchanged:
  cowboy 2.9.0
  cowlib 2.11.0
  ranch 1.8.0
All dependencies are up to date
Erlang/OTP 25 [erts-13.2.1] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1]

Hello World!
Interactive Elixir (1.14.4) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> Goodbye World

17:18:09.349 [notice] Application elixir_hello exited: shutdown

BREAK: (a)bort (A)bort with dump (c)ontinue (p)roc info (i)nfo
       (l)oaded (v)ersion (k)ill (D)b-tables (d)istribution
```

- [ ] testscripts should pass
