### PR TITLE
[remove nixpkgs] enable fallback for packages not in binary store

### DIFF
--- a/internal/boxcli/featureflag/remove_nixpkgs.go
+++ b/internal/boxcli/featureflag/remove_nixpkgs.go
@@ -4,4 +4,4 @@ package featureflag
 // It leverages the search index to directly map <package>@<version> to
 // the /nix/store/<hash>-<package>-<version> that can be fetched from
 // cache.nixpkgs.org.
-var RemoveNixpkgs = disable("REMOVE_NIXPKGS")
+var RemoveNixpkgs = enable("REMOVE_NIXPKGS")

--- a/internal/boxcli/featureflag/remove_nixpkgs.go
+++ b/internal/boxcli/featureflag/remove_nixpkgs.go
@@ -4,4 +4,4 @@ package featureflag
 // It leverages the search index to directly map <package>@<version> to
 // the /nix/store/<hash>-<package>-<version> that can be fetched from
 // cache.nixpkgs.org.
-var RemoveNixpkgs = enable("REMOVE_NIXPKGS")
+var RemoveNixpkgs = disable("REMOVE_NIXPKGS")

--- a/internal/shellgen/tmpl/flake_remove_nixpkgs.nix.tmpl
+++ b/internal/shellgen/tmpl/flake_remove_nixpkgs.nix.tmpl
@@ -17,6 +17,14 @@
    }:
       let
         pkgs = nixpkgs.legacyPackages.{{ .System }};
+        {{- range .FlakeInputs }}
+        {{- if .IsNixpkgs }}
+        {{.PkgImportName}} = (import {{.Name}} {
+          system = "{{ $.System }}";
+          config.allowUnfree = true;
+        });
+        {{- end }}
+        {{- end }}
       in
       {
         devShells.{{ .System }}.default = pkgs.mkShell {


### PR DESCRIPTION
## Summary

Many testscript unit-tests were failing because they use unversioned legacy packages like `"hello"`, as opposed to `hello@latest`, or `hello@<version>`.

These legacy packages do not use the Binary Cache Store.

I considered whether we should treat them automatically as upgraded to `@latest`, but decided against:
1. We'll need this logic in the flake template regardless. There will be some packages that are not in binary store.
2.  This also keeps the `Package.IsInBinaryStore` easier to reason about.

We should instead encourage users to `devbox update` their packages: which our messaging already does. 

The remaining three testscript unit-tests are failing due to "unable to find nix executable" errors. Will fix in followup.

## How was it tested?

enabled feature-flag and ran testscripts: https://github.com/jetpack-io/devbox/actions/runs/5417704606/jobs/9848964717?pr=1236