### PR TITLE
[vscode-extension] fix vscode terminal PATH 

### DIFF
--- a/vscode-extension/src/devbox.ts
+++ b/vscode-extension/src/devbox.ts
@@ -28,11 +28,9 @@ export async function devboxReopen() {
                     // setup required vscode settings
                     progress.report({ message: 'Updating configurations...', increment: 50 });
                     updateVSCodeConf();
-                    setTimeout(() => { }, 1000);
 
                     // Calling CLI to compute devbox env
                     progress.report({ message: 'Calling Devbox to setup environment...', increment: 80 });
-                    // callDevboxIntegrate(workingDir, progress.report, resolve, reject);
                     // To use a custom compiled devbox when testing, change this to an absolute path.
                     const devbox = 'devbox';
                     // run devbox integrate and then close this window

--- a/vscode-extension/src/devbox.ts
+++ b/vscode-extension/src/devbox.ts
@@ -93,9 +93,9 @@ function updateVSCodeConf() {
                     // might cause confusion for users as to why their system installed packages
                     // show up when they type for example `which go` as opposed to the packages
                     // installed by devbox.
-                    return "--no-config";
+                    return ["--no-config"];
                 default:
-                    return "";
+                    return [];
             }
         };
         const shellTypeSlices = shell.split("/");
@@ -104,7 +104,7 @@ function updateVSCodeConf() {
         const devboxCompatibleShell = {
             "devboxCompatibleShell": {
                 "path": shell,
-                "args": [shellArgsMap(shellType)]
+                "args": shellArgsMap(shellType)
             }
         };
 

--- a/vscode-extension/src/devbox.ts
+++ b/vscode-extension/src/devbox.ts
@@ -1,4 +1,4 @@
-import { window, workspace, commands, ProgressLocation, Uri, ConfigurationTarget, Progress } from 'vscode';
+import { window, workspace, commands, ProgressLocation, Uri, ConfigurationTarget } from 'vscode';
 import { spawn, spawnSync } from 'node:child_process';
 
 
@@ -82,12 +82,22 @@ async function setupDotDevbox(workingDir: Uri, dotdevbox: Uri) {
 }
 
 function updateVSCodeConf() {
+    const shell = process.env["SHELL"] ?? "/bin/zsh";
     const devboxCompatibleShell = {
         "devboxCompatibleShell": {
-            "path": "/bin/zsh",
+            "path": shell,
             "args": []
         }
     };
-    workspace.getConfiguration().update('terminal.integrated.profiles.osx', devboxCompatibleShell, ConfigurationTarget.Workspace);
-    workspace.getConfiguration().update('terminal.integrated.defaultProfile.osx', 'devboxCompatibleShell', ConfigurationTarget.Workspace);
+    if (process.platform === 'darwin') {
+        workspace.getConfiguration().update(
+            'terminal.integrated.profiles.osx',
+            devboxCompatibleShell,
+            ConfigurationTarget.Workspace
+        );
+        workspace.getConfiguration().update(
+            'terminal.integrated.defaultProfile.osx',
+            'devboxCompatibleShell',
+            ConfigurationTarget.Workspace);
+    }
 }


### PR DESCRIPTION
## Summary
Fixes the issue where terminal's $PATH env variable wouldn't get updated in integrated terminal.

## How was it tested?
buckle up, the steps are long:

- `cd vscode-extension`
- `vsce package` (install vsce via `npm i -g vsce`)
- `code --install-extension devbox-0.0.7.vsix`
- setup a devbox.json in a sample directory with a couple of packages (e.g., `hello`, `go@1.18`)
- open the sample directory in vscode
- cmd+shift+p and run `Devbox: Reopen in Devbox shell environment`
- after vscode reopens, echo $PATH in terminal