### PR TITLE
Update Contribution Guide To Help Solve Potential Setup Error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ The easiest way to develop Devbox is with Devbox!
        dist/devbox shell
 
 Tip: you can also start VSCode from inside your Devbox shell with `devbox run code`.
-- If you are encountering the error similar to: `line 3: command 'code' not found`, this means you do not have the Visual Studio Code "Shell Command" installed. To do this, follow the official guide: https://code.visualstudio.com/docs/setup/mac. Please refer to the section under: "Launching from the command line".
+- If you are encountering an error similar to: `line 3: command 'code' not found`, this means you do not have the Visual Studio Code "Shell Command" installed. To do this, follow the official guide: https://code.visualstudio.com/docs/setup/mac. Please refer to the section under: "Launching from the command line".
 
 ### Setting up the Environment Without Devbox
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,7 @@ The easiest way to develop Devbox is with Devbox!
        dist/devbox shell
 
 Tip: you can also start VSCode from inside your Devbox shell with `devbox run code`.
+- If you are encountering the error similar to: `line 3: command 'code' not found`, this means you do not have the Visual Studio Code "Shell Command" installed. To do this, follow the official guide: https://code.visualstudio.com/docs/setup/mac. Please refer to the section under: "Launching from the command line".
 
 ### Setting up the Environment Without Devbox
 


### PR DESCRIPTION
## Summary
When I was following the contribution guide, all the steps worked except:

`Tip: you can also start VSCode from inside your Devbox shell with devbox run code.`

I was getting an error stating the command `code` was not found. I checked the file `devbox run code` was running, which is `.devbox/gen/scripts/code.sh`. In the file (line 3), it tries to run `code .` -> which only works if you have installed the Visual Studio shell command.

## How was it tested?
Steps I took:
1. I could not run the command successfully without installing the Visual Studio shell command.
2. I installed the shell command.
3. The command ran successfully.

## Why Is It Useful?
This is useful for developers who do not use Visual Studio Code as their primary IDE, therefore increasing the chances encountering an error on the beginning setup steps
