### PR TITLE
[remove nixpkgs] bug fix: update only the user's sysInfo, rather than for all systems

### DIFF
--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -509,8 +509,8 @@ func (p *Package) ContentAddressedPath() (string, error) {
 
 	ux.Fwarning(
 		os.Stderr,
-		"calculating local_store_path. This may be slow.\n"+
-			"Run `devbox update` to speed this up for next time.",
+		"calculating ca_store_path. This may be slow. "+
+			"Run `devbox update` to speed this up for next time.\n",
 	)
 	localPath, err := nix.ContentAddressedStorePath(sysInfo.StorePath)
 	if err != nil {

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -9,6 +9,7 @@ import (
 
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/devpkg"
+	"go.jetpack.io/devbox/internal/lock"
 	"go.jetpack.io/devbox/internal/nix"
 	"go.jetpack.io/devbox/internal/nix/nixprofile"
 	"go.jetpack.io/devbox/internal/searcher"
@@ -122,6 +123,9 @@ func (d *Devbox) updateDevboxPackage(
 			// Check if the system info is missing for the user's system.
 			sysInfo := d.lockfile.Packages[pkg.Raw].Systems[userSystem]
 			if sysInfo == nil {
+				if d.lockfile.Packages[pkg.Raw].Systems == nil {
+					d.lockfile.Packages[pkg.Raw].Systems = map[string]*lock.SystemInfo{}
+				}
 				d.lockfile.Packages[pkg.Raw].Systems[userSystem] = newEntry.Systems[userSystem]
 				ux.Finfo(d.writer, "Updated system information for %s\n", pkg)
 				return nil

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -115,22 +115,27 @@ func (d *Devbox) updateDevboxPackage(
 			return err
 		}
 
-		// Check if the system info is missing for the user's system.
-		sysInfo := d.lockfile.Packages[pkg.Raw].Systems[userSystem]
-		if sysInfo == nil {
-			d.lockfile.Packages[pkg.Raw] = newEntry
-			ux.Finfo(d.writer, "Updated system information for %s\n", pkg)
-			return nil
-		}
+		// If the newEntry has a system info for the user's system,
+		// then check if we need to update system info
+		if newEntry.Systems[userSystem] != nil {
 
-		// Check if the CAStorePath is missing for the user's system.
-		// Since any one user cannot add this field for all systems,
-		// we'll need to progressively add it to a project's lockfile.
-		if sysInfo.CAStorePath == "" {
-			// Update the CAStorePath for the user's system
-			d.lockfile.Packages[pkg.Raw].Systems[userSystem].CAStorePath = newEntry.Systems[userSystem].CAStorePath
-			ux.Finfo(d.writer, "Updated system information for %s\n", pkg)
-			return nil
+			// Check if the system info is missing for the user's system.
+			sysInfo := d.lockfile.Packages[pkg.Raw].Systems[userSystem]
+			if sysInfo == nil {
+				d.lockfile.Packages[pkg.Raw].Systems[userSystem] = newEntry.Systems[userSystem]
+				ux.Finfo(d.writer, "Updated system information for %s\n", pkg)
+				return nil
+			}
+
+			// Check if the CAStorePath is missing for the user's system.
+			// Since any one user cannot add this field for all systems,
+			// we'll need to progressively add it to a project's lockfile.
+			if sysInfo.CAStorePath == "" {
+				// Update the CAStorePath for the user's system
+				d.lockfile.Packages[pkg.Raw].Systems[userSystem].CAStorePath = newEntry.Systems[userSystem].CAStorePath
+				ux.Finfo(d.writer, "Updated system information for %s\n", pkg)
+				return nil
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

@mikeland73 points out that this line was erroneously updating all SystemInfos:
https://github.com/jetpack-io/devbox/pull/1256/files#r1256408509

Instead, we should only update the missing SystemInfo of the user's current system.

## How was it tested?

- [x] do `devbox update` of a lockfile having another system's SystemInfo
