### PR TITLE
[nix.Input][Part I] Refactor nix.Input -> nix.Package

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -126,7 +126,7 @@ func (d *Devbox) Config() *devconfig.Config {
 }
 
 func (d *Devbox) ConfigHash() (string, error) {
-	hashes := lo.Map(d.PackagesAsInputs(), func(i *nix.Input, _ int) string { return i.Hash() })
+	hashes := lo.Map(d.PackagesAsInputs(), func(i *nix.Package, _ int) string { return i.Hash() })
 	h, err := d.cfg.Hash()
 	if err != nil {
 		return "", err
@@ -339,7 +339,7 @@ func (d *Devbox) Info(ctx context.Context, pkg string, markdown bool) error {
 	}
 	return plugin.PrintReadme(
 		ctx,
-		nix.InputFromString(pkg, d.lockfile),
+		nix.PackageFromString(pkg, d.lockfile),
 		d.projectDir,
 		d.writer,
 		markdown,
@@ -910,8 +910,8 @@ func (d *Devbox) Packages() []string {
 	return d.cfg.Packages
 }
 
-func (d *Devbox) PackagesAsInputs() []*nix.Input {
-	return nix.InputsFromStrings(d.Packages(), d.lockfile)
+func (d *Devbox) PackagesAsInputs() []*nix.Package {
+	return nix.PackageFromStrings(d.Packages(), d.lockfile)
 }
 
 func (d *Devbox) HasDeprecatedPackages() bool {
@@ -926,7 +926,7 @@ func (d *Devbox) HasDeprecatedPackages() bool {
 func (d *Devbox) findPackageByName(name string) (string, error) {
 	results := map[string]bool{}
 	for _, pkg := range d.cfg.Packages {
-		i := nix.InputFromString(pkg, d.lockfile)
+		i := nix.PackageFromString(pkg, d.lockfile)
 		if i.String() == name || i.CanonicalName() == name {
 			results[i.String()] = true
 		}

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -38,8 +38,8 @@ func (d *Devbox) Add(ctx context.Context, pkgsNames ...string) error {
 
 	// Only add packages that are not already in config. If same canonical exists,
 	// replace it.
-	pkgs := []*nix.Input{}
-	for _, pkg := range nix.InputsFromStrings(lo.Uniq(pkgsNames), d.lockfile) {
+	pkgs := []*nix.Package{}
+	for _, pkg := range nix.PackageFromStrings(lo.Uniq(pkgsNames), d.lockfile) {
 		versioned := pkg.Versioned()
 
 		// If exact versioned package is already in the config, skip.
@@ -57,7 +57,7 @@ func (d *Devbox) Add(ctx context.Context, pkgsNames ...string) error {
 			}
 		}
 
-		pkgs = append(pkgs, nix.InputFromString(versioned, d.lockfile))
+		pkgs = append(pkgs, nix.PackageFromString(versioned, d.lockfile))
 		d.cfg.Packages = append(d.cfg.Packages, versioned)
 	}
 
@@ -92,7 +92,7 @@ func (d *Devbox) Add(ctx context.Context, pkgsNames ...string) error {
 	}
 
 	if err := d.lockfile.Add(
-		lo.Map(pkgs, func(pkg *nix.Input, _ int) string { return pkg.Raw })...,
+		lo.Map(pkgs, func(pkg *nix.Package, _ int) string { return pkg.Raw })...,
 	); err != nil {
 		return err
 	}
@@ -298,7 +298,7 @@ func (d *Devbox) removePackagesFromProfile(ctx context.Context, pkgs []string) e
 		return err
 	}
 
-	for _, input := range nix.InputsFromStrings(pkgs, d.lockfile) {
+	for _, input := range nix.PackageFromStrings(pkgs, d.lockfile) {
 		index, err := nix.ProfileListIndex(&nix.ProfileListIndexArgs{
 			Lockfile:   d.lockfile,
 			Writer:     d.writer,
@@ -414,7 +414,7 @@ func (d *Devbox) extraPackagesInProfile(ctx context.Context) ([]*nix.NixProfileL
 	// and since we're reusing the Input objects, this O(n*m) loop becomes O(n+m) wrt the slow operation.
 outer:
 	for _, item := range profileItems {
-		profileInput := nix.InputFromProfileItem(item, d.lockfile)
+		profileInput := nix.PackageFromProfileItem(item, d.lockfile)
 		for _, devboxInput := range devboxInputs {
 			if profileInput.Equals(devboxInput) {
 				continue outer

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -20,7 +20,7 @@ func (d *Devbox) Update(ctx context.Context, pkgs ...string) error {
 		return err
 	}
 
-	pendingPackagesToUpdate := []*nix.Input{}
+	pendingPackagesToUpdate := []*nix.Package{}
 	for _, pkg := range inputs {
 		if pkg.IsLegacy() {
 			fmt.Fprintf(d.writer, "Updating %s -> %s\n", pkg.Raw, pkg.LegacyToVersioned())
@@ -60,7 +60,7 @@ func (d *Devbox) Update(ctx context.Context, pkgs ...string) error {
 	return wrapnix.CreateWrappers(ctx, d)
 }
 
-func (d *Devbox) inputsToUpdate(pkgs ...string) ([]*nix.Input, error) {
+func (d *Devbox) inputsToUpdate(pkgs ...string) ([]*nix.Package, error) {
 	var pkgsToUpdate []string
 	for _, pkg := range pkgs {
 		found, err := d.findPackageByName(pkg)
@@ -73,12 +73,12 @@ func (d *Devbox) inputsToUpdate(pkgs ...string) ([]*nix.Input, error) {
 		pkgsToUpdate = d.Packages()
 	}
 
-	return nix.InputsFromStrings(pkgsToUpdate, d.lockfile), nil
+	return nix.PackageFromStrings(pkgsToUpdate, d.lockfile), nil
 }
 
 func (d *Devbox) updateDevboxPackage(
 	ctx context.Context,
-	pkg *nix.Input,
+	pkg *nix.Package,
 ) error {
 	existing := d.lockfile.Packages[pkg.Raw]
 	newEntry, err := searcher.Client().Resolve(pkg.Raw)
@@ -104,7 +104,7 @@ func (d *Devbox) updateDevboxPackage(
 
 // attemptToUpgradeFlake attempts to upgrade a flake using `nix profile upgrade`
 // and prints an error if it fails, but does not propagate upgrade errors.
-func (d *Devbox) attemptToUpgradeFlake(pkg *nix.Input) error {
+func (d *Devbox) attemptToUpgradeFlake(pkg *nix.Package) error {
 	profilePath, err := d.profilePath()
 	if err != nil {
 		return err

--- a/internal/nix/input.go
+++ b/internal/nix/input.go
@@ -109,9 +109,8 @@ var inputNameRegex = regexp.MustCompile("[^a-zA-Z0-9-]+")
 
 // FlakeInputName generates a name for the input that will be used in the
 // generated flake.nix to import this package. This name must be unique in that
-// flake
-// Note, that input name has nothing to do with the package name or flake name
-// that it may be referencing. That is the Input.raw field.
+// flake so we attach a hash to (quasi) ensure uniqueness.
+// Input name will be different from raw package name
 func (p *Package) FlakeInputName() string {
 	result := ""
 	if p.isLocal() {

--- a/internal/nix/input.go
+++ b/internal/nix/input.go
@@ -20,11 +20,10 @@ import (
 	"go.jetpack.io/devbox/internal/lock"
 )
 
-// Input represents a "package" added to the devbox.json config.
-// The word "input" is used because it will be referenced in a generated flake.nix.
+// Package represents a "package" added to the devbox.json config.
 // A unique feature of flakes is that they have well-defined "inputs" and "outputs".
-// This Input will be aggregated into a specific "flake input" (see shellgen.flakeInput).
-type Input struct {
+// This Package will be aggregated into a specific "flake input" (see shellgen.flakeInput).
+type Package struct {
 	url.URL
 	lockfile lock.Locker
 
@@ -45,95 +44,99 @@ type Input struct {
 	normalizedPackageAttributePathCache string // memoized value from normalizedPackageAttributePath()
 }
 
-// InputsFromStrings constructs Input from the list of package names provided.
+// PackageFromStrings constructs Package from the list of package names provided.
 // These names correspond to devbox packages from the devbox.json config.
-func InputsFromStrings(rawNames []string, l lock.Locker) []*Input {
-	inputs := []*Input{}
+func PackageFromStrings(rawNames []string, l lock.Locker) []*Package {
+	packages := []*Package{}
 	for _, rawName := range rawNames {
-		inputs = append(inputs, InputFromString(rawName, l))
+		packages = append(packages, PackageFromString(rawName, l))
 	}
-	return inputs
+	return packages
 }
 
-// InputsFromStrings constructs Input from the raw name provided.
+// PackageFromString constructs Package from the raw name provided.
 // The raw name corresponds to a devbox package from the devbox.json config.
-func InputFromString(raw string, locker lock.Locker) *Input {
-	// We ignore the error because... TODO @mikeland why?
-	inputURL, _ := url.Parse(raw)
+func PackageFromString(raw string, locker lock.Locker) *Package {
+	// TODO: We should handle this error
+	// TODO: URL might not be best representation since most packages are not urls
+	pkgURL, _ := url.Parse(raw)
 
 	// This handles local flakes in a relative path.
 	// `raw` will be of the form `path:./local_flake_subdir#myPackage`
 	// for which path:<empty>, opaque:./local_subdir, and scheme:path
-	if inputURL.Path == "" && inputURL.Opaque != "" && inputURL.Scheme == "path" {
+	if pkgURL.Path == "" && pkgURL.Opaque != "" && pkgURL.Scheme == "path" {
 		// This normalizes url paths to be absolute. It also ensures all
 		// path urls have a single slash (instead of possibly 3 slashes)
-		normalizedURL := "path:" + filepath.Join(locker.ProjectDir(), inputURL.Opaque)
-		if inputURL.Fragment != "" {
-			normalizedURL += "#" + inputURL.Fragment
+		normalizedURL := "path:" + filepath.Join(locker.ProjectDir(), pkgURL.Opaque)
+		if pkgURL.Fragment != "" {
+			normalizedURL += "#" + pkgURL.Fragment
 		}
-		inputURL, _ = url.Parse(normalizedURL)
+		pkgURL, _ = url.Parse(normalizedURL)
 	}
-	return &Input{*inputURL, locker, raw, ""}
+	return &Package{*pkgURL, locker, raw, ""}
 }
 
-// InputFromProfileItem sets the raw Input as the `item`'s unlockedReference i.e.
-// the flake reference and output attribute path used at install time.
-func InputFromProfileItem(item *NixProfileListItem, locker lock.Locker) *Input {
-	return InputFromString(item.unlockedReference, locker)
+// PackageFromProfileItem constructs a package using the the unlocked reference
+// from profile list item.
+func PackageFromProfileItem(item *NixProfileListItem, locker lock.Locker) *Package {
+	return PackageFromString(item.unlockedReference, locker)
 }
 
-// isLocal specifies whether this input is a local flake.
+// isLocal specifies whether this package is a local flake.
 // Usually, this is of the form: `path:./local_flake_subdir#myPackage`
-func (i *Input) isLocal() bool {
+func (p *Package) isLocal() bool {
 	// Technically flakes allows omitting the scheme for local absolute paths, but
 	// we don't support that (yet).
-	return i.Scheme == "path"
+	return p.Scheme == "path"
 }
 
-// isDevboxPackage specifies whether this input is a `canonicalName@version` nix
-// package defined in a devbox.json config. This is in contrast to a "nix" package
-// that can also be a flake or a legacy attribute path.
-func (i *Input) isDevboxPackage() bool {
-	return i.Scheme == ""
+// isDevboxPackage specifies whether this package is a devbox package. Devbox
+// packages have the format `canonicalName@version`and can be resolved by devbox
+// search. This also returns true for legacy packages which are just an
+// attribute path. An explicit flake reference is _not_ a devbox package.
+func (p *Package) isDevboxPackage() bool {
+	return p.Scheme == ""
 }
 
-// isGithub specifies whether this input is a remote flake hosted on a github repository.
+// isGithub specifies whether this Package is referenced by a remote flake
+// hosted on a github repository.
 // example: github:nixos/nixpkgs/5233fd2ba76a3accb5aaa999c00509a11fd0793c#hello
-func (i *Input) isGithub() bool {
-	return i.Scheme == "github"
+func (p *Package) isGithub() bool {
+	return p.Scheme == "github"
 }
 
 var inputNameRegex = regexp.MustCompile("[^a-zA-Z0-9-]+")
 
-// FlakeInputName refers to the name of this Input that will be used in the
-// generated flake.nix. It is unique, and a slug is appended to avoid collisions.
-//
+// FlakeInputName generates a name for the input that will be used in the
+// generated flake.nix to import this package. This name must be unique in that
+// flake
 // Note, that input name has nothing to do with the package name or flake name
 // that it may be referencing. That is the Input.raw field.
-func (i *Input) FlakeInputName() string {
+func (p *Package) FlakeInputName() string {
 	result := ""
-	if i.isLocal() {
-		result = filepath.Base(i.Path) + "-" + i.Hash()
-	} else if i.isGithub() {
-		result = "gh-" + strings.Join(strings.Split(i.Opaque, "/"), "-")
-	} else if url := i.URLForFlakeInput(); IsGithubNixpkgsURL(url) {
+	if p.isLocal() {
+		result = filepath.Base(p.Path) + "-" + p.Hash()
+	} else if p.isGithub() {
+		result = "gh-" + strings.Join(strings.Split(p.Opaque, "/"), "-")
+	} else if url := p.URLForFlakeInput(); IsGithubNixpkgsURL(url) {
 		commitHash := HashFromNixPkgsURL(url)
 		if len(commitHash) > 6 {
 			commitHash = commitHash[0:6]
 		}
 		result = "nixpkgs-" + commitHash
 	} else {
-		result = i.String() + "-" + i.Hash()
+		result = p.String() + "-" + p.Hash()
 	}
 
 	// replace all non-alphanumeric with dashes
 	return inputNameRegex.ReplaceAllString(result, "-")
 }
 
-// URLForFlakeInput is the url to be used as the input in the generated flake.nix
-func (i *Input) URLForFlakeInput() string {
-	if i.isDevboxPackage() {
-		entry, err := i.lockfile.Resolve(i.Raw)
+// URLForFlakeInput returns the input url to be used in a flake.nix file. This
+// input can be used to import the package.
+func (p *Package) URLForFlakeInput() string {
+	if p.isDevboxPackage() {
+		entry, err := p.lockfile.Resolve(p.Raw)
 		if err != nil {
 			panic(err)
 			// TODO(landau): handle error
@@ -141,40 +144,41 @@ func (i *Input) URLForFlakeInput() string {
 		withoutFragment, _, _ := strings.Cut(entry.Resolved, "#")
 		return withoutFragment
 	}
-	return i.urlWithoutFragment()
+	return p.urlWithoutFragment()
 }
 
 // URLForInstall is used during `nix profile install`.
-// The key difference with URLForFlakeInput is that it has a suffix of `#attributePath`
-func (i *Input) URLForInstall() (string, error) {
-	if i.isDevboxPackage() {
-		entry, err := i.lockfile.Resolve(i.Raw)
+// The key difference with URLForFlakeInput is that it has a suffix of
+// `#attributePath`
+func (p *Package) URLForInstall() (string, error) {
+	if p.isDevboxPackage() {
+		entry, err := p.lockfile.Resolve(p.Raw)
 		if err != nil {
 			return "", err
 		}
 		return entry.Resolved, nil
 	}
-	attrPath, err := i.FullPackageAttributePath()
+	attrPath, err := p.FullPackageAttributePath()
 	if err != nil {
 		return "", err
 	}
-	return i.urlWithoutFragment() + "#" + attrPath, nil
+	return p.urlWithoutFragment() + "#" + attrPath, nil
 }
 
-func (i *Input) normalizedDevboxPackageReference() (string, error) {
-	if !i.isDevboxPackage() {
+func (p *Package) normalizedDevboxPackageReference() (string, error) {
+	if !p.isDevboxPackage() {
 		return "", nil
 	}
 
 	path := ""
-	if i.isVersioned() {
-		entry, err := i.lockfile.Resolve(i.Raw)
+	if p.isVersioned() {
+		entry, err := p.lockfile.Resolve(p.Raw)
 		if err != nil {
 			return "", err
 		}
 		path = entry.Resolved
-	} else if i.isDevboxPackage() {
-		path = i.lockfile.LegacyNixpkgsPath(i.String())
+	} else if p.isDevboxPackage() {
+		path = p.lockfile.LegacyNixpkgsPath(p.String())
 	}
 
 	if path != "" {
@@ -191,65 +195,65 @@ func (i *Input) normalizedDevboxPackageReference() (string, error) {
 
 // PackageAttributePath returns the short attribute path for a package which
 // does not include packages/legacyPackages or the system name.
-func (i *Input) PackageAttributePath() (string, error) {
-	if i.isDevboxPackage() {
-		entry, err := i.lockfile.Resolve(i.Raw)
+func (p *Package) PackageAttributePath() (string, error) {
+	if p.isDevboxPackage() {
+		entry, err := p.lockfile.Resolve(p.Raw)
 		if err != nil {
 			return "", err
 		}
 		_, fragment, _ := strings.Cut(entry.Resolved, "#")
 		return fragment, nil
 	}
-	return i.Fragment, nil
+	return p.Fragment, nil
 }
 
 // FullPackageAttributePath returns the attribute path for a package. It is not
 // always normalized which means it should not be used to compare packages.
 // During happy paths (devbox packages and nix flakes that contains a fragment)
 // it is much faster than NormalizedPackageAttributePath
-func (i *Input) FullPackageAttributePath() (string, error) {
-	if i.isDevboxPackage() {
-		reference, err := i.normalizedDevboxPackageReference()
+func (p *Package) FullPackageAttributePath() (string, error) {
+	if p.isDevboxPackage() {
+		reference, err := p.normalizedDevboxPackageReference()
 		if err != nil {
 			return "", err
 		}
 		_, fragment, _ := strings.Cut(reference, "#")
 		return fragment, nil
 	}
-	return i.NormalizedPackageAttributePath()
+	return p.NormalizedPackageAttributePath()
 }
 
 // NormalizedPackageAttributePath returns an attribute path normalized by nix
 // search. This is useful for comparing different attribute paths that may
 // point to the same package. Note, it may be an expensive call.
-func (i *Input) NormalizedPackageAttributePath() (string, error) {
-	if i.normalizedPackageAttributePathCache != "" {
-		return i.normalizedPackageAttributePathCache, nil
+func (p *Package) NormalizedPackageAttributePath() (string, error) {
+	if p.normalizedPackageAttributePathCache != "" {
+		return p.normalizedPackageAttributePathCache, nil
 	}
-	path, err := i.normalizePackageAttributePath()
+	path, err := p.normalizePackageAttributePath()
 	if err != nil {
 		return path, err
 	}
-	i.normalizedPackageAttributePathCache = path
-	return i.normalizedPackageAttributePathCache, nil
+	p.normalizedPackageAttributePathCache = path
+	return p.normalizedPackageAttributePathCache, nil
 }
 
 // normalizePackageAttributePath calls nix search to find the normalized attribute
 // path. It is an expensive call (~100ms).
-func (i *Input) normalizePackageAttributePath() (string, error) {
+func (p *Package) normalizePackageAttributePath() (string, error) {
 	var query string
-	if i.isDevboxPackage() {
-		if i.isVersioned() {
-			entry, err := i.lockfile.Resolve(i.Raw)
+	if p.isDevboxPackage() {
+		if p.isVersioned() {
+			entry, err := p.lockfile.Resolve(p.Raw)
 			if err != nil {
 				return "", err
 			}
 			query = entry.Resolved
 		} else {
-			query = i.lockfile.LegacyNixpkgsPath(i.String())
+			query = p.lockfile.LegacyNixpkgsPath(p.String())
 		}
 	} else {
-		query = i.String()
+		query = p.String()
 	}
 
 	// We prefer search over just trying to parse the URL because search will
@@ -261,7 +265,7 @@ func (i *Input) normalizePackageAttributePath() (string, error) {
 	}
 
 	// If ambiguous, try to find a default output
-	if len(infos) > 1 && i.Fragment == "" {
+	if len(infos) > 1 && p.Fragment == "" {
 		for key := range infos {
 			if strings.HasSuffix(key, ".default") {
 				return key, nil
@@ -283,7 +287,7 @@ func (i *Input) normalizePackageAttributePath() (string, error) {
 		}
 		return "", usererr.New(
 			"Package \"%s\" is ambiguous. %s",
-			i.String(),
+			p.String(),
 			outputs,
 		)
 	}
@@ -292,54 +296,54 @@ func (i *Input) normalizePackageAttributePath() (string, error) {
 		return "", usererr.New(
 			"Package \"%s\" was found, but we're unable to build it for your system."+
 				" You may need to choose another version or write a custom flake.",
-			i.String(),
+			p.String(),
 		)
 	}
 
-	return "", usererr.New("Package \"%s\" was not found", i.String())
+	return "", usererr.New("Package \"%s\" was not found", p.String())
 }
 
-func (i *Input) urlWithoutFragment() string {
-	u := i.URL // get copy
+func (p *Package) urlWithoutFragment() string {
+	u := p.URL // get copy
 	u.Fragment = ""
 	return u.String()
 }
 
-func (i *Input) Hash() string {
+func (p *Package) Hash() string {
 	// For local flakes, use content hash of the flake.nix file to ensure
-	// user always gets newest input.
-	if i.isLocal() {
-		fileHash, _ := cuecfg.FileHash(filepath.Join(i.Path, "flake.nix"))
+	// user always gets newest flake.
+	if p.isLocal() {
+		fileHash, _ := cuecfg.FileHash(filepath.Join(p.Path, "flake.nix"))
 		if fileHash != "" {
 			return fileHash[:6]
 		}
 	}
 	hasher := md5.New()
-	hasher.Write([]byte(i.String()))
+	hasher.Write([]byte(p.String()))
 	hash := hasher.Sum(nil)
 	shortHash := hex.EncodeToString(hash)[:6]
 	return shortHash
 }
 
-func (i *Input) ValidateExists() (bool, error) {
-	if i.isVersioned() && i.version() == "" {
-		return false, usererr.New("No version specified for %q.", i.Path)
+func (p *Package) ValidateExists() (bool, error) {
+	if p.isVersioned() && p.version() == "" {
+		return false, usererr.New("No version specified for %q.", p.Path)
 	}
-	info, err := i.NormalizedPackageAttributePath()
+	info, err := p.NormalizedPackageAttributePath()
 	return info != "", err
 }
 
-func (i *Input) Equals(other *Input) bool {
-	if i.String() == other.String() {
+func (p *Package) Equals(other *Package) bool {
+	if p.String() == other.String() {
 		return true
 	}
 
 	// check inputs without fragments as optimization. Next step is expensive
-	if i.URLForFlakeInput() != other.URLForFlakeInput() {
+	if p.URLForFlakeInput() != other.URLForFlakeInput() {
 		return false
 	}
 
-	name, err := i.NormalizedPackageAttributePath()
+	name, err := p.NormalizedPackageAttributePath()
 	if err != nil {
 		return false
 	}
@@ -352,34 +356,34 @@ func (i *Input) Equals(other *Input) bool {
 
 // CanonicalName returns the name of the package without the version
 // it only applies to devbox packages
-func (i *Input) CanonicalName() string {
-	if !i.isDevboxPackage() {
+func (p *Package) CanonicalName() string {
+	if !p.isDevboxPackage() {
 		return ""
 	}
-	name, _, _ := strings.Cut(i.Path, "@")
+	name, _, _ := strings.Cut(p.Path, "@")
 	return name
 }
 
-func (i *Input) Versioned() string {
-	if i.isDevboxPackage() && !i.isVersioned() {
-		return i.Raw + "@latest"
+func (p *Package) Versioned() string {
+	if p.isDevboxPackage() && !p.isVersioned() {
+		return p.Raw + "@latest"
 	}
-	return i.Raw
+	return p.Raw
 }
 
-func (i *Input) IsLegacy() bool {
-	return i.isDevboxPackage() && !i.isVersioned()
+func (p *Package) IsLegacy() bool {
+	return p.isDevboxPackage() && !p.isVersioned()
 }
 
-func (i *Input) LegacyToVersioned() string {
-	if !i.IsLegacy() {
-		return i.Raw
+func (p *Package) LegacyToVersioned() string {
+	if !p.IsLegacy() {
+		return p.Raw
 	}
-	return i.Raw + "@latest"
+	return p.Raw + "@latest"
 }
 
-func (i *Input) EnsureNixpkgsPrefetched(w io.Writer) error {
-	hash := i.hashFromNixPkgsURL()
+func (p *Package) EnsureNixpkgsPrefetched(w io.Writer) error {
+	hash := p.hashFromNixPkgsURL()
 	if hash == "" {
 		return nil
 	}
@@ -388,23 +392,23 @@ func (i *Input) EnsureNixpkgsPrefetched(w io.Writer) error {
 
 // version returns the version of the package
 // it only applies to devbox packages
-func (i *Input) version() string {
-	if !i.isDevboxPackage() {
+func (p *Package) version() string {
+	if !p.isDevboxPackage() {
 		return ""
 	}
-	_, version, _ := strings.Cut(i.Path, "@")
+	_, version, _ := strings.Cut(p.Path, "@")
 	return version
 }
 
-func (i *Input) isVersioned() bool {
-	return i.isDevboxPackage() && strings.Contains(i.Path, "@")
+func (p *Package) isVersioned() bool {
+	return p.isDevboxPackage() && strings.Contains(p.Path, "@")
 }
 
-func (i *Input) hashFromNixPkgsURL() string {
-	return HashFromNixPkgsURL(i.URLForFlakeInput())
+func (p *Package) hashFromNixPkgsURL() string {
+	return HashFromNixPkgsURL(p.URLForFlakeInput())
 }
 
-// IsGithubNixpkgsURL returns true if the input is a nixpkgs flake of the form:
+// IsGithubNixpkgsURL returns true if the package is a flake of the form:
 // github:NixOS/nixpkgs/...
 //
 // While there are many ways to specify this input, devbox always uses

--- a/internal/nix/input_test.go
+++ b/internal/nix/input_test.go
@@ -99,7 +99,7 @@ func TestInput(t *testing.T) {
 }
 
 type testInput struct {
-	Input
+	Package
 }
 
 type lockfile struct {
@@ -132,7 +132,7 @@ func (l *lockfile) Resolve(pkg string) (*lock.Package, error) {
 }
 
 func testInputFromString(s, projectDir string) *testInput {
-	return lo.ToPtr(testInput{Input: *InputFromString(s, &lockfile{projectDir})})
+	return lo.ToPtr(testInput{Package: *PackageFromString(s, &lockfile{projectDir})})
 }
 
 func TestHashFromNixPkgsURL(t *testing.T) {

--- a/internal/nix/profile.go
+++ b/internal/nix/profile.go
@@ -79,7 +79,7 @@ type ProfileListIndexArgs struct {
 	List       map[string]*NixProfileListItem
 	Lockfile   *lock.File
 	Writer     io.Writer
-	Input      *Input
+	Input      *Package
 	ProfileDir string
 }
 
@@ -104,7 +104,7 @@ func ProfileListIndex(args *ProfileListIndexArgs) (int, error) {
 	}
 
 	for _, item := range list {
-		existing := InputFromProfileItem(item, args.Lockfile)
+		existing := PackageFromProfileItem(item, args.Lockfile)
 
 		if args.Input.Equals(existing) {
 			return item.index, nil
@@ -210,7 +210,7 @@ type ProfileInstallArgs struct {
 
 // ProfileInstall calls nix profile install with default profile
 func ProfileInstall(args *ProfileInstallArgs) error {
-	input := InputFromString(args.Package, args.Lockfile)
+	input := PackageFromString(args.Package, args.Lockfile)
 	if IsGithubNixpkgsURL(input.URLForFlakeInput()) {
 		if err := ensureNixpkgsPrefetched(args.Writer, input.hashFromNixPkgsURL()); err != nil {
 			return err

--- a/internal/nix/search.go
+++ b/internal/nix/search.go
@@ -16,7 +16,7 @@ var ErrPackageNotFound = errors.New("package not found")
 var ErrPackageNotInstalled = errors.New("package not installed")
 
 func PkgExists(pkg string, lock *lock.File) (bool, error) {
-	return InputFromString(pkg, lock).ValidateExists()
+	return PackageFromString(pkg, lock).ValidateExists()
 }
 
 type Info struct {

--- a/internal/nix/upgrade.go
+++ b/internal/nix/upgrade.go
@@ -9,7 +9,7 @@ import (
 	"go.jetpack.io/devbox/internal/redact"
 )
 
-func Upgrade(ProfileDir string, pkg *Input, lock *lock.File) error {
+func Upgrade(ProfileDir string, pkg *Package, lock *lock.File) error {
 	idx, err := ProfileListIndex(&ProfileListIndexArgs{
 		Lockfile:   lock,
 		Writer:     os.Stderr,

--- a/internal/plugin/files.go
+++ b/internal/plugin/files.go
@@ -12,7 +12,7 @@ import (
 	"go.jetpack.io/devbox/plugins"
 )
 
-func getConfigIfAny(pkg *nix.Input, projectDir string) (*config, error) {
+func getConfigIfAny(pkg *nix.Package, projectDir string) (*config, error) {
 	configFiles, err := plugins.BuiltIn.ReadDir(".")
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/internal/plugin/hooks.go
+++ b/internal/plugin/hooks.go
@@ -5,7 +5,7 @@ package plugin
 
 import "go.jetpack.io/devbox/internal/nix"
 
-func InitHooks(pkgs []*nix.Input, projectDir string) ([]string, error) {
+func InitHooks(pkgs []*nix.Package, projectDir string) ([]string, error) {
 	hooks := []string{}
 	for _, pkg := range pkgs {
 		c, err := getConfigIfAny(pkg, projectDir)

--- a/internal/plugin/includes.go
+++ b/internal/plugin/includes.go
@@ -7,12 +7,12 @@ import (
 	"go.jetpack.io/devbox/internal/nix"
 )
 
-func (m *Manager) parseInclude(include string) (*nix.Input, error) {
+func (m *Manager) parseInclude(include string) (*nix.Package, error) {
 	includeType, name, _ := strings.Cut(include, ":")
 	if includeType != "plugin" {
 		return nil, usererr.New("unknown include type %q", includeType)
 	} else if name == "" {
 		return nil, usererr.New("include name is required")
 	}
-	return nix.InputFromString(name, m.lockfile), nil
+	return nix.PackageFromString(name, m.lockfile), nil
 }

--- a/internal/plugin/info.go
+++ b/internal/plugin/info.go
@@ -16,7 +16,7 @@ import (
 )
 
 func PrintReadme(ctx context.Context,
-	pkg *nix.Input,
+	pkg *nix.Package,
 	projectDir string,
 	w io.Writer,
 	markdown bool,

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -45,8 +45,8 @@ func (m *Manager) ApplyOptions(opts ...managerOption) {
 	}
 }
 
-func (m *Manager) PluginInputs(inputs []*nix.Input) ([]*nix.Input, error) {
-	result := []*nix.Input{}
+func (m *Manager) PluginInputs(inputs []*nix.Package) ([]*nix.Package, error) {
+	result := []*nix.Package{}
 	for _, input := range inputs {
 		config, err := getConfigIfAny(input, m.ProjectDir())
 		if err != nil {
@@ -54,7 +54,7 @@ func (m *Manager) PluginInputs(inputs []*nix.Input) ([]*nix.Input, error) {
 		} else if config == nil {
 			continue
 		}
-		result = append(result, nix.InputsFromStrings(config.Packages, m.lockfile)...)
+		result = append(result, nix.PackageFromStrings(config.Packages, m.lockfile)...)
 	}
 	return result, nil
 }

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -75,11 +75,11 @@ func (m *Manager) Include(included string) error {
 	return err
 }
 
-func (m *Manager) Create(pkg *nix.Input) error {
+func (m *Manager) Create(pkg *nix.Package) error {
 	return m.create(pkg, m.lockfile.Packages[pkg.Raw])
 }
 
-func (m *Manager) create(pkg *nix.Input, locked *lock.Package) error {
+func (m *Manager) create(pkg *nix.Package, locked *lock.Package) error {
 	virtenvPath := filepath.Join(m.ProjectDir(), VirtenvPath)
 	cfg, err := getConfigIfAny(pkg, m.ProjectDir())
 	if err != nil {
@@ -128,7 +128,7 @@ func (m *Manager) create(pkg *nix.Input, locked *lock.Package) error {
 }
 
 func (m *Manager) createFile(
-	pkg *nix.Input,
+	pkg *nix.Package,
 	filePath, contentPath, virtenvPath string,
 ) error {
 	name := pkg.CanonicalName()
@@ -188,11 +188,11 @@ func (m *Manager) createFile(
 // TODO: this should have PluginManager as receiver so we can build once with
 // pkgs, includes, etc
 func (m *Manager) Env(
-	pkgs []*nix.Input,
+	pkgs []*nix.Package,
 	includes []string,
 	computedEnv map[string]string,
 ) (map[string]string, error) {
-	allPkgs := append([]*nix.Input(nil), pkgs...)
+	allPkgs := append([]*nix.Package(nil), pkgs...)
 	for _, included := range includes {
 		input, err := m.parseInclude(included)
 		if err != nil {
@@ -217,7 +217,7 @@ func (m *Manager) Env(
 	return conf.OSExpandEnvMap(env, computedEnv, m.ProjectDir()), nil
 }
 
-func buildConfig(pkg *nix.Input, projectDir, content string) (*config, error) {
+func buildConfig(pkg *nix.Package, projectDir, content string) (*config, error) {
 	cfg := &config{}
 	name := pkg.CanonicalName()
 	t, err := template.New(name + "-template").Parse(content)

--- a/internal/plugin/services.go
+++ b/internal/plugin/services.go
@@ -12,12 +12,12 @@ import (
 )
 
 func (m *Manager) GetServices(
-	pkgs []*nix.Input,
+	pkgs []*nix.Package,
 	includes []string,
 ) (services.Services, error) {
 	allSvcs := services.Services{}
 
-	allPkgs := append([]*nix.Input(nil), pkgs...)
+	allPkgs := append([]*nix.Package(nil), pkgs...)
 	for _, include := range includes {
 		name, err := m.parseInclude(include)
 		if err != nil {

--- a/internal/shellgen/scripts.go
+++ b/internal/shellgen/scripts.go
@@ -23,7 +23,7 @@ const HooksFilename = ".hooks"
 type devboxer interface {
 	Config() *devconfig.Config
 	Lockfile() *lock.File
-	PackagesAsInputs() []*nix.Input
+	PackagesAsInputs() []*nix.Package
 	PluginManager() *plugin.Manager
 	ProjectDir() string
 }


### PR DESCRIPTION
## Summary

I split this up to reduce conflicts. This is part 1 of 3. 

- [x] Part 1: Rename struct Input -> Package. Update comments
- [ ] Part 2: Update callsites to use package instead of inputs
- [ ] Part 3: Move Package struct to devpkg

## How was it tested?

`devbox run build`
