### PR TITLE
[bug] Added abs path ref. to devbox binary in wrappers

### DIFF
--- a/internal/wrapnix/wrapper.go
+++ b/internal/wrapnix/wrapper.go
@@ -49,14 +49,21 @@ func CreateWrappers(ctx context.Context, devbox devboxer) error {
 	if err != nil {
 		return err
 	}
+	// get absolute path of devbox binary that the launcher script invokes
+	// to avoid causing an infinite loop when coreutils gets installed
+	executablePath, err := os.Executable()
+	if err != nil {
+		return err
+	}
 
 	for _, bin := range bins {
 		if err = createWrapper(&createWrapperArgs{
-			devboxer:     devbox,
-			BashPath:     bashPath,
-			Command:      bin,
-			ShellEnvHash: shellEnvHash,
-			destPath:     filepath.Join(destPath, filepath.Base(bin)),
+			devboxer:         devbox,
+			BashPath:         bashPath,
+			Command:          bin,
+			ShellEnvHash:     shellEnvHash,
+			DevboxBinaryPath: executablePath,
+			destPath:         filepath.Join(destPath, filepath.Base(bin)),
 		}); err != nil {
 			return errors.WithStack(err)
 		}
@@ -67,11 +74,11 @@ func CreateWrappers(ctx context.Context, devbox devboxer) error {
 
 type createWrapperArgs struct {
 	devboxer
-	BashPath     string
-	Command      string
-	ShellEnvHash string
-
-	destPath string
+	BashPath         string
+	Command          string
+	ShellEnvHash     string
+	DevboxBinaryPath string
+	destPath         string
 }
 
 func createWrapper(args *createWrapperArgs) error {

--- a/internal/wrapnix/wrapper.sh.tmpl
+++ b/internal/wrapnix/wrapper.sh.tmpl
@@ -19,7 +19,7 @@ DO_NOT_TRACK=1 can be removed once we optimize segment to queue events.
 
 if [[ "${{ .ShellEnvHashKey }}" != "{{ .ShellEnvHash }}" ]] && [[ -z "${{ .ShellEnvHashKey }}_GUARD" ]]; then
 export {{ .ShellEnvHashKey }}_GUARD=true
-eval "$(DO_NOT_TRACK=1 devbox shellenv -c {{ .ProjectDir }})"
+eval "$(DO_NOT_TRACK=1 {{ .DevboxBinaryPath }} shellenv -c {{ .ProjectDir }})"
 fi
 
 {{/*

--- a/internal/wrapnix/wrapper.sh.tmpl
+++ b/internal/wrapnix/wrapper.sh.tmpl
@@ -29,6 +29,6 @@ should be in PATH.
 
 DO_NOT_TRACK=1 can be removed once we optimize segment to queue events.
 */ -}}
-eval "$(DO_NOT_TRACK=1 devbox shellenv only-path-without-wrappers)"
+eval "$(DO_NOT_TRACK=1 {{ .DevboxBinaryPath }} shellenv only-path-without-wrappers)"
 
 exec {{ .Command }} "$@"


### PR DESCRIPTION
## Summary
This fixes an issue where if you install `coreutils` devbox shell in some cases gets stuck in infinite loop due this sequence of events:
1. devbox shell creates wrappers
2. wrappers try to omit wrappers from PATH and call devbox shellenv but it's unsuccessful 
3. devbox call in wrappers uses a couple of util tools (like `tr`) that now have their own wrappers because of coreutils.
4. the process is never able to skip the wrappers hence showing `fork: Resource Temporarily Unavailable`

I think it addresses #881 or at least a portion of it.

The fix:
in step 3 instead of calling devbox (launcher script in /usr/local/bin) we get the absolute path to the devbox binary and reference that directly in wrappers script.
This way the launcher script is not called more than once and avoids getting stuck in infinite loop.

## How was it tested?
- compile -> compiled binary is now in <path to devbox>/dist/devbox
- update line 413 of launcher (/usr/local/devbox) to `local -r bin="<path to devbox>/dist/devbox"`
- in an empty directory run devbox init
- add `coreutils@latest` to devbox.json
- run `devbox shell`