### PR TITLE
Add MySQL docs, update example

### DIFF
--- a/docs/app/docs/devbox_examples/databases/mysql.md
+++ b/docs/app/docs/devbox_examples/databases/mysql.md
@@ -1,0 +1,71 @@
+---
+title: MySQL
+---
+MySQL can be automatically configured for your dev environment by Devbox via the built-in MySQL Plugin. This plugin will activate automatically when you install MySQL using `devbox add mysql80` or `devbox add mysql57`.
+
+[**Example Repo**](https://github.com/jetpack-io/devbox/tree/main/examples/databases/mysql)
+
+[![Open In Devbox.sh](https://jetpack.io/img/devbox/open-in-devbox.svg)](https://devbox.sh/github.com/jetpack-io/devbox/?folder=examples/databases/mysql)
+
+## Adding MySQL to your Shell
+
+`devbox add mysql80`, or in your `devbox.json` add
+
+```json
+    "packages": [
+        "mysql80@latest"
+    ]
+```
+
+You can also install Mysql 5.7 by using `devbox add mysql57`
+
+You can manually add the MySQL Plugin to your `devbox.json` by adding it to your `include` list:
+
+```json
+    "include": [
+        "plugin:mysql"
+    ]
+```
+
+## MySQL Plugin Support
+
+Devbox will automatically create the following configuration when you run `devbox add mysql80` or `devbox add mysql57`. You can view the full configuration by running `devbox info mysql`
+
+
+### Services
+* mysql
+
+You can use `devbox services up|stop mysql` to start or stop the MySQL Server.
+
+### Environment Variables
+
+```bash
+MYSQL_BASEDIR=.devbox/nix/profile/default
+MYSQL_HOME=./.devbox/virtenv/mysql/run
+MYSQL_DATADIR=./.devbox/virtenv/mysql/data
+MYSQL_UNIX_PORT=./.devbox/virtenv/mysql/run/mysql.sock
+MYSQL_PID_FILE=./.devbox/mysql/run/mysql.pid
+```
+
+### Files
+
+The plugin will also create the following helper files in your project's `.devbox/virtenv` folder:
+
+* mysql/flake.nix
+* mysql/setup_db.sh
+* mysql/process-compose.yaml
+
+These files are used to setup your database and service, and should not be modified
+
+### Notes
+
+* This plugin wraps mysqld to work in your local project. For more information, see the `flake.nix` created in your `.devbox/virtenv/mysql` folder.
+* This plugin will create a new database for your project in `MYSQL_DATADIR` if one doesn't exist on shell init.
+* You can use `mysqld` to manually start the server, and `mysqladmin -u root shutdown` to manually stop it
+* `.sock` filepath can only be maximum 100 characters long. You can point to a different path by setting the `MYSQL_UNIX_PORT` env variable in your `devbox.json` as follows:
+
+```json
+"env": {
+    "MYSQL_UNIX_PORT": "/<some-other-path>/mysql.sock"
+}
+```

--- a/docs/app/docs/devbox_examples/index.md
+++ b/docs/app/docs/devbox_examples/index.md
@@ -22,6 +22,7 @@ You can view the full list of examples in our [Example Repo](https://github.com/
 
 ## Databases
 * [MariaDB](databases/mariadb.md)
+* [MySQL](databases/mysql.md)
 * [PostgreSQL](databases/postgres.md)
 * [Redis](databases/redis.md)
 

--- a/docs/app/docs/guides/plugins.md
+++ b/docs/app/docs/guides/plugins.md
@@ -12,6 +12,7 @@ Plugins are available for the following packages. You can activate the plugins f
 * [Caddy](../devbox_examples/servers/caddy.md) (caddy)
 * [Nginx](../devbox_examples/servers/nginx.md) (nginx)
 * [MariaDB](../devbox_examples/databases/mariadb.md) (mariadb, mariadb_10_6...)
+* [MySQL](../devbox_examples/databases/mysql.md) (mysql80, mysql57)
 * [PostgreSQL](../devbox_examples/databases/postgres.md) (postgresql)
 * [Redis](../devbox_examples/databases/redis.md) (redis)
 * [PHP](../devbox_examples/languages/php.md) (php, php80, php81, php82...)

--- a/examples/databases/mysql/README.md
+++ b/examples/databases/mysql/README.md
@@ -1,0 +1,31 @@
+# mysql
+
+## mysql Notes
+
+1. Start the mysql server using `devbox services up`
+1. Create a database using `"mysql -u root < setup_db.sql"`
+1. You can now connect to the database from the command line by running `devbox run connect_db`
+
+## Services
+
+* mysql
+
+Use `devbox services start|stop [service]` to interact with services
+
+## This plugin sets the following environment variables
+
+* MYSQL_BASEDIR=/<projectDir>/.devbox/nix/profile/default
+* MYSQL_HOME=/<projectDir>/.devbox/virtenv/mysql/run
+* MYSQL_DATADIR=/<projectDir>/.devbox/virtenv/mysql/data
+* MYSQL_UNIX_PORT=/<projectDir>/.devbox/virtenv/mysql/run/mysql.sock
+* MYSQL_PID_FILE=/<projectDir>/.devbox/virtenv/mysql/run/mysql.pid
+
+To show this information, run `devbox info mysql`
+
+Note that the `.sock` filepath can only be maximum 100 characters long. You can point to a different path by setting the `MYSQL_UNIX_PORT` env variable in your `devbox.json` as follows:
+
+```
+"env": {
+    "MYSQL_UNIX_PORT": "/<some-other-path>/mysql.sock"
+}
+```

--- a/examples/databases/mysql/devbox.json
+++ b/examples/databases/mysql/devbox.json
@@ -3,12 +3,18 @@
     "mysql80@latest"
   ],
   "shell": {
-    "init_hook": [
-      "echo 'Welcome to devbox!' > /dev/null"
-    ],
+    "init_hook": [],
     "scripts": {
-      "test": [
-        "echo \"Error: no test specified\" && exit 1"
+      "connect_db": [
+        "mysql -u devbox_user -p -D devbox_lamp"
+      ],
+      "test_db_setup": [
+        "mkdir -p /tmp/devbox/mariadb/run",
+        "export MYSQL_UNIX_PORT=/tmp/devbox/mariadb/run/mysql.sock",
+        "devbox services up -b",
+        "sleep 5",
+        "mysql -u root < setup_db.sql",
+        "devbox services stop"
       ]
     }
   }

--- a/examples/databases/mysql/devbox.lock
+++ b/examples/databases/mysql/devbox.lock
@@ -3,7 +3,7 @@
   "packages": {
     "mysql80@latest": {
       "last_modified": "2023-05-01T16:53:22Z",
-      "plugin_version": "0.0.2",
+      "plugin_version": "0.0.1",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#mysql80",
       "version": "8.0.33"
     }

--- a/examples/databases/mysql/setup_db.sql
+++ b/examples/databases/mysql/setup_db.sql
@@ -1,0 +1,20 @@
+-- You should run this query using `mysql -u root < setup_db.sql`
+
+DROP DATABASE IF EXISTS devbox_lamp;
+CREATE DATABASE devbox_lamp;
+
+USE devbox_lamp;
+
+CREATE USER 'devbox_user'@'localhost' IDENTIFIED BY 'password';
+GRANT ALL ON devbox_lamp.* TO 'devbox_user'@'localhost';
+
+DROP TABLE IF EXISTS colors;
+CREATE TABLE colors (
+	id INT NOT NULL AUTO_INCREMENT,
+	name VARCHAR(100) NOT NULL,
+	hex VARCHAR(7) NOT NULL,
+	PRIMARY KEY (id));
+
+INSERT INTO colors (name, hex) VALUES ('red', '#FF0000'), ('blue', '#0000FF'), ('green', '#00FF00');
+
+

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -39,6 +39,7 @@ var templates = map[string]string{
 	"maelstrom":       "examples/cloud_development/maelstrom/",
 	"minikube":        "examples/cloud_development/minikube/",
 	"mariadb":         "examples/databases/mariadb/",
+	"mysql":           "examples/databases/mysql/",
 	"nginx":           "examples/servers/nginx/",
 	"nim":             "examples/development/nim/spinnytest/",
 	"node-npm":        "examples/development/nodejs/nodejs-npm/",


### PR DESCRIPTION
## Summary

Add MySQL docs and align example with MariaDB

## How was it tested?
https://devbox-web-john-lago-jetpack-io.cloud.jetpack.dev/devbox/docs/devbox_examples/databases/mysql/ 

Note: Devbox Cloud link needs our images to update to 0.5.6 in order to support the mysql plugin