### PR TITLE
[env] Add env flags to direnv commands

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -27,7 +27,7 @@ type Devbox interface {
 	Generate(ctx context.Context) error
 	GenerateDevcontainer(ctx context.Context, force bool) error
 	GenerateDockerfile(ctx context.Context, force bool) error
-	GenerateEnvrcFile(ctx context.Context, force bool, additionalFlags []string) error
+	GenerateEnvrcFile(ctx context.Context, force bool, envFlags devopt.EnvFlags) error
 	Info(ctx context.Context, pkg string, markdown bool) error
 	Install(ctx context.Context) error
 	IsEnvEnabled() bool
@@ -67,8 +67,8 @@ func GlobalDataPath() (string, error) {
 	return impl.GlobalDataPath()
 }
 
-func PrintEnvrcContent(w io.Writer, additionalFlags []string) error {
-	return impl.PrintEnvrcContent(w, additionalFlags)
+func PrintEnvrcContent(w io.Writer, envFlags devopt.EnvFlags) error {
+	return impl.PrintEnvrcContent(w, envFlags)
 }
 
 // ExportifySystemPathWithoutWrappers reads $PATH, removes `virtenv/.wrappers/bin` paths,

--- a/devbox.go
+++ b/devbox.go
@@ -27,7 +27,7 @@ type Devbox interface {
 	Generate(ctx context.Context) error
 	GenerateDevcontainer(ctx context.Context, force bool) error
 	GenerateDockerfile(ctx context.Context, force bool) error
-	GenerateEnvrcFile(ctx context.Context, force bool) error
+	GenerateEnvrcFile(ctx context.Context, force bool, additionalFlags []string) error
 	Info(ctx context.Context, pkg string, markdown bool) error
 	Install(ctx context.Context) error
 	IsEnvEnabled() bool
@@ -67,8 +67,8 @@ func GlobalDataPath() (string, error) {
 	return impl.GlobalDataPath()
 }
 
-func PrintEnvrcContent(w io.Writer) error {
-	return impl.PrintEnvrcContent(w)
+func PrintEnvrcContent(w io.Writer, additionalFlags []string) error {
+	return impl.PrintEnvrcContent(w, additionalFlags)
 }
 
 // ExportifySystemPathWithoutWrappers reads $PATH, removes `virtenv/.wrappers/bin` paths,

--- a/internal/boxcli/env.go
+++ b/internal/boxcli/env.go
@@ -9,28 +9,26 @@ import (
 	"github.com/joho/godotenv"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"go.jetpack.io/devbox/internal/impl/devopt"
 )
 
 // to be composed into xyzCmdFlags structs
-type envFlag struct {
-	env     map[string]string
-	envFile string
-}
+type envFlag devopt.EnvFlags
 
 func (f *envFlag) register(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringToStringVarP(
-		&f.env, "env", "e", nil, "environment variables to set in the devbox environment",
+		&f.EnvMap, "env", "e", nil, "environment variables to set in the devbox environment",
 	)
 	cmd.PersistentFlags().StringVar(
-		&f.envFile, "env-file", "", "path to a file containing environment variables to set in the devbox environment",
+		&f.EnvFile, "env-file", "", "path to a file containing environment variables to set in the devbox environment",
 	)
 }
 
 func (f *envFlag) Env(path string) (map[string]string, error) {
 	envs := map[string]string{}
 	var err error
-	if f.envFile != "" {
-		envPath := f.envFile
+	if f.EnvFile != "" {
+		envPath := f.EnvFile
 		if !filepath.IsAbs(envPath) {
 			envPath = filepath.Join(path, envPath)
 		}
@@ -40,7 +38,7 @@ func (f *envFlag) Env(path string) (map[string]string, error) {
 		}
 	}
 
-	for k, v := range f.env {
+	for k, v := range f.EnvMap {
 		envs[k] = v
 	}
 

--- a/internal/boxcli/generate.go
+++ b/internal/boxcli/generate.go
@@ -151,18 +151,9 @@ func runGenerateCmd(cmd *cobra.Command, flags *generateCmdFlags) error {
 }
 
 func runGenerateDirenvCmd(cmd *cobra.Command, flags *generateCmdFlags) error {
-	additionalFlags := []string{}
-	if flags.envFile != "" {
-		additionalFlags = append(additionalFlags, "--env-file", flags.envFile)
-	}
-	if len(flags.env) > 0 {
-		for k, v := range flags.env {
-			additionalFlags = append(additionalFlags, "--env", k+"="+v)
-		}
-	}
-
 	if flags.printEnvrcContent {
-		return devbox.PrintEnvrcContent(cmd.OutOrStdout(), additionalFlags)
+		return devbox.PrintEnvrcContent(
+			cmd.OutOrStdout(), devopt.EnvFlags(flags.envFlag))
 	}
 
 	box, err := devbox.Open(&devopt.Opts{
@@ -173,5 +164,6 @@ func runGenerateDirenvCmd(cmd *cobra.Command, flags *generateCmdFlags) error {
 		return errors.WithStack(err)
 	}
 
-	return box.GenerateEnvrcFile(cmd.Context(), flags.force, additionalFlags)
+	return box.GenerateEnvrcFile(
+		cmd.Context(), flags.force, devopt.EnvFlags(flags.envFlag))
 }

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -431,12 +431,12 @@ func (d *Devbox) GenerateDockerfile(ctx context.Context, force bool) error {
 			d.projectDir, d.getLocalFlakesDirs(), false /* isDevcontainer */))
 }
 
-func PrintEnvrcContent(w io.Writer, additionalFlags []string) error {
-	return generate.EnvrcContent(w, additionalFlags)
+func PrintEnvrcContent(w io.Writer, envFlags devopt.EnvFlags) error {
+	return generate.EnvrcContent(w, envFlags)
 }
 
 // GenerateEnvrcFile generates a .envrc file that makes direnv integration convenient
-func (d *Devbox) GenerateEnvrcFile(ctx context.Context, force bool, additionaFlags []string) error {
+func (d *Devbox) GenerateEnvrcFile(ctx context.Context, force bool, envFlags devopt.EnvFlags) error {
 	ctx, task := trace.NewTask(ctx, "devboxGenerateEnvrc")
 	defer task.End()
 
@@ -461,7 +461,7 @@ func (d *Devbox) GenerateEnvrcFile(ctx context.Context, force bool, additionaFla
 	}
 
 	// .envrc file creation
-	err := generate.CreateEnvrc(ctx, d.projectDir, additionaFlags)
+	err := generate.CreateEnvrc(ctx, d.projectDir, envFlags)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -431,12 +431,12 @@ func (d *Devbox) GenerateDockerfile(ctx context.Context, force bool) error {
 			d.projectDir, d.getLocalFlakesDirs(), false /* isDevcontainer */))
 }
 
-func PrintEnvrcContent(w io.Writer) error {
-	return generate.EnvrcContent(w)
+func PrintEnvrcContent(w io.Writer, additionalFlags []string) error {
+	return generate.EnvrcContent(w, additionalFlags)
 }
 
 // GenerateEnvrcFile generates a .envrc file that makes direnv integration convenient
-func (d *Devbox) GenerateEnvrcFile(ctx context.Context, force bool) error {
+func (d *Devbox) GenerateEnvrcFile(ctx context.Context, force bool, additionaFlags []string) error {
 	ctx, task := trace.NewTask(ctx, "devboxGenerateEnvrc")
 	defer task.End()
 
@@ -461,7 +461,7 @@ func (d *Devbox) GenerateEnvrcFile(ctx context.Context, force bool) error {
 	}
 
 	// .envrc file creation
-	err := generate.CreateEnvrc(ctx, d.projectDir)
+	err := generate.CreateEnvrc(ctx, d.projectDir, additionaFlags)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/internal/impl/devopt/devboxopts.go
+++ b/internal/impl/devopt/devboxopts.go
@@ -13,3 +13,8 @@ type Opts struct {
 	CustomProcessComposeFile string
 	Writer                   io.Writer
 }
+
+type EnvFlags struct {
+	EnvMap  map[string]string
+	EnvFile string
+}

--- a/internal/impl/generate/devcontainer_util.go
+++ b/internal/impl/generate/devcontainer_util.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
+	"fmt"
 	"html/template"
 	"io"
 	"os"
@@ -18,6 +19,7 @@ import (
 	"strings"
 
 	"go.jetpack.io/devbox/internal/debug"
+	"go.jetpack.io/devbox/internal/impl/devopt"
 )
 
 //go:embed tmpl/*
@@ -90,7 +92,7 @@ func CreateDevcontainer(ctx context.Context, path string, pkgs []string) error {
 	return err
 }
 
-func CreateEnvrc(ctx context.Context, path string, additionalFlags []string) error {
+func CreateEnvrc(ctx context.Context, path string, envFlags devopt.EnvFlags) error {
 	defer trace.StartRegion(ctx, "createEnvrc").End()
 
 	// create .envrc file
@@ -99,12 +101,23 @@ func CreateEnvrc(ctx context.Context, path string, additionalFlags []string) err
 		return err
 	}
 	defer file.Close()
-	// get .envrc content
-	tmplName := "envrc.tmpl"
-	t := template.Must(template.ParseFS(tmplFS, "tmpl/"+tmplName))
+
+	flags := []string{}
+
+	if len(envFlags.EnvMap) > 0 {
+		for k, v := range envFlags.EnvMap {
+			flags = append(flags, fmt.Sprintf("--env %s=%s", k, v))
+		}
+	}
+	if envFlags.EnvFile != "" {
+		flags = append(flags, fmt.Sprintf("--env-file %s", envFlags.EnvFile))
+	}
+
+	t := template.Must(template.ParseFS(tmplFS, "tmpl/envrc.tmpl"))
+
 	// write content into file
 	return t.Execute(file, map[string]string{
-		"AdditionalFlags": strings.Join(additionalFlags, " "),
+		"Flags": strings.Join(flags, " "),
 	})
 }
 
@@ -158,10 +171,17 @@ func getDevcontainerContent(pkgs []string) *devcontainerObject {
 	return devcontainerContent
 }
 
-func EnvrcContent(w io.Writer, additionalFlags []string) error {
+func EnvrcContent(w io.Writer, envFlags devopt.EnvFlags) error {
 	tmplName := "envrcContent.tmpl"
 	t := template.Must(template.ParseFS(tmplFS, "tmpl/"+tmplName))
+	envFlag := ""
+	if len(envFlags.EnvMap) > 0 {
+		for k, v := range envFlags.EnvMap {
+			envFlag += fmt.Sprintf("--env %s=%s ", k, v)
+		}
+	}
 	return t.Execute(w, map[string]string{
-		"AdditionalFlags": strings.Join(additionalFlags, " "),
+		"EnvFlag": envFlag,
+		"EnvFile": envFlags.EnvFile,
 	})
 }

--- a/internal/impl/generate/devcontainer_util.go
+++ b/internal/impl/generate/devcontainer_util.go
@@ -90,7 +90,7 @@ func CreateDevcontainer(ctx context.Context, path string, pkgs []string) error {
 	return err
 }
 
-func CreateEnvrc(ctx context.Context, path string) error {
+func CreateEnvrc(ctx context.Context, path string, additionalFlags []string) error {
 	defer trace.StartRegion(ctx, "createEnvrc").End()
 
 	// create .envrc file
@@ -103,7 +103,9 @@ func CreateEnvrc(ctx context.Context, path string) error {
 	tmplName := "envrc.tmpl"
 	t := template.Must(template.ParseFS(tmplFS, "tmpl/"+tmplName))
 	// write content into file
-	return t.Execute(file, nil)
+	return t.Execute(file, map[string]string{
+		"AdditionalFlags": strings.Join(additionalFlags, " "),
+	})
 }
 
 func getDevcontainerContent(pkgs []string) *devcontainerObject {
@@ -156,8 +158,10 @@ func getDevcontainerContent(pkgs []string) *devcontainerObject {
 	return devcontainerContent
 }
 
-func EnvrcContent(w io.Writer) error {
+func EnvrcContent(w io.Writer, additionalFlags []string) error {
 	tmplName := "envrcContent.tmpl"
 	t := template.Must(template.ParseFS(tmplFS, "tmpl/"+tmplName))
-	return t.Execute(w, nil)
+	return t.Execute(w, map[string]string{
+		"AdditionalFlags": strings.Join(additionalFlags, " "),
+	})
 }

--- a/internal/impl/generate/tmpl/envrc.tmpl
+++ b/internal/impl/generate/tmpl/envrc.tmpl
@@ -1,7 +1,7 @@
 # Automatically sets up your devbox environment whenever you cd into this
 # directory via our direnv integration:
 
-eval "$(devbox generate direnv --print-envrc)"
+eval "$(devbox generate direnv --print-envrc{{ if .AdditionalFlags}} {{ .AdditionalFlags }}{{ end }})"
 
 # check out https://www.jetpack.io/devbox/docs/ide_configuration/direnv/
 # for more details

--- a/internal/impl/generate/tmpl/envrc.tmpl
+++ b/internal/impl/generate/tmpl/envrc.tmpl
@@ -1,7 +1,7 @@
 # Automatically sets up your devbox environment whenever you cd into this
 # directory via our direnv integration:
 
-eval "$(devbox generate direnv --print-envrc{{ if .AdditionalFlags}} {{ .AdditionalFlags }}{{ end }})"
+eval "$(devbox generate direnv --print-envrc{{ if .Flags}} {{ .Flags }}{{ end }})"
 
 # check out https://www.jetpack.io/devbox/docs/ide_configuration/direnv/
 # for more details

--- a/internal/impl/generate/tmpl/envrcContent.tmpl
+++ b/internal/impl/generate/tmpl/envrcContent.tmpl
@@ -1,5 +1,5 @@
 use_devbox() {
     watch_file devbox.json
-    eval "$(devbox shellenv --init-hook --install)"
+    eval "$(devbox shellenv --init-hook --install{{ if .AdditionalFlags}} {{ .AdditionalFlags }}{{ end }})"
 }
 use devbox

--- a/internal/impl/generate/tmpl/envrcContent.tmpl
+++ b/internal/impl/generate/tmpl/envrcContent.tmpl
@@ -1,5 +1,8 @@
 use_devbox() {
     watch_file devbox.json
-    eval "$(devbox shellenv --init-hook --install{{ if .AdditionalFlags}} {{ .AdditionalFlags }}{{ end }})"
+    eval "$(devbox shellenv --init-hook --install{{ if .EnvFlag }} {{ .EnvFlag }}{{ end }})"
 }
 use devbox
+{{ if .EnvFile }}
+dotenv_if_exists {{ .EnvFile }}
+{{ end }}

--- a/internal/wrapnix/wrapper.go
+++ b/internal/wrapnix/wrapper.go
@@ -61,7 +61,7 @@ func CreateWrappers(ctx context.Context, devbox devboxer) error {
 	}
 
 	for _, bin := range bins {
-		if err = createWrapper(&createWrapperArgs{
+		if err = createWrapperIfNeeded(&createWrapperArgs{
 			devboxer:         devbox,
 			BashPath:         bashPath,
 			Command:          bin,
@@ -141,7 +141,11 @@ type createWrapperArgs struct {
 	destPath         string
 }
 
-func createWrapper(args *createWrapperArgs) error {
+func createWrapperIfNeeded(args *createWrapperArgs) error {
+	// If hash is already set, the env is up to date, no need for wrappers.
+	if args.ShellEnvHash == os.Getenv(args.ShellEnvHashKey()) {
+		return nil
+	}
 	buf := &bytes.Buffer{}
 	if err := wrapperTemplate.Execute(buf, args); err != nil {
 		return errors.WithStack(err)

--- a/internal/wrapnix/wrapper.go
+++ b/internal/wrapnix/wrapper.go
@@ -61,7 +61,7 @@ func CreateWrappers(ctx context.Context, devbox devboxer) error {
 	}
 
 	for _, bin := range bins {
-		if err = createWrapperIfNeeded(&createWrapperArgs{
+		if err = createWrapper(&createWrapperArgs{
 			devboxer:         devbox,
 			BashPath:         bashPath,
 			Command:          bin,
@@ -141,11 +141,7 @@ type createWrapperArgs struct {
 	destPath         string
 }
 
-func createWrapperIfNeeded(args *createWrapperArgs) error {
-	// If hash is already set, the env is up to date, no need for wrappers.
-	if args.ShellEnvHash == os.Getenv(args.ShellEnvHashKey()) {
-		return nil
-	}
+func createWrapper(args *createWrapperArgs) error {
 	buf := &bytes.Buffer{}
 	if err := wrapperTemplate.Execute(buf, args); err != nil {
 		return errors.WithStack(err)


### PR DESCRIPTION
## Summary

This allows users to generate .envrc files that use custom env variables like so:

```bash
devbox generate direnv -e foo=bar -e foo1=bar2
devbox generate direnv --env-file .env
```

Users can also manually modify `.envrc` files to add additional flags:

`devbox generate direnv --print-envrc -e foo=bar`

## How was it tested?

Generated .envrc file with custom env flags. Then used direnv and verified environment was setup as expected.

## Backward compatibility

Newly generated `.envrc` files that contain `--env` or `--env-file` flags will not be compatible with previous versions of devbox.