### PR TITLE
[remove nixpkgs] Enable installing and removing packages

### DIFF
--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -243,7 +243,7 @@ func (d *Devbox) addPackagesToProfile(ctx context.Context, mode installMode) err
 
 	// If packages are in profile but nixpkgs has been purged, the experience
 	// will be poor when we try to run print-dev-env. So we ensure nixpkgs is
-	// prefetched for all our packages.
+	// prefetched for all relevant packages (those not in binary store).
 	for _, input := range d.PackagesAsInputs() {
 		if err := input.EnsureNixpkgsPrefetched(d.writer); err != nil {
 			return err

--- a/internal/nix/profiles.go
+++ b/internal/nix/profiles.go
@@ -48,7 +48,7 @@ func ProfileList(writer io.Writer, profilePath string) ([]string, error) {
 	return lines, nil
 }
 
-func ProfileInstall(writer io.Writer, profilePath string, urlForInstall string) error {
+func ProfileInstall(writer io.Writer, profilePath string, installable string) error {
 
 	cmd := command(
 		"profile", "install",
@@ -58,7 +58,7 @@ func ProfileInstall(writer io.Writer, profilePath string, urlForInstall string) 
 		// Note that this is not really the priority we care about, since we
 		// use the flake.nix to specify the priority.
 		"--priority", nextPriority(profilePath),
-		urlForInstall,
+		installable,
 	)
 	cmd.Env = allowUnfreeEnv()
 


### PR DESCRIPTION
## Summary

builds on top of #1236

Goal: 
We should be able to install the package without downloading nixpkgs.

Changes made to:
- `nixprofile.ProfileInstall`: use `/nix/store/<hash>` as `installable`
- `nixprofile.ProfileListIndex`: return index when `item.nixStorePath == pkg.PathInStore`
- `devpkgs.Package.ValidateExists`: `true` if `IsInBinaryStore`
- `devpkgs.Package.EnsureNixpkgsPrefetched`: skip if `IsInBinaryStore`.


## How was it tested?

`devbox add go@1.20.3` and `devbox rm go@1.20.3`
- [x] nixpkgs not downloaded