### PR TITLE
[cleanup] Added pure_shell.go and renamed convertEnvToMap

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -170,6 +170,10 @@ func (d *Devbox) Shell(ctx context.Context) error {
 		return err
 	}
 
+	if err = createDevboxSymlink(d); err != nil {
+		return err
+	}
+
 	shellStartTime := envir.GetValueOrDefault(
 		envir.DevboxShellStartTime,
 		telemetry.UnixTimestampFromTime(telemetry.CommandStartTime()),
@@ -723,7 +727,7 @@ func (d *Devbox) computeNixEnv(ctx context.Context, usePrintDevEnvCache bool) (m
 
 	// Append variables from current env if --pure is not passed
 	currentEnv := os.Environ()
-	env, err := d.convertEnvToMap(currentEnv)
+	env, err := d.parseEnvAndExcludeSpecialCases(currentEnv)
 	if err != nil {
 		return nil, err
 	}
@@ -1078,7 +1082,10 @@ func (d *Devbox) addHashToEnv(env map[string]string) error {
 	return err
 }
 
-func (d *Devbox) convertEnvToMap(currentEnv []string) (map[string]string, error) {
+// parseEnvAndExcludeSpecialCases converts env as []string to map[string]string
+// In case of pure shell, it excludes special env keys like HOME and PATH. As well as
+// creating a devbox binary symlink so that it is accessible in pure mode.
+func (d *Devbox) parseEnvAndExcludeSpecialCases(currentEnv []string) (map[string]string, error) {
 	env := make(map[string]string, len(currentEnv))
 	for _, kv := range currentEnv {
 		key, val, found := strings.Cut(kv, "=")
@@ -1105,7 +1112,7 @@ func (d *Devbox) convertEnvToMap(currentEnv []string) (map[string]string, error)
 		if err != nil {
 			return nil, err
 		}
-		includedInPath = append(includedInPath, wrapnix.DotdevboxBinPath(d))
+		includedInPath = append(includedInPath, dotdevboxBinPath(d))
 		env["PATH"] = JoinPathLists(includedInPath...)
 	}
 	return env, nil

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -1083,8 +1083,7 @@ func (d *Devbox) addHashToEnv(env map[string]string) error {
 }
 
 // parseEnvAndExcludeSpecialCases converts env as []string to map[string]string
-// In case of pure shell, it excludes special env keys like HOME and PATH. As well as
-// creating a devbox binary symlink so that it is accessible in pure mode.
+// In case of pure shell, it leaks HOME and it leaks PATH with some modifications
 func (d *Devbox) parseEnvAndExcludeSpecialCases(currentEnv []string) (map[string]string, error) {
 	env := make(map[string]string, len(currentEnv))
 	for _, kv := range currentEnv {

--- a/internal/impl/pure_shell.go
+++ b/internal/impl/pure_shell.go
@@ -1,0 +1,69 @@
+// Copyright 2023 Jetpack Technologies Inc and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package impl
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/internal/debug"
+	"go.jetpack.io/devbox/internal/xdg"
+)
+
+// findNixInPATH looks for locations in PATH which nix might exist and
+// it returns a slice containing all paths that might contain nix.
+// For single-user, and multi-user installation there are default locations
+// unless XDG_* env variables are set. So we look for nix in 3 locations
+// to see if any of those exist in path.
+func findNixInPATH(env map[string]string) ([]string, error) {
+	defaultSingleUserNixBin := fmt.Sprintf("%s/.nix-profile/bin", env["HOME"])
+	defaultMultiUserNixBin := "/nix/var/nix/profiles/default/bin"
+	xdgNixBin := xdg.StateSubpath("/nix/profile/bin")
+	pathElements := strings.Split(env["PATH"], ":")
+	debug.Log("path elements: %v", pathElements)
+	nixBinsInPath := []string{}
+	for _, el := range pathElements {
+		if el == xdgNixBin ||
+			el == defaultSingleUserNixBin ||
+			el == defaultMultiUserNixBin {
+			nixBinsInPath = append(nixBinsInPath, el)
+		}
+	}
+
+	if len(nixBinsInPath) == 0 {
+		// did not find nix executable in PATH, return error
+		return nil, errors.New("could not find any nix executable in PATH. Make sure Nix is installed and in PATH, then try again")
+	}
+	return nixBinsInPath, nil
+}
+
+// Creates a symlink for devbox in .devbox/virtenv/.wrappers/bin
+// so that devbox can be available inside a pure shell
+func createDevboxSymlink(d *Devbox) error {
+
+	// Get absolute path for where devbox is called
+	devboxPath, err := filepath.Abs(os.Args[0])
+	if err != nil {
+		return errors.Wrap(err, "failed to create devbox symlink. Devbox command won't be available inside the shell")
+	}
+	// ensure .devbox/bin directory exists
+	binPath := dotdevboxBinPath(d)
+	if err := os.MkdirAll(binPath, 0755); err != nil {
+		return errors.WithStack(err)
+	}
+	// Create a symlink between devbox and .devbox/bin
+	err = os.Symlink(devboxPath, filepath.Join(binPath, "devbox"))
+	if err != nil && !errors.Is(err, fs.ErrExist) {
+		return errors.Wrap(err, "failed to create devbox symlink. Devbox command won't be available inside the shell")
+	}
+	return nil
+}
+
+func dotdevboxBinPath(d *Devbox) string {
+	return filepath.Join(d.ProjectDir(), ".devbox/bin")
+}

--- a/internal/impl/shell.go
+++ b/internal/impl/shell.go
@@ -411,30 +411,3 @@ func filterPathList(pathList string, keep func(string) bool) string {
 	}
 	return strings.Join(filtered, string(filepath.ListSeparator))
 }
-
-// findNixInPATH looks for locations in PATH which nix might exist and
-// it returns a slice containing all paths that might contain nix.
-// For single-user, and multi-user installation there are default locations
-// unless XDG_* env variables are set. So we look for nix in 3 locations
-// to see if any of those exist in path.
-func findNixInPATH(env map[string]string) ([]string, error) {
-	defaultSingleUserNixBin := fmt.Sprintf("%s/.nix-profile/bin", env["HOME"])
-	defaultMultiUserNixBin := "/nix/var/nix/profiles/default/bin"
-	xdgNixBin := xdg.StateSubpath("/nix/profile/bin")
-	pathElements := strings.Split(env["PATH"], ":")
-	debug.Log("path elements: %v", pathElements)
-	nixBinsInPath := []string{}
-	for _, el := range pathElements {
-		if el == xdgNixBin ||
-			el == defaultSingleUserNixBin ||
-			el == defaultMultiUserNixBin {
-			nixBinsInPath = append(nixBinsInPath, el)
-		}
-	}
-
-	if len(nixBinsInPath) == 0 {
-		// did not find nix executable in PATH, return error
-		return nil, errors.New("could not find any nix executable in PATH. Make sure Nix is installed and in PATH, then try again")
-	}
-	return nixBinsInPath, nil
-}

--- a/internal/wrapnix/wrapper.go
+++ b/internal/wrapnix/wrapper.go
@@ -61,9 +61,6 @@ func CreateWrappers(ctx context.Context, devbox devboxer) error {
 			return errors.WithStack(err)
 		}
 	}
-	if err = createDevboxSymlink(devbox); err != nil {
-		return err
-	}
 
 	return createSymlinksForSupportDirs(devbox.ProjectDir())
 }
@@ -136,32 +133,6 @@ func createSymlinksForSupportDirs(projectDir string) error {
 	return nil
 }
 
-// Creates a symlink for devbox in .devbox/virtenv/.wrappers/bin
-// so that devbox can be available inside a pure shell
-func createDevboxSymlink(devbox devboxer) error {
-
-	// Get absolute path for where devbox is called
-	devboxPath, err := filepath.Abs(os.Args[0])
-	if err != nil {
-		return errors.Wrap(err, "failed to create devbox symlink. Devbox command won't be available inside the shell")
-	}
-	// ensure .devbox/bin directory exists
-	binPath := DotdevboxBinPath(devbox)
-	if err := os.MkdirAll(binPath, 0755); err != nil {
-		return errors.WithStack(err)
-	}
-	// Create a symlink between devbox and .devbox/bin
-	err = os.Symlink(devboxPath, filepath.Join(binPath, "devbox"))
-	if err != nil && !errors.Is(err, fs.ErrExist) {
-		return errors.Wrap(err, "failed to create devbox symlink. Devbox command won't be available inside the shell")
-	}
-	return nil
-}
-
 func wrapperBinPath(devbox devboxer) string {
 	return filepath.Join(devbox.ProjectDir(), plugin.WrapperBinPath)
-}
-
-func DotdevboxBinPath(devbox devboxer) string {
-	return filepath.Join(devbox.ProjectDir(), ".devbox/bin")
 }


### PR DESCRIPTION
## Summary
This is a follow up to [this conversation](https://github.com/jetpack-io/devbox/pull/1143#discussion_r1228862678) and [this conversation](https://github.com/jetpack-io/devbox/pull/1170#pullrequestreview-1484088841).
1. Renamed `ConvertEnvToMap` function to a more precise name. 
2. Added pure_shell.go file under `impl` package and moved related functions to pure shell there.
3. Moved call to function that creates devbox symlink outside of CreateWrappers.

## How was it tested?
- compile
- devbox shell --pure
- inside pure shell run devbox commands (e.g., `devbox version`) to confirm devbox is available inside pure shell.