### PR TITLE
[examples] simplify remote flakes example by dropping `fenix` flake

### DIFF
--- a/examples/flakes/README.md
+++ b/examples/flakes/README.md
@@ -33,7 +33,6 @@ Use `github:<org>/<repo>/<ref>#<output>` as the package name to install from a G
 {
   "packages": [
     "github:nixos/nixpkgs/5233fd2ba76a3accb5aaa999c00509a11fd0793c#hello",
-    "github:nix-community/fenix#stable.toolchain",
     "github:F1bonacc1/process-compose"
   ],
   "shell": {
@@ -45,4 +44,4 @@ Use `github:<org>/<repo>/<ref>#<output>` as the package name to install from a G
 }
 ```
 
-This installs the `hello` package from the 5233fd... commit of Nixpkgs, the `stable.toolchain` output from the `fenix` package in the `nix-community/fenix` repo, and the `default` output from the `F1bonacc1/process-compose` repo.
+This installs the `hello` package from the 5233fd... commit of Nixpkgs, and the `default` output from the `F1bonacc1/process-compose` repo.

--- a/examples/flakes/remote/devbox.json
+++ b/examples/flakes/remote/devbox.json
@@ -1,10 +1,14 @@
 {
   "packages": [
     "github:nixos/nixpkgs/5233fd2ba76a3accb5aaa999c00509a11fd0793c#hello",
+    "github:nixos/nixpkgs/5233fd2ba76a3accb5aaa999c00509a11fd0793c#cowsay",
     "github:F1bonacc1/process-compose"
   ],
   "shell": {
-    "init_hook": null
+    "init_hook": null,
+    "scripts": {
+      "run_test": "cowsay -- hello"
+    }
   },
   "nixpkgs": {
     "commit": "f80ac848e3d6f0c12c52758c0f25c10c97ca3b62"

--- a/examples/flakes/remote/devbox.json
+++ b/examples/flakes/remote/devbox.json
@@ -1,7 +1,6 @@
 {
   "packages": [
     "github:nixos/nixpkgs/5233fd2ba76a3accb5aaa999c00509a11fd0793c#hello",
-    "github:nix-community/fenix#stable.toolchain",
     "github:F1bonacc1/process-compose"
   ],
   "shell": {


### PR DESCRIPTION
## Summary

We should avoid torturing our users who may happen to run this example. The 
fenix flake downloads a ton of nix packages and takes a very long time to be
ready.

## How was it tested?

did `devbox shell`
