### PR TITLE
telemetry: report segment events asynchronously

### DIFF
--- a/internal/boxcli/log.go
+++ b/internal/boxcli/log.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
-	"go.jetpack.io/devbox/internal/envir"
 	"go.jetpack.io/devbox/internal/telemetry"
 )
 
@@ -34,14 +33,14 @@ func doLogCommand(cmd *cobra.Command, args []string) error {
 			return usererr.New("expected a start-time argument for logging the shell-ready event")
 		}
 		telemetry.Event(telemetry.EventShellReady, telemetry.Metadata{
-			CommandStart: envir.ParseShellStart(args[1]),
+			CommandStart: telemetry.ParseShellStart(args[1]),
 		})
 	case "shell-interactive":
 		if len(args) < 2 {
 			return usererr.New("expected a start-time argument for logging the shell-interactive event")
 		}
 		telemetry.Event(telemetry.EventShellInteractive, telemetry.Metadata{
-			CommandStart: envir.ParseShellStart(args[1]),
+			CommandStart: telemetry.ParseShellStart(args[1]),
 		})
 	}
 	return usererr.New("unrecognized event-name %s for command: %s", args[0], cmd.CommandPath())

--- a/internal/boxcli/log.go
+++ b/internal/boxcli/log.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
+	"go.jetpack.io/devbox/internal/envir"
 	"go.jetpack.io/devbox/internal/telemetry"
 )
 
@@ -27,11 +28,21 @@ func doLogCommand(cmd *cobra.Command, args []string) error {
 		return usererr.New("expect an <event-name> arg for command: %s", cmd.CommandPath())
 	}
 
-	if args[0] == "shell-ready" || args[0] == "shell-interactive" {
+	switch eventName := args[0]; eventName {
+	case "shell-ready":
 		if len(args) < 2 {
 			return usererr.New("expected a start-time argument for logging the shell-ready event")
 		}
-		return telemetry.LogShellDurationEvent(args[0] /*event name*/, args[1] /*startTime*/)
+		telemetry.Event(telemetry.EventShellReady, telemetry.Metadata{
+			CommandStart: envir.ParseShellStart(args[1]),
+		})
+	case "shell-interactive":
+		if len(args) < 2 {
+			return usererr.New("expected a start-time argument for logging the shell-interactive event")
+		}
+		telemetry.Event(telemetry.EventShellInteractive, telemetry.Metadata{
+			CommandStart: envir.ParseShellStart(args[1]),
+		})
 	}
 	return usererr.New("unrecognized event-name %s for command: %s", args[0], cmd.CommandPath())
 }

--- a/internal/boxcli/midcobra/telemetry.go
+++ b/internal/boxcli/midcobra/telemetry.go
@@ -4,20 +4,15 @@
 package midcobra
 
 import (
-	"fmt"
 	"os"
 	"runtime/trace"
 	"sort"
-	"strings"
-	"time"
 
-	segment "github.com/segmentio/analytics-go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"go.jetpack.io/devbox"
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
-	"go.jetpack.io/devbox/internal/build"
 	"go.jetpack.io/devbox/internal/envir"
 	"go.jetpack.io/devbox/internal/impl/devopt"
 	"go.jetpack.io/devbox/internal/telemetry"
@@ -33,24 +28,13 @@ func Telemetry() Middleware {
 	return &telemetryMiddleware{}
 }
 
-type telemetryMiddleware struct {
-	// Used during execution:
-	startTime time.Time
-}
+type telemetryMiddleware struct{}
 
 // telemetryMiddleware implements interface Middleware (compile-time check)
 var _ Middleware = (*telemetryMiddleware)(nil)
 
 func (m *telemetryMiddleware) preRun(cmd *cobra.Command, args []string) {
-	m.startTime = telemetry.CommandStartTime()
-
-	telemetry.Start(telemetry.AppDevbox)
-	ctx := cmd.Context()
-	defer trace.StartRegion(ctx, "telemetryPreRun").End()
-	if !telemetry.Enabled() {
-		trace.Log(ctx, "telemetry", "telemetry is disabled")
-		return
-	}
+	telemetry.Start()
 }
 
 func (m *telemetryMiddleware) postRun(cmd *cobra.Command, args []string, runErr error) {
@@ -74,127 +58,12 @@ func (m *telemetryMiddleware) postRun(cmd *cobra.Command, args []string, runErr 
 	meta.InShell = envir.IsDevboxShellEnabled()
 	meta.InBrowser = envir.IsInBrowser()
 	meta.InCloud = envir.IsDevboxCloud()
-	telemetry.Error(runErr, meta)
 
-	if !telemetry.Enabled() {
+	if runErr != nil {
+		telemetry.Error(runErr, meta)
 		return
 	}
-	evt := m.newEventIfValid(cmd, args, runErr)
-	if evt == nil {
-		return
-	}
-	m.trackEvent(evt) // Segment
-}
-
-// Consider renaming this to commandEvent
-// since it has info about the specific command run.
-type event struct {
-	telemetry.Event
-	Command       string
-	CommandArgs   []string
-	CommandError  error
-	CommandHidden bool
-	Failed        bool
-	Packages      []string
-	CommitHash    string // the nikpkgs commit hash in devbox.json
-	InDevboxShell bool
-	DevboxEnv     map[string]any // Devbox-specific environment variables
-	SentryEventID string
-	Shell         string
-}
-
-// newEventIfValid creates a new telemetry event, but returns nil if we cannot construct
-// a valid event.
-func (m *telemetryMiddleware) newEventIfValid(cmd *cobra.Command, args []string, runErr error) *event {
-	subcmd, flags, parseErr := getSubcommand(cmd, args)
-	if parseErr != nil {
-		// Ignore invalid commands
-		return nil
-	}
-
-	pkgs, hash := getPackagesAndCommitHash(cmd)
-
-	// an empty userID means that we do not have a github username saved
-	userID := telemetry.UserIDFromGithubUsername()
-
-	devboxEnv := map[string]interface{}{}
-	for _, e := range os.Environ() {
-		if strings.HasPrefix(e, "DEVBOX") && strings.Contains(e, "=") {
-			key := strings.Split(e, "=")[0]
-			devboxEnv[key] = os.Getenv(key)
-		}
-	}
-
-	return &event{
-		Event: telemetry.Event{
-			AnonymousID: telemetry.DeviceID,
-			AppName:     telemetry.AppDevbox,
-			AppVersion:  build.Version,
-			CloudRegion: os.Getenv(envir.DevboxRegion),
-			Duration:    time.Since(m.startTime),
-			OsName:      build.OS(),
-			UserID:      userID,
-		},
-		Command:      subcmd.CommandPath(),
-		CommandArgs:  flags,
-		CommandError: runErr,
-		// The command is hidden if either the top-level command is hidden or
-		// the specific sub-command that was executed is hidden.
-		CommandHidden: cmd.Hidden || subcmd.Hidden,
-		Failed:        runErr != nil,
-		Packages:      pkgs,
-		CommitHash:    hash,
-		InDevboxShell: envir.IsDevboxShellEnabled(),
-		DevboxEnv:     devboxEnv,
-		Shell:         os.Getenv(envir.Shell),
-	}
-}
-
-func (m *telemetryMiddleware) trackEvent(evt *event) {
-	if evt == nil || evt.CommandHidden {
-		return
-	}
-
-	if evt.CommandError != nil {
-		evt.SentryEventID = telemetry.ExecutionID
-	}
-	segmentClient := telemetry.NewSegmentClient(build.TelemetryKey)
-	defer func() {
-		_ = segmentClient.Close()
-	}()
-
-	// deliberately ignore error
-	_ = segmentClient.Enqueue(segment.Identify{
-		AnonymousId: evt.AnonymousID,
-		UserId:      evt.UserID,
-	})
-
-	_ = segmentClient.Enqueue(segment.Track{ // Ignore errors, telemetry is best effort
-		AnonymousId: evt.AnonymousID, // Use device id instead
-		Event:       fmt.Sprintf("[%s] Command: %s", evt.AppName, evt.Command),
-		Context: &segment.Context{
-			Device: segment.DeviceInfo{
-				Id: evt.AnonymousID,
-			},
-			App: segment.AppInfo{
-				Name:    evt.AppName,
-				Version: evt.AppVersion,
-			},
-			OS: segment.OSInfo{
-				Name: evt.OsName,
-			},
-		},
-		Properties: segment.NewProperties().
-			Set("cloud_region", evt.CloudRegion).
-			Set("command", evt.Command).
-			Set("command_args", evt.CommandArgs).
-			Set("failed", evt.Failed).
-			Set("duration", evt.Duration.Milliseconds()).
-			Set("packages", evt.Packages).
-			Set("sentry_event_id", evt.SentryEventID).
-			Set("shell", evt.Shell),
-		UserId: evt.UserID,
-	})
+	telemetry.Event(telemetry.EventCommandSuccess, meta)
 }
 
 func getSubcommand(cmd *cobra.Command, args []string) (subcmd *cobra.Command, flags []string, err error) {

--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -110,7 +111,13 @@ func Main() {
 		os.Exit(sshshim.Execute(ctx, os.Args))
 	}
 
-	if len(os.Args) > 1 && os.Args[1] == "bug" {
+	if len(os.Args) > 1 && os.Args[1] == "upload-telemetry" {
+		// This subcommand is hidden and only run by devbox itself as a
+		// child process. We need to really make sure that we always
+		// exit and don't leave orphaned processes laying around.
+		time.AfterFunc(5*time.Second, func() {
+			os.Exit(0)
+		})
 		telemetry.Upload()
 		return
 	}

--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -111,7 +111,7 @@ func Main() {
 	}
 
 	if len(os.Args) > 1 && os.Args[1] == "bug" {
-		telemetry.ReportErrors()
+		telemetry.Upload()
 		return
 	}
 

--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -28,7 +28,6 @@ import (
 	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/envir"
 	"go.jetpack.io/devbox/internal/services"
-	"go.jetpack.io/devbox/internal/telemetry"
 	"go.jetpack.io/devbox/internal/ux/stepper"
 )
 
@@ -445,7 +444,7 @@ func shell(username, hostname, projectDir string, shellStartTime time.Time) erro
 	cmd := &openssh.Cmd{
 		DestinationAddr: hostname,
 		PathInVM:        absoluteProjectPathInVM(username, projectPath),
-		ShellStartTime:  telemetry.UnixTimestampFromTime(shellStartTime),
+		ShellStartTime:  envir.FormatShellStart(shellStartTime),
 		Username:        username,
 	}
 	sessionErrors := newSSHSessionErrors()

--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -28,6 +28,7 @@ import (
 	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/envir"
 	"go.jetpack.io/devbox/internal/services"
+	"go.jetpack.io/devbox/internal/telemetry"
 	"go.jetpack.io/devbox/internal/ux/stepper"
 )
 
@@ -444,7 +445,7 @@ func shell(username, hostname, projectDir string, shellStartTime time.Time) erro
 	cmd := &openssh.Cmd{
 		DestinationAddr: hostname,
 		PathInVM:        absoluteProjectPathInVM(username, projectPath),
-		ShellStartTime:  envir.FormatShellStart(shellStartTime),
+		ShellStartTime:  telemetry.FormatShellStart(shellStartTime),
 		Username:        username,
 	}
 	sessionErrors := newSSHSessionErrors()

--- a/internal/cloud/openssh/sshshim/command.go
+++ b/internal/cloud/openssh/sshshim/command.go
@@ -14,7 +14,7 @@ import (
 
 func Execute(ctx context.Context, args []string) int {
 	defer debug.Recover()
-	telemetry.Start(telemetry.AppSSHShim)
+	telemetry.Start()
 	defer telemetry.Stop()
 
 	if err := execute(ctx, args); err != nil {

--- a/internal/envir/env.go
+++ b/internal/envir/env.go
@@ -5,7 +5,6 @@ package envir
 
 const (
 	DevboxCache         = "DEVBOX_CACHE"
-	devboxCLICloudShell = "DEVBOX_CLI_CLOUD_SHELL"
 	DevboxDebug         = "DEVBOX_DEBUG"
 	DevboxFeaturePrefix = "DEVBOX_FEATURE_"
 	DevboxGateway       = "DEVBOX_GATEWAY"
@@ -21,7 +20,8 @@ const (
 	LauncherVersion = "LAUNCHER_VERSION"
 	LauncherPath    = "LAUNCHER_PATH"
 
-	SSHTTY = "SSH_TTY"
+	GitHubUsername = "GITHUB_USER_NAME"
+	SSHTTY         = "SSH_TTY"
 
 	XDGDataHome   = "XDG_DATA_HOME"
 	XDGConfigHome = "XDG_CONFIG_HOME"

--- a/internal/envir/util.go
+++ b/internal/envir/util.go
@@ -6,7 +6,6 @@ package envir
 import (
 	"os"
 	"strconv"
-	"time"
 )
 
 func IsDevboxCloud() bool {
@@ -37,28 +36,6 @@ func IsInBrowser() bool { // TODO: a better name
 func IsCI() bool {
 	ci, err := strconv.ParseBool(os.Getenv("CI"))
 	return ci && err == nil
-}
-
-func ShellStart() time.Time {
-	return ParseShellStart(os.Getenv(DevboxShellStartTime))
-}
-
-func FormatShellStart(t time.Time) string {
-	if t.IsZero() {
-		return ""
-	}
-	return strconv.FormatInt(t.Unix(), 10)
-}
-
-func ParseShellStart(s string) time.Time {
-	if s == "" {
-		return time.Time{}
-	}
-	unix, err := strconv.ParseInt(s, 10, 64)
-	if err != nil {
-		return time.Time{}
-	}
-	return time.Unix(unix, 0)
 }
 
 // GetValueOrDefault gets the value of an environment variable.

--- a/internal/envir/util.go
+++ b/internal/envir/util.go
@@ -6,12 +6,8 @@ package envir
 import (
 	"os"
 	"strconv"
+	"time"
 )
-
-func IsCLICloudShell() bool { // TODO: not used any more
-	cliCloudShell, _ := strconv.ParseBool(os.Getenv(devboxCLICloudShell))
-	return cliCloudShell
-}
 
 func IsDevboxCloud() bool {
 	return os.Getenv(DevboxRegion) != ""
@@ -41,6 +37,28 @@ func IsInBrowser() bool { // TODO: a better name
 func IsCI() bool {
 	ci, err := strconv.ParseBool(os.Getenv("CI"))
 	return ci && err == nil
+}
+
+func ShellStart() time.Time {
+	return ParseShellStart(os.Getenv(DevboxShellStartTime))
+}
+
+func FormatShellStart(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return strconv.FormatInt(t.Unix(), 10)
+}
+
+func ParseShellStart(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	unix, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	return time.Unix(unix, 0)
 }
 
 // GetValueOrDefault gets the value of an environment variable.

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -22,6 +22,7 @@ import (
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/impl/generate"
 	"go.jetpack.io/devbox/internal/shellgen"
+	"go.jetpack.io/devbox/internal/telemetry"
 	"golang.org/x/exp/slices"
 
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
@@ -190,7 +191,7 @@ func (d *Devbox) Shell(ctx context.Context) error {
 		WithHistoryFile(filepath.Join(d.projectDir, shellHistoryFile)),
 		WithProjectDir(d.projectDir),
 		WithEnvVariables(envs),
-		WithShellStartTime(envir.ShellStart()),
+		WithShellStartTime(telemetry.ShellStart()),
 	}
 
 	shell, err := NewDevboxShell(d, opts...)

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -39,7 +39,6 @@ import (
 	"go.jetpack.io/devbox/internal/redact"
 	"go.jetpack.io/devbox/internal/searcher"
 	"go.jetpack.io/devbox/internal/services"
-	"go.jetpack.io/devbox/internal/telemetry"
 	"go.jetpack.io/devbox/internal/ux"
 	"go.jetpack.io/devbox/internal/wrapnix"
 )
@@ -185,18 +184,13 @@ func (d *Devbox) Shell(ctx context.Context) error {
 		return err
 	}
 
-	shellStartTime := envir.GetValueOrDefault(
-		envir.DevboxShellStartTime,
-		telemetry.UnixTimestampFromTime(telemetry.CommandStartTime()),
-	)
-
 	opts := []ShellOption{
 		WithHooksFilePath(shellgen.ScriptPath(d.ProjectDir(), shellgen.HooksFilename)),
 		WithProfile(profileDir),
 		WithHistoryFile(filepath.Join(d.projectDir, shellHistoryFile)),
 		WithProjectDir(d.projectDir),
 		WithEnvVariables(envs),
-		WithShellStartTime(shellStartTime),
+		WithShellStartTime(envir.ShellStart()),
 	}
 
 	shell, err := NewDevboxShell(d, opts...)
@@ -985,7 +979,6 @@ func (d *Devbox) checkOldEnvrc() error {
 					"Run `devbox generate direnv --force` to update it.\n"+
 					"Or silence this warning by setting DEVBOX_NO_ENVRC_UPDATE=1 env variable.\n",
 			)
-
 		}
 	}
 	return nil
@@ -1058,7 +1051,6 @@ func (d *Devbox) setCommonHelperEnvVars(env map[string]string) {
 // buildInputs
 func (d *Devbox) NixBins(ctx context.Context) ([]string, error) {
 	env, err := d.nixEnv(ctx)
-
 	if err != nil {
 		return nil, err
 	}
@@ -1132,7 +1124,6 @@ func (d *Devbox) parseEnvAndExcludeSpecialCases(currentEnv []string) (map[string
 
 // ExportifySystemPathWithoutWrappers is a small utility to filter WrapperBin paths from PATH
 func ExportifySystemPathWithoutWrappers() string {
-
 	path := []string{}
 	for _, p := range strings.Split(os.Getenv("PATH"), string(filepath.ListSeparator)) {
 		// Intentionally do not include projectDir with plugin.WrapperBinPath so that

--- a/internal/impl/shell.go
+++ b/internal/impl/shell.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/alessio/shellescape"
 	"github.com/pkg/errors"
@@ -65,7 +66,7 @@ type DevboxShell struct {
 	historyFile string
 
 	// shellStartTime is the unix timestamp for when the command was invoked
-	shellStartTime string
+	shellStartTime time.Time
 }
 
 type ShellOption func(*DevboxShell)
@@ -197,9 +198,9 @@ func WithProjectDir(projectDir string) ShellOption {
 	}
 }
 
-func WithShellStartTime(time string) ShellOption {
+func WithShellStartTime(t time.Time) ShellOption {
 	return func(s *DevboxShell) {
-		s.shellStartTime = time
+		s.shellStartTime = t
 	}
 }
 
@@ -331,7 +332,7 @@ func (s *DevboxShell) writeDevboxShellrc() (path string, err error) {
 		OriginalInitPath:  s.userShellrcPath,
 		HooksFilePath:     s.hooksFilePath,
 		ShellName:         string(s.name),
-		ShellStartTime:    s.shellStartTime,
+		ShellStartTime:    envir.FormatShellStart(s.shellStartTime),
 		HistoryFile:       strings.TrimSpace(s.historyFile),
 		ExportEnv:         exportify(s.env),
 		PromptHookEnabled: featureflag.PromptHook.Enabled(),

--- a/internal/impl/shell.go
+++ b/internal/impl/shell.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/shenv"
+	"go.jetpack.io/devbox/internal/telemetry"
 
 	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/envir"
@@ -332,7 +333,7 @@ func (s *DevboxShell) writeDevboxShellrc() (path string, err error) {
 		OriginalInitPath:  s.userShellrcPath,
 		HooksFilePath:     s.hooksFilePath,
 		ShellName:         string(s.name),
-		ShellStartTime:    envir.FormatShellStart(s.shellStartTime),
+		ShellStartTime:    telemetry.FormatShellStart(s.shellStartTime),
 		HistoryFile:       strings.TrimSpace(s.historyFile),
 		ExportEnv:         exportify(s.env),
 		PromptHookEnabled: featureflag.PromptHook.Enabled(),

--- a/internal/telemetry/segment.go
+++ b/internal/telemetry/segment.go
@@ -4,35 +4,73 @@
 package telemetry
 
 import (
-	"fmt"
 	"io"
 	"log"
 	"os"
-	"strconv"
-	"strings"
+	"path/filepath"
 	"time"
 
-	"github.com/google/uuid"
-	"github.com/pkg/errors"
 	segment "github.com/segmentio/analytics-go"
 
 	"go.jetpack.io/devbox/internal/build"
-	"go.jetpack.io/devbox/internal/cloud/openssh"
 	"go.jetpack.io/devbox/internal/envir"
 )
 
-// cmdStartTime records the time at the start of any devbox command invocation.
-var cmdStartTime time.Time
+var segmentClient segment.Client
 
-// Event contains common fields used in our segment events
-type Event struct {
-	AnonymousID string
-	AppName     string
-	AppVersion  string
-	Duration    time.Duration
-	CloudRegion string
-	OsName      string
-	UserID      string
+func initSegmentClient() bool {
+	if build.TelemetryKey == "" {
+		return false
+	}
+
+	var err error
+	segmentClient, err = segment.NewWithConfig(build.TelemetryKey, segment.Config{
+		Logger:  segment.StdLogger(log.New(io.Discard, "", 0)),
+		Verbose: false,
+	})
+	return err == nil
+}
+
+func newTrackMessage(name string, meta Metadata) *segment.Track {
+	dur := time.Since(procStartTime)
+	if !meta.CommandStart.IsZero() {
+		dur = time.Since(meta.CommandStart)
+	}
+	return &segment.Track{
+		MessageId:   newEventID(),
+		Type:        "track",
+		AnonymousId: deviceID,
+		UserId:      userID,
+		Timestamp:   time.Now(),
+		Event:       name,
+		Context: &segment.Context{
+			Device: segment.DeviceInfo{
+				Id: deviceID,
+			},
+			App: segment.AppInfo{
+				Name:    appName,
+				Version: build.Version,
+			},
+			OS: segment.OSInfo{
+				Name: build.OS(),
+			},
+		},
+		Properties: segment.Properties{
+			"cloud_region": meta.CloudRegion,
+			"command":      meta.Command,
+			"command_args": meta.CommandFlags,
+			"duration":     dur.Milliseconds(),
+			"packages":     meta.Packages,
+			"shell":        os.Getenv(envir.Shell),
+			"shell_access": shellAccess(),
+		},
+	}
+}
+
+// bufferSegmentMessage buffers a Segment message to disk so that Report can
+// upload it later.
+func bufferSegmentMessage(id string, msg segment.Message) {
+	bufferEvent(filepath.Join(segmentBufferDir, id+".json"), msg)
 }
 
 type shellAccessKind string
@@ -42,118 +80,6 @@ const (
 	ssh     shellAccessKind = "ssh"
 	browser shellAccessKind = "browser"
 )
-
-// NewSegmentClient returns a client object to use for segment logging.
-// Callers are responsible for calling client.Close().
-func NewSegmentClient(telemetryKey string) segment.Client {
-	segmentClient, _ := segment.NewWithConfig(telemetryKey, segment.Config{
-		BatchSize: 1, /* no batching */
-		// Discard logs:
-		Logger:  segment.StdLogger(log.New(io.Discard, "" /* prefix */, 0)),
-		Verbose: false,
-	})
-
-	return segmentClient
-}
-
-// CommandStartTime records and returns the time at the start of the command invocation.
-// It must be called initially at the start of the cobra (or other framework) command
-// stack. Subsequent calls returns the time from the first invocation of this function.
-func CommandStartTime() time.Time {
-	if cmdStartTime.IsZero() {
-		cmdStartTime = time.Now()
-	}
-	return cmdStartTime
-}
-
-// LogShellDurationEvent logs the duration from start of the command
-// till the shell was ready to be interactive.
-func LogShellDurationEvent(eventName string, startTime string) error {
-	if !Enabled() {
-		return nil
-	}
-
-	start, err := timeFromUnixTimestamp(startTime)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	evt := Event{
-		AnonymousID: DeviceID,
-		AppName:     AppDevbox,
-		AppVersion:  build.Version,
-		CloudRegion: os.Getenv(envir.DevboxRegion),
-		Duration:    time.Since(start),
-		OsName:      build.OS(),
-		UserID:      UserIDFromGithubUsername(),
-	}
-
-	segmentClient := NewSegmentClient(build.TelemetryKey)
-	defer func() {
-		_ = segmentClient.Close()
-	}()
-
-	// Ignore errors, telemetry is best effort
-	_ = segmentClient.Enqueue(segment.Track{
-		AnonymousId: evt.AnonymousID,
-		// Event name. We trim the prefix from shell-interactive/shell-ready to avoid redundancy.
-		Event: fmt.Sprintf("[%s] Shell Event: %s", evt.AppName, strings.TrimPrefix(eventName, "shell-")),
-		Context: &segment.Context{
-			Device: segment.DeviceInfo{
-				Id: evt.AnonymousID,
-			},
-			App: segment.AppInfo{
-				Name:    evt.AppName,
-				Version: evt.AppVersion,
-			},
-			OS: segment.OSInfo{
-				Name: evt.OsName,
-			},
-		},
-		Properties: segment.NewProperties().
-			Set("shell_access", shellAccess()).
-			Set("duration", evt.Duration.Milliseconds()),
-		UserId: evt.UserID,
-	})
-	return nil
-}
-
-// UserIDFromGithubUsername returns a uuid string if the user has authenticated with github.
-// If not authenticated, or there's an error, then an empty string is returned, which segment
-// would treat as logged-out or anonymous user.
-func UserIDFromGithubUsername() string {
-	username, err := openssh.GithubUsernameFromLocalFile()
-	if err != nil || username == "" {
-		return ""
-	}
-
-	const salt = "d6134cd5-347d-4b7c-a2d0-295c0f677948"
-	const githubPrefix = "github:"
-
-	// We use a version 5 uuid.
-	// A good comparison of types of uuids is at: https://www.uuidtools.com/uuid-versions-explained
-	return uuid.NewSHA1(uuid.MustParse(salt), []byte(githubPrefix+username)).String()
-}
-
-// timeFromUnixTimestamp is a helper utility that converts the timestamp string
-// into a golang time.Time struct.
-//
-// See UnixTimestampFromTime for the inverse function.
-func timeFromUnixTimestamp(timestamp string) (time.Time, error) {
-	i, err := strconv.ParseInt(timestamp, 10, 64)
-	if err != nil {
-		return time.Time{}, errors.WithStack(err)
-	}
-	return time.Unix(i, 0), nil
-}
-
-// UnixTimestampFromTime is a helper utility that converts a golang time.Time struct
-// to a timestamp string.
-//
-// See timeFromUnixTimestamp for the inverse function.
-func UnixTimestampFromTime(t time.Time) string {
-	return strconv.FormatInt(t.Unix(), 10)
-}
 
 func shellAccess() shellAccessKind {
 	// Check if running in devbox cloud

--- a/internal/telemetry/sentry.go
+++ b/internal/telemetry/sentry.go
@@ -4,19 +4,12 @@
 package telemetry
 
 import (
-	"crypto/rand"
-	"encoding/hex"
-	"encoding/json"
-	"io/fs"
-	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"reflect"
 	"runtime"
 	"runtime/debug"
 	"strings"
-	"sync/atomic"
 	"time"
 	"unicode"
 	"unicode/utf8"
@@ -25,85 +18,11 @@ import (
 	"github.com/pkg/errors"
 
 	"go.jetpack.io/devbox/internal/build"
-	"go.jetpack.io/devbox/internal/envir"
-	"go.jetpack.io/devbox/internal/redact"
-	"go.jetpack.io/devbox/internal/xdg"
 )
 
-var ExecutionID string
+var ExecutionID = newEventID()
 
-func init() {
-	// Generate event UUIDs the same way the Sentry SDK does:
-	// https://github.com/getsentry/sentry-go/blob/d9ce5344e7e1819921ea4901dd31e47a200de7e0/util.go#L15
-	id := make([]byte, 16)
-	_, _ = rand.Read(id)
-	id[6] &= 0x0F
-	id[6] |= 0x40
-	id[8] &= 0x3F
-	id[8] |= 0x80
-	ExecutionID = hex.EncodeToString(id)
-}
-
-var needsFlush atomic.Bool
-var started bool
-
-// Start enables telemetry for the current program.
-func Start(appName string) {
-	if started || envir.DoNotTrack() {
-		return
-	}
-	started = initSentry(appName)
-}
-
-// Stop stops gathering telemetry and flushes buffered events to disk.
-func Stop() {
-	if !started || !needsFlush.Load() {
-		return
-	}
-
-	// Report errors in a separate process so we don't block exiting.
-	exe, err := os.Executable()
-	if err == nil {
-		_ = exec.Command(exe, "bug").Start()
-	}
-	started = false
-}
-
-var errorBufferDir = xdg.StateSubpath(filepath.FromSlash("devbox/sentry"))
-
-func ReportErrors() {
-	if !initSentry(AppDevbox) {
-		return
-	}
-
-	dirEntries, err := os.ReadDir(errorBufferDir)
-	if err != nil {
-		return
-	}
-	for _, entry := range dirEntries {
-		if !entry.Type().IsRegular() || filepath.Ext(entry.Name()) != ".json" {
-			continue
-		}
-
-		path := filepath.Join(errorBufferDir, entry.Name())
-		data, err := os.ReadFile(path)
-		// Always delete the file so we don't end up with an infinitely growing
-		// backlog of errors.
-		_ = os.Remove(path)
-		if err != nil {
-			continue
-		}
-
-		event := &sentry.Event{}
-		if err := json.Unmarshal(data, event); err != nil {
-			continue
-		}
-		sentry.CaptureEvent(event)
-	}
-	sentry.Flush(3 * time.Second)
-}
-
-func initSentry(appName string) bool {
+func initSentryClient(appName string) bool {
 	if appName == "" {
 		panic("telemetry.Start: app name is empty")
 	}
@@ -130,143 +49,6 @@ func initSentry(appName string) bool {
 		},
 	})
 	return err == nil
-}
-
-type Metadata struct {
-	Command      string
-	CommandFlags []string
-	FeatureFlags map[string]bool
-
-	InShell   bool
-	InCloud   bool
-	InBrowser bool
-
-	NixpkgsHash string
-	Packages    []string
-
-	CloudRegion string
-	CloudCache  string
-}
-
-func (m *Metadata) cmdContext() map[string]any {
-	sentryCtx := map[string]any{}
-	if m.Command != "" {
-		sentryCtx["Name"] = m.Command
-	}
-	if len(m.CommandFlags) > 0 {
-		sentryCtx["Flags"] = m.CommandFlags
-	}
-	return sentryCtx
-}
-
-func (m *Metadata) envContext() map[string]any {
-	sentryCtx := map[string]any{
-		"In Shell":   m.InShell,
-		"In Cloud":   m.InCloud,
-		"In Browser": m.InBrowser,
-	}
-	if m.CloudCache != "" {
-		sentryCtx["Cloud Cache"] = m.CloudCache
-	}
-	if m.CloudRegion != "" {
-		sentryCtx["Cloud Region"] = m.CloudRegion
-	}
-	return sentryCtx
-}
-
-func (m *Metadata) featureContext() map[string]any {
-	if len(m.FeatureFlags) == 0 {
-		return nil
-	}
-
-	sentryCtx := make(map[string]any, len(m.FeatureFlags))
-	for name, enabled := range m.FeatureFlags {
-		sentryCtx[name] = enabled
-	}
-	return sentryCtx
-}
-
-func (m *Metadata) pkgContext() map[string]any {
-	if len(m.Packages) == 0 {
-		return nil
-	}
-
-	// Every package currently has the same commit hash as its version, but this
-	// format will allow us to use individual package versions in the future.
-	pkgVersion := "nixpkgs"
-	if m.NixpkgsHash != "" {
-		pkgVersion += "/" + m.NixpkgsHash
-	}
-	pkgVersion += "#"
-	pkgContext := make(map[string]any, len(m.Packages))
-	for _, pkg := range m.Packages {
-		pkgContext[pkg] = pkgVersion + pkg
-	}
-	return pkgContext
-}
-
-// Error reports an error to the telemetry server.
-func Error(err error, meta Metadata) {
-	if !started || err == nil {
-		return
-	}
-
-	event := &sentry.Event{
-		EventID:   sentry.EventID(ExecutionID),
-		Level:     sentry.LevelError,
-		User:      sentry.User{ID: DeviceID},
-		Exception: newSentryException(redact.Error(err)),
-		Contexts: map[string]map[string]any{
-			"os": {
-				"name": build.OS(),
-			},
-			"device": {
-				"arch": runtime.GOARCH,
-			},
-			"runtime": {
-				"name":    "Go",
-				"version": strings.TrimPrefix(runtime.Version(), "go"),
-			},
-		},
-	}
-	if meta.Command != "" {
-		event.Tags = map[string]string{"command": meta.Command}
-	}
-	if sentryCtx := meta.cmdContext(); len(sentryCtx) > 0 {
-		event.Contexts["Command"] = sentryCtx
-	}
-	if sentryCtx := meta.envContext(); len(sentryCtx) > 0 {
-		event.Contexts["Devbox Environment"] = sentryCtx
-	}
-	if sentryCtx := meta.featureContext(); len(sentryCtx) > 0 {
-		event.Contexts["Feature Flags"] = sentryCtx
-	}
-	if sentryCtx := meta.pkgContext(); len(sentryCtx) > 0 {
-		event.Contexts["Devbox Packages"] = sentryCtx
-	}
-	bufferEvent(event)
-}
-
-// bufferEvent buffers a Sentry event to disk so that ReportErrors can upload
-// it later.
-func bufferEvent(event *sentry.Event) {
-	data, err := json.Marshal(event)
-	if err != nil {
-		return
-	}
-
-	file := filepath.Join(errorBufferDir, string(event.EventID)+".json")
-	err = os.WriteFile(file, data, 0600)
-	if errors.Is(err, fs.ErrNotExist) {
-		// XDG specifies perms 0700.
-		if err := os.MkdirAll(errorBufferDir, 0700); err != nil {
-			return
-		}
-		err = os.WriteFile(file, data, 0600)
-	}
-	if err == nil {
-		needsFlush.Store(true)
-	}
 }
 
 func newSentryException(err error) []sentry.Exception {
@@ -400,4 +182,10 @@ func splitPkgFunc(name string) (pkgPath string, funcName string) {
 	// pkgPath = go.jetpack.io/devbox/internal/impl
 	// funcName = (*Devbox).RunScript
 	return dir + pkgName, fn
+}
+
+// bufferSentryEvent buffers a Sentry event to disk so that Report can upload it
+// later.
+func bufferSentryEvent(event *sentry.Event) {
+	bufferEvent(filepath.Join(sentryBufferDir, string(event.EventID)+".json"), event)
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -53,7 +53,7 @@ var (
 
 // Start enables telemetry for the current program.
 func Start() {
-	if started || envir.DoNotTrack() {
+	if started || envir.DoNotTrack() || build.SentryDSN == "" || build.TelemetryKey == "" {
 		return
 	}
 
@@ -87,6 +87,10 @@ func Stop() {
 }
 
 func Event(e EventName, meta Metadata) {
+	if !started {
+		return
+	}
+
 	switch e {
 	case EventCommandSuccess:
 		bufferSegmentMessage(commandEvent(meta))

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -4,33 +4,326 @@
 package telemetry
 
 import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
 	"github.com/denisbrodbeck/machineid"
+	"github.com/getsentry/sentry-go"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	segment "github.com/segmentio/analytics-go"
 
 	"go.jetpack.io/devbox/internal/build"
 	"go.jetpack.io/devbox/internal/envir"
+	"go.jetpack.io/devbox/internal/redact"
+	"go.jetpack.io/devbox/internal/xdg"
 )
 
-var DeviceID string
+const appName = "devbox"
+
+type EventName int
 
 const (
-	AppDevbox  = "devbox"
-	AppSSHShim = "devbox-sshshim"
+	EventCommandSuccess EventName = iota
+	EventShellInteractive
+	EventShellReady
 )
 
-func init() {
-	// TODO(gcurtis): clean this up so that Sentry and Segment use the same
-	// start/stop functions.
-	if envir.DoNotTrack() || build.TelemetryKey == "" {
+var (
+	deviceID string
+	userID   string
+
+	// procStartTime records the start time of the current process.
+	procStartTime = time.Now()
+	needsFlush    atomic.Bool
+	started       bool
+)
+
+// Start enables telemetry for the current program.
+func Start() {
+	if started || envir.DoNotTrack() {
 		return
 	}
-	enabled = true
 
-	const salt = "64ee464f-9450-4b14-8d9c-014c0012ac1a"
-	DeviceID, _ = machineid.ProtectedID(salt) // Ensure machine id is hashed and non-identifiable
+	const deviceSalt = "64ee464f-9450-4b14-8d9c-014c0012ac1a"
+	deviceID, _ = machineid.ProtectedID(deviceSalt)
+
+	username := os.Getenv(envir.GitHubUsername)
+	if username != "" {
+		const uidSalt = "d6134cd5-347d-4b7c-a2d0-295c0f677948"
+		const githubPrefix = "github:"
+
+		// userID is a v5 UUID which is basically a SHA hash of the username.
+		// See https://www.uuidtools.com/uuid-versions-explained for a comparison of UUIDs.
+		userID = uuid.NewSHA1(uuid.MustParse(uidSalt), []byte(githubPrefix+username)).String()
+	}
+	started = true
 }
 
-var enabled bool
+// Stop stops gathering telemetry and flushes buffered events to disk.
+func Stop() {
+	if !started || !needsFlush.Load() {
+		return
+	}
 
-func Enabled() bool {
-	return enabled
+	// Report errors in a separate process so we don't block exiting.
+	exe, err := os.Executable()
+	if err == nil {
+		_ = exec.Command(exe, "bug").Start()
+	}
+	started = false
+}
+
+func Event(e EventName, meta Metadata) {
+	switch e {
+	case EventCommandSuccess:
+		bufferSegmentMessage(commandEvent(meta))
+	case EventShellInteractive:
+		name := fmt.Sprintf("[%s] Shell Event: interactive", appName)
+		msg := newTrackMessage(name, meta)
+		bufferSegmentMessage(msg.MessageId, msg)
+	case EventShellReady:
+		name := fmt.Sprintf("[%s] Shell Event: ready", appName)
+		msg := newTrackMessage(name, meta)
+		bufferSegmentMessage(msg.MessageId, msg)
+	}
+}
+
+func commandEvent(meta Metadata) (id string, msg *segment.Track) {
+	name := fmt.Sprintf("[%s] Command: %s", appName, meta.Command)
+	msg = newTrackMessage(name, meta)
+	return msg.MessageId, msg
+}
+
+// Error reports an error to the telemetry server.
+func Error(err error, meta Metadata) {
+	if !started || err == nil {
+		return
+	}
+
+	event := &sentry.Event{
+		EventID:   sentry.EventID(ExecutionID),
+		Level:     sentry.LevelError,
+		User:      sentry.User{ID: deviceID},
+		Exception: newSentryException(redact.Error(err)),
+		Contexts: map[string]map[string]any{
+			"os": {
+				"name": build.OS(),
+			},
+			"device": {
+				"arch": runtime.GOARCH,
+			},
+			"runtime": {
+				"name":    "Go",
+				"version": strings.TrimPrefix(runtime.Version(), "go"),
+			},
+		},
+	}
+	if meta.Command != "" {
+		event.Tags = map[string]string{"command": meta.Command}
+	}
+	if sentryCtx := meta.cmdContext(); len(sentryCtx) > 0 {
+		event.Contexts["Command"] = sentryCtx
+	}
+	if sentryCtx := meta.envContext(); len(sentryCtx) > 0 {
+		event.Contexts["Devbox Environment"] = sentryCtx
+	}
+	if sentryCtx := meta.featureContext(); len(sentryCtx) > 0 {
+		event.Contexts["Feature Flags"] = sentryCtx
+	}
+	if sentryCtx := meta.pkgContext(); len(sentryCtx) > 0 {
+		event.Contexts["Devbox Packages"] = sentryCtx
+	}
+
+	// Prefer using the user ID instead of the device ID when it's
+	// available.
+	if userID != "" {
+		event.User.ID = userID
+	}
+	bufferSentryEvent(event)
+
+	msgID, msg := commandEvent(meta)
+	msg.Properties["failed"] = true
+	msg.Properties["sentry_event_id"] = event.EventID
+	bufferSegmentMessage(msgID, msg)
+}
+
+type Metadata struct {
+	Command      string
+	CommandFlags []string
+	CommandStart time.Time
+	FeatureFlags map[string]bool
+
+	InShell   bool
+	InCloud   bool
+	InBrowser bool
+
+	NixpkgsHash string
+	Packages    []string
+
+	CloudRegion string
+	CloudCache  string
+}
+
+func (m *Metadata) cmdContext() map[string]any {
+	sentryCtx := map[string]any{}
+	if m.Command != "" {
+		sentryCtx["Name"] = m.Command
+	}
+	if len(m.CommandFlags) > 0 {
+		sentryCtx["Flags"] = m.CommandFlags
+	}
+	return sentryCtx
+}
+
+func (m *Metadata) envContext() map[string]any {
+	sentryCtx := map[string]any{
+		"In Shell":   m.InShell,
+		"In Cloud":   m.InCloud,
+		"In Browser": m.InBrowser,
+	}
+	if m.CloudCache != "" {
+		sentryCtx["Cloud Cache"] = m.CloudCache
+	}
+	if m.CloudRegion != "" {
+		sentryCtx["Cloud Region"] = m.CloudRegion
+	}
+	return sentryCtx
+}
+
+func (m *Metadata) featureContext() map[string]any {
+	if len(m.FeatureFlags) == 0 {
+		return nil
+	}
+
+	sentryCtx := make(map[string]any, len(m.FeatureFlags))
+	for name, enabled := range m.FeatureFlags {
+		sentryCtx[name] = enabled
+	}
+	return sentryCtx
+}
+
+func (m *Metadata) pkgContext() map[string]any {
+	if len(m.Packages) == 0 {
+		return nil
+	}
+
+	// Every package currently has the same commit hash as its version, but this
+	// format will allow us to use individual package versions in the future.
+	pkgVersion := "nixpkgs"
+	if m.NixpkgsHash != "" {
+		pkgVersion += "/" + m.NixpkgsHash
+	}
+	pkgVersion += "#"
+	pkgContext := make(map[string]any, len(m.Packages))
+	for _, pkg := range m.Packages {
+		pkgContext[pkg] = pkgVersion + pkg
+	}
+	return pkgContext
+}
+
+var (
+	sentryBufferDir  = xdg.StateSubpath(filepath.FromSlash("devbox/sentry"))
+	segmentBufferDir = xdg.StateSubpath(filepath.FromSlash("devbox/segment"))
+)
+
+func Upload() {
+	wg := sync.WaitGroup{} //nolint:varnamelen
+	wg.Add(2)
+	go func() {
+		if !initSentryClient(appName) {
+			return
+		}
+
+		events := restoreEvents[sentry.Event](sentryBufferDir)
+		for _, e := range events {
+			sentry.CaptureEvent(&e)
+		}
+		sentry.Flush(3 * time.Second)
+		wg.Done()
+	}()
+	go func() {
+		if !initSegmentClient() {
+			return
+		}
+		events := restoreEvents[segment.Track](segmentBufferDir)
+		for _, e := range events {
+			segmentClient.Enqueue(e) //nolint:errcheck
+		}
+		segmentClient.Close()
+		wg.Done()
+	}()
+	wg.Wait()
+}
+
+func restoreEvents[E any](dir string) []E {
+	dirEntries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+
+	var events []E
+	for _, entry := range dirEntries {
+		if !entry.Type().IsRegular() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+
+		path := filepath.Join(dir, entry.Name())
+		data, err := os.ReadFile(path)
+		// Always delete the file so we don't end up with an infinitely growing
+		// backlog of errors.
+		_ = os.Remove(path)
+		if err != nil {
+			continue
+		}
+
+		var event E
+		if err := json.Unmarshal(data, &event); err != nil {
+			continue
+		}
+		events = append(events, event)
+	}
+	return events
+}
+
+func bufferEvent(file string, event any) {
+	data, err := json.Marshal(event)
+	if err != nil {
+		return
+	}
+
+	err = os.WriteFile(file, data, 0o600)
+	if errors.Is(err, fs.ErrNotExist) {
+		// XDG specifies perms 0700.
+		if err := os.MkdirAll(filepath.Dir(file), 0o700); err != nil {
+			return
+		}
+		err = os.WriteFile(file, data, 0o600)
+	}
+	if err == nil {
+		needsFlush.Store(true)
+	}
+}
+
+func newEventID() string {
+	// Generate event UUIDs the same way the Sentry SDK does:
+	// https://github.com/getsentry/sentry-go/blob/d9ce5344e7e1819921ea4901dd31e47a200de7e0/util.go#L15
+	id := make([]byte, 16)
+	_, _ = rand.Read(id)
+	id[6] &= 0x0F
+	id[6] |= 0x40
+	id[8] &= 0x3F
+	id[8] |= 0x80
+	return hex.EncodeToString(id)
 }


### PR DESCRIPTION
Instead of blocking the process from exiting, buffer Segment events to disk and start another process to upload them. With this change all telemetry should be non-blocking.

Most of the Segment event logic now lives in the telemetry package instead of the cobra middleware. A bunch of the unused logic around tracking CLI SSH sessions has also been removed. The telemetry package API now looks something like:

```go
type EventName int

const (
	EventCommandSuccess EventName = iota
	EventShellInteractive
	EventShellReady
)

func Error(err error, meta Metadata)
func Event(e EventName, meta Metadata)
func Start()
func Stop()
func Upload()
```

Fixes #1003.