### PR TITLE
[CLI] Added http url handling to create template

### DIFF
--- a/internal/boxcli/create.go
+++ b/internal/boxcli/create.go
@@ -17,19 +17,21 @@ import (
 type createCmdFlags struct {
 	showAll  bool
 	template string
+	repo     string
+	subdir   string
 }
 
 func createCmd() *cobra.Command {
 	flags := &createCmdFlags{}
 	command := &cobra.Command{
-		Use:   "create [dir] --template <template>",
+		Use:   "create [dir] --template <template> | --repo <repo URL> --subdir <subdirectory>",
 		Short: "Initialize a directory as a devbox project using a template",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if flags.template == "" {
+			if flags.template == "" && flags.repo == "" {
 				fmt.Fprintf(
 					cmd.ErrOrStderr(),
-					"Usage: devbox create [dir] --template <template>\n\n",
+					"Usage: devbox create [dir] --template <template> | --repo <repo URL> --subdir <subdirectory>\n\n",
 				)
 				templates.List(cmd.ErrOrStderr(), flags.showAll)
 				if !flags.showAll {
@@ -52,6 +54,14 @@ func createCmd() *cobra.Command {
 		&flags.showAll, "show-all", false,
 		"show all available templates",
 	)
+	command.Flags().StringVarP(
+		&flags.repo, "repo", "r", "",
+		"Git repository HTTPS URL to import template files from. Example: https://github.com/jetpack-io/devbox",
+	)
+	command.Flags().StringVarP(
+		&flags.subdir, "subdir", "s", "",
+		"Subdirectory of the Git repository in which the template files reside. Example: examples/tutorial",
+	)
 
 	return command
 }
@@ -63,7 +73,7 @@ func runCreateCmd(cmd *cobra.Command, args []string, flags *createCmdFlags) erro
 		path = filepath.Join(wd, flags.template)
 	}
 
-	err := templates.Init(cmd.ErrOrStderr(), flags.template, path)
+	err := templates.Init(cmd.ErrOrStderr(), flags.template, flags.repo, flags.subdir, path)
 	if err != nil {
 		return err
 	}

--- a/internal/boxcli/create.go
+++ b/internal/boxcli/create.go
@@ -58,12 +58,13 @@ func createCmd() *cobra.Command {
 		&flags.repo, "repo", "r", "",
 		"Git repository HTTPS URL to import template files from. Example: https://github.com/jetpack-io/devbox",
 	)
-	command.Flags().MarkHidden("repo")
 	command.Flags().StringVarP(
 		&flags.subdir, "subdir", "s", "",
 		"Subdirectory of the Git repository in which the template files reside. Example: examples/tutorial",
 	)
-	command.Flags().MarkHidden("subdir")
+	// this command marks a flag as hidden. Error handling for it is not necessary.
+	_ = command.Flags().MarkHidden("repo")
+	_ = command.Flags().MarkHidden("subdir")
 
 	return command
 }

--- a/internal/boxcli/create.go
+++ b/internal/boxcli/create.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/templates"
 	"go.jetpack.io/devbox/internal/ux"
 )
@@ -76,7 +77,14 @@ func runCreateCmd(cmd *cobra.Command, args []string, flags *createCmdFlags) erro
 		path = filepath.Join(wd, flags.template)
 	}
 
-	err := templates.Init(cmd.ErrOrStderr(), flags.template, flags.repo, flags.subdir, path)
+	var err error
+	if flags.template != "" {
+		err = templates.InitFromName(cmd.ErrOrStderr(), flags.template, path)
+	} else if flags.repo != "" {
+		err = templates.InitFromRepo(cmd.ErrOrStderr(), flags.repo, flags.subdir, path)
+	} else {
+		err = usererr.New("either --template or --repo need to be specified")
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/boxcli/create.go
+++ b/internal/boxcli/create.go
@@ -71,11 +71,7 @@ func createCmd() *cobra.Command {
 }
 
 func runCreateCmd(cmd *cobra.Command, args []string, flags *createCmdFlags) error {
-	path := pathArg(args)
-	if path == "" {
-		wd, _ := os.Getwd()
-		path = filepath.Join(wd, flags.template)
-	}
+	path := handlePath(args, flags)
 
 	var err error
 	if flags.template != "" {
@@ -96,4 +92,19 @@ func runCreateCmd(cmd *cobra.Command, args []string, flags *createCmdFlags) erro
 	)
 
 	return nil
+}
+
+func handlePath(args []string, flags *createCmdFlags) string {
+	path := pathArg(args)
+	wd, _ := os.Getwd()
+	if path == "" {
+		if flags.template != "" {
+			path = filepath.Join(wd, flags.template)
+		} else if flags.repo != "" && flags.subdir == "" {
+			path = filepath.Join(wd, filepath.Base(flags.repo))
+		} else if flags.repo != "" && flags.subdir != "" {
+			path = filepath.Join(wd, filepath.Base(flags.subdir))
+		}
+	}
+	return path
 }

--- a/internal/boxcli/create.go
+++ b/internal/boxcli/create.go
@@ -24,14 +24,14 @@ type createCmdFlags struct {
 func createCmd() *cobra.Command {
 	flags := &createCmdFlags{}
 	command := &cobra.Command{
-		Use:   "create [dir] --template <template> | --repo <repo URL> --subdir <subdirectory>",
+		Use:   "create [dir] --template <template>",
 		Short: "Initialize a directory as a devbox project using a template",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if flags.template == "" && flags.repo == "" {
 				fmt.Fprintf(
 					cmd.ErrOrStderr(),
-					"Usage: devbox create [dir] --template <template> | --repo <repo URL> --subdir <subdirectory>\n\n",
+					"Usage: devbox create [dir] --template <template>\n\n",
 				)
 				templates.List(cmd.ErrOrStderr(), flags.showAll)
 				if !flags.showAll {
@@ -58,10 +58,12 @@ func createCmd() *cobra.Command {
 		&flags.repo, "repo", "r", "",
 		"Git repository HTTPS URL to import template files from. Example: https://github.com/jetpack-io/devbox",
 	)
+	command.Flags().MarkHidden("repo")
 	command.Flags().StringVarP(
 		&flags.subdir, "subdir", "s", "",
 		"Subdirectory of the Git repository in which the template files reside. Example: examples/tutorial",
 	)
+	command.Flags().MarkHidden("subdir")
 
 	return command
 }

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTemplatesExist(t *testing.T) {
@@ -25,4 +26,57 @@ func TestTemplatesExist(t *testing.T) {
 			t.Errorf("Directory/devbox.json for %s does not exist", path)
 		}
 	}
+}
+
+func TestGetTemplateRepoAndSubdir(t *testing.T) {
+	// devbox create --template=nonexistenttemplate
+	_, _, err := GetTemplateRepoAndSubdir(
+		"nonexistenttemplate",
+		"",
+		"",
+	)
+	assert.Error(t, err)
+
+	// devbox create --template=apache --repo="https://example.com/org/repo.git" \
+	// --subdir="examples/test/should/ignore/repo/and/subdir"
+	repoURL, subdirPath, err := GetTemplateRepoAndSubdir(
+		"apache",
+		"https://example.com/org/repo.git",
+		"examples/test/should/ignore/repo/and/subdir",
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://github.com/jetpack-io/devbox", repoURL)
+	assert.Equal(t, "examples/servers/apache/", subdirPath)
+
+	// devbox create --repo="https://github.com/jetpack-io/typeid.git"
+	repoURL, subdirPath, err = GetTemplateRepoAndSubdir(
+		"",
+		"https://github.com/jetpack-io/typeid.git",
+		"",
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://github.com/jetpack-io/typeid", repoURL)
+	assert.Equal(t, "", subdirPath)
+
+	// devbox create --repo="https://github.com/jetpack-io/devbox" \
+	// --subdir="examples/servers/apache"
+	repoURL, subdirPath, err = GetTemplateRepoAndSubdir(
+		"",
+		"https://github.com/jetpack-io/devbox",
+		"examples/servers/apache",
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://github.com/jetpack-io/devbox", repoURL)
+	assert.Equal(t, "examples/servers/apache", subdirPath)
+
+	// devbox create --repo="git@github.com:jetpack-io/devbox.git" \
+	// --subdir="examples/servers/apache"
+	repoURL, subdirPath, err = GetTemplateRepoAndSubdir(
+		"",
+		"git@github.com:jetpack-io/devbox.git",
+		"examples/servers/apache",
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "git@github.com:jetpack-io/devbox", repoURL)
+	assert.Equal(t, "examples/servers/apache", subdirPath)
 }

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -28,55 +28,21 @@ func TestTemplatesExist(t *testing.T) {
 	}
 }
 
-func TestGetTemplateRepoAndSubdir(t *testing.T) {
-	// devbox create --template=nonexistenttemplate
-	_, _, err := GetTemplateRepoAndSubdir(
-		"nonexistenttemplate",
-		"",
-		"",
-	)
+func TestParseRepoURL(t *testing.T) {
+	// devbox create --repo="http:::/not.valid/a//a??a?b=&&c#hi"
+	_, err := ParseRepoURL("http:::/not.valid/a//a??a?b=&&c#hi")
 	assert.Error(t, err)
-
-	// devbox create --template=apache --repo="https://example.com/org/repo.git" \
-	// --subdir="examples/test/should/ignore/repo/and/subdir"
-	repoURL, subdirPath, err := GetTemplateRepoAndSubdir(
-		"apache",
-		"https://example.com/org/repo.git",
-		"examples/test/should/ignore/repo/and/subdir",
-	)
+	_, err = ParseRepoURL("http//github.com")
+	assert.Error(t, err)
+	_, err = ParseRepoURL("github.com")
+	assert.Error(t, err)
+	_, err = ParseRepoURL("/foo/bar")
+	assert.Error(t, err)
+	_, err = ParseRepoURL("http://")
+	assert.Error(t, err)
+	_, err = ParseRepoURL("git@github.com:jetpack-io/devbox.git")
+	assert.Error(t, err)
+	u, err := ParseRepoURL("http://github.com")
 	assert.NoError(t, err)
-	assert.Equal(t, "https://github.com/jetpack-io/devbox", repoURL)
-	assert.Equal(t, "examples/servers/apache/", subdirPath)
-
-	// devbox create --repo="https://github.com/jetpack-io/typeid.git"
-	repoURL, subdirPath, err = GetTemplateRepoAndSubdir(
-		"",
-		"https://github.com/jetpack-io/typeid.git",
-		"",
-	)
-	assert.NoError(t, err)
-	assert.Equal(t, "https://github.com/jetpack-io/typeid", repoURL)
-	assert.Equal(t, "", subdirPath)
-
-	// devbox create --repo="https://github.com/jetpack-io/devbox" \
-	// --subdir="examples/servers/apache"
-	repoURL, subdirPath, err = GetTemplateRepoAndSubdir(
-		"",
-		"https://github.com/jetpack-io/devbox",
-		"examples/servers/apache",
-	)
-	assert.NoError(t, err)
-	assert.Equal(t, "https://github.com/jetpack-io/devbox", repoURL)
-	assert.Equal(t, "examples/servers/apache", subdirPath)
-
-	// devbox create --repo="git@github.com:jetpack-io/devbox.git" \
-	// --subdir="examples/servers/apache"
-	repoURL, subdirPath, err = GetTemplateRepoAndSubdir(
-		"",
-		"git@github.com:jetpack-io/devbox.git",
-		"examples/servers/apache",
-	)
-	assert.NoError(t, err)
-	assert.Equal(t, "git@github.com:jetpack-io/devbox", repoURL)
-	assert.Equal(t, "examples/servers/apache", subdirPath)
+	assert.Equal(t, "http://github.com", u)
 }


### PR DESCRIPTION
## Summary
Added arbitrary git repo url handling to `devbox create` by adding `--repo` and `--subdir` flags. The behavior is as follows:
Either `--template` or `--repo` are required flags.
When `--template` is provided, we clone from devbox and use the mapping (no change)
When `--repo` is provided we clone that repo and if `--subdir` is provided, we copy over only the contents of the `subdir` otherwise, the whole repo is copied over.

Update: marked the 2 new flags (`--repo` and `--subdir`) hidden.

## How was it tested?
See unit tests
