### PR TITLE
[easy][minor fix] add error object to error message's format string inputs

### DIFF
--- a/internal/nix/nixprofile/profile.go
+++ b/internal/nix/nixprofile/profile.go
@@ -135,7 +135,7 @@ func parseNixProfileListItem(line string) (*NixProfileListItem, error) {
 	}
 	index, err := strconv.Atoi(scanner.Text())
 	if err != nil {
-		return nil, redact.Errorf("error parsing \"nix profile list\" output: %w: %s", line)
+		return nil, redact.Errorf("error parsing \"nix profile list\" output: %w: %s", err, line)
 	}
 
 	if !scanner.Scan() {


### PR DESCRIPTION
## Summary

*Motivation*
Seeing this output:
```
error parsing "nix profile list" output: %!w(string=Index:              0): %!s(MISSING)
go.jetpack.io/devbox/internal/nix/nixprofile.parseNixProfileListItem
	/home/runner/work/devbox/devbox/internal/nix/nixprofile/profile.go:138
```
in failing CICD: https://github.com/jetpack-io/devbox/actions/runs/5658605381/job/15330281379

This fixes the error message, not the underlying cause

*Fix*
%w format string in golang is for errors. Docs: https://pkg.go.dev/fmt#Errorf

## How was it tested?
