### PR TITLE
[bugs]: add other sysinfos, but respect existing ca paths

### DIFF
--- a/internal/boxcli/featureflag/feature.go
+++ b/internal/boxcli/featureflag/feature.go
@@ -6,6 +6,7 @@ package featureflag
 import (
 	"os"
 	"strconv"
+	"testing"
 
 	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/envir"
@@ -52,6 +53,10 @@ func (f *feature) Enabled() bool {
 		return on
 	}
 	return f.enabled
+}
+
+func (f *feature) EnableForTest(t *testing.T) {
+	t.Setenv(envir.DevboxFeaturePrefix+f.name, "1")
 }
 
 // All returns a map of all known features flags and whether they're enabled.

--- a/internal/impl/update_test.go
+++ b/internal/impl/update_test.go
@@ -28,3 +28,186 @@ func TestUpdateNewPackageIsAdded(t *testing.T) {
 
 	require.Contains(t, lockfile.Packages, raw)
 }
+
+func TestUpdateNewCurrentSysInfoIsAdded(t *testing.T) {
+	devbox := devboxForTesting(t)
+
+	raw := "hello@1.2.3"
+	sys := "system1"
+	devPkg := &devpkg.Package{
+		Raw: raw,
+	}
+	resolved := &lock.Package{
+		Resolved: "resolved-flake-reference",
+		Systems: map[string]*lock.SystemInfo{
+			sys: {
+				StorePath:   "store_path1",
+				CAStorePath: "ca_path1",
+			},
+		},
+	}
+	lockfile := &lock.File{
+		Packages: map[string]*lock.Package{
+			raw: {
+				Resolved: "resolved-flake-reference",
+				Version:  "1",
+				// No system infos.
+			},
+		},
+	}
+
+	err := devbox.mergeResolvedPackageToLockfile(context.Background(), devPkg, resolved, lockfile)
+	require.NoError(t, err, "update failed")
+
+	require.Contains(t, lockfile.Packages, raw)
+	require.Contains(t, lockfile.Packages[raw].Systems, sys)
+	require.Equal(t, "store_path1", lockfile.Packages[raw].Systems[sys].StorePath)
+}
+
+func TestUpdateNewSysInfoIsAdded(t *testing.T) {
+	devbox := devboxForTesting(t)
+
+	raw := "hello@1.2.3"
+	sys1 := "system1" // current system
+	sys2 := "system2"
+	devPkg := &devpkg.Package{
+		Raw: raw,
+	}
+	resolved := &lock.Package{
+		Resolved: "resolved-flake-reference",
+		Systems: map[string]*lock.SystemInfo{
+			sys1: {
+				StorePath:   "store_path1",
+				CAStorePath: "ca_path1",
+			},
+			sys2: {
+				StorePath: "store_path2",
+			},
+		},
+	}
+	lockfile := &lock.File{
+		Packages: map[string]*lock.Package{
+			raw: {
+				Resolved: "resolved-flake-reference",
+				Version:  "1",
+				Systems: map[string]*lock.SystemInfo{
+					sys1: {
+						StorePath:   "store_path1",
+						CAStorePath: "ca_path1",
+					},
+					// Missing sys2
+				},
+			},
+		},
+	}
+
+	err := devbox.mergeResolvedPackageToLockfile(context.Background(), devPkg, resolved, lockfile)
+	require.NoError(t, err, "update failed")
+
+	require.Contains(t, lockfile.Packages, raw)
+	require.Contains(t, lockfile.Packages[raw].Systems, sys1)
+	require.Contains(t, lockfile.Packages[raw].Systems, sys2)
+	require.Equal(t, "store_path2", lockfile.Packages[raw].Systems[sys2].StorePath)
+}
+
+func TestUpdateOtherSysInfoIsReplaced(t *testing.T) {
+	devbox := devboxForTesting(t)
+
+	raw := "hello@1.2.3"
+	sys1 := "system1" // current system
+	sys2 := "system2"
+	devPkg := &devpkg.Package{
+		Raw: raw,
+	}
+	resolved := &lock.Package{
+		Resolved: "resolved-flake-reference",
+		Systems: map[string]*lock.SystemInfo{
+			sys1: {
+				StorePath:   "store_path1",
+				CAStorePath: "ca_path1",
+			},
+			sys2: {
+				StorePath: "store_path2",
+			},
+		},
+	}
+	lockfile := &lock.File{
+		Packages: map[string]*lock.Package{
+			raw: {
+				Resolved: "resolved-flake-reference",
+				Version:  "1",
+				Systems: map[string]*lock.SystemInfo{
+					sys1: {
+						StorePath:   "store_path1",
+						CAStorePath: "ca_path1",
+					},
+					sys2: {
+						StorePath:   "mismatching_store_path",
+						CAStorePath: "ca_path2",
+					},
+				},
+			},
+		},
+	}
+
+	err := devbox.mergeResolvedPackageToLockfile(context.Background(), devPkg, resolved, lockfile)
+	require.NoError(t, err, "update failed")
+
+	require.Contains(t, lockfile.Packages, raw)
+	require.Contains(t, lockfile.Packages[raw].Systems, sys1)
+	require.Contains(t, lockfile.Packages[raw].Systems, sys2)
+	require.Equal(t, "store_path1", lockfile.Packages[raw].Systems[sys1].StorePath)
+	require.Equal(t, "store_path2", lockfile.Packages[raw].Systems[sys2].StorePath)
+	require.Empty(t, lockfile.Packages[raw].Systems[sys2].CAStorePath)
+}
+
+func TestUpdateCAPathIsNotReplaced(t *testing.T) {
+	devbox := devboxForTesting(t)
+
+	raw := "hello@1.2.3"
+	sys1 := "system1" // current system
+	sys2 := "system2"
+	devPkg := &devpkg.Package{
+		Raw: raw,
+	}
+	resolved := &lock.Package{
+		Resolved: "resolved-flake-reference",
+		Systems: map[string]*lock.SystemInfo{
+			sys1: {
+				StorePath:   "store_path1",
+				CAStorePath: "ca_path1",
+			},
+			sys2: {
+				StorePath: "store_path2",
+				// No CAPath here because this is not the current system.
+			},
+		},
+	}
+	lockfile := &lock.File{
+		Packages: map[string]*lock.Package{
+			raw: {
+				Resolved: "resolved-flake-reference",
+				Version:  "1",
+				Systems: map[string]*lock.SystemInfo{
+					sys1: {
+						StorePath:   "store_path1",
+						CAStorePath: "ca_path1",
+					},
+					sys2: {
+						StorePath:   "store_path2",
+						CAStorePath: "ca_path2", // we already have CAPath for this system; it should not be replaced
+					},
+				},
+			},
+		},
+	}
+
+	err := devbox.mergeResolvedPackageToLockfile(context.Background(), devPkg, resolved, lockfile)
+	require.NoError(t, err, "update failed")
+
+	require.Contains(t, lockfile.Packages, raw)
+	require.Contains(t, lockfile.Packages[raw].Systems, sys1)
+	require.Contains(t, lockfile.Packages[raw].Systems, sys2)
+	require.Equal(t, "store_path2", lockfile.Packages[raw].Systems[sys2].StorePath)
+	require.Equal(t, "ca_path2", lockfile.Packages[raw].Systems[sys2].CAStorePath)
+}


### PR DESCRIPTION
## Summary
This should fix the two remaining bugs in the lockfile merging logic:

1. If we have new system infos for a system that is not our own, add them anyway.
2. If we have a system info whose StorePath does not match the existing info's StorePath, then replace the info. This is to ensure correctness--all infos should come from the same resolved package version.

## How was it tested?
Added unit tests!