### PR TITLE
(cli) Don't check version when updating devbox

### DIFF
--- a/internal/vercheck/vercheck.go
+++ b/internal/vercheck/vercheck.go
@@ -47,6 +47,7 @@ var isDevBuild = build.IsDev
 var commandSkipList = []string{
 	"devbox global shellenv",
 	"devbox shellenv",
+	"devbox version update",
 }
 
 // CheckVersion checks the launcher and binary versions and prints a notice if


### PR DESCRIPTION
## Summary

I don't think it is necessary to warn users about a fresh new version if they are updating devbox

## How was it tested?

`go run main.go update`