### PR TITLE
[Docs] Fix link for Laravel "Open in Devbox.sh"

### DIFF
--- a/docs/app/docs/devbox_examples/stacks/laravel.md
+++ b/docs/app/docs/devbox_examples/stacks/laravel.md
@@ -8,7 +8,7 @@ This example shows how to build a simple Laravel application backed by MariaDB a
 
 [Example Repo](https://github.com/jetpack-io/devbox/tree/main/examples/stacks/laravel)
 
-[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/new?template=laravel)
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox/?folder=examples/stacks/laravel)
 
 ## How to Run
 


### PR DESCRIPTION
## Summary
Change link to an example link, until we publish the template

## How was it tested?

localhost
