### PR TITLE
[bin wrappers] fixes for only-path-without-wrappers call

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -33,7 +33,7 @@ type Devbox interface {
 	Install(ctx context.Context) error
 	IsEnvEnabled() bool
 	ListScripts() []string
-	PrintEnv(opts *devopt.PrintEnv) (string, error)
+	PrintEnv(ctx context.Context, includeHooks bool) (string, error)
 	PrintEnvVars(ctx context.Context) ([]string, error)
 	PrintGlobalList() error
 	Pull(ctx context.Context, overwrite bool, path string) error
@@ -73,4 +73,8 @@ func GlobalDataPath() (string, error) {
 
 func PrintEnvrcContent(w io.Writer) error {
 	return impl.PrintEnvrcContent(w)
+}
+
+func OnlyPathWithoutWrappers() string {
+	return impl.OnlyPathWithoutWrappers()
 }

--- a/devbox.go
+++ b/devbox.go
@@ -75,6 +75,11 @@ func PrintEnvrcContent(w io.Writer) error {
 	return impl.PrintEnvrcContent(w)
 }
 
-func OnlyPathWithoutWrappers() string {
-	return impl.OnlyPathWithoutWrappers()
+// ExportifySystemPathWithoutWrappers reads $PATH, removes `virtenv/.wrappers/bin` paths,
+// and returns a string of the form `export PATH=....`
+//
+// This small utility function could have been inlined in the boxcli caller, but
+// needed the impl.exportify functionality. It does not depend on core-devbox.
+func ExportifySystemPathWithoutWrappers() string {
+	return impl.ExportifySystemPathWithoutWrappers()
 }

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -59,7 +59,7 @@ func runShellCmd(cmd *cobra.Command, flags shellCmdFlags) error {
 	if flags.printEnv {
 		// false for includeHooks is because init hooks is not compatible with .envrc files generated
 		// by versions older than 0.4.6
-		script, err := box.PrintEnv(&devopt.PrintEnv{Ctx: cmd.Context()})
+		script, err := box.PrintEnv(cmd.Context(), false /*includeHooks*/)
 		if err != nil {
 			return err
 		}

--- a/internal/boxcli/shellenv.go
+++ b/internal/boxcli/shellenv.go
@@ -77,11 +77,7 @@ func shellEnvFunc(cmd *cobra.Command, flags shellEnvCmdFlags) (string, error) {
 		}
 	}
 
-	opts := &devopt.PrintEnv{
-		Ctx:          cmd.Context(),
-		IncludeHooks: flags.runInitHook,
-	}
-	envStr, err := box.PrintEnv(opts)
+	envStr, err := box.PrintEnv(cmd.Context(), flags.runInitHook)
 	if err != nil {
 		return "", err
 	}
@@ -89,12 +85,7 @@ func shellEnvFunc(cmd *cobra.Command, flags shellEnvCmdFlags) (string, error) {
 	return envStr, nil
 }
 
-type shellEnvOnlyPathWithoutWrappersCmdFlags struct {
-	config configFlags
-}
-
 func shellEnvOnlyPathWithoutWrappersCmd() *cobra.Command {
-	flags := shellEnvOnlyPathWithoutWrappersCmdFlags{}
 	command := &cobra.Command{
 		Use:     "only-path-without-wrappers",
 		Hidden:  true,
@@ -102,38 +93,14 @@ func shellEnvOnlyPathWithoutWrappersCmd() *cobra.Command {
 		Args:    cobra.ExactArgs(0),
 		PreRunE: ensureNixInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			s, err := shellEnvOnlyPathWithoutWrappersFunc(cmd, &flags)
-			if err != nil {
-				return err
-			}
+			s := shellEnvOnlyPathWithoutWrappersFunc()
 			fmt.Fprintln(cmd.OutOrStdout(), s)
-			fmt.Fprintln(cmd.OutOrStdout(), "hash -r")
 			return nil
 		},
 	}
-	flags.config.register(command)
 	return command
 }
 
-func shellEnvOnlyPathWithoutWrappersFunc(cmd *cobra.Command, flags *shellEnvOnlyPathWithoutWrappersCmdFlags) (string, error) {
-
-	box, err := devbox.Open(&devopt.Opts{
-		Dir:    flags.config.path,
-		Writer: cmd.ErrOrStderr(),
-		Pure:   false,
-	})
-	if err != nil {
-		return "", err
-	}
-
-	opts := &devopt.PrintEnv{
-		Ctx:                     cmd.Context(),
-		OnlyPathWithoutWrappers: true,
-	}
-	envStr, err := box.PrintEnv(opts)
-	if err != nil {
-		return "", err
-	}
-
-	return envStr, nil
+func shellEnvOnlyPathWithoutWrappersFunc() string {
+	return devbox.OnlyPathWithoutWrappers()
 }

--- a/internal/boxcli/shellenv.go
+++ b/internal/boxcli/shellenv.go
@@ -89,7 +89,7 @@ func shellEnvOnlyPathWithoutWrappersCmd() *cobra.Command {
 	command := &cobra.Command{
 		Use:     "only-path-without-wrappers",
 		Hidden:  true,
-		Short:   "Print shell commands that export PATH without the bin-wrappers",
+		Short:   "[internal] Print shell command that exports the system $PATH without the bin-wrappers paths.",
 		Args:    cobra.ExactArgs(0),
 		PreRunE: ensureNixInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -102,5 +102,5 @@ func shellEnvOnlyPathWithoutWrappersCmd() *cobra.Command {
 }
 
 func shellEnvOnlyPathWithoutWrappersFunc() string {
-	return devbox.OnlyPathWithoutWrappers()
+	return devbox.ExportifySystemPathWithoutWrappers()
 }

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -293,7 +293,7 @@ func (d *Devbox) RunScript(ctx context.Context, cmdName string, cmdArgs []string
 // creates all wrappers, but does not run init hooks. It is used to power
 // devbox install cli command.
 func (d *Devbox) Install(ctx context.Context) error {
-	if _, err := d.PrintEnv(&devopt.PrintEnv{Ctx: ctx}); err != nil {
+	if _, err := d.PrintEnv(ctx, false /*includeHooks*/); err != nil {
 		return err
 	}
 	return wrapnix.CreateWrappers(ctx, d)
@@ -309,8 +309,8 @@ func (d *Devbox) ListScripts() []string {
 	return keys
 }
 
-func (d *Devbox) PrintEnv(opts *devopt.PrintEnv) (string, error) {
-	ctx, task := trace.NewTask(opts.Ctx, "devboxPrintEnv")
+func (d *Devbox) PrintEnv(ctx context.Context, includeHooks bool) (string, error) {
+	ctx, task := trace.NewTask(ctx, "devboxPrintEnv")
 	defer task.End()
 
 	if err := d.ensurePackagesAreInstalled(ctx, ensure); err != nil {
@@ -322,23 +322,9 @@ func (d *Devbox) PrintEnv(opts *devopt.PrintEnv) (string, error) {
 		return "", err
 	}
 
-	if opts.OnlyPathWithoutWrappers {
-		path := []string{}
-		for _, p := range strings.Split(envs["PATH"], string(filepath.ListSeparator)) {
-			if !strings.Contains(p, plugin.WrapperPath) {
-				path = append(path, p)
-			}
-		}
-
-		// reset envs to be PATH only!
-		envs = map[string]string{
-			"PATH": strings.Join(path, string(filepath.ListSeparator)),
-		}
-	}
-
 	envStr := exportify(envs)
 
-	if opts.IncludeHooks {
+	if includeHooks {
 		hooksStr := ". " + d.scriptPath(hooksFilename)
 		envStr = fmt.Sprintf("%s\n%s;\n", envStr, hooksStr)
 	}
@@ -360,6 +346,25 @@ func (d *Devbox) PrintEnvVars(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 	return keyEqualsValue(envs), nil
+}
+
+// OnlyPathWithoutWrappers is a small utility to filter WrapperBin paths from PATH
+func OnlyPathWithoutWrappers() string {
+
+	path := []string{}
+	for _, p := range strings.Split(os.Getenv("PATH"), string(filepath.ListSeparator)) {
+		// Intentionally do not include projectDir with plugin.WrapperBinPath so that
+		// we filter out bin-wrappers for devbox-global and devbox-project.
+		if !strings.Contains(p, plugin.WrapperBinPath) {
+			path = append(path, p)
+		}
+	}
+
+	envs := map[string]string{
+		"PATH": strings.Join(path, string(filepath.ListSeparator)),
+	}
+
+	return exportify(envs)
 }
 
 func (d *Devbox) ShellEnvHash(ctx context.Context) (string, error) {

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -348,25 +348,6 @@ func (d *Devbox) PrintEnvVars(ctx context.Context) ([]string, error) {
 	return keyEqualsValue(envs), nil
 }
 
-// OnlyPathWithoutWrappers is a small utility to filter WrapperBin paths from PATH
-func OnlyPathWithoutWrappers() string {
-
-	path := []string{}
-	for _, p := range strings.Split(os.Getenv("PATH"), string(filepath.ListSeparator)) {
-		// Intentionally do not include projectDir with plugin.WrapperBinPath so that
-		// we filter out bin-wrappers for devbox-global and devbox-project.
-		if !strings.Contains(p, plugin.WrapperBinPath) {
-			path = append(path, p)
-		}
-	}
-
-	envs := map[string]string{
-		"PATH": strings.Join(path, string(filepath.ListSeparator)),
-	}
-
-	return exportify(envs)
-}
-
 func (d *Devbox) ShellEnvHash(ctx context.Context) (string, error) {
 	envs, err := d.nixEnv(ctx)
 	if err != nil {
@@ -1246,4 +1227,23 @@ func (d *Devbox) convertEnvToMap(currentEnv []string) (map[string]string, error)
 		env["PATH"] = nixInPath
 	}
 	return env, nil
+}
+
+// ExportifySystemPathWithoutWrappers is a small utility to filter WrapperBin paths from PATH
+func ExportifySystemPathWithoutWrappers() string {
+
+	path := []string{}
+	for _, p := range strings.Split(os.Getenv("PATH"), string(filepath.ListSeparator)) {
+		// Intentionally do not include projectDir with plugin.WrapperBinPath so that
+		// we filter out bin-wrappers for devbox-global and devbox-project.
+		if !strings.Contains(p, plugin.WrapperBinPath) {
+			path = append(path, p)
+		}
+	}
+
+	envs := map[string]string{
+		"PATH": strings.Join(path, string(filepath.ListSeparator)),
+	}
+
+	return exportify(envs)
 }

--- a/internal/impl/devopt/devboxopts.go
+++ b/internal/impl/devopt/devboxopts.go
@@ -1,7 +1,6 @@
 package devopt
 
 import (
-	"context"
 	"io"
 )
 
@@ -10,10 +9,4 @@ type Opts struct {
 	Pure           bool
 	IgnoreWarnings bool
 	Writer         io.Writer
-}
-
-type PrintEnv struct {
-	Ctx                     context.Context
-	IncludeHooks            bool
-	OnlyPathWithoutWrappers bool
 }

--- a/internal/wrapnix/wrapper.sh.tmpl
+++ b/internal/wrapnix/wrapper.sh.tmpl
@@ -1,6 +1,6 @@
 #!{{ .BashPath }}
 
-{{/* 
+{{/*
 # If env variable has never been set by devbox we set it, but also
 # default to env value set by user. This means plugin env variables behave a bit
 # differently than devbox.json env variables which are always set once.
@@ -29,9 +29,13 @@ export {{ .ShellEnvHashKey }}_GUARD=true
 eval "$(DO_NOT_TRACK=1 devbox shellenv -c {{ .ProjectDir }})"
 fi
 
-# So that we do not invoke other bin-wrappers from
-# this bin-wrapper. Instead, we directly invoke the binary from the nix store, which
-# should be in PATH.
-eval "$(devbox shellenv only-path-without-wrappers)"
+{{/*
+We call only-path-without-wrappers so that we do not invoke other bin-wrappers from
+this bin-wrapper. Instead, we directly invoke the binary from the nix store, which
+should be in PATH.
+
+DO_NOT_TRACK=1 can be removed once we optimize segment to queue events.
+*/ -}}
+eval "$(DO_NOT_TRACK=1 devbox shellenv only-path-without-wrappers)"
 
 exec {{ .Command }} "$@"


### PR DESCRIPTION
## Summary

follow up to #1160 

correctness:
- consolidate some code into calling `wrapnix.GetWrapperBinPath`
- the earlier code had a bug where I forgot to call `-c <project dir>`, but that is moot now (see below change)

perf:
- call DO_NOT_TRACK=1  to minimize segment perf impact
- simplify OnlyPathWithoutWrappers to directly call `os.Getenv("PATH")`, remove WrapperBins, and exportify it. This function is used in a very specific context, so we can _know_ we can  skip the nix.ComputeEnv calculation.
- Doing `time devbox shellenv only-path-without-wrappers` is now consistently ~ 18-25 milliseconds. 

I have a slight preference for this over writing PATH to a file and sourcing it, since we may run into correctness issues with that file getting outdated, and it'll introduce perf regression on every shellenv call to write the file.

## How was it tested?

- [x] testscripts pass
- [x] `iex -S mix` works

visual inspection:
```
    1 #!/nix/store/w849dr5qcbrrnxv69sy7kdnifa9jpjyf-bash-5.2-p15/bin/bash
  2
  3
  4
  5 if [[ "$__DEVBOX_SHELLENV_HASH_ac6a60d54a9d1ba6618cce8d40bfdfb50059d814edfe5f49bca3168c5c34e970" != "b1a4903de70aa4d610ecb00ffb3dd755913b4505651e6bebbf41571a406d415c" ]] &    & [[ -z "$__DEVBOX_SHELLENV_HASH_ac6a60d54a9d1ba6618cce8d40bfdfb50059d814edfe5f49bca3168c5c34e970_GUARD" ]]; then
  6 export __DEVBOX_SHELLENV_HASH_ac6a60d54a9d1ba6618cce8d40bfdfb50059d814edfe5f49bca3168c5c34e970_GUARD=true
  7 eval "$(DO_NOT_TRACK=1 devbox shellenv -c /Users/savil/code/jetpack/devbox/examples/development/elixir/elixir_hello)"
  8 fi
  9
 10 eval "$(DO_NOT_TRACK=1 devbox shellenv only-path-without-wrappers -c /Users/savil/code/jetpack/devbox/examples/development/elixir/elixir_hello)"
 11
 12 exec /nix/store/47whvyx9x48ishndcjw71xs7l0a6v6sd-elixir-1.14.4/bin/iex "$@"
```
