### PR TITLE
[remove nixpkgs] move installableForPackage to a Package.Installable method

### DIFF
--- a/internal/nix/nixprofile/profile.go
+++ b/internal/nix/nixprofile/profile.go
@@ -228,7 +228,7 @@ func ProfileInstall(args *ProfileInstallArgs) error {
 		fmt.Fprintf(args.Writer, "%s\n", stepMsg)
 	}
 
-	installable, err := installableForPackage(input)
+	installable, err := input.Installable()
 	if err != nil {
 		return err
 	}
@@ -257,29 +257,4 @@ func ProfileRemoveItems(profilePath string, items []*NixProfileListItem) error {
 		indexes = append(indexes, strconv.Itoa(item.index))
 	}
 	return nix.ProfileRemove(profilePath, indexes)
-}
-
-// installableForPackage determines how nix profile should install this package.
-// Keeping in `nixprofile` package since its specific to how nix profile works,
-// rather than a general property of devpkg.Package
-func installableForPackage(pkg *devpkg.Package) (string, error) {
-	inCache, err := pkg.IsInBinaryCache()
-	if err != nil {
-		return "", err
-	}
-
-	if inCache {
-		// TODO savil: change to ContentAddressablePath?
-		installable, err := pkg.InputAddressedPath()
-		if err != nil {
-			return "", err
-		}
-		return installable, nil
-	}
-
-	installable, err := pkg.URLForInstall()
-	if err != nil {
-		return "", err
-	}
-	return installable, nil
 }


### PR DESCRIPTION
## Summary

I didn't feel strongly about where this lived. Moving to Package.Installable 
upon @mikeland73's suggestion in https://github.com/jetpack-io/devbox/pull/1255#discussion_r1256401600

## How was it tested?

compiles
