### PR TITLE
fix --process-compose-file issue

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -42,7 +42,7 @@ type Devbox interface {
 	Remove(ctx context.Context, pkgs ...string) error
 	RestartServices(ctx context.Context, services ...string) error
 	RunScript(ctx context.Context, scriptName string, scriptArgs []string) error
-	Services() (services.Services, error)
+	Services(userProcessCompose string) (services.Services, error)
 	// Shell generates the devbox environment and launches nix-shell as a child process.
 	Shell(ctx context.Context) error
 	StartProcessManager(ctx context.Context, requestedServices []string, background bool, processComposeFileOrDir string) error

--- a/devbox.go
+++ b/devbox.go
@@ -42,7 +42,7 @@ type Devbox interface {
 	Remove(ctx context.Context, pkgs ...string) error
 	RestartServices(ctx context.Context, services ...string) error
 	RunScript(ctx context.Context, scriptName string, scriptArgs []string) error
-	Services(userProcessCompose string) (services.Services, error)
+	Services() (services.Services, error)
 	// Shell generates the devbox environment and launches nix-shell as a child process.
 	Shell(ctx context.Context) error
 	StartProcessManager(ctx context.Context, requestedServices []string, background bool, processComposeFileOrDir string) error

--- a/internal/boxcli/services.go
+++ b/internal/boxcli/services.go
@@ -169,8 +169,9 @@ func startProcessManager(
 	flags serviceUpFlags,
 ) error {
 	box, err := devbox.Open(&devopt.Opts{
-		Dir:    servicesFlags.config.path,
-		Writer: cmd.ErrOrStderr(),
+		Dir:                      servicesFlags.config.path,
+		CustomProcessComposeFile: flags.processComposeFile,
+		Writer:                   cmd.ErrOrStderr(),
 	})
 	if err != nil {
 		return errors.WithStack(err)

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -658,6 +658,19 @@ func (d *Devbox) StartProcessManager(
 	background bool,
 	processComposeFileOrDir string,
 ) error {
+
+	if !d.IsEnvEnabled() {
+		args := []string{"services", "up"}
+		args = append(args, requestedServices...)
+		if processComposeFileOrDir != "" {
+			args = append(args, "--process-compose-file", processComposeFileOrDir)
+		}
+		if background {
+			args = append(args, "--background")
+		}
+		return d.RunScript(ctx, "devbox", args)
+	}
+
 	svcs, err := d.Services()
 	if err != nil {
 		return err
@@ -687,21 +700,9 @@ func (d *Devbox) StartProcessManager(
 			return err
 		}
 	}
-	if !d.IsEnvEnabled() {
-		args := []string{"services", "up"}
-		args = append(args, requestedServices...)
-		if processComposeFileOrDir != "" {
-			args = append(args, "--process-compose-file", processComposeFileOrDir)
-		}
-		if background {
-			args = append(args, "--background")
-		}
-		return d.RunScript(ctx, "devbox", args)
-	}
 
 	// Start the process manager
 
-	fmt.Printf("Starting with File or Dir: %s\n", processComposeFileOrDir)
 	return services.StartProcessManager(
 		ctx,
 		d.writer,

--- a/internal/impl/devopt/devboxopts.go
+++ b/internal/impl/devopt/devboxopts.go
@@ -5,9 +5,10 @@ import (
 )
 
 type Opts struct {
-	AllowInsecureAdds bool
-	Dir               string
-	Pure              bool
-	IgnoreWarnings    bool
-	Writer            io.Writer
+	AllowInsecureAdds        bool
+	Dir                      string
+	Pure                     bool
+	IgnoreWarnings           bool
+	CustomProcessComposeFile string
+	Writer                   io.Writer
 }

--- a/internal/services/config.go
+++ b/internal/services/config.go
@@ -14,8 +14,8 @@ import (
 	"go.jetpack.io/devbox/internal/cuecfg"
 )
 
-func FromUserProcessCompose(projectDir string) Services {
-	processComposeYaml := lookupProcessCompose(projectDir, "")
+func FromUserProcessCompose(projectDir string, userProcessCompose string) Services {
+	processComposeYaml := lookupProcessCompose(projectDir, userProcessCompose)
 	if processComposeYaml == "" {
 		return nil
 	}

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -122,11 +122,9 @@ func StartProcessManager(
 	availableServices Services,
 	projectDir string,
 	processComposeBinPath string,
-	processComposeFilePath string,
 	processComposeBackground bool,
 ) error {
 	// Check if process-compose is already running
-
 	if ProcessManagerIsRunning(projectDir) {
 		return fmt.Errorf("process-compose is already running. To stop it, run `devbox services stop`")
 	}


### PR DESCRIPTION
## Summary

Fix the issue where passing a custom process compose file with `--process-compose-file` failed to load custom services

## How was it tested?

1. Add a process-compose.yaml with a service in a custom path
2. Load the file with `devbox services up --process-compose-file path/to/file
3. Verify that the service starts
