### PR TITLE
[nix] enable `auto-allocate-uids` experimental flag

### DIFF
--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -104,7 +104,7 @@ func FlakeNixpkgs(commit string) string {
 }
 
 func ExperimentalFlags() []string {
-	options := []string{"nix-command", "flakes"}
+	options := []string{"nix-command", "flakes", "auto-allocate-uids"}
 	if featureflag.RemoveNixpkgs.Enabled() {
 		options = append(options, "fetch-closure")
 	}


### PR DESCRIPTION

![Screenshot 2023-07-09 4 27 28 PM](https://github.com/jetpack-io/devbox/assets/15877106/b54d2f87-011d-40c9-9cba-69ebc5903e66)

## Summary

In this Pull Request, I enabled the experimental flag `auto-allocate-uids` to address an issue related to the installation of Nix packages. The error occurred when executing the command `/nix/var/nix/profiles/default/bin/nix print-dev-env /root/.local/share/devbox/global/default/.devbox/gen/flake/flake.nix --extra-experimental-features ca-derivations --option experimental-features nix-command flakes --json, which resulted in an exit status of 1.`

To resolve this issue, I modified the `ExperimentalFlags` function by adding the `"auto-allocate-uids"` option to the list of experimental flags. 

This change is specifically intended for a Linux environment with Nix version 2.15, installed using the instructions provided at https://github.com/DeterminateSystems/nix-installer

## How was it tested?
You can retry the package installation by running the command `devbox global add gh`.


