### PR TITLE
[tests] Add test for old nix versions

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -139,7 +139,8 @@ jobs:
           echo "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}" > ~/.config/nix/nix.conf
 
           devbox run echo "Installing packages..."
-          devbox rm go
+      - name: Test removing package
+        run: devbox rm go
   
   test-with-old-nix-version:
     strategy:
@@ -156,7 +157,7 @@ jobs:
         run: go install ./cmd/devbox
       - name: Install nix
         run: sh <(curl -L https://releases.nixos.org/nix/nix-${{ matrix.version }}/install) --daemon
-      - name: Install nix and devbox packages
+      - name: Install devbox packages
         run: |
           # Setup github authentication to ensure Github's rate limits are not hit.
           # If this works, we can consider refactoring this into a reusable github action helper.
@@ -164,4 +165,5 @@ jobs:
           echo "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}" > ~/.config/nix/nix.conf
 
           devbox run echo "Installing packages..."
-          devbox rm go
+      - name: Test removing package
+        run: devbox rm go

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -139,8 +139,9 @@ jobs:
           echo "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}" > ~/.config/nix/nix.conf
 
           devbox run echo "Installing packages..."
+          devbox rm go
   
-  old-nix-version:
+  test-with-old-nix-version:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -163,3 +164,4 @@ jobs:
           echo "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}" > ~/.config/nix/nix.conf
 
           devbox run echo "Installing packages..."
+          devbox rm go

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -139,3 +139,27 @@ jobs:
           echo "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}" > ~/.config/nix/nix.conf
 
           devbox run echo "Installing packages..."
+  
+  old-nix-version:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        version: [2.15.1]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: ./go.mod
+      - name: Build devbox
+        run: go install ./cmd/devbox
+      - name: Install nix
+        run: sh <(curl -L https://releases.nixos.org/nix/nix-${{ matrix.version }}/install) --daemon
+      - name: Install nix and devbox packages
+        run: |
+          # Setup github authentication to ensure Github's rate limits are not hit.
+          # If this works, we can consider refactoring this into a reusable github action helper.
+          mkdir -p ~/.config/nix
+          echo "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}" > ~/.config/nix/nix.conf
+
+          devbox run echo "Installing packages..."


### PR DESCRIPTION
## Summary

Since we saw CLI format change (See https://github.com/jetpack-io/devbox/pull/1308) we should test against many nix versions.

Possible followup: In `main` should we run all nix versions?

## How was it tested?
CICD