### PR TITLE
[remove nixpkgs] Naming: update Package methods to InputAddressedPath and ContentAddressedPath, and s/BinaryStore/BinaryCache

### DIFF
--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -243,7 +243,7 @@ func (d *Devbox) addPackagesToProfile(ctx context.Context, mode installMode) err
 
 	// If packages are in profile but nixpkgs has been purged, the experience
 	// will be poor when we try to run print-dev-env. So we ensure nixpkgs is
-	// prefetched for all relevant packages (those not in binary store).
+	// prefetched for all relevant packages (those not in binary cache).
 	for _, input := range d.PackagesAsInputs() {
 		if err := input.EnsureNixpkgsPrefetched(d.writer); err != nil {
 			return err

--- a/internal/lock/lockfile.go
+++ b/internal/lock/lockfile.go
@@ -38,7 +38,8 @@ type Package struct {
 }
 
 type SystemInfo struct {
-	// StorePath is the cache key in the Binary Cache Store (cache.nixos.org)
+	// StorePath is the input-addressed path for the nix package in /nix/store
+	// It is the cache key in the Binary Cache Store (cache.nixos.org)
 	// It is of the form <hash>-<name>-<version>
 	// <name> may be different from the canonicalName so we store the full store path.
 	StorePath string `json:"store_path,omitempty"`

--- a/internal/nix/nixprofile/profile.go
+++ b/internal/nix/nixprofile/profile.go
@@ -31,7 +31,7 @@ func ProfileListItems(
 	}
 
 	// The `line` output is of the form:
-	// <index> <UnlockedReference> <LockedReference> <NixStorePath>
+	// <index> <UnlockedReference> <LockedReference> <InputAddressedPath>
 	//
 	// Using an example:
 	// 0 github:NixOS/nixpkgs/52e3e80afff4b16ccb7c52e9f0f5220552f03d04#legacyPackages.x86_64-darwin.go_1_19 github:NixOS/nixpkgs/52e3e80afff4b16ccb7c52e9f0f5220552f03d04#legacyPackages.x86_64-darwin.go_1_19 /nix/store/w0lyimyyxxfl3gw40n46rpn1yjrl3q85-go-1.19.3
@@ -69,12 +69,13 @@ func ProfileListIndex(args *ProfileListIndexArgs) (int, error) {
 		}
 	}
 
-	inStore, err := args.Input.IsInBinaryStore()
+	inCache, err := args.Input.IsInBinaryCache()
 	if err != nil {
 		return -1, err
 	}
-	if inStore {
-		pathInStore, err := args.Input.PathInBinaryStore()
+	if inCache {
+		// TODO savil: change to ContentAddressedPath?
+		pathInStore, err := args.Input.InputAddressedPath()
 		if err != nil {
 			return -1, err
 		}
@@ -209,12 +210,12 @@ type ProfileInstallArgs struct {
 func ProfileInstall(args *ProfileInstallArgs) error {
 	input := devpkg.PackageFromString(args.Package, args.Lockfile)
 
-	isInBinaryStore, err := input.IsInBinaryStore()
+	inCache, err := input.IsInBinaryCache()
 	if err != nil {
 		return err
 	}
 
-	if !isInBinaryStore && nix.IsGithubNixpkgsURL(input.URLForFlakeInput()) {
+	if !inCache && nix.IsGithubNixpkgsURL(input.URLForFlakeInput()) {
 		if err := nix.EnsureNixpkgsPrefetched(args.Writer, input.HashFromNixPkgsURL()); err != nil {
 			return err
 		}
@@ -262,14 +263,14 @@ func ProfileRemoveItems(profilePath string, items []*NixProfileListItem) error {
 // Keeping in `nixprofile` package since its specific to how nix profile works,
 // rather than a general property of devpkg.Package
 func installableForPackage(pkg *devpkg.Package) (string, error) {
-	isInBinaryStore, err := pkg.IsInBinaryStore()
+	inCache, err := pkg.IsInBinaryCache()
 	if err != nil {
 		return "", err
 	}
 
-	if isInBinaryStore {
-		// TODO savil: change to ContentAddressablePath when that is implemented
-		installable, err := pkg.PathInBinaryStore()
+	if inCache {
+		// TODO savil: change to ContentAddressablePath?
+		installable, err := pkg.InputAddressedPath()
 		if err != nil {
 			return "", err
 		}

--- a/internal/nix/nixprofile/profile.go
+++ b/internal/nix/nixprofile/profile.go
@@ -31,7 +31,7 @@ func ProfileListItems(
 	}
 
 	// The `line` output is of the form:
-	// <index> <UnlockedReference> <LockedReference> <InputAddressedPath>
+	// <index> <UnlockedReference> <LockedReference> <NixStorePath>
 	//
 	// Using an example:
 	// 0 github:NixOS/nixpkgs/52e3e80afff4b16ccb7c52e9f0f5220552f03d04#legacyPackages.x86_64-darwin.go_1_19 github:NixOS/nixpkgs/52e3e80afff4b16ccb7c52e9f0f5220552f03d04#legacyPackages.x86_64-darwin.go_1_19 /nix/store/w0lyimyyxxfl3gw40n46rpn1yjrl3q85-go-1.19.3

--- a/internal/shellgen/flake_input.go
+++ b/internal/shellgen/flake_input.go
@@ -80,12 +80,12 @@ func flakeInputs(ctx context.Context, packages []*devpkg.Package) ([]*flakeInput
 			return true
 		}
 
-		inStore, err := item.IsInBinaryStore()
+		inCache, err := item.IsInBinaryCache()
 		if err != nil {
 			// Ignore this error for now. TODO savil: return error?
 			return true
 		}
-		return !inStore
+		return !inCache
 	})
 
 	order := []string{}

--- a/internal/shellgen/flake_plan.go
+++ b/internal/shellgen/flake_plan.go
@@ -11,11 +11,11 @@ import (
 // flakePlan contains the data to populate the top level flake.nix file
 // that builds the devbox environment
 type flakePlan struct {
-	BinaryCacheStore string
-	NixpkgsInfo      *NixpkgsInfo
-	FlakeInputs      []*flakeInput
-	Packages         []*devpkg.Package
-	System           string
+	BinaryCache string
+	NixpkgsInfo *NixpkgsInfo
+	FlakeInputs []*flakeInput
+	Packages    []*devpkg.Package
+	System      string
 }
 
 func newFlakePlan(ctx context.Context, devbox devboxer) (*flakePlan, error) {
@@ -73,10 +73,10 @@ func newFlakePlan(ctx context.Context, devbox devboxer) (*flakePlan, error) {
 	}
 
 	return &flakePlan{
-		BinaryCacheStore: devpkg.BinaryCacheStore,
-		FlakeInputs:      flakeInputs,
-		NixpkgsInfo:      nixpkgsInfo,
-		Packages:         packages,
-		System:           system,
+		BinaryCache: devpkg.BinaryCache,
+		FlakeInputs: flakeInputs,
+		NixpkgsInfo: nixpkgsInfo,
+		Packages:    packages,
+		System:      system,
 	}, nil
 }

--- a/internal/shellgen/tmpl/flake_remove_nixpkgs.nix.tmpl
+++ b/internal/shellgen/tmpl/flake_remove_nixpkgs.nix.tmpl
@@ -30,11 +30,11 @@
         devShells.{{ .System }}.default = pkgs.mkShell {
           buildInputs = [
             {{- range .Packages }}
-            {{- if .IsInBinaryStore }}
+            {{- if .IsInBinaryCache }}
             (builtins.fetchClosure{
-              fromStore = "{{ $.BinaryCacheStore }}";
-              fromPath = "{{ .PathInBinaryStore }}";
-              toPath = "{{ .ContentAddressedStorePath }}";
+              fromStore = "{{ $.BinaryCache }}";
+              fromPath = "{{ .InputAddressedPath }}";
+              toPath = "{{ .ContentAddressedPath }}";
             })
             {{- end }}
             {{- end }}


### PR DESCRIPTION
## Summary

This PR is a follow up to this request from @gcurtis:
https://github.com/jetpack-io/devbox/pull/1256#pullrequestreview-1517592912

BUT having `NixStorePath` and `ContentAddressedPath` seemed odd since content-addressed paths
are also nix store paths. So, in this PR, I'm explicit about `NixStorePath` being
`InputAddressedPath`.


Also - changed `BinaryStore` to `BinaryCache`.

**RFC**:
I didn't change the `lock.SystemInfo` struct, I've left it as:
```
type SystemInfo struct {
	// StorePath is the input-addressed path for the nix package in /nix/store
	// It is the cache key in the Binary Cache Store (cache.nixos.org)
	// It is of the form <hash>-<name>-<version>
	// <name> may be different from the canonicalName so we store the full store path.
	StorePath string `json:"store_path,omitempty"`
	// CAStorePath is the content-addressed path for the nix package in /nix/store
	// It is of the form <hash>-<name>-<version>
	CAStorePath string `json:"ca_store_path,omitempty"`
}
```

I think this could be okay, because the default `store_path` for nix is input-addressed, for now at least.

If you'd like I can change `StorePath` to be explicitly:
```
InputAddrStorePath string `json:"input_addr_path, omitempty"
ContentAddrStorePath string `json:"content_addr_path, omitempty"
```

Let me know!

## How was it tested?

compiles
