### PR TITLE
[docs] add documentation for devbox version update (#1355)

### DIFF
--- a/docs/app/docs/cli_reference/devbox_version.md
+++ b/docs/app/docs/cli_reference/devbox_version.md
@@ -3,8 +3,13 @@
 Print version information
 
 ```bash
-devbox version [flags]
+devbox version [update] [flags]
 ```
+
+## Subcommands
+
+* [devbox version update](devbox_version_update.md)	 - Check for a new version of devbox and update if available
+
 
 ## Options
 

--- a/docs/app/docs/cli_reference/devbox_version_update.md
+++ b/docs/app/docs/cli_reference/devbox_version_update.md
@@ -1,0 +1,20 @@
+# devbox version update
+
+Check for a new version of devbox and update if available
+
+```bash
+devbox version update [flags]
+```
+
+## Options
+
+<!-- Markdown Table of Options -->
+| Option | Description |
+| --- | --- |
+| `-h, --help` | help for update |
+| `-q, --quiet` | Quiet mode: Suppresses logs. |
+
+## SEE ALSO
+
+* [devbox](./devbox.md)	 - Instant, easy, predictable shells and containers
+


### PR DESCRIPTION
## Summary
Adds documentation for `devbox version update`. Fixes #1355

## How was it tested?
I used the [included devbox](https://github.com/jetpack-io/devbox/tree/main/docs#website).