### PR TITLE
[rm nixpkgs] Add more info on errors for debuggability

### DIFF
--- a/internal/lock/resolve.go
+++ b/internal/lock/resolve.go
@@ -91,8 +91,8 @@ func buildLockSystemInfos(pkg *searcher.PackageVersion) (map[string]*SystemInfo,
 	for sysName, sysInfo := range pkg.Systems {
 
 		// guard against missing search data
-		if sysInfo.StoreHash == "" || sysInfo.StoreName == "" || sysInfo.StoreVersion == "" {
-			debug.Log("WARN: skipping %s in %s due to missing store name or hash or version\n", pkg.Name, sysName)
+		if sysInfo.StoreHash == "" || sysInfo.StoreName == "" {
+			debug.Log("WARN: skipping %s in %s due to missing store name or hash", pkg.Name, sysName)
 			continue
 		}
 


### PR DESCRIPTION
## Summary
* ~Skips packages with missing store versions, since they're needed for the store path.~
* Adds debug line and context to error msg to aid in debugging.

A related question: My understanding is that nix store paths are of the form `/nix/store/<hash>-<pkg>`, and _not_ of the form `/nix/store/<hash>-<pkg>-<version>`. Meaning that some (most) package names just add the version suffix as convention. So I'm a bit worried about trying to parse the version from the name and then essentially reconstructing that here. Would prefer to just pass the untouched pkg name and use that. @gcurtis why do we parse out the version separately (if that's what we're doing)?

Another thing is I noticed that as long as the hash we pass to `nix store make-content-addressed` is correct, then the rest doesn't matter. Example:
```
> nix store make-content-addressed /nix/store/glb4gpim82f0bmzcpayvklbfqc6qzvwj-this-does-not-matter --json
asked 'https://cache.nixos.org' for '/nix/store/glb4gpim82f0bmzcpayvklbfqc6qzvwj-this-does-not-matter' but got '/nix/store/glb4gpim82f0bmzcpayvklbfqc6qzvwj-jq-1.6-bin' # <-- the path we want.
```
We could potentially try to recover from errors by using the path in that response. (Update: I think it's ok to just fail instead of trying to parse the response and recovering).

## How was it tested?
Manually by returning fake data from the calls to the search service.