### PR TITLE
[services] Fix process-compose not being installed

### DIFF
--- a/internal/boxcli/services.go
+++ b/internal/boxcli/services.go
@@ -45,8 +45,9 @@ func servicesCmd() *cobra.Command {
 	serviceUpFlags := serviceUpFlags{}
 	serviceStopFlags := serviceStopFlags{}
 	servicesCommand := &cobra.Command{
-		Use:   "services",
-		Short: "Interact with devbox services",
+		Use:               "services",
+		Short:             "Interact with devbox services",
+		PersistentPreRunE: ensureNixInstalled,
 	}
 
 	lsCommand := &cobra.Command{

--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -281,7 +281,10 @@ func (p *Package) normalizePackageAttributePath() (string, error) {
 
 	// We prefer search over just trying to parse the URL because search will
 	// guarantee that the package exists for the current system.
-	infos, _ := nix.Search(query)
+	infos, err := nix.Search(query)
+	if err != nil {
+		return "", err
+	}
 
 	if len(infos) == 1 {
 		return lo.Keys(infos)[0], nil


### PR DESCRIPTION
## Summary

On new devbox/nix installations, nix is not in PATH. For most commands, we add nix to path (add, shell, run, etc), but not for services.

Longer term, we probably don't want this if we want to support non-nix package services.

## How was it tested?

In fresh docker ubuntu, ran:

```bash
devbox init
devbox services ls
devbox add apache
devbox services up
```
