### PR TITLE
remove cuego.Complete from cuecfg.Marshal

### DIFF
--- a/internal/cuecfg/cuecfg.go
+++ b/internal/cuecfg/cuecfg.go
@@ -8,18 +8,12 @@ import (
 	"os"
 	"path/filepath"
 
-	"cuelang.org/go/cuego"
 	"github.com/pkg/errors"
 )
 
 // TODO: add support for .cue
 
 func Marshal(valuePtr any, extension string) ([]byte, error) {
-	err := cuego.Complete(valuePtr)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
 	switch extension {
 	case ".json", ".lock":
 		return MarshalJSON(valuePtr)

--- a/internal/devconfig/config.go
+++ b/internal/devconfig/config.go
@@ -22,7 +22,7 @@ const DefaultName = "devbox.json"
 type Config struct {
 	// Packages is the slice of Nix packages that devbox makes available in
 	// its environment. Deliberately do not omitempty.
-	Packages []string `cue:"[...string]" json:"packages"`
+	Packages []string `json:"packages"`
 
 	// Env allows specifying env variables
 	Env map[string]string `json:"env,omitempty"`
@@ -52,7 +52,7 @@ type NixpkgsConfig struct {
 
 // Stage contains a subset of fields from plansdk.Stage
 type Stage struct {
-	Command string `cue:"string" json:"command"`
+	Command string `json:"command"`
 }
 
 func DefaultConfig() *Config {


### PR DESCRIPTION
## Summary

`cuego.Complete` leads to non-trivial complexity when dealing with custom json
marshalling. In particular, it does a round-trip JSON marshal/unmarshal and fields
that are not handled by golang's json-framework can be lost. This interferes
with custom marshalling/unmarshalling.

`cuego.Complete` is only needed if we rely on the `cue:` annotations to autocomplete some fields (I mean, assign default values respecting cue constraints). We don't rely on this, so, right now it is superfluous.

I also remove the `cue:` annotations in a couple of structs since we do not
rely on them.

## How was it tested?

- [x] `devbox init` should produce the expected output
- [x] `devbox add` 
- [x] `devbox rm`

testscript unit tests must pass
