### PR TITLE
[plugins] New github repo structure

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -113,7 +113,7 @@ jobs:
           DEVBOX_DEBUG: ${{ (!matrix.run-example-tests || inputs.example-debug) && '1' || '0' }}
           DEVBOX_EXAMPLE_TESTS: ${{ matrix.run-example-tests }}
           # Used in `go test -timeout` flag. Needs a value that time.ParseDuration can parse.
-          DEVBOX_GOLANG_TEST_TIMEOUT: "${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && '35m' || '15m' }}"
+          DEVBOX_GOLANG_TEST_TIMEOUT: "${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && '35m' || '20m' }}"
         run: |
           go test -v -timeout $DEVBOX_GOLANG_TEST_TIMEOUT ./...
 

--- a/examples/plugins/github-with-revision/devbox.json
+++ b/examples/plugins/github-with-revision/devbox.json
@@ -11,6 +11,6 @@
     }
   },
   "include": [
-    "github:jetpack-io/devbox-plugin-example/6ea0ef9e12ab58dbbb145ca8f3a465611cb603a9#devbox"
+    "github:jetpack-io/devbox-plugin-example/d9c00334353c9b1294c7bd5dbea128c149b2eb3a"
   ]
 }

--- a/examples/plugins/github/devbox.json
+++ b/examples/plugins/github/devbox.json
@@ -12,6 +12,6 @@
   },
   "include": [
     "github:jetpack-io/devbox-plugin-example",
-    "github:jetpack-io/devbox-plugin-example#custom-name"
+    "github:jetpack-io/devbox-plugin-example?dir=custom-dir"
   ]
 }


### PR DESCRIPTION
## Summary

This follows the following plan:

- No manifest
- Use flake notation `github:org/repo/<revision>?dir=<dir>`
- Use `plugin.json` as config file name

TODO (in follow up):
- Special case `plugin:<name>` to our own plugin repo.

## How was it tested?

`devbox run run_test`
