### PR TITLE
[bugfix] Write back lockfile after devbox update

### DIFF
--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -518,8 +518,8 @@ func (p *Package) ContentAddressedPath() (string, error) {
 
 	ux.Fwarning(
 		os.Stderr,
-		"calculating ca_store_path. This may be slow. "+
-			"Run `devbox update` to speed this up for next time.\n",
+		fmt.Sprintf("calculating ca_store_path for %s. This may be slow. "+
+			"Run `devbox update` to speed this up for next time.\n", sysInfo.StorePath),
 	)
 	localPath, err := nix.ContentAddressedStorePath(sysInfo.StorePath)
 	if err != nil {

--- a/internal/lock/package.go
+++ b/internal/lock/package.go
@@ -45,13 +45,8 @@ func (p *Package) IsAllowInsecure() bool {
 }
 
 func (i *SystemInfo) Equals(other *SystemInfo) bool {
-	if i == nil {
-		return other == nil
+	if i == nil || other == nil {
+		return i == other
 	}
-	if other == nil {
-		return false
-	}
-
-	return i.StorePath == other.StorePath &&
-		i.CAStorePath == other.CAStorePath
+	return *i == *other
 }

--- a/internal/lock/package.go
+++ b/internal/lock/package.go
@@ -22,11 +22,11 @@ type Package struct {
 type SystemInfo struct {
 	// StorePath is the input-addressed path for the nix package in /nix/store
 	// It is the cache key in the Binary Cache Store (cache.nixos.org)
-	// It is of the form <hash>-<name>-<version>
+	// It is of the form /nix/store/<hash>-<name>-<version>
 	// <name> may be different from the canonicalName so we store the full store path.
 	StorePath string `json:"store_path,omitempty"`
 	// CAStorePath is the content-addressed path for the nix package in /nix/store
-	// It is of the form <hash>-<name>-<version>
+	// It is of the form /nix/store/<hash>-<name>-<version>
 	CAStorePath string `json:"ca_store_path,omitempty"`
 }
 
@@ -42,4 +42,16 @@ func (p *Package) IsAllowInsecure() bool {
 		return false
 	}
 	return p.AllowInsecure
+}
+
+func (i *SystemInfo) Equals(other *SystemInfo) bool {
+	if i == nil {
+		return other == nil
+	}
+	if other == nil {
+		return false
+	}
+
+	return i.StorePath == other.StorePath &&
+		i.CAStorePath == other.CAStorePath
 }


### PR DESCRIPTION
## Summary

After calling `devbox update`, we were not writing back to `devbox.lock`. `ensurePkgsAreInstalled` would then return early because the local lock file hadn't changed (since it re-reads `devbox.lock` from disk, rather than using the updated in-memory lockfile), so it would skip writing the lockfile as well.

This also makes the lockfile a bit more self-healing, since it will overwrite the current user's sysInfo entirely, rather than just adding the CAStorePath. This ensures that the StorePath and CAStorePath are written together.

## How was it tested?
Manually, but plan to add testscripts in separate PR. I tested a few different scenarios, notably:

1. `devbox update` adds system info for current user without changing system info for other systems.
2. If current system info is missing something (either CAStorePath or Path), `devbox update` will restore it.
3. If, say, CAStorePath is missing for the current system, and the user calls `devbox shell`, then we'll print a warning instructing the user to run `devbox update`. Calling it will then actually fix the lockfile and the warning will not be reprinted. It's worth mentioning that the warning will only be shown once to the user, because then they'll cache print-dev-env, so we won't re-exercise the path that computes CAStorePath. Not super ideal, but good enough I think.
4. If current system info is missing entirely, it is added.
5. If current system info exists and matches new one, nothing is done and we print "Already up-to-date"