### PR TITLE
[filegen] move NixpkgsInfo into filegen (no more plansdk)

### DIFF
--- a/internal/devconfig/config.go
+++ b/internal/devconfig/config.go
@@ -11,11 +11,9 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/cuecfg"
 	"go.jetpack.io/devbox/internal/impl/shellcmd"
-	"go.jetpack.io/devbox/internal/planner/plansdk"
 )
 
 const DefaultName = "devbox.json"
@@ -86,8 +84,11 @@ func (c *Config) Equals(other *Config) bool {
 }
 
 func (c *Config) NixPkgsCommitHash() string {
+	// The commit hash for nixpkgs-unstable on 2023-01-25 from status.nixos.org
+	const DefaultNixpkgsCommit = "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
+
 	if c == nil || c.Nixpkgs == nil || c.Nixpkgs.Commit == "" {
-		return plansdk.DefaultNixpkgsCommit
+		return DefaultNixpkgsCommit
 	}
 	return c.Nixpkgs.Commit
 }

--- a/internal/filegen/flake_input.go
+++ b/internal/filegen/flake_input.go
@@ -8,7 +8,6 @@ import (
 	"github.com/samber/lo"
 	"go.jetpack.io/devbox/internal/goutil"
 	"go.jetpack.io/devbox/internal/nix"
-	"go.jetpack.io/devbox/internal/planner/plansdk"
 )
 
 type flakeInput struct {
@@ -39,7 +38,7 @@ func (f *flakeInput) URLWithCaching() string {
 		return f.URL
 	}
 	hash := nix.HashFromNixPkgsURL(f.URL)
-	return plansdk.GetNixpkgsInfo(hash).URL
+	return getNixpkgsInfo(hash).URL
 }
 
 func (f *flakeInput) PkgImportName() string {

--- a/internal/filegen/flake_plan.go
+++ b/internal/filegen/flake_plan.go
@@ -3,18 +3,16 @@ package filegen
 import (
 	"context"
 	"runtime/trace"
-
-	"go.jetpack.io/devbox/internal/planner/plansdk"
 )
 
-// FlakePlan contains the data to populate the top level flake.nix file
+// flakePlan contains the data to populate the top level flake.nix file
 // that builds the devbox environment
-type FlakePlan struct {
-	NixpkgsInfo *plansdk.NixpkgsInfo
+type flakePlan struct {
+	NixpkgsInfo *NixpkgsInfo
 	FlakeInputs []*flakeInput
 }
 
-func newFlakePlan(ctx context.Context, devbox devboxer) (*FlakePlan, error) {
+func newFlakePlan(ctx context.Context, devbox devboxer) (*flakePlan, error) {
 	ctx, task := trace.NewTask(ctx, "devboxFlakePlan")
 	defer task.End()
 
@@ -37,20 +35,20 @@ func newFlakePlan(ctx context.Context, devbox devboxer) (*FlakePlan, error) {
 		}
 	}
 
-	shellPlan := &FlakePlan{}
+	shellPlan := &flakePlan{}
 	var err error
 	shellPlan.FlakeInputs, err = flakeInputs(ctx, devbox)
 	if err != nil {
 		return nil, err
 	}
 
-	nixpkgsInfo := plansdk.GetNixpkgsInfo(devbox.Config().NixPkgsCommitHash())
+	nixpkgsInfo := getNixpkgsInfo(devbox.Config().NixPkgsCommitHash())
 
 	// This is an optimization. Try to reuse the nixpkgs info from the flake
 	// inputs to avoid introducing a new one.
 	for _, input := range shellPlan.FlakeInputs {
 		if input.IsNixpkgs() {
-			nixpkgsInfo = plansdk.GetNixpkgsInfo(input.HashFromNixPkgsURL())
+			nixpkgsInfo = getNixpkgsInfo(input.HashFromNixPkgsURL())
 			break
 		}
 	}

--- a/internal/filegen/generate.go
+++ b/internal/filegen/generate.go
@@ -148,7 +148,7 @@ var templateFuncs = template.FuncMap{
 	"debug":    debug.IsEnabled,
 }
 
-func makeFlakeFile(outPath string, plan *FlakePlan) error {
+func makeFlakeFile(outPath string, plan *flakePlan) error {
 	flakeDir := filepath.Join(outPath, "flake")
 	err := writeFromTemplate(flakeDir, plan, "flake.nix")
 	if err != nil {

--- a/internal/filegen/nixpkgs.go
+++ b/internal/filegen/nixpkgs.go
@@ -1,7 +1,7 @@
 // Copyright 2023 Jetpack Technologies Inc and contributors. All rights reserved.
 // Use of this source code is governed by the license in the LICENSE file.
 
-package plansdk
+package filegen
 
 import (
 	"fmt"
@@ -18,10 +18,7 @@ type NixpkgsInfo struct {
 	TarURL string
 }
 
-// The commit hash for nixpkgs-unstable on 2023-01-25 from status.nixos.org
-const DefaultNixpkgsCommit = "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"
-
-func GetNixpkgsInfo(commitHash string) *NixpkgsInfo {
+func getNixpkgsInfo(commitHash string) *NixpkgsInfo {
 	url := fmt.Sprintf("github:NixOS/nixpkgs/%s", commitHash)
 	if mirror := nixpkgsMirrorURL(commitHash); mirror != "" {
 		url = mirror


### PR DESCRIPTION
## Summary

1. Move `NixpkgsInfo` into package `filegen`. 
2. Make its functions internal, since it is only used within filegen.
3. Move DefaultNixpkgsCommit to devconfig package, since it is only used there.

## How was it tested?

compiles
