### PR TITLE
[per-OS Packages] Add platforms and excluded_platforms functionality

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -19,7 +19,7 @@ type Devbox interface {
 	// Add adds Nix packages to the config so that they're available in the devbox
 	// environment. It validates that the Nix packages exist, and install them.
 	// Adding duplicate packages is a no-op.
-	Add(ctx context.Context, pkgs ...string) error
+	Add(ctx context.Context, platform, excludePlatform string, pkgs ...string) error
 	Config() *devconfig.Config
 	ProjectDir() string
 	// Generate creates the directory of Nix files and the Dockerfile that define

--- a/internal/boxcli/add.go
+++ b/internal/boxcli/add.go
@@ -18,8 +18,10 @@ import (
 const toSearchForPackages = "To search for packages, use the `devbox search` command"
 
 type addCmdFlags struct {
-	config        configFlags
-	allowInsecure bool
+	config          configFlags
+	allowInsecure   bool
+	platform        string
+	excludePlatform string
 }
 
 func addCmd() *cobra.Command {
@@ -50,7 +52,13 @@ func addCmd() *cobra.Command {
 	flags.config.register(command)
 	command.Flags().BoolVar(
 		&flags.allowInsecure, "allow-insecure", false,
-		"Allow adding packages marked as insecure.")
+		"allow adding packages marked as insecure.")
+	command.Flags().StringVar(
+		&flags.platform, "platform", "",
+		"add packages to run on only this platform.")
+	command.Flags().StringVar(
+		&flags.excludePlatform, "exclude-platform", "",
+		"exclude packages from a specific platform.")
 
 	return command
 }
@@ -65,5 +73,5 @@ func addCmdFunc(cmd *cobra.Command, args []string, flags addCmdFlags) error {
 		return errors.WithStack(err)
 	}
 
-	return box.Add(cmd.Context(), args...)
+	return box.Add(cmd.Context(), flags.platform, flags.excludePlatform, args...)
 }

--- a/internal/devconfig/packages.go
+++ b/internal/devconfig/packages.go
@@ -2,10 +2,14 @@ package devconfig
 
 import (
 	"encoding/json"
+	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
+	"go.jetpack.io/devbox/internal/nix"
 	"go.jetpack.io/devbox/internal/searcher"
+	"go.jetpack.io/devbox/internal/ux"
 	"golang.org/x/exp/slices"
 )
 
@@ -26,6 +30,11 @@ type Packages struct {
 	// NOTE: this is not a pointer to make debugging failure cases easier
 	// (get dumps of the values, not memory addresses)
 	Collection []Package `json:"-,omitempty"`
+}
+
+// TODO savil: rm
+func (pkgs *Packages) Kind() int {
+	return int(pkgs.jsonKind)
 }
 
 // VersionedNames returns a list of package names with versions.
@@ -53,6 +62,84 @@ func (pkgs *Packages) Remove(versionedName string) {
 	pkgs.Collection = slices.DeleteFunc(pkgs.Collection, func(pkg Package) bool {
 		return pkg.name == name && pkg.Version == version
 	})
+}
+
+// AddPlatform adds a platform to the list of platforms for a given package
+func (pkgs *Packages) AddPlatform(versionedname, platform string) error {
+	if err := nix.EnsureValidPlatform(platform); err != nil {
+		return errors.WithStack(err)
+	}
+
+	name, version := parseVersionedName(versionedname)
+	for idx, pkg := range pkgs.Collection {
+		if pkg.name == name && pkg.Version == version {
+
+			// Check if the platform is already present
+			alreadyPresent := false
+			for _, existing := range pkg.Platforms {
+				if existing == platform {
+					alreadyPresent = true
+					break
+				}
+			}
+
+			// Add the platform if it's not already present
+			if !alreadyPresent {
+				pkg.Platforms = append(pkg.Platforms, platform)
+			}
+
+			// Adding any platform will restrict installation to it, so
+			// the ExcludedPlatforms are no longer needed
+			pkg.ExcludedPlatforms = nil
+
+			pkgs.jsonKind = jsonMap
+			pkg.kind = regular
+			pkgs.Collection[idx] = pkg
+			return nil
+		}
+	}
+	return errors.Errorf("package %s not found", versionedname)
+}
+
+// ExcludePlatform adds a platform to the list of excluded platforms for a given package
+func (pkgs *Packages) ExcludePlatform(versionedName, platform string) error {
+	if err := nix.EnsureValidPlatform(platform); err != nil {
+		return errors.WithStack(err)
+	}
+
+	name, version := parseVersionedName(versionedName)
+	for idx, pkg := range pkgs.Collection {
+		if pkg.name == name && pkg.Version == version {
+
+			// Check if the platform is already present
+			alreadyPresent := false
+			for _, existing := range pkg.ExcludedPlatforms {
+				if existing == platform {
+					alreadyPresent = true
+					break
+				}
+			}
+
+			if !alreadyPresent {
+				pkg.ExcludedPlatforms = append(pkg.ExcludedPlatforms, platform)
+			}
+			if len(pkg.Platforms) > 0 {
+				ux.Finfo(
+					os.Stderr,
+					"Excluding a platform for %[1]s is a bit redundant because it will only be installed on: %[2]v. "+
+						"Consider removing the `platform` field from %[1]s's definition in your devbox."+
+						"json if you intend for %[1]s to be installed on all platforms except %[3]s.\n",
+					versionedName, strings.Join(pkg.Platforms, ", "), platform,
+				)
+			}
+
+			pkgs.jsonKind = jsonMap
+			pkg.kind = regular
+			pkgs.Collection[idx] = pkg
+			return nil
+		}
+	}
+	return errors.Errorf("package %s not found", versionedName)
 }
 
 func (pkgs *Packages) UnmarshalJSON(data []byte) error {
@@ -123,7 +210,8 @@ type Package struct {
 	// deliberately not adding omitempty
 	Version string `json:"version"`
 
-	// TODO: add other fields like platforms
+	Platforms         []string `json:"platforms,omitempty"`
+	ExcludedPlatforms []string `json:"excluded_platforms,omitempty"`
 }
 
 func NewVersionOnlyPackage(name, version string) Package {
@@ -143,11 +231,32 @@ func NewPackage(name string, values map[string]any) Package {
 		version = ""
 	}
 
-	return Package{
-		kind:    regular,
-		name:    name,
-		Version: version.(string),
+	var platforms []string
+	if p, ok := values["platforms"]; ok {
+		platforms = p.([]string)
 	}
+	var excludedPlatforms []string
+	if e, ok := values["excluded_platforms"]; ok {
+		excludedPlatforms = e.([]string)
+	}
+
+	return Package{
+		kind:              regular,
+		name:              name,
+		Version:           version.(string),
+		Platforms:         platforms,
+		ExcludedPlatforms: excludedPlatforms,
+	}
+}
+
+// TODO savil: rm
+func (p *Package) Name() string {
+	return p.name
+}
+
+// TODO savil: rm
+func (p *Package) Kind() int {
+	return int(p.kind)
 }
 
 func (p *Package) VersionedName() string {
@@ -181,6 +290,10 @@ func (p *Package) UnmarshalJSON(data []byte) error {
 
 	*p = Package(*alias)
 	p.kind = regular
+
+	// TODO savil. needed?
+	//p.Platforms = alias.Platforms
+	//p.ExcludedPlatforms = alias.ExcludedPlatforms
 	return nil
 }
 

--- a/internal/devconfig/packages.go
+++ b/internal/devconfig/packages.go
@@ -248,7 +248,8 @@ func NewPackage(name string, values map[string]any) Package {
 // If the package has a list of platforms, it is enabled only on those platforms.
 // If the package has a list of excluded platforms, it is enabled on all platforms
 // except those.
-func (p *Package) enabledOnPlatform(platform string) bool {
+func (p *Package) IsEnabledOnPlatform() bool {
+	platform := nix.MustGetSystem()
 	if len(p.Platforms) > 0 {
 		for _, plt := range p.Platforms {
 			if plt == platform {
@@ -271,10 +272,6 @@ func (p *Package) VersionedName() string {
 		name += "@" + p.Version
 	}
 	return name
-}
-
-func (p *Package) IsEnabledOnPlatform() bool {
-	return p.enabledOnPlatform(nix.MustGetSystem())
 }
 
 func (p *Package) UnmarshalJSON(data []byte) error {

--- a/internal/devconfig/packages_test.go
+++ b/internal/devconfig/packages_test.go
@@ -118,6 +118,56 @@ func TestJsonifyConfigPackages(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "map-with-platforms-and-excluded-platforms-local-flake",
+			jsonConfig: `{"packages":{"path:my-php-flake#hello":{"version":"latest",` +
+				`"platforms":["x86_64-darwin","aarch64-linux"],` +
+				`"excluded_platforms":["x86_64-linux"]}}}`,
+			expected: Packages{
+				jsonKind: jsonMap,
+				Collection: []Package{
+					NewPackage("path:my-php-flake#hello", map[string]any{
+						"version":            "latest",
+						"platforms":          []string{"x86_64-darwin", "aarch64-linux"},
+						"excluded_platforms": []string{"x86_64-linux"},
+					}),
+				},
+			},
+		},
+		{
+			name: "map-with-platforms-and-excluded-platforms-remote-flake",
+			jsonConfig: `{"packages":{"github:F1bonacc1/process-compose/v0.43.1":` +
+				`{"version":"latest",` +
+				`"platforms":["x86_64-darwin","aarch64-linux"],` +
+				`"excluded_platforms":["x86_64-linux"]}}}`,
+			expected: Packages{
+				jsonKind: jsonMap,
+				Collection: []Package{
+					NewPackage("github:F1bonacc1/process-compose/v0.43.1", map[string]any{
+						"version":            "latest",
+						"platforms":          []string{"x86_64-darwin", "aarch64-linux"},
+						"excluded_platforms": []string{"x86_64-linux"},
+					}),
+				},
+			},
+		},
+		{
+			name: "map-with-platforms-and-excluded-platforms-nixpkgs-reference",
+			jsonConfig: `{"packages":{"github:nixos/nixpkgs/5233fd2ba76a3accb5aaa999c00509a11fd0793c#hello":` +
+				`{"version":"latest",` +
+				`"platforms":["x86_64-darwin","aarch64-linux"],` +
+				`"excluded_platforms":["x86_64-linux"]}}}`,
+			expected: Packages{
+				jsonKind: jsonMap,
+				Collection: []Package{
+					NewPackage("github:nixos/nixpkgs/5233fd2ba76a3accb5aaa999c00509a11fd0793c#hello", map[string]any{
+						"version":            "latest",
+						"platforms":          []string{"x86_64-darwin", "aarch64-linux"},
+						"excluded_platforms": []string{"x86_64-linux"},
+					}),
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -193,6 +243,24 @@ func TestParseVersionedName(t *testing.T) {
 			name:            "with-trailing-@-sign",
 			input:           "emacsPackages.@",
 			expectedName:    "emacsPackages.@",
+			expectedVersion: "",
+		},
+		{
+			name:            "local-flake",
+			input:           "path:my-php-flake#hello",
+			expectedName:    "path:my-php-flake#hello",
+			expectedVersion: "",
+		},
+		{
+			name:            "remote-flake",
+			input:           "github:F1bonacc1/process-compose/v0.43.1",
+			expectedName:    "github:F1bonacc1/process-compose/v0.43.1",
+			expectedVersion: "",
+		},
+		{
+			name:            "nixpkgs-reference",
+			input:           "github:nixos/nixpkgs/5233fd2ba76a3accb5aaa999c00509a11fd0793c#hello",
+			expectedName:    "github:nixos/nixpkgs/5233fd2ba76a3accb5aaa999c00509a11fd0793c#hello",
 			expectedVersion: "",
 		},
 	}

--- a/internal/devconfig/packages_test.go
+++ b/internal/devconfig/packages_test.go
@@ -209,24 +209,3 @@ func TestParseVersionedName(t *testing.T) {
 		})
 	}
 }
-
-func TestConvertToKind(t *testing.T) {
-	testCase := Packages{
-		jsonKind:   jsonList,
-		Collection: packagesFromLegacyList([]string{"python", "hello@latest", "go@1.20"}),
-	}
-
-	expected := Packages{
-		jsonKind: jsonMap,
-		Collection: []Package{
-			NewVersionOnlyPackage("python", "" /*version*/),
-			NewVersionOnlyPackage("hello", "latest"),
-			NewVersionOnlyPackage("go", "1.20"),
-		},
-	}
-
-	testCase.convertToKind(jsonMap)
-	if !reflect.DeepEqual(testCase, expected) {
-		t.Errorf("expected: %+v, got: %+v", expected, testCase)
-	}
-}

--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -412,13 +412,7 @@ func (p *Package) Versioned() string {
 }
 
 func (p *Package) IsLegacy() bool {
-	if !p.IsDevboxPackage() || p.isVersioned() {
-		return false
-	}
-	if p.IsInstallable() {
-		return false
-	}
-	return p.lockfile.Get(p.Raw).GetSource() == ""
+	return p.IsDevboxPackage() && !p.isVersioned() && p.lockfile.Get(p.Raw).GetSource() == ""
 }
 
 func (p *Package) LegacyToVersioned() string {
@@ -549,4 +543,13 @@ func (p *Package) StoreName() (string, error) {
 		return "", err
 	}
 	return name, nil
+}
+
+func (p *Package) EnsureUninstallableIsInLockfile() error {
+	// TODO savil: Do we need the IsDevboxPackage check here?
+	if !p.IsInstallable() || !p.IsDevboxPackage() {
+		return nil
+	}
+	_, err := p.lockfile.Resolve(p.Raw)
+	return err
 }

--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -412,7 +412,13 @@ func (p *Package) Versioned() string {
 }
 
 func (p *Package) IsLegacy() bool {
-	return p.IsDevboxPackage() && !p.isVersioned() && p.lockfile.Get(p.Raw).GetSource() == ""
+	if !p.IsDevboxPackage() || p.isVersioned() {
+		return false
+	}
+	if p.IsInstallable() {
+		return false
+	}
+	return p.lockfile.Get(p.Raw).GetSource() == ""
 }
 
 func (p *Package) LegacyToVersioned() string {

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -242,6 +242,17 @@ func (d *Devbox) ensurePackagesAreInstalled(ctx context.Context, mode installMod
 		return err
 	}
 
+	// Update lockfile with new packages that are not to be installed
+	cfgPkgs, err := d.ConfigPackages()
+	if err != nil {
+		return err
+	}
+	for _, pkg := range cfgPkgs {
+		if err := pkg.EnsureUninstallableIsInLockfile(); err != nil {
+			return err
+		}
+	}
+
 	return d.lockfile.Save()
 }
 

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -48,7 +48,6 @@ func (d *Devbox) Add(ctx context.Context, platform, excludePlatform string, pkgs
 	addedPackageNames := []string{}
 	existingPackageNames := d.PackageNames()
 	for _, pkg := range pkgs {
-
 		// If exact versioned package is already in the config, skip.
 		if slices.Contains(existingPackageNames, pkg.Versioned()) {
 			addedPackageNames = append(addedPackageNames, pkg.Versioned())

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -243,11 +243,7 @@ func (d *Devbox) ensurePackagesAreInstalled(ctx context.Context, mode installMod
 	}
 
 	// Update lockfile with new packages that are not to be installed
-	cfgPkgs, err := d.ConfigPackages()
-	if err != nil {
-		return err
-	}
-	for _, pkg := range cfgPkgs {
+	for _, pkg := range d.configPackages() {
 		if err := pkg.EnsureUninstallableIsInLockfile(); err != nil {
 			return err
 		}

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -34,7 +34,7 @@ func (d *Devbox) Update(ctx context.Context, pkgs ...string) error {
 			// Calling Add function with the original package names, since
 			// Add will automatically append @latest if search is able to handle that.
 			// If not, it will fallback to the nixpkg format.
-			if err := d.Add(ctx, pkg.Raw); err != nil {
+			if err := d.Add(ctx, "" /*platform*/, "" /*excludePlatform*/, pkg.Raw); err != nil {
 				return err
 			}
 		} else {

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -185,7 +185,8 @@ var nixPlatforms = []string{
 	"x86_64-darwin",
 	"x86_64-linux",
 	// not technically supported, but should work?
-	// ref.
+	// ref. https://nixos.wiki/wiki/Nix_on_ARM
+	// ref. https://github.com/jetpack-io/devbox/pull/1300
 	"armv7l-linux",
 }
 

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -121,7 +121,12 @@ func ExperimentalFlags() []string {
 // TODO: rename to System
 func MustGetSystem() string {
 	if cachedSystem == "" {
-		panic("MustGetSystem called before being initialized by System")
+		// For internal calls (during tests), this may not be initialized properly
+		// so do a best-effort attempt to initialize it.
+		_, err := System()
+		if err != nil {
+			panic("MustGetSystem called before being initialized by System")
+		}
 	}
 	return cachedSystem
 }

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -128,7 +128,7 @@ func MustGetSystem() string {
 
 var cachedSystem string
 
-// TODO: rename to ComputeSystem
+// TODO: rename to ComputeSystem or ComputePlatform?
 func System() (string, error) {
 	// For Savil to debug "remove nixpkgs" feature. The Search api lacks x86-darwin info.
 	// So, I need to fake that I am x86-linux and inspect the output in generated devbox.lock
@@ -176,6 +176,28 @@ func Version() (string, error) {
 	}
 	version = strings.TrimSpace(strings.TrimPrefix(out, prefix))
 	return version, nil
+}
+
+var nixPlatforms = []string{
+	"aarch64-darwin",
+	"aarch64-linux",
+	"i686-linux",
+	"x86_64-darwin",
+	"x86_64-linux",
+	// not technically supported, but should work?
+	// ref.
+	"armv7l-linux",
+}
+
+// EnsureValidPlatform returns an error if the platform is not supported by nix.
+// https://nixos.org/manual/nix/stable/installation/supported-platforms.html
+func EnsureValidPlatform(platform string) error {
+	for _, p := range nixPlatforms {
+		if p == platform {
+			return nil
+		}
+	}
+	return usererr.New("Unsupported platform: %s. Valid platforms are: %v", platform, nixPlatforms)
 }
 
 // Warning: be careful using the bins in default/bin, they won't always match bins

--- a/testscripts/add/add_platforms.test.txt
+++ b/testscripts/add/add_platforms.test.txt
@@ -1,0 +1,54 @@
+# Testscript for exercising adding packages
+
+# exec devbox init
+exec devbox install
+! exec rg --version
+! exec vim --version
+
+# First, add a --platform, and verify that the []string packages
+# becomes a map[string]any packages
+exec devbox add ripgrep --platform x86_64-darwin
+json.superset devbox.json expected_devbox1.json
+
+# Second, add another platform: verify that it adds to the platforms array
+exec devbox add ripgrep --platform x86_64-linux
+# Third, add an excluded-platform too
+exec devbox add vim --exclude-platform x86_64-linux
+
+json.superset devbox.json expected_devbox2.json
+
+-- devbox.json --
+{
+  "packages": [
+    "hello",
+    "cowsay@latest"
+  ]
+}
+
+-- expected_devbox1.json --
+{
+  "packages": {
+    "hello": "",
+    "cowsay": "latest",
+    "ripgrep": {
+      "version": "latest",
+      "platforms": ["x86_64-darwin"]
+    }
+  }
+}
+
+-- expected_devbox2.json --
+{
+  "packages": {
+    "hello": "",
+    "cowsay": "latest",
+    "ripgrep": {
+      "version": "latest",
+      "platforms": ["x86_64-darwin", "x86_64-linux"]
+    },
+    "vim": {
+      "version": "latest",
+      "excluded_platforms": ["x86_64-linux"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

**Motivation**
Some users have a need to install platform-specific packages. For example, `glibcLocales` cannot be installed on macOS but may be needed on Linux.

**Approach**
We enable two flags in `devbox add`:
```
# install on all platforms except x86_64-darwin
> devbox add glibcLocales --exclude-platform x86_64-darwin

# only install on x86_64-darwin and aarch64-darwin
> devbox add darwin.apple_sdk.frameworks.Security --platform x86_64-darwin 
> devbox add darwin.apple_sdk.frameworks.Security --platform aarch64-darwin 
```

Follow up PRs:
- [ ]  enable multiple `--platform` flag uses
- [ ] detect if `devbox add` fails due to platform-mismatch and suggest `--exclude-platform` flag

## How was it tested?

Added testscript unit test

Adhoc testing:
```
savil@Savil-Srivastavas-MacBook-Pro ~/c/j/d/e/d/g/hello-world (savil/config-packages-2)> rm -rf .devbox
savil@Savil-Srivastavas-MacBook-Pro ~/c/j/d/e/d/g/hello-world (savil/config-packages-2)> devbox shell
Ensuring packages are installed.

Installing package: go@1.19.8.

[1/1] go@1.19.8
[1/1] go@1.19.8: Success
Starting a devbox shell...
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish
```

Install for a different platform than the one i am currently running on
```
(devbox) savil@Savil-Srivastavas-MacBook-Pro ~/c/j/d/e/d/g/hello-world (savil/config-packages-2)> devbox add hello --platform x86_64-linux
(devbox) savil@Savil-Srivastavas-MacBook-Pro ~/c/j/d/e/d/g/hello-world (savil/config-packages-2)> cat devbox.json
{
  "packages": {
    "go": "1.19.8",
    "hello": {
      "version": "latest",
      "platforms": [
        "x86_64-linux"
      ]
    }
  },
  "shell": {
    "init_hook": [
      "export \"GOROOT=$(go env GOROOT)\""
    ],
    "scripts": {
      "run_test": "go run main.go"
    }
  }
}
(devbox) savil@Savil-Srivastavas-MacBook-Pro ~/c/j/d/e/d/g/hello-world (savil/config-packages-2)> which hello
(devbox) savil@Savil-Srivastavas-MacBook-Pro ~/c/j/d/e/d/g/hello-world (savil/config-packages-2) [1]>
```

Install on all platforms except my current platform
```
(devbox) savil@Savil-Srivastavas-MacBook-Pro ~/c/j/d/e/d/g/hello-world (savil/config-packages-2) [1]> devbox add cowsay --exclude-platform x86_64-darwin
(devbox) savil@Savil-Srivastavas-MacBook-Pro ~/c/j/d/e/d/g/hello-world (savil/config-packages-2)> which cowsay
(devbox) savil@Savil-Srivastavas-MacBook-Pro ~/c/j/d/e/d/g/hello-world (savil/config-packages-2) [1]> cat devbox.json
{
  "packages": {
    "go": "1.19.8",
    "hello": {
      "version": "latest",
      "platforms": [
        "x86_64-linux"
      ]
    },
    "cowsay": {
      "version": "latest",
      "excluded_platforms": [
        "x86_64-darwin"
      ]
    }
  },
  "shell": {
    "init_hook": [
      "export \"GOROOT=$(go env GOROOT)\""
    ],
    "scripts": {
      "run_test": "go run main.go"
    }
  }
}
```

Ensure basic adding still works
```
(devbox) savil@Savil-Srivastavas-MacBook-Pro ~/c/j/d/e/d/g/hello-world (savil/config-packages-2)> which vim
/usr/bin/vim
(devbox) savil@Savil-Srivastavas-MacBook-Pro ~/c/j/d/e/d/g/hello-world (savil/config-packages-2)> devbox add vim

Installing package: vim@latest.

[1/1] vim@latest
[1/1] vim@latest: Success
(devbox) savil@Savil-Srivastavas-MacBook-Pro ~/c/j/d/e/d/g/hello-world (savil/config-packages-2)> which vim
/Users/savil/code/jetpack/devbox/examples/development/go/hello-world/.devbox/virtenv/.wrappers/bin/vim
(devbox) savil@Savil-Srivastavas-MacBook-Pro ~/c/j/d/e/d/g/hello-world (savil/config-packages-2)> cat devbox.json
{
  "packages": {
    "go": "1.19.8",
    "hello": {
      "version": "latest",
      "platforms": [
        "x86_64-linux"
      ]
    },
    "cowsay": {
      "version": "latest",
      "excluded_platforms": [
        "x86_64-darwin"
      ]
    },
    "vim": "latest"
  },
  "shell": {
    "init_hook": [
      "export \"GOROOT=$(go env GOROOT)\""
    ],
    "scripts": {
      "run_test": "go run main.go"
    }
  }
}
```


