### PR TITLE
[Config Packages] Enable optional map spec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,8 +39,8 @@ require (
 	github.com/stretchr/testify v1.8.2
 	github.com/wk8/go-ordered-map/v2 v2.1.8
 	github.com/zealic/go2node v0.1.0
-	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
-	golang.org/x/mod v0.9.0
+	golang.org/x/exp v0.0.0-20230807204917-050eac23e9de
+	golang.org/x/mod v0.11.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module go.jetpack.io/devbox
 go 1.20
 
 require (
-	cuelang.org/go v0.4.3
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/MicahParks/keyfunc/v2 v2.1.0
@@ -39,11 +38,19 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.2
+	github.com/wk8/go-ordered-map/v2 v2.1.8
 	github.com/zealic/go2node v0.1.0
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 	golang.org/x/mod v0.9.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/buger/jsonparser v1.1.1 // indirect
+	github.com/kr/pretty v0.1.0 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 )
 
 require (
@@ -64,7 +71,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.10 // indirect
 	github.com/aws/smithy-go v1.13.5 // indirect
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
-	github.com/cockroachdb/apd/v2 v2.0.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dsnet/compress v0.0.1 // indirect
@@ -75,10 +81,8 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/klauspost/compress v1.16.3 // indirect
 	github.com/klauspost/pgzip v1.2.5 // indirect
-	github.com/lib/pq v1.10.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
-	github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de // indirect
 	github.com/nwaples/rardecode/v2 v2.0.0-beta.2 // indirect
 	github.com/pierrec/lz4/v4 v4.1.17 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -88,7 +92,6 @@ require (
 	github.com/therootcompany/xz v1.0.1 // indirect
 	github.com/ulikunitz/xz v0.5.11 // indirect
 	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
-	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/term v0.6.0 // indirect
 	golang.org/x/text v0.8.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-envparse v0.1.0
+	github.com/iancoleman/orderedmap v0.3.0
 	github.com/mattn/go-isatty v0.0.18
 	github.com/mholt/archiver/v4 v4.0.0-alpha.7
 	github.com/pelletier/go-toml/v2 v2.0.7

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-envparse v0.1.0
-	github.com/iancoleman/orderedmap v0.3.0
 	github.com/mattn/go-isatty v0.0.18
 	github.com/mholt/archiver/v4 v4.0.0-alpha.7
 	github.com/pelletier/go-toml/v2 v2.0.7

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,8 @@ github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/iancoleman/orderedmap v0.3.0 h1:5cbR2grmZR/DiVt+VJopEhtVs9YGInGIxAoMJn+Ichc=
+github.com/iancoleman/orderedmap v0.3.0/go.mod h1:XuLcCUkdL5owUCQeF2Ue9uuw1EptkJDkXXS7VoV7XGE=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-cuelang.org/go v0.4.3 h1:W3oBBjDTm7+IZfCKZAmC8uDG0eYfJL4Pp/xbbCMKaVo=
-cuelang.org/go v0.4.3/go.mod h1:7805vR9H+VoBNdWFdI7jyDR3QLUPp4+naHfbcgp55HI=
 github.com/AlecAivazis/survey/v2 v2.3.6 h1:NvTuVHISgTHEHeBFqt6BHOe4Ny/NwGZr7w+F8S9ziyw=
 github.com/AlecAivazis/survey/v2 v2.3.6/go.mod h1:4AuI9b7RjAR+G7v9+C4YSlX/YL3K3cWNXgWXOhllqvI=
 github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=
@@ -59,6 +57,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.19.0 h1:2DQLAKDteoEDI8zpCzqBMaZlJuoE
 github.com/aws/aws-sdk-go-v2/service/sts v1.19.0/go.mod h1:BgQOMsg8av8jset59jelyPW7NoZcZXLVpDsXunGDrk8=
 github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
+github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
+github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/bmatcuk/doublestar/v4 v4.6.0 h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvzIZhEXc=
 github.com/bmatcuk/doublestar/v4 v4.6.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
@@ -67,6 +67,8 @@ github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx2
 github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
 github.com/briandowns/spinner v1.23.0 h1:alDF2guRWqa/FOZZYWjlMIx2L6H0wyewPxo/CH4Pt2A=
 github.com/briandowns/spinner v1.23.0/go.mod h1:rPG4gmXeN3wQV/TsAY4w8lPdIM6RX3yqeBQJSrbXjuE=
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cavaliergopher/grab/v3 v3.0.1 h1:4z7TkBfmPjmLAAmkkAZNX/6QJ1nNFdv3SdIHXju0Fr4=
 github.com/cavaliergopher/grab/v3 v3.0.1/go.mod h1:1U/KNnD+Ft6JJiYoYBAimKH2XrYptb8Kl3DFGmsjpq4=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -74,8 +76,6 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cloudflare/ahocorasick v0.0.0-20210425175752-730270c3e184 h1:8yL+85JpbwrIc6m+7N1iYrjn/22z68jwrTIBOJHNe4k=
 github.com/cloudflare/ahocorasick v0.0.0-20210425175752-730270c3e184/go.mod h1:tGWUZLZp9ajsxUOnHmFFLnqnlKXsCn6GReG4jAD59H0=
-github.com/cockroachdb/apd/v2 v2.0.2 h1:weh8u7Cneje73dDh+2tEVLUvyBc89iwepWCD8b8034E=
-github.com/cockroachdb/apd/v2 v2.0.2/go.mod h1:DDxRlzC2lo3/vSlmSoS7JkqbbrARPuFOGr0B9pvN3Gw=
 github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -91,7 +91,6 @@ github.com/denisbrodbeck/machineid v1.0.1/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbj
 github.com/dsnet/compress v0.0.1 h1:PlZu0n3Tuv04TzpfPbrnI0HW/YwodEXDS+oPKahKF0Q=
 github.com/dsnet/compress v0.0.1/go.mod h1:Aw8dCMJ7RioblQeTqt88akK31OvO8Dhf5JflhBbQEHo=
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
-github.com/emicklei/proto v1.6.15 h1:XbpwxmuOPrdES97FrSfpyy67SSCV/wBIKXqgJzh6hNw=
 github.com/f1bonacc1/process-compose v0.43.1 h1:XAN7ohegNfMFxYnj59g2jN7y6HfnJWhDCGtD/nN/TbE=
 github.com/f1bonacc1/process-compose v0.43.1/go.mod h1:jvg1NakjJd8V1LjGKu21HLLOVxbwkOHEgkaDjSWRXc0=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
@@ -108,7 +107,6 @@ github.com/go-redis/redis v6.15.5+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8w
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang-jwt/jwt/v5 v5.0.0 h1:1n1XNM9hk7O9mnQoNBGolZvzebBQ7p93ULHRc28XJUE=
 github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -133,6 +131,7 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
@@ -143,9 +142,12 @@ github.com/klauspost/pgzip v1.2.5 h1:qnWYvvKqedOF2ulHpMG72XQol4ILEJ8k2wwRl/Km8oE
 github.com/klauspost/pgzip v1.2.5/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
-github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
-github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
+github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
@@ -160,8 +162,6 @@ github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQ
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mholt/archiver/v4 v4.0.0-alpha.7 h1:xzByj8G8tj0Oq7ZYYU4+ixL/CVb5ruWCm0EZQ1PjOkE=
 github.com/mholt/archiver/v4 v4.0.0-alpha.7/go.mod h1:Fs8qUkO74HHaidabihzYephJH8qmGD/nCP6tE5xC9BM=
-github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de h1:D5x39vF5KCwKQaw+OC9ZPiLVHXz3UFw2+psEX+gYcto=
-github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de/go.mod h1:kJun4WP5gFuHZgRjZUWWuH1DTxCtxbHDOIJsudS8jzY=
 github.com/nwaples/rardecode/v2 v2.0.0-beta.2 h1:e3mzJFJs4k83GXBEiTaQ5HgSc/kOK8q0rDaRO0MPaOk=
 github.com/nwaples/rardecode/v2 v2.0.0-beta.2/go.mod h1:yntwv/HfMc/Hbvtq9I19D1n58te3h6KsqCf3GxyfBGY=
 github.com/onsi/ginkgo v1.6.0 h1:Ix8l273rp3QzYgXSR+c8d1fTG7UPgYkOSELPhiY/YGw=
@@ -175,12 +175,10 @@ github.com/pierrec/lz4/v4 v4.1.17/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFu
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
-github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/protocolbuffers/txtpbfmt v0.0.0-20201118171849-f6a6b3f636fc h1:gSVONBi2HWMFXCa9jFdYvYk7IwW/mTLxWOF7rXS4LO0=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
@@ -219,6 +217,8 @@ github.com/therootcompany/xz v1.0.1/go.mod h1:3K3UH1yCKgBneZYhuQUvJ9HPD19UEXEI0B
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/ulikunitz/xz v0.5.11 h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8=
 github.com/ulikunitz/xz v0.5.11/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
+github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c h1:3lbZUMbMiGUW/LMkfsEABsc5zNT9+b1CvsJx47JzJ8g=
 github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c/go.mod h1:UrdRz5enIKZ63MEE3IF9l2/ebyx59GyGgPi+tICQdmM=
 github.com/yuin/gopher-lua v0.0.0-20190514113301-1cd887cd7036/go.mod h1:gqRgreBUhTSL0GeU64rtZ3Uq3wtjOa/TB2YfrtkCbVQ=
@@ -231,7 +231,6 @@ golang.org/x/mod v0.9.0 h1:KENHtAZL2y3NLMYZeHY9DW8HW8V+kQyJsY/V9JlKvCs=
 golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
-golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190204203706-41f3e6584952/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/go.sum
+++ b/go.sum
@@ -223,10 +223,10 @@ github.com/yuin/gopher-lua v0.0.0-20190514113301-1cd887cd7036/go.mod h1:gqRgreBU
 github.com/zaffka/mongodb-boltdb-mock v0.0.0-20221014194232-b4bb03fbe3a0/go.mod h1:GsDD1qsG+86MeeCG7ndi6Ei3iGthKL3wQ7PTFigDfNY=
 github.com/zealic/go2node v0.1.0 h1:ofxpve08cmLJBwFdI0lPCk9jfwGWOSD+s6216x0oAaA=
 github.com/zealic/go2node v0.1.0/go.mod h1:GrkFr+HctXwP7vzcU9RsgtAeJjTQ6Ud0IPCQAqpTfBg=
-golang.org/x/exp v0.0.0-20230321023759-10a507213a29 h1:ooxPy7fPvB4kwsA2h+iBNHkAbp/4JxTSwCmvdjEYmug=
-golang.org/x/exp v0.0.0-20230321023759-10a507213a29/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
-golang.org/x/mod v0.9.0 h1:KENHtAZL2y3NLMYZeHY9DW8HW8V+kQyJsY/V9JlKvCs=
-golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/exp v0.0.0-20230807204917-050eac23e9de h1:l5Za6utMv/HsBWWqzt4S8X17j+kt1uVETUX5UFhn2rE=
+golang.org/x/exp v0.0.0-20230807204917-050eac23e9de/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
+golang.org/x/mod v0.11.0 h1:bUO06HqtnRcc/7l71XBe4WcqTZ+3AH1J59zWDDwLKgU=
+golang.org/x/mod v0.11.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,6 @@ github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/iancoleman/orderedmap v0.3.0 h1:5cbR2grmZR/DiVt+VJopEhtVs9YGInGIxAoMJn+Ichc=
-github.com/iancoleman/orderedmap v0.3.0/go.mod h1:XuLcCUkdL5owUCQeF2Ue9uuw1EptkJDkXXS7VoV7XGE=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/internal/boxcli/midcobra/telemetry.go
+++ b/internal/boxcli/midcobra/telemetry.go
@@ -101,5 +101,5 @@ func getPackagesAndCommitHash(c *cobra.Command) ([]string, string) {
 		return []string{}, ""
 	}
 
-	return box.Config().Packages, box.Config().NixPkgsCommitHash()
+	return box.Config().Packages.VersionedNames(), box.Config().NixPkgsCommitHash()
 }

--- a/internal/cuecfg/json.go
+++ b/internal/cuecfg/json.go
@@ -10,6 +10,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const Indent = "  "
+
 // MarshalJSON marshals the given value to JSON. It does not HTML escape and
 // adds standard indentation.
 //
@@ -19,7 +21,7 @@ import (
 func MarshalJSON(v interface{}) ([]byte, error) {
 	buff := &bytes.Buffer{}
 	e := json.NewEncoder(buff)
-	e.SetIndent("", "  ")
+	e.SetIndent("", Indent)
 	e.SetEscapeHTML(false)
 	if err := e.Encode(v); err != nil {
 		return nil, errors.WithStack(err)

--- a/internal/devconfig/config.go
+++ b/internal/devconfig/config.go
@@ -22,7 +22,7 @@ const DefaultName = "devbox.json"
 type Config struct {
 	// Packages is the slice of Nix packages that devbox makes available in
 	// its environment. Deliberately do not omitempty.
-	Packages []string `json:"packages"`
+	Packages Packages `json:"packages"`
 
 	// Env allows specifying env variables
 	Env map[string]string `json:"env,omitempty"`
@@ -57,7 +57,8 @@ type Stage struct {
 
 func DefaultConfig() *Config {
 	return &Config{
-		Packages: []string{}, // initialize to empty slice instead of nil for consistent marshalling
+		// initialize to empty slice instead of nil for consistent marshalling
+		Packages: Packages{Collection: []Package{}},
 		Shell: &shellConfig{
 			Scripts: map[string]*shellcmd.Commands{
 				"test": {

--- a/internal/devconfig/packages.go
+++ b/internal/devconfig/packages.go
@@ -189,13 +189,10 @@ func (p Package) MarshalJSON() ([]byte, error) {
 func parseVersionedName(versionedName string) (name, version string) {
 	var found bool
 	name, version, found = searcher.ParseVersionedPackage(versionedName)
-	if found {
-		return name, version
-	} else {
+	if !found {
 		// Case without any @version in the versionedName
-		name = versionedName
 		// We deliberately do not set version to `latest`
-		version = ""
+		return versionedName, "" /*version*/
 	}
 	return name, version
 }

--- a/internal/devconfig/packages.go
+++ b/internal/devconfig/packages.go
@@ -1,0 +1,213 @@
+package devconfig
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/iancoleman/orderedmap"
+	"github.com/pkg/errors"
+)
+
+type jsonKind int
+
+const (
+	// jsonList is the legacy format for packages
+	jsonList jsonKind = iota
+	// jsonMap is the new format for packages
+	jsonMap jsonKind = iota
+)
+
+type Packages struct {
+	jsonKind jsonKind
+
+	// Collection contains the set of package definitions
+	// We don't want this key to be serialized automatically, hence the "key" in json is "-"
+	Collection []Package `json:"-,omitempty"`
+}
+
+// VersionedNames returns a list of package names with versions.
+// NOTE: if the package is unversioned, the version will be omitted (doesn't default to @latest).
+//
+// example:
+// ["package1", "package2@latest", "package3@1.20"]
+func (pkgs *Packages) VersionedNames() []string {
+	result := []string{}
+	for _, p := range pkgs.Collection {
+		name := p.name
+		if p.Version != "" {
+			name += "@" + p.Version
+		}
+		result = append(result, name)
+	}
+	return result
+}
+
+// Add adds a package to the list of packages
+func (pkgs *Packages) Add(versionedName string) {
+	name, version := parseVersionedName(versionedName)
+	pkgs.Collection = append(pkgs.Collection, NewVersionOnlyPackage(name, version))
+}
+
+// Remove removes a package from the list of packages
+func (pkgs *Packages) Remove(versionedName string) error {
+	name, version := parseVersionedName(versionedName)
+	for idx, pkg := range pkgs.Collection {
+		if pkg.name == name && pkg.Version == version {
+			pkgs.Collection = append(pkgs.Collection[:idx], pkgs.Collection[idx+1:]...)
+			return nil
+		}
+	}
+	return errors.Errorf("package %s not found", versionedName)
+}
+
+func (pkgs *Packages) UnmarshalJSON(data []byte) error {
+
+	// First, attempt to unmarshal as a list of strings (legacy format)
+	var packages []string
+	if err := json.Unmarshal(data, &packages); err == nil {
+		pkgs.Collection = packagesFromLegacyList(packages)
+		pkgs.jsonKind = jsonList
+		return nil
+	}
+
+	// Second, attempt to unmarshal as a map of Packages
+	// We use orderedmap to preserve the order of the packages. While the JSON
+	// specification specifies that maps are unordered, we do rely on the order
+	// for certain functionality.
+	orderedMap := orderedmap.New()
+	err := json.Unmarshal(data, &orderedMap)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	packagesList := []Package{}
+	for _, name := range orderedMap.Keys() {
+		// The value may be a JSON object or a string
+		packageValue, _ := orderedMap.Get(name)
+
+		// Test if the value is a JSON object. Since the Collection was unmarshalled
+		// as an orderedmap, this JSON object will also be defaulted to an orderedmap.
+		if packageMap, ok := packageValue.(orderedmap.OrderedMap); ok {
+			p := NewPackage(name, &packageMap)
+			packagesList = append(packagesList, p)
+
+			// Test if the value is a string:
+		} else if packageString, ok := packageValue.(string); ok {
+			p := NewVersionOnlyPackage(name, packageString)
+			packagesList = append(packagesList, p)
+
+		} else {
+			return errors.Errorf("invalid package %packageValue of type: %T", packageValue, packageValue)
+		}
+	}
+	pkgs.Collection = packagesList
+	pkgs.jsonKind = jsonMap
+	return nil
+}
+
+func (pkgs *Packages) MarshalJSON() ([]byte, error) {
+	if pkgs.jsonKind == jsonList {
+		packagesList := []string{}
+		for _, p := range pkgs.Collection {
+
+			// Version may be empty for unversioned packages
+			packageToWrite := p.name
+			if p.Version != "" {
+				packageToWrite += "@" + p.Version
+			}
+			packagesList = append(packagesList, packageToWrite)
+		}
+		return json.Marshal(packagesList)
+	}
+
+	orderedMap := orderedmap.New()
+	for _, p := range pkgs.Collection {
+		orderedMap.Set(p.name, p)
+	}
+	return json.Marshal(orderedMap)
+}
+
+type packageKind int
+
+const (
+	versionOnly packageKind = iota
+	regular     packageKind = iota
+)
+
+type Package struct {
+	kind    packageKind
+	name    string
+	Version string `json:"version"`
+
+	// TODO: add other fields like platforms
+}
+
+func NewVersionOnlyPackage(name, version string) Package {
+	return Package{
+		kind:    versionOnly,
+		name:    name,
+		Version: version,
+	}
+}
+
+func NewPackage(name string, packageMap *orderedmap.OrderedMap) Package {
+	version, ok := packageMap.Get("version")
+	if !ok {
+		// For legacy packages, the version may not be specified. We leave it blank
+		// here, and code that consumes the Config is expected to handle this case
+		// (e.g. by defaulting to @latest).
+		version = ""
+	}
+
+	return Package{
+		kind:    regular,
+		name:    name,
+		Version: version.(string),
+	}
+}
+
+func (p Package) MarshalJSON() ([]byte, error) {
+	if p.kind == versionOnly {
+		return json.Marshal(p.Version)
+	}
+
+	// If we have a regular package, we want to marshal the entire struct:
+	type Alias Package // Use an alias-type to avoid infinite recursion
+	return json.Marshal((Alias)(p))
+}
+
+// parseVersionedName parses the name and version from package@version representation
+func parseVersionedName(versionedName string) (name, version string) {
+	// use the last @ symbol as the version delimiter, some packages have @ in the name
+	atSymbolIndex := strings.LastIndex(versionedName, "@")
+	if atSymbolIndex != -1 {
+		// Common case: package@version
+		if atSymbolIndex != len(versionedName)-1 {
+			name, version = versionedName[:atSymbolIndex], versionedName[atSymbolIndex+1:]
+		} else {
+			// This case handles packages that end with `@` in the name
+			// example: `emacsPackages.@`
+			name = versionedName[:atSymbolIndex] + "@"
+		}
+	} else {
+		// Case without any @version: package
+		name = versionedName
+
+		// We deliberately do not set version to latest so that we don't
+		// automatically modify the devbox.json file. It should only be modified
+		// upon `devbox update`.
+		// version = "latest"
+	}
+	return name, version
+}
+
+// packagesFromLegacyList converts a list of strings to a list of packages
+// Example inputs: `["python@latest", "hello", "cowsay@1"]`
+func packagesFromLegacyList(packages []string) []Package {
+	packagesList := []Package{}
+	for _, p := range packages {
+		name, version := parseVersionedName(p)
+		packagesList = append(packagesList, NewVersionOnlyPackage(name, version))
+	}
+	return packagesList
+}

--- a/internal/devconfig/packages.go
+++ b/internal/devconfig/packages.go
@@ -2,10 +2,10 @@ package devconfig
 
 import (
 	"encoding/json"
-	"strings"
 
 	"github.com/pkg/errors"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
+	"go.jetpack.io/devbox/internal/searcher"
 	"golang.org/x/exp/slices"
 )
 
@@ -187,25 +187,15 @@ func (p Package) MarshalJSON() ([]byte, error) {
 
 // parseVersionedName parses the name and version from package@version representation
 func parseVersionedName(versionedName string) (name, version string) {
-	// use the last @ symbol as the version delimiter, some packages have @ in the name
-	atSymbolIndex := strings.LastIndex(versionedName, "@")
-	if atSymbolIndex != -1 {
-		// Common case: package@version
-		if atSymbolIndex != len(versionedName)-1 {
-			name, version = versionedName[:atSymbolIndex], versionedName[atSymbolIndex+1:]
-		} else {
-			// This case handles packages that end with `@` in the name
-			// example: `emacsPackages.@`
-			name = versionedName[:atSymbolIndex] + "@"
-		}
+	var found bool
+	name, version, found = searcher.ParseVersionedPackage(versionedName)
+	if found {
+		return name, version
 	} else {
-		// Case without any @version: package
+		// Case without any @version in the versionedName
 		name = versionedName
-
-		// We deliberately do not set version to latest so that we don't
-		// automatically modify the devbox.json file. It should only be modified
-		// upon `devbox update`.
-		// version = "latest"
+		// We deliberately do not set version to `latest`
+		version = ""
 	}
 	return name, version
 }

--- a/internal/devconfig/packages_test.go
+++ b/internal/devconfig/packages_test.go
@@ -1,0 +1,177 @@
+package devconfig
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/iancoleman/orderedmap"
+	"go.jetpack.io/devbox/internal/cuecfg"
+)
+
+// TestJsonifyConfigPackages tests the jsonMarshal and jsonUnmarshal of the Config.Packages field
+func TestJsonifyConfigPackages(t *testing.T) {
+	testCases := []struct {
+		name       string
+		jsonConfig string
+		expected   Packages
+	}{
+		{
+			name:       "empty-list",
+			jsonConfig: `{"packages":[]}`,
+			expected: Packages{
+				jsonKind:   jsonList,
+				Collection: []Package{},
+			},
+		},
+		{
+			name:       "empty-map",
+			jsonConfig: `{"packages":{}}`,
+			expected: Packages{
+				jsonKind:   jsonMap,
+				Collection: []Package{},
+			},
+		},
+		{
+			name:       "flat-list",
+			jsonConfig: `{"packages":["python","go@1.20"]}`,
+			expected: Packages{
+				jsonKind:   jsonList,
+				Collection: packagesFromLegacyList([]string{"python", "go@1.20"}),
+			},
+		},
+		{
+			name:       "map-with-string-value",
+			jsonConfig: `{"packages":{"python":"latest","go":"1.20"}}`,
+			expected: Packages{
+				jsonKind: jsonMap,
+				Collection: []Package{
+					NewVersionOnlyPackage("python", "latest"),
+					NewVersionOnlyPackage("go", "1.20"),
+				},
+			},
+		},
+
+		{
+			name:       "map-with-struct-value",
+			jsonConfig: `{"packages":{"python":{"version":"latest"}}}`,
+			expected: Packages{
+				jsonKind: jsonMap,
+				Collection: []Package{
+					NewPackage("python", orderedMapFromPairs([][]string{{"version", "latest"}})),
+				},
+			},
+		},
+		{
+			name:       "map-with-string-and-struct-values",
+			jsonConfig: `{"packages":{"go":"1.20","emacs":"latest","python":{"version":"latest"}}}`,
+			expected: Packages{
+				jsonKind: jsonMap,
+				Collection: []Package{
+					NewVersionOnlyPackage("go", "1.20"),
+					NewVersionOnlyPackage("emacs", "latest"),
+					NewPackage("python", orderedMapFromPairs([][]string{{"version", "latest"}})),
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			config := &Config{}
+			if err := json.Unmarshal([]byte(testCase.jsonConfig), config); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(config.Packages, testCase.expected) {
+				t.Errorf("expected: %v, got: %v", testCase.expected, config.Packages)
+			}
+
+			marshalled, err := json.Marshal(config)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if string(marshalled) != testCase.jsonConfig {
+				t.Errorf("expected: %v, got: %v", testCase.jsonConfig, string(marshalled))
+			}
+
+			// We also test cuecfg.Marshal because elsewhere in our code we rely on it.
+			// While in this PR it is now a simple wrapper over json.Marshal, we want to
+			// ensure that any future changes to that function don't break our code.
+			marshalled, err = cuecfg.Marshal(config, ".json")
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			// We need to pretty-print the expected output because cuecfg.Marshal returns
+			// the json pretty-printed.
+			expected := &bytes.Buffer{}
+			if err := json.Indent(expected, []byte(testCase.jsonConfig), "", cuecfg.Indent); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if string(marshalled) != expected.String() {
+				t.Errorf("expected: %v, got: %v", testCase.jsonConfig, string(marshalled))
+			}
+		})
+	}
+}
+
+// orderedMapFromPairs takes a list of key-value pairs and returns an orderedmap
+func orderedMapFromPairs(fields [][]string) *orderedmap.OrderedMap {
+	m := orderedmap.New()
+	for _, field := range fields {
+		m.Set(field[0], field[1])
+	}
+	return m
+}
+
+func TestParseVersionedName(t *testing.T) {
+	testCases := []struct {
+		name            string
+		input           string
+		expectedName    string
+		expectedVersion string
+	}{
+		{
+			name:            "no-version",
+			input:           "python",
+			expectedName:    "python",
+			expectedVersion: "",
+		},
+		{
+			name:            "with-version-latest",
+			input:           "python@latest",
+			expectedName:    "python",
+			expectedVersion: "latest",
+		},
+		{
+			name:            "with-version",
+			input:           "python@1.2.3",
+			expectedName:    "python",
+			expectedVersion: "1.2.3",
+		},
+		{
+			name:            "with-two-@-signs",
+			input:           "emacsPackages.@@latest",
+			expectedName:    "emacsPackages.@",
+			expectedVersion: "latest",
+		},
+		{
+			name:            "with-trailing-@-sign",
+			input:           "emacsPackages.@",
+			expectedName:    "emacsPackages.@",
+			expectedVersion: "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			name, version := parseVersionedName(testCase.input)
+			if name != testCase.expectedName {
+				t.Errorf("expected: %v, got: %v", testCase.expectedName, name)
+			}
+			if version != testCase.expectedVersion {
+				t.Errorf("expected: %v, got: %v", testCase.expectedVersion, version)
+			}
+		})
+	}
+}

--- a/internal/devconfig/packages_test.go
+++ b/internal/devconfig/packages_test.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/iancoleman/orderedmap"
 	"go.jetpack.io/devbox/internal/cuecfg"
 )
 
@@ -35,10 +34,10 @@ func TestJsonifyConfigPackages(t *testing.T) {
 		},
 		{
 			name:       "flat-list",
-			jsonConfig: `{"packages":["python","go@1.20"]}`,
+			jsonConfig: `{"packages":["python","hello@latest","go@1.20"]}`,
 			expected: Packages{
 				jsonKind:   jsonList,
-				Collection: packagesFromLegacyList([]string{"python", "go@1.20"}),
+				Collection: packagesFromLegacyList([]string{"python", "hello@latest", "go@1.20"}),
 			},
 		},
 		{
@@ -59,7 +58,7 @@ func TestJsonifyConfigPackages(t *testing.T) {
 			expected: Packages{
 				jsonKind: jsonMap,
 				Collection: []Package{
-					NewPackage("python", orderedMapFromPairs([][]string{{"version", "latest"}})),
+					NewPackage("python", map[string]any{"version": "latest"}),
 				},
 			},
 		},
@@ -71,7 +70,7 @@ func TestJsonifyConfigPackages(t *testing.T) {
 				Collection: []Package{
 					NewVersionOnlyPackage("go", "1.20"),
 					NewVersionOnlyPackage("emacs", "latest"),
-					NewPackage("python", orderedMapFromPairs([][]string{{"version", "latest"}})),
+					NewPackage("python", map[string]any{"version": "latest"}),
 				},
 			},
 		},
@@ -113,15 +112,6 @@ func TestJsonifyConfigPackages(t *testing.T) {
 			}
 		})
 	}
-}
-
-// orderedMapFromPairs takes a list of key-value pairs and returns an orderedmap
-func orderedMapFromPairs(fields [][]string) *orderedmap.OrderedMap {
-	m := orderedmap.New()
-	for _, field := range fields {
-		m.Set(field[0], field[1])
-	}
-	return m
 }
 
 func TestParseVersionedName(t *testing.T) {

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -918,7 +918,7 @@ func (d *Devbox) nixFlakesFilePath() string {
 
 // Packages returns the list of Packages to be installed in the nix shell.
 func (d *Devbox) Packages() []string {
-	return d.cfg.Packages
+	return d.cfg.Packages.VersionedNames()
 }
 
 func (d *Devbox) PackagesAsInputs() []*devpkg.Package {
@@ -946,7 +946,7 @@ func (d *Devbox) HasDeprecatedPackages() bool {
 
 func (d *Devbox) findPackageByName(name string) (string, error) {
 	results := map[string]bool{}
-	for _, pkg := range d.cfg.Packages {
+	for _, pkg := range d.cfg.Packages.VersionedNames() {
 		i := devpkg.PackageFromString(pkg, d.lockfile)
 		if i.String() == name || i.CanonicalName() == name {
 			results[i.String()] = true

--- a/internal/impl/global.go
+++ b/internal/impl/global.go
@@ -18,7 +18,7 @@ import (
 const currentGlobalProfile = "default"
 
 func (d *Devbox) PrintGlobalList() error {
-	for _, p := range d.cfg.Packages {
+	for _, p := range d.cfg.Packages.VersionedNames() {
 		fmt.Fprintf(d.writer, "* %s\n", p)
 	}
 	return nil

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -136,9 +136,7 @@ func (d *Devbox) Remove(ctx context.Context, pkgs ...string) error {
 		found, _ := d.findPackageByName(pkg)
 		if found != "" {
 			packagesToUninstall = append(packagesToUninstall, found)
-			if err := d.cfg.Packages.Remove(found); err != nil {
-				return errors.WithStack(err)
-			}
+			d.cfg.Packages.Remove(found)
 		} else {
 			missingPkgs = append(missingPkgs, pkg)
 		}

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -45,9 +45,10 @@ func (d *Devbox) Add(ctx context.Context, pkgsNames ...string) error {
 	// names of added packages (even if they are already in config). We use this
 	// to know the exact name to mark as allowed insecure later on.
 	addedPackageNames := []string{}
+	existingPackageNames := d.cfg.Packages.VersionedNames()
 	for _, pkg := range pkgs {
 		// If exact versioned package is already in the config, skip.
-		if slices.Contains(d.cfg.Packages, pkg.Versioned()) {
+		if slices.Contains(existingPackageNames, pkg.Versioned()) {
 			addedPackageNames = append(addedPackageNames, pkg.Versioned())
 			continue
 		}
@@ -80,7 +81,7 @@ func (d *Devbox) Add(ctx context.Context, pkgsNames ...string) error {
 			return usererr.New("Package %s not found", pkg.Raw)
 		}
 
-		d.cfg.Packages = append(d.cfg.Packages, packageNameForConfig)
+		d.cfg.Packages.Add(packageNameForConfig)
 		addedPackageNames = append(addedPackageNames, packageNameForConfig)
 	}
 
@@ -135,7 +136,9 @@ func (d *Devbox) Remove(ctx context.Context, pkgs ...string) error {
 		found, _ := d.findPackageByName(pkg)
 		if found != "" {
 			packagesToUninstall = append(packagesToUninstall, found)
-			d.cfg.Packages = lo.Without(d.cfg.Packages, found)
+			if err := d.cfg.Packages.Remove(found); err != nil {
+				return errors.WithStack(err)
+			}
 		} else {
 			missingPkgs = append(missingPkgs, pkg)
 		}

--- a/internal/searcher/parse.go
+++ b/internal/searcher/parse.go
@@ -9,10 +9,19 @@ import (
 
 // ParseVersionedPackage checks if the given package is a versioned package
 // (`python@3.10`) and returns its name and version
-func ParseVersionedPackage(pkg string) (string, string, bool) {
-	lastIndex := strings.LastIndex(pkg, "@")
-	if lastIndex == -1 {
+func ParseVersionedPackage(versionedName string) (name string, version string, found bool) {
+	// use the last @ symbol as the version delimiter, some packages have @ in the name
+	atSymbolIndex := strings.LastIndex(versionedName, "@")
+	if atSymbolIndex == -1 {
 		return "", "", false
 	}
-	return pkg[:lastIndex], pkg[lastIndex+1:], true
+	if atSymbolIndex == len(versionedName)-1 {
+		// This case handles packages that end with `@` in the name
+		// example: `emacsPackages.@`
+		return "", "", false
+	}
+
+	// Common case: package@version
+	name, version = versionedName[:atSymbolIndex], versionedName[atSymbolIndex+1:]
+	return name, version, true
 }

--- a/internal/searcher/parse_test.go
+++ b/internal/searcher/parse_test.go
@@ -1,0 +1,66 @@
+package searcher
+
+import (
+	"testing"
+)
+
+func TestParseVersionedPackage(t *testing.T) {
+	testCases := []struct {
+		name            string
+		input           string
+		expectedFound   bool
+		expectedName    string
+		expectedVersion string
+	}{
+		{
+			name:            "no-version",
+			input:           "python",
+			expectedFound:   false,
+			expectedName:    "",
+			expectedVersion: "",
+		},
+		{
+			name:            "with-version-latest",
+			input:           "python@latest",
+			expectedFound:   true,
+			expectedName:    "python",
+			expectedVersion: "latest",
+		},
+		{
+			name:            "with-version",
+			input:           "python@1.2.3",
+			expectedFound:   true,
+			expectedName:    "python",
+			expectedVersion: "1.2.3",
+		},
+		{
+			name:            "with-two-@-signs",
+			input:           "emacsPackages.@@latest",
+			expectedFound:   true,
+			expectedName:    "emacsPackages.@",
+			expectedVersion: "latest",
+		},
+		{
+			name:            "with-trailing-@-sign",
+			input:           "emacsPackages.@",
+			expectedFound:   false,
+			expectedName:    "",
+			expectedVersion: "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			name, version, found := ParseVersionedPackage(testCase.input)
+			if found != testCase.expectedFound {
+				t.Errorf("expected: %v, got: %v", testCase.expectedFound, found)
+			}
+			if name != testCase.expectedName {
+				t.Errorf("expected: %v, got: %v", testCase.expectedName, name)
+			}
+			if version != testCase.expectedVersion {
+				t.Errorf("expected: %v, got: %v", testCase.expectedVersion, version)
+			}
+		})
+	}
+}

--- a/testscripts/testrunner/assert.go
+++ b/testscripts/testrunner/assert.go
@@ -46,17 +46,17 @@ func assertDevboxJSONPackagesContains(script *testscript.TestScript, neg bool, a
 	script.Check(err)
 
 	expected := args[1]
-	for _, actual := range list.Packages {
+	for _, actual := range list.Packages.VersionedNames() {
 		if actual == expected {
 			if neg {
-				script.Fatalf("value '%s' found in '%s'", expected, list.Packages)
+				script.Fatalf("value '%s' found in '%s'", expected, list.Packages.VersionedNames())
 			}
 			return
 		}
 	}
 
 	if !neg {
-		script.Fatalf("value '%s' not found in '%s'", expected, list.Packages)
+		script.Fatalf("value '%s' not found in '%s'", expected, list.Packages.VersionedNames())
 	}
 }
 


### PR DESCRIPTION
## Summary

**Motivation**
User feedback is leading us to add more parameters besides version to the packages config.
For instance, some packages may only need to be added on certain platforms.

Previously, packages were specified as `[]string`. For example:
```
{
  "packages": [
    "python@3.9",
    "hello",
    "cowsay@latest"
  ],
  ...
}
```

In the new format, they can also be specified as:
```
{
   "packages": {
      "python": "3.9",
      "hello": "",
      "cowsay": {
        "version": "latest",
      }
   }
}
```
NOTE: `python` is an inline-version, while `cowsay` has a struct value which can
accomodate other fields like `platforms`.

**Approach**
For now, we enable both packages as List and Map to work. The default continues to be List.
We do this by adding a `Packages` struct and `Package` struct with custom JSON marshalling and unmarshalling.

**Future PRs**
1. Introduce `Packages.platforms` and/or `Packages.excludedPlatforms` fields. Use them when installing to nix profile, and generating the flake.nix.
2. Introduce `devbox add` and `devbox rm` flags for platform-specific packages.
3. Detect package usage failures when due to platform mis-match and suggest using CLI commands to run to make platform-specific.

## How was it tested?

Added `TestJsonifyConfigPackages` and other unit-tests

testscripts pass

`devbox init` produces the same output as before.
