### PR TITLE
[Packages] Introduce the concept of Installable packages

### DIFF
--- a/internal/devconfig/packages.go
+++ b/internal/devconfig/packages.go
@@ -36,18 +36,9 @@ type Packages struct {
 func (pkgs *Packages) VersionedNames() []string {
 	result := make([]string, 0, len(pkgs.Collection))
 	for _, p := range pkgs.Collection {
-		name := p.name
-		if p.Version != "" {
-			name += "@" + p.Version
-		}
-		result = append(result, name)
+		result = append(result, p.VersionedName())
 	}
 	return result
-}
-
-func (pkgs *Packages) VersionedNamesForPlatform() ([]string, error) {
-	// TODO savil. Next PR will update this implementation
-	return pkgs.VersionedNames(), nil
 }
 
 // Add adds a package to the list of packages
@@ -157,6 +148,19 @@ func NewPackage(name string, values map[string]any) Package {
 		name:    name,
 		Version: version.(string),
 	}
+}
+
+func (p *Package) VersionedName() string {
+	name := p.name
+	if p.Version != "" {
+		name += "@" + p.Version
+	}
+	return name
+}
+
+func (p *Package) IsEnabledOnPlatform() (bool, error) {
+	// TODO savil. Next PR will update this implementation
+	return true, nil
 }
 
 func (p *Package) UnmarshalJSON(data []byte) error {

--- a/internal/devconfig/packages.go
+++ b/internal/devconfig/packages.go
@@ -158,9 +158,9 @@ func (p *Package) VersionedName() string {
 	return name
 }
 
-func (p *Package) IsEnabledOnPlatform() (bool, error) {
+func (p *Package) IsEnabledOnPlatform() bool {
 	// TODO savil. Next PR will update this implementation
-	return true, nil
+	return true
 }
 
 func (p *Package) UnmarshalJSON(data []byte) error {

--- a/internal/devconfig/packages.go
+++ b/internal/devconfig/packages.go
@@ -45,9 +45,9 @@ func (pkgs *Packages) VersionedNames() []string {
 	return result
 }
 
-func (pkgs *Packages) VersionedNamesForPlatform() []string {
+func (pkgs *Packages) VersionedNamesForPlatform() ([]string, error) {
 	// TODO savil. Next PR will update this implementation
-	return pkgs.VersionedNames()
+	return pkgs.VersionedNames(), nil
 }
 
 // Add adds a package to the list of packages

--- a/internal/devconfig/packages.go
+++ b/internal/devconfig/packages.go
@@ -45,6 +45,11 @@ func (pkgs *Packages) VersionedNames() []string {
 	return result
 }
 
+func (pkgs *Packages) VersionedNamesForPlatform() []string {
+	// TODO savil. Next PR will update this implementation
+	return pkgs.VersionedNames()
+}
+
 // Add adds a package to the list of packages
 func (pkgs *Packages) Add(versionedName string) {
 	name, version := parseVersionedName(versionedName)

--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -63,16 +63,12 @@ func PackageFromStrings(rawNames []string, l lock.Locker) []*Package {
 	return packages
 }
 
-func PackagesFromConfig(config *devconfig.Config, l lock.Locker) ([]*Package, error) {
+func PackagesFromConfig(config *devconfig.Config, l lock.Locker) []*Package {
 	result := []*Package{}
 	for _, pkg := range config.Packages.Collection {
-		isInstallable, err := pkg.IsEnabledOnPlatform()
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, newPackage(pkg.VersionedName(), isInstallable, l))
+		result = append(result, newPackage(pkg.VersionedName(), pkg.IsEnabledOnPlatform(), l))
 	}
-	return result, nil
+	return result
 }
 
 // PackageFromString constructs Package from the raw name provided.

--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -18,6 +18,7 @@ import (
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/cuecfg"
+	"go.jetpack.io/devbox/internal/devconfig"
 	"go.jetpack.io/devbox/internal/lock"
 	"go.jetpack.io/devbox/internal/nix"
 	"go.jetpack.io/devbox/internal/vercheck"
@@ -46,6 +47,9 @@ type Package struct {
 	//    example: github:nixos/nixpkgs/5233fd2ba76a3accb5aaa999c00509a11fd0793c#hello
 	Raw string
 
+	// isInstallable is true if the package may be enabled on the current platform.
+	isInstallable bool
+
 	normalizedPackageAttributePathCache string // memoized value from normalizedPackageAttributePath()
 }
 
@@ -59,9 +63,26 @@ func PackageFromStrings(rawNames []string, l lock.Locker) []*Package {
 	return packages
 }
 
+func PackagesFromConfig(config *devconfig.Config, l lock.Locker) ([]*Package, error) {
+	result := []*Package{}
+	for _, pkg := range config.Packages.Collection {
+		isInstallable, err := pkg.IsEnabledOnPlatform()
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, newPackage(pkg.VersionedName(), isInstallable, l))
+	}
+	return result, nil
+}
+
 // PackageFromString constructs Package from the raw name provided.
 // The raw name corresponds to a devbox package from the devbox.json config.
 func PackageFromString(raw string, locker lock.Locker) *Package {
+	// Packages are installable by default.
+	return newPackage(raw, true /*isInstallable*/, locker)
+}
+
+func newPackage(raw string, isInstallable bool, locker lock.Locker) *Package {
 	// TODO: We should handle this error
 	// TODO: URL might not be best representation since most packages are not urls
 	pkgURL, _ := url.Parse(raw)
@@ -79,7 +100,7 @@ func PackageFromString(raw string, locker lock.Locker) *Package {
 		pkgURL, _ = url.Parse(normalizedURL)
 	}
 
-	return &Package{URL: *pkgURL, lockfile: locker, Raw: raw}
+	return &Package{URL: *pkgURL, lockfile: locker, Raw: raw, isInstallable: isInstallable}
 }
 
 // isLocal specifies whether this package is a local flake.
@@ -144,6 +165,12 @@ func (p *Package) URLForFlakeInput() string {
 		return withoutFragment
 	}
 	return p.urlWithoutFragment()
+}
+
+// IsInstallable returns whether this package is installable. Not to be confused
+// with the Installable() method which returns the corresponding nix concept.
+func (p *Package) IsInstallable() bool {
+	return p.isInstallable
 }
 
 // Installable for this package. Installable is a nix concept defined here:

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -959,10 +959,9 @@ func (d *Devbox) InstallablePackages() []*devpkg.Package {
 	})
 }
 
-// AllPackages returns user packages and plugin packages concatenated in
-// correct order
-// TODO: rename AllPackages to InstallableAndPluginPackages
-func (d *Devbox) AllPackages() ([]*devpkg.Package, error) {
+// InstallableAndPluginPackages returns installable user packages and plugin
+// packages concatenated in correct order
+func (d *Devbox) AllInstallablePackages() ([]*devpkg.Package, error) {
 	userPackages := d.InstallablePackages()
 	pluginPackages, err := d.PluginManager().PluginPackages(userPackages)
 	if err != nil {

--- a/internal/impl/flakes.go
+++ b/internal/impl/flakes.go
@@ -14,7 +14,7 @@ func (d *Devbox) getLocalFlakesDirs() []string {
 	localFlakeDirs := []string{}
 
 	// searching through installed packages to get location of local flakes
-	for _, pkg := range d.ConfigPackageNames() {
+	for _, pkg := range d.PackageNames() {
 		// filtering local flakes packages
 		if strings.HasPrefix(pkg, "path:") {
 			pkgDirAndName, _ := strings.CutPrefix(pkg, "path:")

--- a/internal/impl/flakes.go
+++ b/internal/impl/flakes.go
@@ -14,7 +14,7 @@ func (d *Devbox) getLocalFlakesDirs() []string {
 	localFlakeDirs := []string{}
 
 	// searching through installed packages to get location of local flakes
-	for _, pkg := range d.Packages() {
+	for _, pkg := range d.ConfigPackageNames() {
 		// filtering local flakes packages
 		if strings.HasPrefix(pkg, "path:") {
 			pkgDirAndName, _ := strings.CutPrefix(pkg, "path:")

--- a/internal/impl/global.go
+++ b/internal/impl/global.go
@@ -18,7 +18,7 @@ import (
 const currentGlobalProfile = "default"
 
 func (d *Devbox) PrintGlobalList() error {
-	for _, p := range d.cfg.Packages.VersionedNames() {
+	for _, p := range d.ConfigPackageNames() {
 		fmt.Fprintf(d.writer, "* %s\n", p)
 	}
 	return nil

--- a/internal/impl/global.go
+++ b/internal/impl/global.go
@@ -18,7 +18,7 @@ import (
 const currentGlobalProfile = "default"
 
 func (d *Devbox) PrintGlobalList() error {
-	for _, p := range d.ConfigPackageNames() {
+	for _, p := range d.PackageNames() {
 		fmt.Fprintf(d.writer, "* %s\n", p)
 	}
 	return nil

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -197,7 +197,7 @@ func (d *Devbox) ensurePackagesAreInstalled(ctx context.Context, mode installMod
 	}
 
 	// Create plugin directories first because packages might need them
-	for _, pkg := range d.PackagesAsInputs() {
+	for _, pkg := range d.InstallablePackages() {
 		if err := d.PluginManager().Create(pkg); err != nil {
 			return err
 		}
@@ -375,7 +375,7 @@ func (d *Devbox) tidyProfile(ctx context.Context) error {
 // pendingPackagesForInstallation returns a list of packages that are in
 // devbox.json or global devbox.json but are not yet installed in the nix
 // profile. It maintains the order of packages as specified by
-// Devbox.packages() (higher priority first)
+// Devbox.AllPackages() (higher priority first)
 func (d *Devbox) pendingPackagesForInstallation(ctx context.Context) ([]*devpkg.Package, error) {
 	defer trace.StartRegion(ctx, "pendingPackages").End()
 
@@ -428,7 +428,7 @@ func (d *Devbox) extraPackagesInProfile(ctx context.Context) ([]*nixprofile.NixP
 	if err != nil {
 		return nil, err
 	}
-	devboxInputs := d.PackagesAsInputs()
+	devboxInputs := d.PlatformPackages()
 
 	if len(devboxInputs) == len(profileItems) {
 		// Optimization: skip comparison if number of packages are the same. This only works

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -389,7 +389,7 @@ func (d *Devbox) pendingPackagesForInstallation(ctx context.Context) ([]*devpkg.
 	if err != nil {
 		return nil, err
 	}
-	packages, err := d.AllPackages()
+	packages, err := d.AllInstallablePackages()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -428,7 +428,10 @@ func (d *Devbox) extraPackagesInProfile(ctx context.Context) ([]*nixprofile.NixP
 	if err != nil {
 		return nil, err
 	}
-	devboxInputs := d.PlatformPackages()
+	devboxInputs, err := d.InstallablePackages()
+	if err != nil {
+		return nil, err
+	}
 
 	if len(devboxInputs) == len(profileItems) {
 		// Optimization: skip comparison if number of packages are the same. This only works

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -45,7 +45,7 @@ func (d *Devbox) Add(ctx context.Context, pkgsNames ...string) error {
 	// names of added packages (even if they are already in config). We use this
 	// to know the exact name to mark as allowed insecure later on.
 	addedPackageNames := []string{}
-	existingPackageNames := d.cfg.Packages.VersionedNames()
+	existingPackageNames := d.ConfigPackageNames()
 	for _, pkg := range pkgs {
 		// If exact versioned package is already in the config, skip.
 		if slices.Contains(existingPackageNames, pkg.Versioned()) {

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -45,7 +45,7 @@ func (d *Devbox) Add(ctx context.Context, pkgsNames ...string) error {
 	// names of added packages (even if they are already in config). We use this
 	// to know the exact name to mark as allowed insecure later on.
 	addedPackageNames := []string{}
-	existingPackageNames := d.ConfigPackageNames()
+	existingPackageNames := d.PackageNames()
 	for _, pkg := range pkgs {
 		// If exact versioned package is already in the config, skip.
 		if slices.Contains(existingPackageNames, pkg.Versioned()) {
@@ -428,11 +428,7 @@ func (d *Devbox) extraPackagesInProfile(ctx context.Context) ([]*nixprofile.NixP
 	if err != nil {
 		return nil, err
 	}
-	devboxInputs, err := d.InstallablePackages()
-	if err != nil {
-		return nil, err
-	}
-
+	devboxInputs := d.InstallablePackages()
 	if len(devboxInputs) == len(profileItems) {
 		// Optimization: skip comparison if number of packages are the same. This only works
 		// because we assume that all packages in `devbox.json` have just been added to the

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -75,7 +75,7 @@ func (d *Devbox) inputsToUpdate(pkgs ...string) ([]*devpkg.Package, error) {
 		pkgsToUpdate = append(pkgsToUpdate, found)
 	}
 	if len(pkgsToUpdate) == 0 {
-		pkgsToUpdate = d.ConfigPackageNames()
+		pkgsToUpdate = d.PackageNames()
 	}
 
 	return devpkg.PackageFromStrings(pkgsToUpdate, d.lockfile), nil

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -75,7 +75,7 @@ func (d *Devbox) inputsToUpdate(pkgs ...string) ([]*devpkg.Package, error) {
 		pkgsToUpdate = append(pkgsToUpdate, found)
 	}
 	if len(pkgsToUpdate) == 0 {
-		pkgsToUpdate = d.Packages()
+		pkgsToUpdate = d.ConfigPackageNames()
 	}
 
 	return devpkg.PackageFromStrings(pkgsToUpdate, d.lockfile), nil

--- a/internal/lock/interfaces.go
+++ b/internal/lock/interfaces.go
@@ -6,7 +6,7 @@ package lock
 type devboxProject interface {
 	ConfigHash() (string, error)
 	NixPkgsCommitHash() string
-	ConfigPackageNames() []string
+	PackageNames() []string
 	ProjectDir() string
 }
 

--- a/internal/lock/interfaces.go
+++ b/internal/lock/interfaces.go
@@ -6,7 +6,7 @@ package lock
 type devboxProject interface {
 	ConfigHash() (string, error)
 	NixPkgsCommitHash() string
-	Packages() []string
+	ConfigPackageNames() []string
 	ProjectDir() string
 }
 

--- a/internal/lock/lockfile.go
+++ b/internal/lock/lockfile.go
@@ -141,7 +141,7 @@ func IsLegacyPackage(pkg string) bool {
 // Tidy ensures that the lockfile has the set of packages corresponding to the devbox.json config.
 // It gets rid of older packages that are no longer needed.
 func (f *File) Tidy() {
-	f.Packages = lo.PickByKeys(f.Packages, f.devboxProject.ConfigPackageNames())
+	f.Packages = lo.PickByKeys(f.Packages, f.devboxProject.PackageNames())
 }
 
 // IsUpToDateAndInstalled returns true if the lockfile is up to date and the

--- a/internal/lock/lockfile.go
+++ b/internal/lock/lockfile.go
@@ -141,7 +141,7 @@ func IsLegacyPackage(pkg string) bool {
 // Tidy ensures that the lockfile has the set of packages corresponding to the devbox.json config.
 // It gets rid of older packages that are no longer needed.
 func (f *File) Tidy() {
-	f.Packages = lo.PickByKeys(f.Packages, f.devboxProject.Packages())
+	f.Packages = lo.PickByKeys(f.Packages, f.devboxProject.ConfigPackageNames())
 }
 
 // IsUpToDateAndInstalled returns true if the lockfile is up to date and the

--- a/internal/nix/install.go
+++ b/internal/nix/install.go
@@ -95,12 +95,19 @@ func isRoot() bool {
 	return os.Geteuid() == 0
 }
 
-func EnsureNixInstalled(writer io.Writer, withDaemonFunc func() *bool) error {
+func EnsureNixInstalled(writer io.Writer, withDaemonFunc func() *bool) (err error) {
+	defer func() {
+		if err == nil {
+			// call System to ensure its value is internally cached so we can rely on MustGetSystem
+			_, err = System()
+		}
+	}()
+
 	if BinaryInstalled() {
 		return nil
 	}
 	if dirExists() {
-		if err := SourceNixEnv(); err != nil {
+		if err = SourceNixEnv(); err != nil {
 			return err
 		} else if BinaryInstalled() {
 			return nil
@@ -122,12 +129,12 @@ func EnsureNixInstalled(writer io.Writer, withDaemonFunc func() *bool) error {
 		fmt.Scanln()
 	}
 
-	if err := Install(writer, withDaemonFunc()); err != nil {
+	if err = Install(writer, withDaemonFunc()); err != nil {
 		return err
 	}
 
 	// Source again
-	if err := SourceNixEnv(); err != nil {
+	if err = SourceNixEnv(); err != nil {
 		return err
 	}
 

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -118,8 +118,17 @@ func ExperimentalFlags() []string {
 	}
 }
 
+// TODO: rename to System
+func MustGetSystem() string {
+	if cachedSystem == "" {
+		panic("MustGetSystem called before being initialized by System")
+	}
+	return cachedSystem
+}
+
 var cachedSystem string
 
+// TODO: rename to ComputeSystem
 func System() (string, error) {
 	// For Savil to debug "remove nixpkgs" feature. The Search api lacks x86-darwin info.
 	// So, I need to fake that I am x86-linux and inspect the output in generated devbox.lock

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -15,7 +15,7 @@ type Manager struct {
 }
 
 type devboxProject interface {
-	Packages() []string
+	PlatformPackageNames() []string
 	ProjectDir() string
 }
 

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -15,7 +15,7 @@ type Manager struct {
 }
 
 type devboxProject interface {
-	InstallablePackageNames() ([]string, error)
+	PackageNames() []string
 	ProjectDir() string
 }
 

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -15,7 +15,7 @@ type Manager struct {
 }
 
 type devboxProject interface {
-	PlatformPackageNames() []string
+	InstallablePackageNames() ([]string, error)
 	ProjectDir() string
 }
 

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -163,10 +163,11 @@ func (m *Manager) createFile(
 		"DevboxDirRoot":        filepath.Join(m.ProjectDir(), devboxDirName),
 		"DevboxProfileDefault": filepath.Join(m.ProjectDir(), nix.ProfilePath),
 		"PackageAttributePath": attributePath,
-		"Packages":             m.Packages(),
-		"System":               system,
-		"URLForInput":          urlForInput,
-		"Virtenv":              filepath.Join(virtenvPath, name),
+		// TODO savil: not sure about this one.
+		"Packages":    m.PlatformPackageNames(),
+		"System":      system,
+		"URLForInput": urlForInput,
+		"Virtenv":     filepath.Join(virtenvPath, name),
 	}); err != nil {
 		return errors.WithStack(err)
 	}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -157,17 +157,21 @@ func (m *Manager) createFile(
 		urlForInput = pkg.URLForFlakeInput()
 	}
 
+	packages, err := m.InstallablePackageNames()
+	if err != nil {
+		return err
+	}
+
 	var buf bytes.Buffer
 	if err = tmpl.Execute(&buf, map[string]any{
 		"DevboxDir":            filepath.Join(m.ProjectDir(), devboxDirName, name),
 		"DevboxDirRoot":        filepath.Join(m.ProjectDir(), devboxDirName),
 		"DevboxProfileDefault": filepath.Join(m.ProjectDir(), nix.ProfilePath),
 		"PackageAttributePath": attributePath,
-		// TODO savil: not sure about this one.
-		"Packages":    m.PlatformPackageNames(),
-		"System":      system,
-		"URLForInput": urlForInput,
-		"Virtenv":     filepath.Join(virtenvPath, name),
+		"Packages":             packages,
+		"System":               system,
+		"URLForInput":          urlForInput,
+		"Virtenv":              filepath.Join(virtenvPath, name),
 	}); err != nil {
 		return errors.WithStack(err)
 	}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -157,18 +157,13 @@ func (m *Manager) createFile(
 		urlForInput = pkg.URLForFlakeInput()
 	}
 
-	packages, err := m.InstallablePackageNames()
-	if err != nil {
-		return err
-	}
-
 	var buf bytes.Buffer
 	if err = tmpl.Execute(&buf, map[string]any{
 		"DevboxDir":            filepath.Join(m.ProjectDir(), devboxDirName, name),
 		"DevboxDirRoot":        filepath.Join(m.ProjectDir(), devboxDirName),
 		"DevboxProfileDefault": filepath.Join(m.ProjectDir(), nix.ProfilePath),
 		"PackageAttributePath": attributePath,
-		"Packages":             packages,
+		"Packages":             m.PackageNames(),
 		"System":               system,
 		"URLForInput":          urlForInput,
 		"Virtenv":              filepath.Join(virtenvPath, name),

--- a/internal/shellgen/flake_plan.go
+++ b/internal/shellgen/flake_plan.go
@@ -34,7 +34,7 @@ func newFlakePlan(ctx context.Context, devbox devboxer) (*flakePlan, error) {
 		}
 	}
 
-	packages, err := devbox.AllPackages()
+	packages, err := devbox.AllInstallablePackages()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/shellgen/scripts.go
+++ b/internal/shellgen/scripts.go
@@ -43,14 +43,9 @@ func WriteScriptsToFiles(devbox devboxer) error {
 		return errors.WithStack(err)
 	}
 
-	packages, err := devbox.InstallablePackages()
-	if err != nil {
-		return err
-	}
-
 	// Write all hooks to a file.
 	written := map[string]struct{}{} // set semantics; value is irrelevant
-	pluginHooks, err := plugin.InitHooks(packages, devbox.ProjectDir())
+	pluginHooks, err := plugin.InitHooks(devbox.InstallablePackages(), devbox.ProjectDir())
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/internal/shellgen/scripts.go
+++ b/internal/shellgen/scripts.go
@@ -23,8 +23,12 @@ const HooksFilename = ".hooks"
 type devboxer interface {
 	Config() *devconfig.Config
 	Lockfile() *lock.File
+<<<<<<< HEAD
 	PackagesAsInputs() []*devpkg.Package
 	AllPackages() ([]*devpkg.Package, error)
+=======
+	PlatformPackages() []*devpkg.Package
+>>>>>>> 2079687d (Split PackagesAsInputs into ConfigPackages and PlatformPackages)
 	PluginManager() *plugin.Manager
 	ProjectDir() string
 }
@@ -45,7 +49,7 @@ func WriteScriptsToFiles(devbox devboxer) error {
 
 	// Write all hooks to a file.
 	written := map[string]struct{}{} // set semantics; value is irrelevant
-	pluginHooks, err := plugin.InitHooks(devbox.PackagesAsInputs(), devbox.ProjectDir())
+	pluginHooks, err := plugin.InitHooks(devbox.PlatformPackages(), devbox.ProjectDir())
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/internal/shellgen/scripts.go
+++ b/internal/shellgen/scripts.go
@@ -23,7 +23,7 @@ const HooksFilename = ".hooks"
 type devboxer interface {
 	Config() *devconfig.Config
 	Lockfile() *lock.File
-	AllPackages() ([]*devpkg.Package, error)
+	AllInstallablePackages() ([]*devpkg.Package, error)
 	InstallablePackages() []*devpkg.Package
 	PluginManager() *plugin.Manager
 	ProjectDir() string

--- a/internal/shellgen/scripts.go
+++ b/internal/shellgen/scripts.go
@@ -23,12 +23,8 @@ const HooksFilename = ".hooks"
 type devboxer interface {
 	Config() *devconfig.Config
 	Lockfile() *lock.File
-<<<<<<< HEAD
-	PackagesAsInputs() []*devpkg.Package
 	AllPackages() ([]*devpkg.Package, error)
-=======
-	PlatformPackages() []*devpkg.Package
->>>>>>> 2079687d (Split PackagesAsInputs into ConfigPackages and PlatformPackages)
+	InstallablePackages() []*devpkg.Package
 	PluginManager() *plugin.Manager
 	ProjectDir() string
 }
@@ -47,9 +43,14 @@ func WriteScriptsToFiles(devbox devboxer) error {
 		return errors.WithStack(err)
 	}
 
+	packages, err := devbox.InstallablePackages()
+	if err != nil {
+		return err
+	}
+
 	// Write all hooks to a file.
 	written := map[string]struct{}{} // set semantics; value is irrelevant
-	pluginHooks, err := plugin.InitHooks(devbox.PlatformPackages(), devbox.ProjectDir())
+	pluginHooks, err := plugin.InitHooks(packages, devbox.ProjectDir())
 	if err != nil {
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
## Summary

This PR lays some groundwork for introducing platform-specific packages in a later PR (#1358)

This PR makes the following changes to `devbox` struct:
1. Replace `devbox.Packages` with `ConfigPackageNames()` and `InstallablePackageNames()`. 
2. Replace `devbox.PackagesAsInputs` with `ConfigPackages()` and `InstallablePackages()`. 
Updates callers to call the appropriate one.

**devpkg.Package changes**
I also introduce a new method `devpkg.PackagesFromConfig`, which enables us to add an `isInstallable bool` field on the `devpkg.Package`. I needed this because it affects the implementation of certain methods (such as `IsLegacy` changed in #1358).

One can still construct via `PackagesFromStrings` which default to `isInstallable = true` (as before). I audited the callers.

## How was it tested?

Did adhoc testing.
Testscript unit tests should pass.
