### PR TITLE
[filegen] move devcontainer_util.go into package filegen; make tmplFS internal

### DIFF
--- a/internal/filegen/devcontainer_util.go
+++ b/internal/filegen/devcontainer_util.go
@@ -1,16 +1,13 @@
 // Copyright 2023 Jetpack Technologies Inc and contributors. All rights reserved.
 // Use of this source code is governed by the license in the LICENSE file.
 
-package generate
-
-// TODO move this to package filegen at impl/filegen
-// no need to be in `boxcli`.
+package filegen
 
 import (
 	"context"
-	"embed"
 	"encoding/json"
 	"html/template"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -47,7 +44,7 @@ type dockerfileData struct {
 }
 
 // CreateDockerfile creates a Dockerfile in path and writes devcontainerDockerfile.tmpl's content into it
-func CreateDockerfile(ctx context.Context, tmplFS embed.FS, path string, localFlakeDirs []string, isDevcontainer bool) error {
+func CreateDockerfile(ctx context.Context, path string, localFlakeDirs []string, isDevcontainer bool) error {
 	defer trace.StartRegion(ctx, "createDockerfile").End()
 
 	// create dockerfile
@@ -87,7 +84,7 @@ func CreateDevcontainer(ctx context.Context, path string, pkgs []string) error {
 	return err
 }
 
-func CreateEnvrc(ctx context.Context, tmplFS embed.FS, path string) error {
+func CreateEnvrc(ctx context.Context, path string) error {
 	defer trace.StartRegion(ctx, "createEnvrc").End()
 
 	// create .envrc file
@@ -151,4 +148,10 @@ func getDevcontainerContent(pkgs []string) *devcontainerObject {
 		// TODO: add support for other common languages
 	}
 	return devcontainerContent
+}
+
+func EnvrcContent(w io.Writer) error {
+	tmplName := "envrcContent.tmpl"
+	t := template.Must(template.ParseFS(tmplFS, "tmpl/"+tmplName))
+	return t.Execute(w, nil)
 }

--- a/internal/filegen/generate.go
+++ b/internal/filegen/generate.go
@@ -22,11 +22,8 @@ import (
 	"go.jetpack.io/devbox/internal/planner/plansdk"
 )
 
-// TmplFS docblock to satisfy silly linter.
-// TODO savil: move package generate in boxcli into this filegen package, and then make `TmplFS` internal
-//
 //go:embed tmpl/*
-var TmplFS embed.FS
+var tmplFS embed.FS
 
 var shellFiles = []string{"shell.nix"}
 
@@ -81,7 +78,7 @@ func writeFromTemplate(path string, plan any, tmplName string) error {
 		tmpl.Funcs(templateFuncs)
 
 		var err error
-		tmpl, err = tmpl.ParseFS(TmplFS, "tmpl/"+tmplKey)
+		tmpl, err = tmpl.ParseFS(tmplFS, "tmpl/"+tmplKey)
 		if err != nil {
 			return errors.WithStack(err)
 		}


### PR DESCRIPTION
## Summary

This moves the `devcontainer_util.go` file into `filegen`. I didn't like `impl` code calling into `boxcli/generate`. The direction should be `boxcli` -> `impl` -> `{helper packages}`. Also, would be nice to keep `boxcli` for `cobra.Command` logic.

We can now also make `filegen.TmplFS` internal i.e. `filegen.tmplFS`

Needed to create `filegen.EnvrcContent` since it was inlined in `impl/devbox.go`.

**RFC**: Arguably, this is unrelated to the rest of `filegen` which has to do with generating `flake.nix` and `scripts` files in aid of `PrintEnv`. So, we can also move into its own self-contained package. Let me know if that's preferable (and suggest a package name!)

## How was it tested?

compiles
