### PR TITLE
[nix input] Add comments, and renames for clarity

### DIFF
--- a/internal/nix/input.go
+++ b/internal/nix/input.go
@@ -59,21 +59,21 @@ func InputsFromStrings(rawNames []string, l lock.Locker) []*Input {
 // The raw name corresponds to a devbox package from the devbox.json config.
 func InputFromString(raw string, locker lock.Locker) *Input {
 	// We ignore the error because... TODO @mikeland why?
-	u, _ := url.Parse(raw)
+	inputURL, _ := url.Parse(raw)
 
 	// This handles local flakes in a relative path.
 	// `raw` will be of the form `path:./local_flake_subdir#myPackage`
 	// for which path:<empty>, opaque:./local_subdir, and scheme:path
-	if u.Path == "" && u.Opaque != "" && u.Scheme == "path" {
+	if inputURL.Path == "" && inputURL.Opaque != "" && inputURL.Scheme == "path" {
 		// This normalizes url paths to be absolute. It also ensures all
 		// path urls have a single slash (instead of possibly 3 slashes)
-		normalizedURL := "path:" + filepath.Join(locker.ProjectDir(), u.Opaque)
-		if u.Fragment != "" {
-			normalizedURL += "#" + u.Fragment
+		normalizedURL := "path:" + filepath.Join(locker.ProjectDir(), inputURL.Opaque)
+		if inputURL.Fragment != "" {
+			normalizedURL += "#" + inputURL.Fragment
 		}
-		u, _ = url.Parse(normalizedURL)
+		inputURL, _ = url.Parse(normalizedURL)
 	}
-	return &Input{*u, locker, raw, ""}
+	return &Input{*inputURL, locker, raw, ""}
 }
 
 // InputFromProfileItem sets the raw Input as the `item`'s unlockedReference i.e.

--- a/internal/nix/input.go
+++ b/internal/nix/input.go
@@ -90,8 +90,9 @@ func (i *Input) isLocal() bool {
 	return i.Scheme == "path"
 }
 
-// isDevboxPackage specifies whether this input is a nix package defined in a devbox.json config.
-// Usually, this is of the form: `name@version`.
+// isDevboxPackage specifies whether this input is a `canonicalName@version` nix
+// package defined in a devbox.json config. This is in contrast to a "nix" package
+// that can also be a flake or a legacy attribute path.
 func (i *Input) isDevboxPackage() bool {
 	return i.Scheme == ""
 }

--- a/internal/nix/input_test.go
+++ b/internal/nix/input_test.go
@@ -92,8 +92,8 @@ func TestInput(t *testing.T) {
 		if urlWithoutFragment := i.urlWithoutFragment(); testCase.urlWithoutFragment != urlWithoutFragment {
 			t.Errorf("URLWithoutFragment() = %v, want %v", urlWithoutFragment, testCase.urlWithoutFragment)
 		}
-		if urlForInput := i.URLForFlake(); testCase.urlForInput != urlForInput {
-			t.Errorf("URLForFlake() = %v, want %v", urlForInput, testCase.urlForInput)
+		if urlForInput := i.URLForFlakeInput(); testCase.urlForInput != urlForInput {
+			t.Errorf("URLForFlakeInput() = %v, want %v", urlForInput, testCase.urlForInput)
 		}
 	}
 }
@@ -167,7 +167,7 @@ func TestHashFromNixPkgsURL(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		result := CommitHashFromNixPkgsURL(test.url)
+		result := HashFromNixPkgsURL(test.url)
 		if result != test.expected {
 			t.Errorf(
 				"Expected hash '%s' for URL '%s', but got '%s'",

--- a/internal/nix/input_test.go
+++ b/internal/nix/input_test.go
@@ -86,14 +86,14 @@ func TestInput(t *testing.T) {
 
 	for _, testCase := range cases {
 		i := testInputFromString(testCase.pkg, projectDir)
-		if name := i.InputName(); testCase.name != name {
+		if name := i.FlakeInputName(); testCase.name != name {
 			t.Errorf("Name() = %v, want %v", name, testCase.name)
 		}
 		if urlWithoutFragment := i.urlWithoutFragment(); testCase.urlWithoutFragment != urlWithoutFragment {
 			t.Errorf("URLWithoutFragment() = %v, want %v", urlWithoutFragment, testCase.urlWithoutFragment)
 		}
-		if urlForInput := i.URLForInput(); testCase.urlForInput != urlForInput {
-			t.Errorf("URLForInput() = %v, want %v", urlForInput, testCase.urlForInput)
+		if urlForInput := i.URLForFlake(); testCase.urlForInput != urlForInput {
+			t.Errorf("URLForFlake() = %v, want %v", urlForInput, testCase.urlForInput)
 		}
 	}
 }
@@ -167,7 +167,7 @@ func TestHashFromNixPkgsURL(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		result := HashFromNixPkgsURL(test.url)
+		result := CommitHashFromNixPkgsURL(test.url)
 		if result != test.expected {
 			t.Errorf(
 				"Expected hash '%s' for URL '%s', but got '%s'",

--- a/internal/nix/profile.go
+++ b/internal/nix/profile.go
@@ -211,7 +211,7 @@ type ProfileInstallArgs struct {
 // ProfileInstall calls nix profile install with default profile
 func ProfileInstall(args *ProfileInstallArgs) error {
 	input := InputFromString(args.Package, args.Lockfile)
-	if IsGithubNixpkgsURL(input.URLForInput()) {
+	if IsGithubNixpkgsURL(input.URLForFlake()) {
 		if err := ensureNixpkgsPrefetched(args.Writer, input.hashFromNixPkgsURL()); err != nil {
 			return err
 		}

--- a/internal/nix/profile.go
+++ b/internal/nix/profile.go
@@ -211,7 +211,7 @@ type ProfileInstallArgs struct {
 // ProfileInstall calls nix profile install with default profile
 func ProfileInstall(args *ProfileInstallArgs) error {
 	input := InputFromString(args.Package, args.Lockfile)
-	if IsGithubNixpkgsURL(input.URLForFlake()) {
+	if IsGithubNixpkgsURL(input.URLForFlakeInput()) {
 		if err := ensureNixpkgsPrefetched(args.Writer, input.hashFromNixPkgsURL()); err != nil {
 			return err
 		}

--- a/internal/nix/search.go
+++ b/internal/nix/search.go
@@ -99,7 +99,7 @@ func searchSystem(url string, system string) map[string]*Info {
 	// Search will download nixpkgs if it's not already downloaded. Adding this
 	// check here provides a slightly better UX.
 	if IsGithubNixpkgsURL(url) {
-		hash := CommitHashFromNixPkgsURL(url)
+		hash := HashFromNixPkgsURL(url)
 		// purposely ignore error here. The function already prints an error.
 		// We don't want to panic or stop execution if we can't prefetch.
 		_ = ensureNixpkgsPrefetched(writer, hash)

--- a/internal/nix/search.go
+++ b/internal/nix/search.go
@@ -99,7 +99,7 @@ func searchSystem(url string, system string) map[string]*Info {
 	// Search will download nixpkgs if it's not already downloaded. Adding this
 	// check here provides a slightly better UX.
 	if IsGithubNixpkgsURL(url) {
-		hash := HashFromNixPkgsURL(url)
+		hash := CommitHashFromNixPkgsURL(url)
 		// purposely ignore error here. The function already prints an error.
 		// We don't want to panic or stop execution if we can't prefetch.
 		_ = ensureNixpkgsPrefetched(writer, hash)

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -45,8 +45,8 @@ func (m *Manager) ApplyOptions(opts ...managerOption) {
 	}
 }
 
-func (m *Manager) PluginPackages(inputs []*nix.Input) ([]*nix.Input, error) {
-	pkgs := []*nix.Input{}
+func (m *Manager) PluginInputs(inputs []*nix.Input) ([]*nix.Input, error) {
+	result := []*nix.Input{}
 	for _, input := range inputs {
 		config, err := getConfigIfAny(input, m.ProjectDir())
 		if err != nil {
@@ -54,7 +54,7 @@ func (m *Manager) PluginPackages(inputs []*nix.Input) ([]*nix.Input, error) {
 		} else if config == nil {
 			continue
 		}
-		pkgs = append(pkgs, nix.InputsFromStrings(config.Packages, m.lockfile)...)
+		result = append(result, nix.InputsFromStrings(config.Packages, m.lockfile)...)
 	}
-	return pkgs, nil
+	return result, nil
 }

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -161,7 +161,7 @@ func (m *Manager) createFile(
 		"PackageAttributePath": attributePath,
 		"Packages":             m.Packages(),
 		"System":               system,
-		"URLForInput":          pkg.URLForFlake(),
+		"URLForInput":          pkg.URLForFlakeInput(),
 		"Virtenv":              filepath.Join(virtenvPath, name),
 	}); err != nil {
 		return errors.WithStack(err)

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -161,7 +161,7 @@ func (m *Manager) createFile(
 		"PackageAttributePath": attributePath,
 		"Packages":             m.Packages(),
 		"System":               system,
-		"URLForInput":          pkg.URLForInput(),
+		"URLForInput":          pkg.URLForFlake(),
 		"Virtenv":              filepath.Join(virtenvPath, name),
 	}); err != nil {
 		return errors.WithStack(err)

--- a/internal/shellgen/flake_input.go
+++ b/internal/shellgen/flake_input.go
@@ -30,14 +30,14 @@ func (f *flakeInput) HashFromNixPkgsURL() string {
 	if !f.IsNixpkgs() {
 		return ""
 	}
-	return nix.CommitHashFromNixPkgsURL(f.URL)
+	return nix.HashFromNixPkgsURL(f.URL)
 }
 
 func (f *flakeInput) URLWithCaching() string {
 	if !f.IsNixpkgs() {
 		return f.URL
 	}
-	hash := nix.CommitHashFromNixPkgsURL(f.URL)
+	hash := nix.HashFromNixPkgsURL(f.URL)
 	return getNixpkgsInfo(hash).URL
 }
 
@@ -86,16 +86,16 @@ func flakeInputs(ctx context.Context, devbox devboxer) ([]*flakeInput, error) {
 		if err != nil {
 			return nil, err
 		}
-		if flkInput, ok := flakeInputs[input.URLForFlake()]; !ok {
-			order = append(order, input.URLForFlake())
-			flakeInputs[input.URLForFlake()] = &flakeInput{
+		if flkInput, ok := flakeInputs[input.URLForFlakeInput()]; !ok {
+			order = append(order, input.URLForFlakeInput())
+			flakeInputs[input.URLForFlakeInput()] = &flakeInput{
 				Name:     input.FlakeInputName(),
-				URL:      input.URLForFlake(),
+				URL:      input.URLForFlakeInput(),
 				Packages: []string{AttributePath},
 			}
 		} else {
 			flkInput.Packages = lo.Uniq(
-				append(flakeInputs[input.URLForFlake()].Packages, AttributePath),
+				append(flakeInputs[input.URLForFlakeInput()].Packages, AttributePath),
 			)
 		}
 	}


### PR DESCRIPTION
## Summary

I find `nix.Input` fairly hard to understand. I make a first pass at adding
comments and renaming functions and variables for clarity. Made it about
halfway through the `nix/input.go` file.

**nomenclature**: I have tried to ensure consistency around:
1.  `inputs` referring to `nix.Input`
2. `flakeInputs` referring to `shellgen.flakeInput`
3. `packages` referring to raw strings that are in the packages list in `devbox.json`.

cc @mikeland73 

## How was it tested?

Have not tested. Please review carefully.

relying on testscripts passing.
