### PR TITLE
[easy] copy devbox.lock in generated Dockerfile

### DIFF
--- a/internal/impl/generate/tmpl/devcontainerDockerfile.tmpl
+++ b/internal/impl/generate/tmpl/devcontainerDockerfile.tmpl
@@ -15,6 +15,7 @@ RUN wget --quiet --output-document=/dev/stdout https://get.jetpack.io/devbox   |
 # Step 4: Installing your devbox project
 WORKDIR /code
 COPY devbox.json devbox.json
+COPY devbox.lock devbox.lock
 {{if len .LocalFlakeDirs}}
 # Step 6: Copying local flakes directories
 {{- end}}


### PR DESCRIPTION
## Summary

Mohsen has a PR that will eventually copy all the code of the project into
the dockerfile, but I can see why that may be complicated.

For now, sending a quick fix to just copy the `devbox.lock` file 
so that our users get the exact packages they expect. This line can be removed
when the aforementioned PR is ready.

## How was it tested?

ran `devbox generate dockerfile` and saw the `COPY devbox.lock devbox.lock` 
line was present
