### PR TITLE
[rm nixpkgs] Install same package in profile as in flake.nix

### DIFF
--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -156,8 +156,7 @@ func (p *Package) Installable() (string, error) {
 	}
 
 	if inCache {
-		// TODO savil: change to ContentAddressablePath?
-		installable, err := p.InputAddressedPath()
+		installable, err := p.ContentAddressedPath()
 		if err != nil {
 			return "", err
 		}

--- a/internal/nix/nixprofile/profile.go
+++ b/internal/nix/nixprofile/profile.go
@@ -75,8 +75,7 @@ func ProfileListIndex(args *ProfileListIndexArgs) (int, error) {
 		return -1, err
 	}
 	if inCache {
-		// TODO savil: change to ContentAddressedPath?
-		pathInStore, err := args.Input.InputAddressedPath()
+		pathInStore, err := args.Input.Installable()
 		if err != nil {
 			return -1, err
 		}


### PR DESCRIPTION
## Summary
I don't really expect there to be a difference here, but for consistency, we should be installing exactly the same packages in profile and in flake.nix, even if we expect the contents to be the same.

## How was it tested?
Before:
```
> DEVBOX_FEATURE_REMOVE_NIXPKGS=1 devbox rm hello
> DEVBOX_FEATURE_REMOVE_NIXPKGS=1 devbox add hello@2.12.1
> cat devbox.lock
...
    "hello@2.12.1": {
      "last_modified": "1970-01-01T00:00:00Z",
      "resolved": "github:NixOS/nixpkgs/eb751d65225ec53de9cf3d88acbf08d275882389#hello",
      "source": "devbox-search",
      "systems": {
        "aarch64-darwin": {
          "store_path": "/nix/store/qh8s6yb93b1wl0jxg5i0pfq2rf7qm44j-hello-2.12.1"
        },
        "x86_64-darwin": {
          "store_path": "/nix/store/ycbqd7822qcnasaqy0mmiv2j9n9m62yl-hello-2.12.1",
          "ca_store_path": "/nix/store/1jaa5hqp6pv43z7p3xc7gkck0q3rkg4n-hello-2.12.1"
        },
        "x86_64-linux": {
          "store_path": "/nix/store/8n3pr83b7aab975gwrd6hnk10pqphr59-hello-2.12.1"
        }
      }
    },
...
> ls -la .devbox/nix/profile/default/bin
total 0
dr-xr-xr-x  5 root  nixbld  160 Dec 31  1969 .
dr-xr-xr-x  5 root  nixbld  160 Dec 31  1969 ..
lrwxr-xr-x  1 root  nixbld   66 Dec 31  1969 hello -> /nix/store/ycbqd7822qcnasaqy0mmiv2j9n9m62yl-hello-2.12.1/bin/hello

> DEVBOX_FEATURE_REMOVE_NIXPKGS=1 devbox run -- tail -n 1 '$(which hello)'
exec /nix/store/1jaa5hqp6pv43z7p3xc7gkck0q3rkg4n-hello-2.12.1/bin/hello "$@"
```

After
```
> ls -la .devbox/nix/profile/default/bin
total 0
dr-xr-xr-x  5 root  nixbld  160 Dec 31  1969 .
dr-xr-xr-x  5 root  nixbld  160 Dec 31  1969 ..
lrwxr-xr-x  1 root  nixbld   66 Dec 31  1969 hello -> /nix/store/1jaa5hqp6pv43z7p3xc7gkck0q3rkg4n-hello-2.12.1/bin/hello
```