### PR TITLE
move nix.System call inside featureflag.RemoveNixpkgs if-condition

### DIFF
--- a/internal/lock/lockfile.go
+++ b/internal/lock/lockfile.go
@@ -88,14 +88,13 @@ func (l *File) Remove(pkgs ...string) error {
 func (l *File) Resolve(pkg string) (*Package, error) {
 	entry, hasEntry := l.Packages[pkg]
 
-	userSystem, err := nix.System()
-	if err != nil {
-		return nil, err
-	}
-
 	// If the package's system info is missing, we need to resolve it again.
 	needsSysInfo := false
 	if hasEntry && featureflag.RemoveNixpkgs.Enabled() {
+		userSystem, err := nix.System()
+		if err != nil {
+			return nil, err
+		}
 		needsSysInfo = entry.Systems[userSystem] == nil
 	}
 


### PR DESCRIPTION
## Summary

I'm not yet entirely sure why, but #1245 led to some testscript error.
For now, I'm hiding the nix.System call inside the feature flag's if-condition
to get the testscripts status to green again on `main`.

## How was it tested?

testscripts should pass
