### PR TITLE
[devcontainer] Changed to single user nix in devcontainer

### DIFF
--- a/internal/impl/generate/devcontainer_util.go
+++ b/internal/impl/generate/devcontainer_util.go
@@ -128,7 +128,7 @@ func getDevcontainerContent(pkgs []string) *devcontainerObject {
 			},
 		},
 		// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-		RemoteUser: "devbox",
+		RemoteUser: "root",
 	}
 
 	// match only python3 or python3xx as package names

--- a/internal/impl/generate/tmpl/devcontainerDockerfile.tmpl
+++ b/internal/impl/generate/tmpl/devcontainerDockerfile.tmpl
@@ -4,27 +4,16 @@ FROM debian:stable-slim
 RUN apt-get update
 RUN apt-get -y install bash binutils git{{if .IsDevcontainer}} gnupg2{{- end}} xz-utils wget sudo
 
-# Step 2: Setting up devbox user
-ENV DEVBOX_USER=devbox
-RUN adduser $DEVBOX_USER
-RUN usermod -aG sudo $DEVBOX_USER
-RUN echo "devbox ALL=(ALL:ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/$DEVBOX_USER
-
-USER $DEVBOX_USER
+# Step 2: Installing Nix
+RUN wget --output-document=/dev/stdout https://nixos.org/nix/install | sh -s -- --daemon
+RUN . ~/.nix-profile/etc/profile.d/nix.sh
+ENV PATH="/root/.nix-profile/bin:$PATH"
 
 # Step 3: Installing devbox
 RUN wget --quiet --output-document=/dev/stdout https://get.jetpack.io/devbox   | bash -s -- -f
-RUN chown -R "${DEVBOX_USER}:${DEVBOX_USER}" /usr/local/bin/devbox
 
-# Step 4: Installing Nix
-RUN wget --output-document=/dev/stdout https://nixos.org/nix/install | sh -s -- --no-daemon
-RUN . ~/.nix-profile/etc/profile.d/nix.sh
-# updating PATH
-ENV PATH="/home/${DEVBOX_USER}/.nix-profile/bin:/home/${DEVBOX_USER}/.devbox/nix/profile/default/bin:${PATH}"
-
-# Step 5: Installing your devbox project
+# Step 4: Installing your devbox project
 WORKDIR /code
-RUN sudo chown $DEVBOX_USER:root /code
 COPY devbox.json devbox.json
 {{if len .LocalFlakeDirs}}
 # Step 6: Copying local flakes directories
@@ -32,7 +21,7 @@ COPY devbox.json devbox.json
 {{range $i, $element := .LocalFlakeDirs -}}
 COPY {{$element}} {{$element}}
 {{end}}
-RUN devbox install
+RUN devbox run -- echo "Installed Packages."
 {{if .IsDevcontainer}}
 RUN devbox shellenv --init-hook >> ~/.profile
 {{- else}}


### PR DESCRIPTION
## Summary
Multi user nix installation with creating a devbox user in dockerfile causes an issue in devcontainer with Nix due to permission issues with subdirectories nix creates in `/tmp/`. Changing to a single user installation and handling everything under root user in docker seems to fix the issue.

## How was it tested?
- `devbox init && devbox add hello`
- `devbox generate devcontainer`
- open vscode: `code .`
- in vscode command palette (cmd + shift + p) run `Dev Containers: Rebuild Without Cache and Reopen in Container`
- confirm that devcontainer gets created successfully and vscode switches to remote devcontainer environment.