### PR TITLE
[docs] sidebars.js, "guides/plugins" section is duplicated

### DIFF
--- a/docs/app/sidebars.js
+++ b/docs/app/sidebars.js
@@ -59,9 +59,6 @@ const sidebars = {
         },{
             type: 'doc',
             id: 'guides/services'
-        }, {
-            type: 'doc',
-            id: 'guides/plugins'
         }]
     }, {
         type: 'category',


### PR DESCRIPTION
"guides/plugins" was duplicated

## Summary

![image](https://github.com/jetpack-io/devbox/assets/7515/c7ad5dc8-f154-41ca-9a50-faa43c0bb357)

![image](https://github.com/jetpack-io/devbox/assets/7515/fb7ff639-6a1b-4ad3-9209-7df43c9e2d28)


## How was it tested?
Not tested