### PR TITLE
devbox add fallthrough and fallback for packages not handled by search

### DIFF
--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -403,7 +403,7 @@ func (p *Package) Versioned() string {
 }
 
 func (p *Package) IsLegacy() bool {
-	return p.isDevboxPackage() && !p.isVersioned()
+	return p.isDevboxPackage() && !p.isVersioned() && p.lockfile.Source(p.Raw) == ""
 }
 
 func (p *Package) LegacyToVersioned() string {

--- a/internal/devpkg/package_test.go
+++ b/internal/devpkg/package_test.go
@@ -119,6 +119,10 @@ func (l *lockfile) LegacyNixpkgsPath(pkg string) string {
 	)
 }
 
+func (l *lockfile) Source(pkg string) string {
+	return ""
+}
+
 func (l *lockfile) Resolve(pkg string) (*lock.Package, error) {
 	switch {
 	case strings.Contains(pkg, "path:"):

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -31,12 +31,10 @@ func (d *Devbox) Update(ctx context.Context, pkgs ...string) error {
 			if err := d.Remove(ctx, pkg.Raw); err != nil {
 				return err
 			}
-			if err := d.lockfile.ResolveToCurrentNixpkgCommitHash(
-				pkg.LegacyToVersioned(),
-			); err != nil {
-				return err
-			}
-			if err := d.Add(ctx, pkg.LegacyToVersioned()); err != nil {
+			// Calling Add function with the original package names, since
+			// Add will automatically append @latest if search is able to handle that.
+			// If not, it will fallback to the nixpkg format.
+			if err := d.Add(ctx, pkg.Raw); err != nil {
 				return err
 			}
 		} else {

--- a/internal/lock/interfaces.go
+++ b/internal/lock/interfaces.go
@@ -14,4 +14,5 @@ type Locker interface {
 	LegacyNixpkgsPath(string) string
 	ProjectDir() string
 	Resolve(string) (*Package, error)
+	Source(string) string
 }

--- a/internal/lock/lockfile.go
+++ b/internal/lock/lockfile.go
@@ -17,6 +17,10 @@ import (
 )
 
 const lockFileVersion = "1"
+const (
+	NixpkgSource       string = "nixpkg"
+	DevboxSearchSource        = "devbox-search"
+)
 
 // Lightly inspired by package-lock.json
 type File struct {
@@ -32,6 +36,7 @@ type Package struct {
 	LastModified  string `json:"last_modified,omitempty"`
 	PluginVersion string `json:"plugin_version,omitempty"`
 	Resolved      string `json:"resolved,omitempty"`
+	Source        string `json:"source,omitempty"`
 	Version       string `json:"version,omitempty"`
 	// Systems is keyed by the system name
 	Systems map[string]*SystemInfo `json:"systems,omitempty"`
@@ -97,7 +102,10 @@ func (l *File) Resolve(pkg string) (*Package, error) {
 		} else if IsLegacyPackage(pkg) {
 			// These are legacy packages without a version. Resolve to nixpkgs with
 			// whatever hash is in the devbox.json
-			locked = &Package{Resolved: l.LegacyNixpkgsPath(pkg)}
+			locked = &Package{
+				Resolved: l.LegacyNixpkgsPath(pkg),
+				Source:   NixpkgSource,
+			}
 		}
 		l.Packages[pkg] = locked
 	}
@@ -117,7 +125,10 @@ func (l *File) ResolveToCurrentNixpkgCommitHash(pkg string) error {
 			"only allowed version is @latest. Otherwise we can't guarantee the " +
 				"version will resolve")
 	}
-	l.Packages[pkg] = &Package{Resolved: l.LegacyNixpkgsPath(name)}
+	l.Packages[pkg] = &Package{
+		Resolved: l.LegacyNixpkgsPath(name),
+		Source:   NixpkgSource,
+	}
 	return nil
 }
 
@@ -131,6 +142,14 @@ func (l *File) LegacyNixpkgsPath(pkg string) string {
 		l.NixPkgsCommitHash(),
 		pkg,
 	)
+}
+
+func (l *File) Source(pkg string) string {
+	entry, hasEntry := l.Packages[pkg]
+	if !hasEntry || entry.Resolved == "" {
+		return ""
+	}
+	return entry.Source
 }
 
 // This probably belongs in input.go but can't add it there because it will

--- a/internal/lock/lockfile.go
+++ b/internal/lock/lockfile.go
@@ -18,8 +18,8 @@ import (
 
 const lockFileVersion = "1"
 const (
-	NixpkgSource       string = "nixpkg"
-	DevboxSearchSource        = "devbox-search"
+	nixpkgSource       string = "nixpkg"
+	devboxSearchSource string = "devbox-search"
 )
 
 // Lightly inspired by package-lock.json
@@ -104,7 +104,7 @@ func (l *File) Resolve(pkg string) (*Package, error) {
 			// whatever hash is in the devbox.json
 			locked = &Package{
 				Resolved: l.LegacyNixpkgsPath(pkg),
-				Source:   NixpkgSource,
+				Source:   nixpkgSource,
 			}
 		}
 		l.Packages[pkg] = locked
@@ -116,20 +116,6 @@ func (l *File) Resolve(pkg string) (*Package, error) {
 func (l *File) ForceResolve(pkg string) (*Package, error) {
 	delete(l.Packages, pkg)
 	return l.Resolve(pkg)
-}
-
-func (l *File) ResolveToCurrentNixpkgCommitHash(pkg string) error {
-	name, version, found := strings.Cut(pkg, "@")
-	if found && version != "latest" {
-		return errors.New(
-			"only allowed version is @latest. Otherwise we can't guarantee the " +
-				"version will resolve")
-	}
-	l.Packages[pkg] = &Package{
-		Resolved: l.LegacyNixpkgsPath(name),
-		Source:   NixpkgSource,
-	}
-	return nil
 }
 
 func (l *File) Save() error {

--- a/internal/lock/resolve.go
+++ b/internal/lock/resolve.go
@@ -57,7 +57,7 @@ func (l *File) FetchResolvedPackage(pkg string) (*Package, error) {
 			packageInfo.AttrPaths[0],
 		),
 		Version: packageInfo.Version,
-		Source:  DevboxSearchSource,
+		Source:  devboxSearchSource,
 		Systems: sysInfos,
 	}, nil
 }

--- a/internal/lock/resolve.go
+++ b/internal/lock/resolve.go
@@ -57,6 +57,7 @@ func (l *File) FetchResolvedPackage(pkg string) (*Package, error) {
 			packageInfo.AttrPaths[0],
 		),
 		Version: packageInfo.Version,
+		Source:  DevboxSearchSource,
 		Systems: sysInfos,
 	}, nil
 }


### PR DESCRIPTION
## Summary
`devbox add` fallthrough and fallback for packages not handled by search.

This PR does not do the following:
1. Print a warning that a package is in a fallthrough case (I'm unclear if a warning is needed?)
2. Accept an alternative nixpkg commit hash for that specific package (I'm unclear if we are deprecating `nixpkg` commit field in `devbox.json` immediately?)

I'd like to address those two things above if needed in a separate PR as a follow up.

Example lockfile:
```
{
  "lockfile_version": "1",
  "packages": {
    "python310": {
      "plugin_version": "0.0.1",
      "resolved": "github:NixOS/nixpkgs/f80ac848e3d6f0c12c52758c0f25c10c97ca3b62#python310",
      "source": "nixpkg"
    },
    "python310Packages.pip@latest": {
      "last_modified": "2023-05-06T16:57:53Z",
      "plugin_version": "0.0.1",
      "resolved": "github:NixOS/nixpkgs/16b3b0c53b1ee8936739f8c588544e7fcec3fc60#python310Packages.pip",
      "source": "devbox-search",
      "version": "23.0.1"
    },
    "stdenv.cc.cc.lib": {
      "resolved": "github:NixOS/nixpkgs/f80ac848e3d6f0c12c52758c0f25c10c97ca3b62#stdenv.cc.cc.lib",
      "source": "nixpkg"
    }
  }
}

```

## How was it tested?
In the Tensorflow example:
```
devbox add stdenv.cc.cc.lib
devbox add nodejs-16_x
devbox update
```