### PR TITLE
Update quickstart.mdx

### DIFF
--- a/docs/app/docs/quickstart.mdx
+++ b/docs/app/docs/quickstart.mdx
@@ -169,7 +169,7 @@ Once you publish your Devbox project to Github, you can help other developers ge
 * **[Devbox Global](devbox_global.md):** Learn how to use the devbox as a global package manager
 * **[Devbox Scripts](guides/scripts.md):** Automate setup steps and configuration for your shell using Devbox Scripts.
 * **[Configuration Guide](configuration.md):** Learn how to configure your shell and dev environment with `devbox.json`.
-* **[Browse Examples](https://github.com/jetpack-io/devbox-examples):** You can see how to create a development environment for your favorite tools or languages by browsing the Devbox Examples repo.
+* **[Browse Examples](https://github.com/jetpack-io/devbox/tree/main/examples):** You can see how to create a development environment for your favorite tools or languages by browsing the Devbox Examples repo.
 
 ### Use Devbox with your IDE
 * **[Direnv Integration](ide_configuration/direnv.md):** Devbox can integrate with [direnv](https://direnv.net/) to automatically activate your shell and packages when you navigate to your project.


### PR DESCRIPTION
Link points to archived repo. Changed to current examples.

## Summary
The **Browse Examples** button is currently pointing to the archived example repo
## How was it tested?
