### PR TITLE
[CLI] Changed default nix bash to bashInteractive

### DIFF
--- a/internal/impl/shell.go
+++ b/internal/impl/shell.go
@@ -111,7 +111,7 @@ func shellPath(devbox *Devbox) (path string, err error) {
 
 	cmd := exec.Command(
 		"nix", "eval", "--raw",
-		fmt.Sprintf("%s#bash", nix.FlakeNixpkgs(devbox.cfg.NixPkgsCommitHash())),
+		fmt.Sprintf("%s#bashInteractive", nix.FlakeNixpkgs(devbox.cfg.NixPkgsCommitHash())),
 	)
 	cmd.Args = append(cmd.Args, nix.ExperimentalFlags()...)
 	out, err := cmd.Output()
@@ -119,6 +119,14 @@ func shellPath(devbox *Devbox) (path string, err error) {
 		return "", errors.WithStack(err)
 	}
 	bashNixStorePath = string(out)
+
+	// install bashInteractive in nix/store without creating a symlink to local directory (--no-link)
+	cmd = exec.Command("nix", "build", bashNixStorePath, "--no-link")
+	cmd.Args = append(cmd.Args, nix.ExperimentalFlags()...)
+	err = cmd.Run()
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
 
 	if bashNixStorePath != "" {
 		// the output is the raw path to the bash installation in the /nix/store


### PR DESCRIPTION
## Summary
In `shellPath()` function where we decide which type of shell to use when dropping user in devbox shell, if we can't figure out the shell, we drop the user in the default `bash` that nix installs in store. But this bash doesn't handle arrow keys and keyboard combinations very well, so it creates a frustrating experience for users (including pure shell users).  `bashInteractive` package has all these capabilities and makes the experience better for a 'default' shell. 

So this PR changes this:
- `nix eval <bash>` to get store path and use to create default shell
to this:
- `nix eval <bashInteractive>` to get store path
- nix build <generated store path>
- use store path to create default shell

Addresses #1193

## How was it tested?
- compile
- ./devbox shell --pure
OR 
- unset $SHELL
- ./devbox shell
