### PR TITLE
Fix broken envrc template

### DIFF
--- a/internal/impl/generate/tmpl/envrcContent.tmpl
+++ b/internal/impl/generate/tmpl/envrcContent.tmpl
@@ -1,6 +1,6 @@
 use_devbox() {
     watch_file devbox.json
-    {{ .PromptHookEnabled }}
+    {{ if .PromptHookEnabled }}
     eval "$(devbox export --init-hook --install)"
     {{ else }}
     eval "$(devbox shellenv --init-hook --install)"


### PR DESCRIPTION
## Summary

## How was it tested?

I ran it and it didn't explode with 
```
$ devbox generate direnv --print-envrc
Error: template: envrcContent.tmpl:5: unexpected {{else}}
```