### PR TITLE
Mysql Plugin v1

### DIFF
--- a/examples/databases/mysql/devbox.json
+++ b/examples/databases/mysql/devbox.json
@@ -1,0 +1,15 @@
+{
+  "packages": [
+    "mysql80@latest"
+  ],
+  "shell": {
+    "init_hook": [
+      "echo 'Welcome to devbox!' > /dev/null"
+    ],
+    "scripts": {
+      "test": [
+        "echo \"Error: no test specified\" && exit 1"
+      ]
+    }
+  }
+}

--- a/examples/databases/mysql/devbox.lock
+++ b/examples/databases/mysql/devbox.lock
@@ -1,0 +1,11 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "mysql80@latest": {
+      "last_modified": "2023-05-01T16:53:22Z",
+      "plugin_version": "0.0.2",
+      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#mysql80",
+      "version": "8.0.33"
+    }
+  }
+}

--- a/plugins/mysql.json
+++ b/plugins/mysql.json
@@ -1,6 +1,6 @@
 {
     "name": "mysql",
-    "version": "0.0.2",
+    "version": "0.0.1",
     "match": "^mysql?[0-9]*$",
     "readme": "* This plugin wraps mysqld and mysql_install_db to work in your local project\n* This plugin will create a new database for your project in MYSQL_DATADIR if one doesn't exist on shell init. This DB will be started in `insecure` mode, so be sure to add a root password after creation if needed.\n* Use mysqld to manually start the server, and `mysqladmin -u root shutdown` to manually stop it",
     "env": {

--- a/plugins/mysql.json
+++ b/plugins/mysql.json
@@ -1,0 +1,27 @@
+{
+    "name": "mysql",
+    "version": "0.0.2",
+    "match": "^mysql?[0-9]*$",
+    "readme": "* This plugin wraps mysqld and mysql_install_db to work in your local project\n* This plugin will create a new database for your project in MYSQL_DATADIR if one doesn't exist on shell init. This DB will be started in `insecure` mode, so be sure to add a root password after creation if needed.\n* Use mysqld to manually start the server, and `mysqladmin -u root shutdown` to manually stop it",
+    "env": {
+      "MYSQL_BASEDIR": "{{ .DevboxProfileDefault }}",
+      "MYSQL_HOME": "{{ .Virtenv }}/run",
+      "MYSQL_DATADIR": "{{ .Virtenv }}/data",
+      "MYSQL_UNIX_PORT": "{{ .Virtenv }}/run/mysql.sock",
+      "MYSQL_PID_FILE": "{{ .Virtenv }}/run/mysql.pid"
+    },
+    "create_files": {
+      "{{ .Virtenv }}/run": "",
+      "{{ .Virtenv }}/flake.nix": "mysql/flake.nix",
+      "{{ .Virtenv }}/setup_db.sh": "mysql/setup_db.sh",
+      "{{ .Virtenv }}/process-compose.yaml": "mysql/process-compose.yaml"
+    },
+    "packages": [
+      "path:{{ .Virtenv }}"
+    ],
+    "shell": {
+      "init_hook": [
+        "bash {{ .Virtenv }}/setup_db.sh"
+      ]
+    }
+  }

--- a/plugins/mysql/flake.nix
+++ b/plugins/mysql/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "A flake that outputs MySQL with custom configuration and aliases to work in Devbox";
+
+  inputs = {
+    nixpkgs.url = "{{.URLForInput}}";
+  };
+
+  outputs = {self, nixpkgs}:
+    let
+      mysql-bin =  nixpkgs.legacyPackages.{{.System}}.symlinkJoin {
+
+        name = "mysql-wrapped";
+        paths = [nixpkgs.legacyPackages.{{ .System }}.{{.PackageAttributePath}}];
+        nativeBuildInputs = [ nixpkgs.legacyPackages.{{.System}}.makeWrapper];
+        postBuild = ''
+
+          wrapProgram $out/bin/mysqld \
+            --add-flags '--datadir=''$MYSQL_DATADIR --pid-file=''$MYSQL_PID_FILE --socket=''$MYSQL_UNIX_PORT';
+
+          wrapProgram $out/bin/mysqld_safe \
+            --add-flags '--datadir=''$MYSQL_DATADIR --pid-file=''$MYSQL_PID_FILE --socket=''$MYSQL_UNIX_PORT';
+        '';
+      };
+    in{
+      packages.{{.System}} = {
+        default = mysql-bin;
+      };
+    };
+}

--- a/plugins/mysql/process-compose.yaml
+++ b/plugins/mysql/process-compose.yaml
@@ -1,0 +1,17 @@
+version: "0.5"
+
+processes:
+  mysql:
+    command: "mysqld 2> $MYSQL_HOME/mysql.log & MYSQL_PID=$! && echo 'Starting mysqld... check mariadb_logs for details'"
+    is_daemon: true
+    shutdown:
+      command: "mysqladmin -u root shutdown"
+    availability:
+      restart: "always"
+    depends_on:
+      mysql_logs:
+        condition: "process_started"
+  mysql_logs:
+    command: "tail -f $MYSQL_HOME/mysql.log"
+    availability:
+      restart: "always"

--- a/plugins/mysql/setup_db.sh
+++ b/plugins/mysql/setup_db.sh
@@ -1,0 +1,7 @@
+#! bash
+
+if [ ! -d "$MYSQL_DATADIR" ]; then
+# Install the Database
+   mkdir $MYSQL_DATADIR
+   mysqld --initialize-insecure
+fi


### PR DESCRIPTION
## Summary

Adds a plugin for MySQL DB. Implementation is very similar to MariaDB plugin, except: 

1. init_hook is changed to use `mysqld --initialize-insecure`
2. removed unnecessary symlink wrappers from flake.nix
3. renamed services

## How was it tested?

`devbox shell` using the example in this PR, then: 
* `devbox services up` -- should show mysql + mysql_logs 
* `devbox run mysql` -- should give you a mysql console