### PR TITLE
[update][easy] Run nix flake update

### DIFF
--- a/internal/nix/upgrade.go
+++ b/internal/nix/upgrade.go
@@ -7,9 +7,10 @@ import (
 
 	"go.jetpack.io/devbox/internal/lock"
 	"go.jetpack.io/devbox/internal/redact"
+	"go.jetpack.io/devbox/internal/ux"
 )
 
-func Upgrade(ProfileDir string, pkg *Input, lock *lock.File) error {
+func ProfileUpgrade(ProfileDir string, pkg *Input, lock *lock.File) error {
 	idx, err := ProfileListIndex(&ProfileListIndexArgs{
 		Lockfile:   lock,
 		Writer:     os.Stderr,
@@ -28,6 +29,19 @@ func Upgrade(ProfileDir string, pkg *Input, lock *lock.File) error {
 	if err != nil {
 		return redact.Errorf(
 			"error running \"nix profile upgrade\": %s: %w", out, err)
+	}
+	return nil
+}
+
+func FlakeUpdate(ProfileDir string) error {
+	ux.Finfo(os.Stderr, "Running \"nix flake update\"\n")
+	cmd := exec.Command("nix", "flake", "update", ProfileDir)
+	cmd.Args = append(cmd.Args, ExperimentalFlags()...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return redact.Errorf(
+			"error running \"nix flake update\": %s: %w", out, err)
+
 	}
 	return nil
 }

--- a/internal/shellgen/generate.go
+++ b/internal/shellgen/generate.go
@@ -37,7 +37,7 @@ func GenerateForPrintEnv(ctx context.Context, devbox devboxer) error {
 		return err
 	}
 
-	outPath := filepath.Join(devbox.ProjectDir(), ".devbox/gen")
+	outPath := genPath(devbox)
 
 	for _, file := range shellFiles {
 		err := writeFromTemplate(outPath, plan, file)
@@ -52,7 +52,7 @@ func GenerateForPrintEnv(ctx context.Context, devbox devboxer) error {
 		return errors.WithStack(err)
 	}
 
-	err = makeFlakeFile(outPath, plan)
+	err = makeFlakeFile(devbox, outPath, plan)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -148,8 +148,8 @@ var templateFuncs = template.FuncMap{
 	"debug":    debug.IsEnabled,
 }
 
-func makeFlakeFile(outPath string, plan *flakePlan) error {
-	flakeDir := filepath.Join(outPath, "flake")
+func makeFlakeFile(d devboxer, outPath string, plan *flakePlan) error {
+	flakeDir := FlakePath(d)
 	err := writeFromTemplate(flakeDir, plan, "flake.nix")
 	if err != nil {
 		return errors.WithStack(err)

--- a/internal/shellgen/path.go
+++ b/internal/shellgen/path.go
@@ -1,0 +1,14 @@
+// Copyright 2023 Jetpack Technologies Inc and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package shellgen
+
+import "path/filepath"
+
+func genPath(d devboxer) string {
+	return filepath.Join(d.ProjectDir(), ".devbox/gen")
+}
+
+func FlakePath(d devboxer) string {
+	return filepath.Join(genPath(d), "flake")
+}


### PR DESCRIPTION
## Summary

Ensure we update flake when updating devbox packages. This helps in some edge cases where the user adds an unlocked flake.

## How was it tested?

`devbox update`
