### PR TITLE
fix: release for armv7l

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,10 +21,17 @@ builds:
     goos:
       - linux
       - darwin
+    goarch:
+      - 386
+      - amd64
+      - arm64
+      - arm
+    goarm:
+      - 7
 archives:
   - files:
       - no-files-will-match-* # Glob that does not match to create archive with only binaries.
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if eq .Arch "arm" }}v{{ .Arm }}l{{ end }}'
 snapshot:
   name_template: "{{ .Env.EDGE_TAG }}"
 checksum:


### PR DESCRIPTION
## Summary

This should release devbox for an armv7l machine.

I've added the default values in case there was no value found here: https://goreleaser.com/customization/builds/#builds

Closes #1299

## How was it tested?

Manually created a release: `TELEMETRY_KEY=whatever SENTRY_DSN=whatever EDGE_TAG=0.0.0-dev goreleaser release --clean --skip-publish --skip-announce --snapshot` unpacked the armv7l binary and ran it on my Raspberry PI.
