### PR TITLE
Update the Yarn overlay example and make sure it works

### DIFF
--- a/examples/flakes/overlay/devbox.json
+++ b/examples/flakes/overlay/devbox.json
@@ -1,7 +1,8 @@
 {
   "packages": [
-    "fnm",
-    "path:yarn-overlay#yarn"
+    "path:yarn-overlay#yarn",
+    "fnm@latest",
+    "nodejs@16.8"
   ],
   "shell": {
     "init_hook": [

--- a/examples/flakes/overlay/devbox.lock
+++ b/examples/flakes/overlay/devbox.lock
@@ -1,0 +1,17 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "fnm@latest": {
+      "last_modified": "2023-05-06T16:57:53Z",
+      "resolved": "github:NixOS/nixpkgs/16b3b0c53b1ee8936739f8c588544e7fcec3fc60#fnm",
+      "source": "devbox-search",
+      "version": "1.33.1"
+    },
+    "nodejs@16.8": {
+      "last_modified": "2021-09-06T20:58:52Z",
+      "resolved": "github:NixOS/nixpkgs/fc3de6da83863f8f36fdcac1c199c6066a6a0378#nodejs-16_x",
+      "source": "devbox-search",
+      "version": "16.8.0"
+    }
+  }
+}

--- a/examples/flakes/overlay/yarn-overlay/flake.lock
+++ b/examples/flakes/overlay/yarn-overlay/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1659446231,
-        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
+        "lastModified": 1630961932,
+        "narHash": "sha256-2vV8AQEPcWDoDmKnu20wjGVaE1LhmCp8bc3UaEg/vnE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
+        "rev": "fc3de6da83863f8f36fdcac1c199c6066a6a0378",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-21.11",
+        "rev": "fc3de6da83863f8f36fdcac1c199c6066a6a0378",
         "type": "indirect"
       }
     },

--- a/examples/flakes/overlay/yarn-overlay/flake.nix
+++ b/examples/flakes/overlay/yarn-overlay/flake.nix
@@ -3,7 +3,7 @@
     "This flake outputs a modified version of Yarn that uses NodeJS 16";
 
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-21.11";
+    nixpkgs.url = "nixpkgs/fc3de6da83863f8f36fdcac1c199c6066a6a0378";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -17,7 +17,7 @@
         yarn = prev.yarn.override { nodejs = final.pkgs.nodejs-16_x; };
       });
 
-      # 
+      #
       pkgs =
         import nixpkgs {
           inherit system;
@@ -25,14 +25,11 @@
           overlays = [ overlay ];
         };
 
-    in {
+    in rec {
       # For our outputs, we'll return the modified Yarn package from our overridden nixpkgs.
       packages = {
         yarn = pkgs.yarn;
       };
-
-      # [Optional] Set yarn as the default package output for this flake
-      defaultPackage = self.packages.yarn;
     }
   );
 }


### PR DESCRIPTION
## Summary

- Fixes the yarn overlay example so that the nodejs16 version matches the one installed by devbox
- Updates the lockfile

## How was it tested?
`devbox shell`
`yarn versions`