### PR TITLE
[update] Update flakes

### DIFF
--- a/examples/flakes/php/my-php-flake/flake.nix
+++ b/examples/flakes/php/my-php-flake/flake.nix
@@ -15,7 +15,7 @@
         packages = {
           # Flakes can export multiple packages. To include specific packages in
           # devbox.json you can use url fragments (e.g. path:my-flake#my-package)
-          php = pkgs.php.withExtensions ({ enabled, all }: enabled ++ (with all; [ ds ]));
+          php = pkgs.php.withExtensions ({ enabled, all }: enabled ++ (with all; [ ds memcached ]));
           hello = pkgs.hello;
 
           # If you only want to export a single package, you can name it default which allows

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -45,27 +45,11 @@ func (d *Devbox) Update(ctx context.Context, pkgs ...string) error {
 			if err = d.attemptToUpgradeFlake(pkg); err != nil {
 				return err
 			}
-			continue
-		}
-		existing := d.lockfile.Packages[pkg.Raw]
-		newEntry, err := searcher.Client().Resolve(pkg.Raw)
-		if err != nil {
-			return err
-		}
-		if existing != nil && existing.Version != newEntry.Version {
-			ux.Finfo(d.writer, "Updating %s %s -> %s\n", pkg, existing.Version, newEntry.Version)
-			if err := d.removePackagesFromProfile(ctx, []string{pkg.Raw}); err != nil {
-				// Warn but continue. TODO(landau): ensurePackagesAreInstalled should
-				// sync the profile so we don't need to do this manually.
-				ux.Fwarning(d.writer, "Failed to remove %s from profile: %s\n", pkg, err)
-			}
-		} else if existing == nil {
-			ux.Finfo(d.writer, "Resolved %s to %[1]s %[2]s\n", pkg, newEntry.Resolved)
 		} else {
-			ux.Finfo(d.writer, "Already up-to-date %s %s\n", pkg, existing.Version)
+			if err = d.updateDevboxPackage(ctx, pkg); err != nil {
+				return err
+			}
 		}
-		// Set the new entry after we've removed the old package from the profile
-		d.lockfile.Packages[pkg.Raw] = newEntry
 	}
 
 	// TODO(landau): Improve output
@@ -90,6 +74,32 @@ func (d *Devbox) inputsToUpdate(pkgs ...string) ([]*nix.Input, error) {
 	}
 
 	return nix.InputsFromStrings(pkgsToUpdate, d.lockfile), nil
+}
+
+func (d *Devbox) updateDevboxPackage(
+	ctx context.Context,
+	pkg *nix.Input,
+) error {
+	existing := d.lockfile.Packages[pkg.Raw]
+	newEntry, err := searcher.Client().Resolve(pkg.Raw)
+	if err != nil {
+		return err
+	}
+	if existing != nil && existing.Version != newEntry.Version {
+		ux.Finfo(d.writer, "Updating %s %s -> %s\n", pkg, existing.Version, newEntry.Version)
+		if err := d.removePackagesFromProfile(ctx, []string{pkg.Raw}); err != nil {
+			// Warn but continue. TODO(landau): ensurePackagesAreInstalled should
+			// sync the profile so we don't need to do this manually.
+			ux.Fwarning(d.writer, "Failed to remove %s from profile: %s\n", pkg, err)
+		}
+	} else if existing == nil {
+		ux.Finfo(d.writer, "Resolved %s to %[1]s %[2]s\n", pkg, newEntry.Resolved)
+	} else {
+		ux.Finfo(d.writer, "Already up-to-date %s %s\n", pkg, existing.Version)
+	}
+	// Set the new entry after we've removed the old package from the profile
+	d.lockfile.Packages[pkg.Raw] = newEntry
+	return nil
 }
 
 // attemptToUpgradeFlake attempts to upgrade a flake using `nix profile upgrade`

--- a/internal/nix/upgrade.go
+++ b/internal/nix/upgrade.go
@@ -1,0 +1,33 @@
+package nix
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"go.jetpack.io/devbox/internal/lock"
+	"go.jetpack.io/devbox/internal/redact"
+)
+
+func Upgrade(ProfileDir string, pkg *Input, lock *lock.File) error {
+	idx, err := ProfileListIndex(&ProfileListIndexArgs{
+		Lockfile:   lock,
+		Writer:     os.Stderr,
+		Input:      pkg,
+		ProfileDir: ProfileDir,
+	})
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command("nix", "profile", "upgrade",
+		"--profile", ProfileDir,
+		fmt.Sprintf("%d", idx),
+	)
+	cmd.Args = append(cmd.Args, ExperimentalFlags()...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return redact.Errorf(
+			"error running \"nix profile upgrade\": %s: %w", out, err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Update flakes via `nix profile upgrade`.

Purposefully forgiving.

Note: local flakes don't need updating because they automatically use latest version of file.

fixes https://github.com/jetpack-io/devbox/issues/1094

## How was it tested?

```bash
devbox add github:F1bonacc1/process-compose 
devbox update github:F1bonacc1/process-compose
```

This works, but but need to test something that will actually update.

