### PR TITLE
[shellenv] filter out DEVBOX_LATEST_VERSION env var

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -1008,6 +1008,8 @@ func (d *Devbox) configEnvs(computedEnv map[string]string) map[string]string {
 // from the slice of [os.Environ] variables before sourcing them. These are
 // variables that are set automatically by a new shell.
 var ignoreCurrentEnvVar = map[string]bool{
+	envir.DevboxLatestVersion: true,
+
 	// Devbox may change the working directory of the shell, so using the
 	// original PWD and OLDPWD would be wrong.
 	"PWD":    true,


### PR DESCRIPTION
## Summary

The Devbox launcher invokes the Devbox binary with `DEVBOX_LATEST_VERSION` env-var
being set. The Devbox binary uses this env-var to determine if a new version is 
available, and if it needs to alert the user to update.

This env-var was never intended to be "exported" to the rest of the environment.
However, `devbox shellenv` was doing so.

This becomes problematic if a user does `eval $(devbox global shellenv)` in 
their shellrc file, and has done `devbox global add coreutils`. Then, doing `ls`
or `cat <file>`, or using any of the coreutils programs seems to trigger 
an avalanche of "new Devbox available" notices. 

Fix:
this PR filters out `DEVBOX_LATEST_VERSION` from the environment that shellenv
exports.

## How was it tested?

```
> export DEVBOX_LATEST_VERSION=0.5.12

# verify it was being exported
> devbox shellenv | grep "DEVBOX_LATEST"
DEVBOX_LATEST_VERSION=0.5.12

> devbox run build

# no longer present
> devbox shellenv | grep "DEVBOX_LATEST"
```
