### PR TITLE
[cleanup] remove unused Env code from bin-wrapper template

### DIFF
--- a/internal/wrapnix/wrapper.go
+++ b/internal/wrapnix/wrapper.go
@@ -69,7 +69,6 @@ type createWrapperArgs struct {
 	devboxer
 	BashPath     string
 	Command      string
-	Env          map[string]string
 	ShellEnvHash string
 
 	destPath string

--- a/internal/wrapnix/wrapper.sh.tmpl
+++ b/internal/wrapnix/wrapper.sh.tmpl
@@ -6,13 +6,6 @@
 # differently than devbox.json env variables which are always set once.
 */ -}}
 
-{{ range $k, $v := .Env }}
-if [[ -z "$__DEVBOX_SET_{{ $k }}" ]]; then 
-  export {{ $k }}="${ {{- $k }}:-{{ $v }}}"
-  export __DEVBOX_SET_{{ $k }}="1"
-fi
-{{- end }}
-
 {{/*
 We use ShellEnvHashKey to prevent doing shellenv if the correct environment is
 already set. (perf optimization)


### PR DESCRIPTION
## Summary

The `Env` doesn't seem to be set in the template data.
Was removed in https://github.com/jetpack-io/devbox/pull/1150/files#diff-cedf8befe2d1cf00c67c8c48fcb5dd556a871376ae57de3406f91b4d0c2c0de1

## How was it tested?

Have not tested. Relying on testscripts examples.
