### PR TITLE
[vscode-extension] Adding missing commands to devbox vscode extension - v0.1.1

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the "devbox" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.1.1]
+
+- Fixed documentation
+- Added devbox install command
+- Added devbox update command
+
 ## [0.1.0]
 
 - Added reopen in devbox shell environment feature that allows projects with devbox.json

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -9,6 +9,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Fixed documentation
 - Added devbox install command
 - Added devbox update command
+- Added devbox search command
 
 ## [0.1.0]
 

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -35,6 +35,7 @@ NOTE: Requires devbox CLI v0.5.5 and above
 - **Run:** Runs a script from devbox.json if specified
 - **Install** Install packages specified in devbox.json
 - **Update** Update packages specified in devbox.json
+- **Search** Search for packages to add to your devbox project
 - **Generate DevContainer files:** Generates devcontainer.json & Dockerfile inside .devcontainers directory. This allows for running vscode in a container or GitHub Codespaces.
 - **Generate a Dockerfile from devbox.json:** Generates a Dockerfile a project's root directory. This allows for running the devbox project in a container.
 - **Reopen in Devbox shell environment:** Allows projects with devbox.json

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -8,9 +8,6 @@ This is the official VSCode extension for [devbox](https://github.com/jetpack-io
 
 If a Devbox Cloud instance (from [devbox.sh](https://devbox.sh)) has an `Open In Desktop` button, this extension will make VSCode to be able to connect its workspace to the instance.
 
-NOTE: Requires devbox CLI v0.5.5 and above
-  installed and in PATH. This feature is in beta. Please report any bugs/issues in [Github](https://github.com/jetpack-io/devbox) or our [Discord](https://discord.gg/Rr5KPJq7).
-
 ### Auto Shell on a devbox project
 
 When VSCode Terminal is opened on a devbox project, this extension detects `devbox.json` and runs `devbox shell` so terminal is automatically in devbox shell environment. Can be turned off in settings.
@@ -24,6 +21,9 @@ If the opened workspace in VSCode has a devbox.json file, from command palette, 
 3. Interact with Devbox CLI to setup a devbox shell.
 4. Close current VSCode window and reopen it in a devbox shell environment as if VSCode was opened from a devbox shell terminal.
 
+NOTE: Requires devbox CLI v0.5.5 and above
+  installed and in PATH. This feature is in beta. Please report any bugs/issues in [Github](https://github.com/jetpack-io/devbox) or our [Discord](https://discord.gg/Rr5KPJq7).
+
 ### Run devbox commands from command palette
 
 `cmd/ctrl + shift + p` opens vscode's command palette. Typing devbox filters all available commands devbox extension can run. Those commands are:
@@ -33,6 +33,8 @@ If the opened workspace in VSCode has a devbox.json file, from command palette, 
 - **Remove:** Removes a package from devbox.json
 - **Shell:** Opens a terminal and runs devbox shell
 - **Run:** Runs a script from devbox.json if specified
+- **Install** Install packages specified in devbox.json
+- **Update** Update packages specified in devbox.json
 - **Generate DevContainer files:** Generates devcontainer.json & Dockerfile inside .devcontainers directory. This allows for running vscode in a container or GitHub Codespaces.
 - **Generate a Dockerfile from devbox.json:** Generates a Dockerfile a project's root directory. This allows for running the devbox project in a container.
 - **Reopen in Devbox shell environment:** Allows projects with devbox.json

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -43,6 +43,10 @@
         "title": "Devbox: Update - Update packages in your devbox project"
       },
       {
+        "command": "devbox.search",
+        "title": "Devbox: Search - Search for packages for your devbox project"
+      },
+      {
         "command": "devbox.generateDockerfile",
         "title": "Devbox: Generate a Dockerfile from devbox.json"
       },
@@ -83,6 +87,10 @@
         },
         {
           "command": "devbox.update",
+          "when": "devbox.configFileExists == true"
+        },
+        {
+          "command": "devbox.search",
           "when": "devbox.configFileExists == true"
         },
         {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -35,6 +35,14 @@
         "title": "Devbox: Reopen in Devbox shell environment"
       },
       {
+        "command": "devbox.install",
+        "title": "Devbox: Install - Install packages in your devbox project"
+      },
+      {
+        "command": "devbox.update",
+        "title": "Devbox: Update - Update packages in your devbox project"
+      },
+      {
         "command": "devbox.generateDockerfile",
         "title": "Devbox: Generate a Dockerfile from devbox.json"
       },
@@ -66,7 +74,16 @@
           "when": "devbox.configFileExists == true"
         },
         {
-          "command": "devbox.reopen"
+          "command": "devbox.reopen",
+          "when": "devbox.configFileExists == true"
+        },
+        {
+          "command": "devbox.install",
+          "when": "devbox.configFileExists == true"
+        },
+        {
+          "command": "devbox.update",
+          "when": "devbox.configFileExists == true"
         },
         {
           "command": "devbox.add",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "devbox",
   "displayName": "devbox by jetpack.io",
   "description": "devbox integration for VSCode",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "icon": "assets/icon.png",
   "repository": {
     "type": "git",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -85,6 +85,11 @@ export function activate(context: ExtensionContext) {
 		await runInTerminal('devbox update', true);
 	});
 
+	const devboxSearch = commands.registerCommand('devbox.search', async () => {
+		const result = await window.showInputBox({ placeHolder: "Name or a subset of a name of a package to search" });
+		await runInTerminal(`devbox search ${result}`, true);
+	});
+
 	const setupDevcontainer = commands.registerCommand('devbox.setupDevContainer', async () => {
 		await runInTerminal('devbox generate devcontainer', true);
 	});
@@ -102,6 +107,7 @@ export function activate(context: ExtensionContext) {
 	context.subscriptions.push(devboxRun);
 	context.subscriptions.push(devboxInit);
 	context.subscriptions.push(devboxInstall);
+	context.subscriptions.push(devboxSearch);
 	context.subscriptions.push(devboxUpdate);
 	context.subscriptions.push(devboxRemove);
 	context.subscriptions.push(devboxShell);

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -77,9 +77,18 @@ export function activate(context: ExtensionContext) {
 		commands.executeCommand('setContext', 'devbox.configFileExists', true);
 	});
 
+	const devboxInstall = commands.registerCommand('devbox.install', async () => {
+		await runInTerminal('devbox install', true);
+	});
+
+	const devboxUpdate = commands.registerCommand('devbox.update', async () => {
+		await runInTerminal('devbox update', true);
+	});
+
 	const setupDevcontainer = commands.registerCommand('devbox.setupDevContainer', async () => {
 		await runInTerminal('devbox generate devcontainer', true);
 	});
+
 	const generateDockerfile = commands.registerCommand('devbox.generateDockerfile', async () => {
 		await runInTerminal('devbox generate dockerfile', true);
 	});
@@ -92,6 +101,8 @@ export function activate(context: ExtensionContext) {
 	context.subscriptions.push(devboxAdd);
 	context.subscriptions.push(devboxRun);
 	context.subscriptions.push(devboxInit);
+	context.subscriptions.push(devboxInstall);
+	context.subscriptions.push(devboxUpdate);
 	context.subscriptions.push(devboxRemove);
 	context.subscriptions.push(devboxShell);
 	context.subscriptions.push(setupDevcontainer);


### PR DESCRIPTION
## Summary
- Fixed small issue in readme from last release
- added missing commands from CLI to vscode extension's command palette (install, update, search)

Q: should I add more devbox commands? e.g., global, info, version, auth, etc.

## How was it tested?
- vsce package
- code --install <generated-devbox>.vsix
- open a project with devbox.json
- cmd+shift+p and type devbox
- confirm install, update and search exists in the list of available commands and try them.