### PR TITLE
[rust template] Add cfg(test) attribute to mod test

### DIFF
--- a/examples/development/rust/rust-stable-hello-world/src/main.rs
+++ b/examples/development/rust/rust-stable-hello-world/src/main.rs
@@ -6,6 +6,7 @@ fn hello_world() -> &'static str {
     return "Hello, world!";
 }
 
+#[cfg(test)]
 mod tests {
   use super::*;
 


### PR DESCRIPTION
Got this error:
```
cargo run . 
   Compiling rust-stable-hello-world v0.1.0 (/home/savil/repo/rust)
warning: unused import: `super::*`
  --> src/main.rs:10:7
   |
10 |   use super::*;
   |       ^^^^^^^^
   |
help: consider adding a `#[cfg(test)]` to the containing module
  --> src/main.rs:9:1
   |
9  | mod tests {
   | ^^^^^^^^^
   = note: `#[warn(unused_imports)]` on by default
```

Afterwards:
```
❯ cargo test 
   Compiling rust-stable-hello-world v0.1.0 (/home/savil/repo/rust)
    Finished test [unoptimized + debuginfo] target(s) in 0.25s
     Running unittests src/main.rs (target/debug/deps/rust_stable_hello_world-5499c8f65b21de0b)

running 1 test
test tests::test_hello_world ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


~/repo/rust is 📦 v0.1.0 via 🦀 v1.71.0 via ❄️  impure (nix-shell-env) 
❯ cargo run 
   Compiling rust-stable-hello-world v0.1.0 (/home/savil/repo/rust)
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/rust-stable-hello-world`
Hello, world!
```

## Summary

## How was it tested?
