### PR TITLE
[global] Better error message when profile doesn't exist

### DIFF
--- a/internal/boxcli/pull.go
+++ b/internal/boxcli/pull.go
@@ -13,8 +13,10 @@ import (
 	"github.com/spf13/cobra"
 
 	"go.jetpack.io/devbox"
+	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/goutil"
 	"go.jetpack.io/devbox/internal/impl/devopt"
+	"go.jetpack.io/devbox/internal/pullbox/s3"
 )
 
 type pullCmdFlags struct {
@@ -69,6 +71,11 @@ func pullCmdFunc(cmd *cobra.Command, url string, flags *pullCmdFlags) error {
 			return nil
 		}
 		err = box.Pull(cmd.Context(), flags.force, pullPath)
+	}
+	if errors.Is(err, s3.ErrProfileNotFound) {
+		return usererr.New(
+			"Profile not found. Use `devbox global push` to create a new profile.",
+		)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

If path doesn't exist, S3 returns access denied. Show a better error message. This can be improved by checking if object exists (But that would slow things down, so maybe only check if the initial pull failed so we can show a better error message).

## How was it tested?

* deleted my profile manually
* Ran `devbox global pull`