### PR TITLE
[CLI] Added a "\n" to end of writefile

### DIFF
--- a/internal/cuecfg/cuecfg.go
+++ b/internal/cuecfg/cuecfg.go
@@ -82,7 +82,7 @@ func WriteFile(path string, value any) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	data = append(data, "\n"...)
+	data = append(data, '\n')
 	return errors.WithStack(os.WriteFile(path, data, 0644))
 }
 

--- a/internal/cuecfg/cuecfg.go
+++ b/internal/cuecfg/cuecfg.go
@@ -82,7 +82,7 @@ func WriteFile(path string, value any) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-
+	data = append(data, "\n"...)
 	return errors.WithStack(os.WriteFile(path, data, 0644))
 }
 


### PR DESCRIPTION
## Summary
Added '\n' to end of `WriteFile()` in `cuecfg` package. This resolves an issue of devbox.json unnecessarily showing up in PR diffs because the newline at the end of the file is removed by CLI and was added by IDE formatters.

However, this function is used to write the config to a file as well as a couple of other cases such as in `auth` package. 
I'm guessing the `\n` for cases other than writing config won't cause an issue. But I haven't tested those cases.

Addresses #1248 

## How was it tested?
- compile
- `./devbox init` has a newline at the end of devbox.json and devbox.lock
- `./devbox add hello` keeps the newline at the end of devbox.json and devbox.lock