### PR TITLE
[CLI] Added TERM as leaking env vars in pure shell

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -1103,7 +1103,8 @@ func (d *Devbox) parseEnvAndExcludeSpecialCases(currentEnv []string) (map[string
 		// handling special cases to for pure shell
 		// Passing HOME for pure shell to leak through otherwise devbox binary won't work
 		// We also include PATH to find the nix installation. It is cleaned for pure mode below
-		if !d.pure || key == "HOME" || key == "PATH" {
+		// TERM leaking through is to enable colored text in the pure shell
+		if !d.pure || key == "HOME" || key == "PATH" || key == "TERM" {
 			env[key] = val
 		}
 	}


### PR DESCRIPTION
## Summary
Added `$TERM` to the list of env vars that leak to pure shell. Reason being, Pure shell doesn't allow colorful text in prompt because TERM variable is unset. 
Adding the TERM allows pure shell to know if terminal supports color and enable it.

Addresses #1200

## How was it tested?
- compile
- `./devbox shell --pure`
- `ls -a`
- `ls -a --color`
- confirm directories and executables show in different colors when `--color` is passed.