### PR TITLE
[pure shell] Fixed devbox not being in path

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -1218,12 +1218,14 @@ func (d *Devbox) convertEnvToMap(currentEnv []string) (map[string]string, error)
 	// handling special case for PATH
 	if d.pure {
 		// Finding nix executables in path and passing it through
-		// Needed for devbox commands inside pure shell to work
-		nixInPath, err := findNixInPATH(env)
+		// As well as adding devbox itself to PATH
+		// Both are needed for devbox commands inside pure shell to work
+		includedInPath, err := findNixInPATH(env)
 		if err != nil {
 			return nil, err
 		}
-		env["PATH"] = nixInPath
+		includedInPath = append(includedInPath, wrapnix.DotdevboxBinPath(d))
+		env["PATH"] = JoinPathLists(includedInPath...)
 	}
 	return env, nil
 }

--- a/internal/impl/shell.go
+++ b/internal/impl/shell.go
@@ -412,20 +412,29 @@ func filterPathList(pathList string, keep func(string) bool) string {
 	return strings.Join(filtered, string(filepath.ListSeparator))
 }
 
-func findNixInPATH(env map[string]string) (string, error) {
+// findNixInPATH looks for locations in PATH which nix might exist and
+// it returns a slice containing all paths that might contain nix.
+// For single-user, and multi-user installation there are default locations
+// unless XDG_* env variables are set. So we look for nix in 3 locations
+// to see if any of those exist in path.
+func findNixInPATH(env map[string]string) ([]string, error) {
 	defaultSingleUserNixBin := fmt.Sprintf("%s/.nix-profile/bin", env["HOME"])
 	defaultMultiUserNixBin := "/nix/var/nix/profiles/default/bin"
 	xdgNixBin := xdg.StateSubpath("/nix/profile/bin")
 	pathElements := strings.Split(env["PATH"], ":")
 	debug.Log("path elements: %v", pathElements)
+	nixBinsInPath := []string{}
 	for _, el := range pathElements {
 		if el == xdgNixBin ||
 			el == defaultSingleUserNixBin ||
 			el == defaultMultiUserNixBin {
-			return el, nil
+			nixBinsInPath = append(nixBinsInPath, el)
 		}
 	}
 
-	// did not find nix executable in PATH, return error
-	return "", errors.New("could not find any nix executable in PATH. Make sure Nix is installed and in PATH, then try again")
+	if len(nixBinsInPath) == 0 {
+		// did not find nix executable in PATH, return error
+		return nil, errors.New("could not find any nix executable in PATH. Make sure Nix is installed and in PATH, then try again")
+	}
+	return nixBinsInPath, nil
 }

--- a/internal/wrapnix/wrapper.go
+++ b/internal/wrapnix/wrapper.go
@@ -145,8 +145,13 @@ func createDevboxSymlink(devbox devboxer) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to create devbox symlink. Devbox command won't be available inside the shell")
 	}
-	// Create a symlink between devbox in .wrappers/bin
-	err = os.Symlink(devboxPath, filepath.Join(wrapperBinPath(devbox), "devbox"))
+	// ensure .devbox/bin directory exists
+	binPath := DotdevboxBinPath(devbox)
+	if err := os.MkdirAll(binPath, 0755); err != nil {
+		return errors.WithStack(err)
+	}
+	// Create a symlink between devbox and .devbox/bin
+	err = os.Symlink(devboxPath, filepath.Join(binPath, "devbox"))
 	if err != nil && !errors.Is(err, fs.ErrExist) {
 		return errors.Wrap(err, "failed to create devbox symlink. Devbox command won't be available inside the shell")
 	}
@@ -155,4 +160,8 @@ func createDevboxSymlink(devbox devboxer) error {
 
 func wrapperBinPath(devbox devboxer) string {
 	return filepath.Join(devbox.ProjectDir(), plugin.WrapperBinPath)
+}
+
+func DotdevboxBinPath(devbox devboxer) string {
+	return filepath.Join(devbox.ProjectDir(), ".devbox/bin")
 }


### PR DESCRIPTION
## Summary
Fixed an issue which caused devbox to disappear from PATH in pure shell mode.

NOTE: Moved the location of the symlink from `.devbox/virtenv/bin` to `.devbox/bin`. I'm open to changing the location but since it's only in pure mode and the location doesn't really affect the user (they can just use `$(which devbox)` inside the shell to get the location dynamically) I'm eager to not have the location of devbox symlink be a blocking issue.

## How was it tested?
- compile
- ./devbox shell --pure
- which devbox
- which nix
