### PR TITLE
[remove nixpkgs] part 1: write info for nix store paths in lockfile

### DIFF
--- a/internal/boxcli/featureflag/remove_nixpkgs.go
+++ b/internal/boxcli/featureflag/remove_nixpkgs.go
@@ -1,0 +1,7 @@
+package featureflag
+
+// RemoveNixpkgs will generate flake.nix code that skips downloads of nixpkgs.
+// It leverages the search index to directly map <package>@<version> to
+// the /nix/store/<hash>-<package>-<version> that can be fetched from
+// cache.nixpkgs.org.
+var RemoveNixpkgs = disabled("REMOVE_NIXPKGS")

--- a/internal/searcher/client.go
+++ b/internal/searcher/client.go
@@ -11,6 +11,8 @@ import (
 	"net/url"
 
 	"github.com/pkg/errors"
+	"github.com/samber/lo"
+	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/devpkg"
 	"go.jetpack.io/devbox/internal/envir"
@@ -66,6 +68,20 @@ func (c *client) Resolve(pkg string) (*lock.Package, error) {
 	if len(result.Results) == 0 {
 		return nil, nix.ErrPackageNotFound
 	}
+
+	searchVersion := result.Results[0].Packages[0].Version
+	sysInfoMap := map[string]*lock.SystemInfo{}
+	if featureflag.RemoveNixpkgs.Enabled() {
+		// we use searchVersion instead of version so that "latest" is resolved
+		// to a concrete version before we get the package's system info
+		sysInfo, err := c.resolvePackageSystemInfoIfAny(name, searchVersion)
+		if err != nil {
+			return nil, err
+		}
+		if sysInfo != nil {
+			sysInfoMap[sysInfo.System] = sysInfo
+		}
+	}
 	return &lock.Package{
 		LastModified: result.Results[0].Packages[0].Date,
 		Resolved: fmt.Sprintf(
@@ -73,8 +89,45 @@ func (c *client) Resolve(pkg string) (*lock.Package, error) {
 			result.Results[0].Packages[0].NixpkgCommit,
 			result.Results[0].Packages[0].AttributePath,
 		),
-		Version: result.Results[0].Packages[0].Version,
+		Version: searchVersion,
+		Systems: sysInfoMap,
 	}, nil
+}
+
+// resolvePackageSystemInfoIfAny is temporary, until the search API returns
+// the "system info" like the store-hash. This uses the /pkg api that is
+// for nixhub.io as a temporary workaround.
+func (c *client) resolvePackageSystemInfoIfAny(pkgName, version string) (*lock.SystemInfo, error) {
+	packageResults, err := execPackageQuery(c.host, pkgName)
+	if err != nil {
+		return nil, err
+	}
+
+	var ok bool
+	result, ok := lo.Find(
+		packageResults, func(result *PackageResult) bool { return result.Version == version })
+	if !ok {
+		return nil, nil
+	}
+
+	userSystem, err := nix.System()
+	if err != nil {
+		return nil, err
+	}
+
+	var systemInfo *lock.SystemInfo
+	for sysName, sysInfo := range result.Systems {
+		if sysName == userSystem {
+			systemInfo = &lock.SystemInfo{
+				System:       sysName,
+				FromHash:     sysInfo.StoreHash,
+				StoreName:    sysInfo.StoreName,
+				StoreVersion: sysInfo.StoreVersion,
+			}
+			break
+		}
+	}
+	return systemInfo, nil
 }
 
 func execSearch(url string) (*SearchResult, error) {
@@ -89,4 +142,24 @@ func execSearch(url string) (*SearchResult, error) {
 	}
 	var result SearchResult
 	return &result, json.Unmarshal(data, &result)
+}
+
+func execPackageQuery(endpoint, pkgName string) ([]*PackageResult, error) {
+	url, err := url.JoinPath(endpoint, "pkg", pkgName)
+	if err != nil {
+		return nil, err
+	}
+	response, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	data, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []*PackageResult
+	return result, json.Unmarshal(data, &result)
 }

--- a/internal/searcher/model.go
+++ b/internal/searcher/model.go
@@ -29,3 +29,27 @@ type SearchResult struct {
 	Results     []Result `json:"results"`
 	Suggestions []Result `json:"suggestions"`
 }
+
+// Package api:
+// https://search.devbox.sh/pkg/<name>
+type PackageResult struct {
+	Summary  string                `json:"summary"`
+	Homepage string                `json:"homepage"`
+	License  string                `json:"license"`
+	Name     string                `json:"name"`
+	Version  string                `json:"version"`
+	Systems  map[string]SystemInfo `json:"systems"`
+}
+
+type SystemInfo struct {
+	ID           int      `json:"id"`
+	CommitHash   string   `json:"commit_hash"`
+	System       string   `json:"system"`
+	LastUpdated  int      `json:"last_updated"`
+	StoreHash    string   `json:"store_hash"`
+	StoreName    string   `json:"store_name"`
+	StoreVersion string   `json:"store_version"`
+	MetaName     string   `json:"meta_name"`
+	MetaVersion  []string `json:"meta_version"`
+	AttrPaths    []string `json:"attr_paths"`
+}


### PR DESCRIPTION
## Summary

**Motivation For "Remove Nixpkgs"**
Today, when adding a versioned package, Devbox will look up the versioned package’s metadata by mapping the user-specified version to a nixpkgs commit hash and an attribute path. This `nixpkgs/<commit hash>#attributePath` is used in the generated flake.nix. 

We want to remove the dependency on the nixpkgs commit hash, so that the user need not download that nixpkgs artifact, and spend time resolving it.


**Essence of the approach**
Today, when adding a versioned package, Devbox will look up the versioned package’s metadata by mapping the user-specified version to a nixpkgs commit hash and an attribute path. This `nixpkgs/<commit hash>#attributePath` is used in the generated flake.nix. 
```
builtins.fetchClosure {
  fromStore = "https://cache.nixos.org";
  fromPath = /nix/store/r2jd6ygnmirm2g803mksqqjm4y39yi6i-git-2.33.1;
  toPath = /nix/store/ldbhlwhh39wha58rm61bkiiwm6j7211j-git-2.33.1;
}
```

if we can map `git@2.33.1` to the `/nix/store` paths, then we need not download nixpkgs.

**Implementation in this PR**

This PR focusses on the resolving packages to the "locked" representation in `devbox.lock`. Anytime a package is added or removed, we check if the `devbox.lock` needs additional `SystemInfo` for each package. This `SystemInfo` can be used to derive `fromPath` and `toPath` in `builtins.fetchClosure`.

Next PR will read this information from the lockfile to generate a `flake.nix` that uses `builtins.fetchClosure`.

cc @mikeland73 

## How was it tested?

Using the devbox repository, did `devbox add hello`.

```
diff --git a/devbox.json b/devbox.json
index 7b263cb4..55ee3f8a 100644
--- a/devbox.json
+++ b/devbox.json
@@ -2,7 +2,8 @@
   "packages": [
     "go@1.20",
     "actionlint@1.6.23",
-    "golangci-lint@1.52.2"
+    "golangci-lint@1.52.2",
+    "hello@latest"
   ],
   "env": {
     "PATH": "$PATH:$PWD/dist"
diff --git a/devbox.lock b/devbox.lock
index 7dffa054..3baae253 100644
--- a/devbox.lock
+++ b/devbox.lock
@@ -4,17 +4,78 @@
     "actionlint@1.6.23": {
       "last_modified": "2023-03-31T22:52:29Z",
       "resolved": "github:NixOS/nixpkgs/242246ee1e58f54d2322227fc5eef53b4a616a31#actionlint",
-      "version": "1.6.23"
+      "version": "1.6.23",
+      "systems": {
+        "aarch64-darwin": {
+          "System": "aarch64-darwin",
+          "from_hash": "zx4pz0wxyh7fww34fmkvy11rjx36jn14",
+          "store_name": "actionlint",
+          "store_version": "1.6.23"
+        },
+        "x86_64-linux": {
+          "System": "x86_64-linux",
+          "from_hash": "cffgrw9ynyfxirqpakx96m4v080pnmxz",
+          "store_name": "actionlint",
+          "store_version": "1.6.23"
+        }
+      }
     },
     "go@1.20": {
       "last_modified": "2023-05-01T16:53:22Z",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#go",
-      "version": "1.20.3"
+      "version": "1.20.3",
+      "systems": {
+        "aarch64-darwin": {
+          "System": "aarch64-darwin",
+          "from_hash": "pn1m11aq5ridxm6qcvpazmrrj3kqln71",
+          "store_name": "go",
+          "store_version": "1.20.3"
+        },
+        "x86_64-linux": {
+          "System": "x86_64-linux",
+          "from_hash": "mzrw2zphz9xx9s3qq8x5zpf18isp0jga",
+          "store_name": "go",
+          "store_version": "1.20.3"
+        }
+      }
     },
     "golangci-lint@1.52.2": {
       "last_modified": "2023-05-01T16:53:22Z",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#golangci-lint",
-      "version": "1.52.2"
+      "version": "1.52.2",
+      "systems": {
+        "aarch64-darwin": {
+          "System": "aarch64-darwin",
+          "from_hash": "rp380cz8gxv8pw5zq985yblym19vr9g8",
+          "store_name": "golangci-lint",
+          "store_version": "1.52.2"
+        },
+        "x86_64-linux": {
+          "System": "x86_64-linux",
+          "from_hash": "9cl7cbahf1zqfwc3mfp44bkd9h82c1pg",
+          "store_name": "golangci-lint",
+          "store_version": "1.52.2"
+        }
+      }
+    },
+    "hello@latest": {
+      "last_modified": "2023-05-01T16:53:22Z",
+      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#hello",
+      "version": "2.12.1",
+      "systems": {
+        "aarch64-darwin": {
+          "System": "aarch64-darwin",
+          "from_hash": "qh8s6yb93b1wl0jxg5i0pfq2rf7qm44j",
+          "store_name": "hello",
+          "store_version": "2.12.1"
+        },
+        "x86_64-linux": {
+          "System": "x86_64-linux",
+          "from_hash": "8n3pr83b7aab975gwrd6hnk10pqphr59",
+          "store_name": "hello",
+          "store_version": "2.12.1"
+        }
+      }
     }
   }
 }
\ No newline at end of file

```