### PR TITLE
Add Global Gems to Path

### DIFF
--- a/plugins/ruby.json
+++ b/plugins/ruby.json
@@ -1,8 +1,9 @@
 {
   "name": "ruby",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "match": "^ruby([0-9_]*[0-9]+)?$",
   "env": {
+    "PATH": "{{ .Virtenv }}/bin/:$PATH",
     "RUBY_CONFDIR": "{{ .Virtenv }}",
     "GEMRC": "{{ .Virtenv }}/.gemrc",
     "GEM_HOME": "{{ .Virtenv }}"


### PR DESCRIPTION
## Summary

Fixes an issue where global gems (like rails) were not included in PATH

## How was it tested?

Using the Rails example: 

```
devbox shell
which rails
(should show the rails in `virtenv`)
```
