### PR TITLE
[plugins] Allow multiple plugins per repo

### DIFF
--- a/examples/plugins/github-with-revision/devbox.json
+++ b/examples/plugins/github-with-revision/devbox.json
@@ -11,6 +11,6 @@
     }
   },
   "include": [
-    "github:jetpack-io/devbox-plugin-example/6ea0ef9e12ab58dbbb145ca8f3a465611cb603a9"
+    "github:jetpack-io/devbox-plugin-example/6ea0ef9e12ab58dbbb145ca8f3a465611cb603a9#devbox"
   ]
 }

--- a/examples/plugins/github/devbox.json
+++ b/examples/plugins/github/devbox.json
@@ -11,6 +11,7 @@
     }
   },
   "include": [
-    "github:jetpack-io/devbox-plugin-example"
+    "github:jetpack-io/devbox-plugin-example",
+    "github:jetpack-io/devbox-plugin-example#custom-name"
   ]
 }

--- a/examples/plugins/github/test.sh
+++ b/examples/plugins/github/test.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
 expected="I AM SET (new value)"
-if [ "$MY_ENV_VAR" == "$expected" ]; then
+custom_expected="I AM SET TO CUSTOM (new value)"
+if [ "$MY_ENV_VAR" == "$expected" ] && [ "$MY_ENV_VAR_CUSTOM" == "$MY_ENV_VAR_CUSTOM" ]; then
   echo "Success! MY_ENV_VAR is set to '$MY_ENV_VAR'"
+  echo "Success! MY_ENV_VAR_CUSTOM is set to '$MY_ENV_VAR_CUSTOM'"
 else
   echo "MY_ENV_VAR environment variable is not set to '$expected'"
+  echo "MY_ENV_VAR MY_ENV_VAR_CUSTOM variable is not set to '$MY_ENV_VAR_CUSTOM'"
   exit 1
 fi

--- a/internal/plugin/files.go
+++ b/internal/plugin/files.go
@@ -18,7 +18,7 @@ func getConfigIfAny(pkg Includable, projectDir string) (*config, error) {
 	case *devpkg.Package:
 		return getBuiltinPluginConfig(pkg, projectDir)
 	case *githubPlugin:
-		return getConfigFromGithub(pkg, projectDir)
+		return pkg.buildConfig(projectDir)
 	case *localPlugin:
 		content, err := os.ReadFile(pkg.path)
 		if err != nil && !os.IsNotExist(err) {
@@ -59,12 +59,4 @@ func getBuiltinPluginConfig(pkg Includable, projectDir string) (*config, error) 
 		return cfg, nil
 	}
 	return nil, nil
-}
-
-func getConfigFromGithub(pkg *githubPlugin, projectDir string) (*config, error) {
-	content, err := pkg.FileContent("devbox.json")
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	return buildConfig(pkg, projectDir, string(content))
 }


### PR DESCRIPTION
## Summary

This makes 2 changes:

* Allow multiple plugins per repo using fragment syntax (similar to nixpkgs)
* Rename default from `devbox.json` to `default.json`

## How was it tested?

example tests
