### PR TITLE
ci: upgrade nix install action, use it in nix-test-versions

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -31,6 +31,12 @@ permissions:
   contents: read
   pull-requests: read
 
+defaults:
+  run:
+    # Explicitly setting the shell to bash runs commands with
+    # `bash --noprofile --norc -eo pipefail` instead of `bash -e`.
+    shell: bash
+
 env:
   HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}"
   HOMEBREW_NO_ANALYTICS: 1
@@ -102,10 +108,10 @@ jobs:
             brew install dash zsh
           fi
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v1
+        uses: DeterminateSystems/nix-installer-action@v4
         with:
           logger: pretty
-          nix-build-user-count: 4
+          extra-conf: experimental-features = ca-derivations fetch-closure
       - name: Run tests
         env:
           # For devbox.json tests, we default to non-debug mode since the debug output is less useful than for unit testscripts.
@@ -115,6 +121,15 @@ jobs:
           # Used in `go test -timeout` flag. Needs a value that time.ParseDuration can parse.
           DEVBOX_GOLANG_TEST_TIMEOUT: "${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && '35m' || '20m' }}"
         run: |
+          echo "::group::Nix version"
+          nix --version
+          echo "::endgroup::"
+          echo "::group::Contents of /etc/nix/nix.conf"
+          cat /etc/nix/nix.conf || true
+          echo "::endgroup::"
+          echo "::group::Resolved Nix config"
+          nix show-config
+          echo "::endgroup::"
           go test -v -timeout $DEVBOX_GOLANG_TEST_TIMEOUT ./...
 
   auto-nix-install: # ensure Devbox installs nix and works properly after installation.
@@ -141,12 +156,14 @@ jobs:
           devbox run echo "Installing packages..."
       - name: Test removing package
         run: devbox rm go
-  
-  test-with-old-nix-version:
+
+  # Run a sanity test to make sure Devbox can install and remove packages with
+  # the last 3 Nix releases.
+  test-nix-versions:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        version: [2.15.1]
+        version: [2.15.1, 2.16.1, 2.17.0]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -155,15 +172,23 @@ jobs:
           go-version-file: ./go.mod
       - name: Build devbox
         run: go install ./cmd/devbox
-      - name: Install nix
-        run: sh <(curl -L https://releases.nixos.org/nix/nix-${{ matrix.version }}/install) --daemon
-      - name: Install devbox packages
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v4
+        with:
+          logger: pretty
+          extra-conf: experimental-features = ca-derivations fetch-closure
+          nix-package-url: https://releases.nixos.org/nix/nix-${{ matrix.version }}/nix-${{ matrix.version }}-${{ runner.arch == 'X64' && 'x86_64' || 'aarch64' }}-${{ runner.os == 'macOS' && 'darwin' || 'linux' }}.tar.xz
+      - name: Run devbox install, devbox run, devbox rm
         run: |
-          # Setup github authentication to ensure Github's rate limits are not hit.
-          # If this works, we can consider refactoring this into a reusable github action helper.
-          mkdir -p ~/.config/nix
-          echo "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}" > ~/.config/nix/nix.conf
-
-          devbox run echo "Installing packages..."
-      - name: Test removing package
-        run: devbox rm go
+          echo "::group::Nix version"
+          nix --version
+          echo "::endgroup::"
+          echo "::group::Contents of /etc/nix/nix.conf"
+          cat /etc/nix/nix.conf || true
+          echo "::endgroup::"
+          echo "::group::Resolved Nix config"
+          nix show-config
+          echo "::endgroup::"
+          devbox install
+          devbox run -- echo "Hello from devbox!"
+          devbox rm go

--- a/internal/nix/store_test.go
+++ b/internal/nix/store_test.go
@@ -2,18 +2,23 @@ package nix
 
 import (
 	"fmt"
+	"strings"
 	"testing"
+
+	"golang.org/x/exp/slices"
 )
 
 func TestContentAddressedPath(t *testing.T) {
-
 	testCases := []struct {
 		storePath string
-		expected  string
+		expected  []string
 	}{
 		{
 			"/nix/store/r2jd6ygnmirm2g803mksqqjm4y39yi6i-git-2.33.1",
-			"/nix/store/ldbhlwhh39wha58rm61bkiiwm6j7211j-git-2.33.1",
+			[]string{
+				"/nix/store/ldbhlwhh39wha58rm61bkiiwm6j7211j-git-2.33.1",
+				"/nix/store/d49wyvsz5nkqa23qp4p0ikr04mw9n4h9-git-2.33.1",
+			},
 		},
 	}
 
@@ -23,10 +28,9 @@ func TestContentAddressedPath(t *testing.T) {
 			if err != nil {
 				t.Errorf("got error: %v", err)
 			}
-			if out != testCase.expected {
-				t.Errorf("got %s, want %s", out, testCase.expected)
+			if !slices.Contains(testCase.expected, out) {
+				t.Errorf("got %q, want any of:\n%s", out, strings.Join(testCase.expected, "\n"))
 			}
 		})
-
 	}
 }

--- a/internal/nix/store_test.go
+++ b/internal/nix/store_test.go
@@ -16,7 +16,10 @@ func TestContentAddressedPath(t *testing.T) {
 		{
 			"/nix/store/r2jd6ygnmirm2g803mksqqjm4y39yi6i-git-2.33.1",
 			[]string{
+				// Hash from before Nix 2.17.0.
 				"/nix/store/ldbhlwhh39wha58rm61bkiiwm6j7211j-git-2.33.1",
+
+				// Hash after Nix 2.17.0.
 				"/nix/store/d49wyvsz5nkqa23qp4p0ikr04mw9n4h9-git-2.33.1",
 			},
 		},


### PR DESCRIPTION
Changes extracted from #1311 so they can be merged sooner.

- Upgrade the Nix installer action to v4 and configure the experimental features Devbox needs.
- Print out the Nix version, `/etc/nix/nix.conf`, and the resolved Nix config to make debugging easier.
- Do the same for `test-nix-versions` and add the last 3 Nix releases to the matrix. Nix 2.15.1 is the current stable version and 2.17.0 is the latest.
- Update `TestContentAddressedPath` to accept hashes from Nix <2.17 and 2.17+.