### PR TITLE
Added --root-user flag to devbox generate

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -25,8 +25,8 @@ type Devbox interface {
 	// Generate creates the directory of Nix files and the Dockerfile that define
 	// the devbox environment.
 	Generate(ctx context.Context) error
-	GenerateDevcontainer(ctx context.Context) error
-	GenerateDockerfile(ctx context.Context) error
+	GenerateDevcontainer(ctx context.Context, generateOpts devopt.GenerateOpts) error
+	GenerateDockerfile(ctx context.Context, generateOpts devopt.GenerateOpts) error
 	GenerateEnvrcFile(ctx context.Context, force bool, envFlags devopt.EnvFlags) error
 	Info(ctx context.Context, pkg string, markdown bool) error
 	Install(ctx context.Context) error

--- a/devbox.go
+++ b/devbox.go
@@ -25,8 +25,8 @@ type Devbox interface {
 	// Generate creates the directory of Nix files and the Dockerfile that define
 	// the devbox environment.
 	Generate(ctx context.Context) error
-	GenerateDevcontainer(ctx context.Context, force bool) error
-	GenerateDockerfile(ctx context.Context, force bool) error
+	GenerateDevcontainer(ctx context.Context) error
+	GenerateDockerfile(ctx context.Context) error
 	GenerateEnvrcFile(ctx context.Context, force bool, envFlags devopt.EnvFlags) error
 	Info(ctx context.Context, pkg string, markdown bool) error
 	Install(ctx context.Context) error

--- a/internal/boxcli/generate.go
+++ b/internal/boxcli/generate.go
@@ -18,6 +18,7 @@ type generateCmdFlags struct {
 	force             bool
 	printEnvrcContent bool
 	githubUsername    string
+	rootUser          bool
 }
 
 func generateCmd() *cobra.Command {
@@ -64,6 +65,8 @@ func devcontainerCmd() *cobra.Command {
 	}
 	command.Flags().BoolVarP(
 		&flags.force, "force", "f", false, "force overwrite on existing files")
+	command.Flags().BoolVarP(
+		&flags.rootUser, "root-user", "r", false, "Use root as default user inside the container")
 	return command
 }
 
@@ -81,6 +84,8 @@ func dockerfileCmd() *cobra.Command {
 	}
 	command.Flags().BoolVarP(
 		&flags.force, "force", "f", false, "force overwrite existing files")
+	command.Flags().BoolVarP(
+		&flags.rootUser, "root-user", "r", false, "Use root as default user inside the container")
 	flags.config.register(command)
 	return command
 }
@@ -143,9 +148,9 @@ func runGenerateCmd(cmd *cobra.Command, flags *generateCmdFlags) error {
 	case "debug":
 		return box.Generate(cmd.Context())
 	case "devcontainer":
-		return box.GenerateDevcontainer(cmd.Context(), flags.force)
+		return box.GenerateDevcontainer(cmd.Context(), flags.force, flags.rootUser)
 	case "dockerfile":
-		return box.GenerateDockerfile(cmd.Context(), flags.force)
+		return box.GenerateDockerfile(cmd.Context(), flags.force, flags.rootUser)
 	}
 	return nil
 }

--- a/internal/boxcli/generate.go
+++ b/internal/boxcli/generate.go
@@ -140,21 +140,21 @@ func runGenerateCmd(cmd *cobra.Command, flags *generateCmdFlags) error {
 	box, err := devbox.Open(&devopt.Opts{
 		Dir:    flags.config.path,
 		Writer: cmd.ErrOrStderr(),
-		GenerateOpts: devopt.GenerateOpts{
-			Force:    flags.force,
-			RootUser: flags.rootUser,
-		},
 	})
 	if err != nil {
 		return errors.WithStack(err)
+	}
+	generateOpts := devopt.GenerateOpts{
+		Force:    flags.force,
+		RootUser: flags.rootUser,
 	}
 	switch cmd.Use {
 	case "debug":
 		return box.Generate(cmd.Context())
 	case "devcontainer":
-		return box.GenerateDevcontainer(cmd.Context())
+		return box.GenerateDevcontainer(cmd.Context(), generateOpts)
 	case "dockerfile":
-		return box.GenerateDockerfile(cmd.Context())
+		return box.GenerateDockerfile(cmd.Context(), generateOpts)
 	}
 	return nil
 }

--- a/internal/boxcli/generate.go
+++ b/internal/boxcli/generate.go
@@ -65,8 +65,8 @@ func devcontainerCmd() *cobra.Command {
 	}
 	command.Flags().BoolVarP(
 		&flags.force, "force", "f", false, "force overwrite on existing files")
-	command.Flags().BoolVarP(
-		&flags.rootUser, "root-user", "r", false, "Use root as default user inside the container")
+	command.Flags().BoolVar(
+		&flags.rootUser, "root-user", false, "Use root as default user inside the container")
 	return command
 }
 
@@ -84,8 +84,8 @@ func dockerfileCmd() *cobra.Command {
 	}
 	command.Flags().BoolVarP(
 		&flags.force, "force", "f", false, "force overwrite existing files")
-	command.Flags().BoolVarP(
-		&flags.rootUser, "root-user", "r", false, "Use root as default user inside the container")
+	command.Flags().BoolVar(
+		&flags.rootUser, "root-user", false, "Use root as default user inside the container")
 	flags.config.register(command)
 	return command
 }
@@ -140,6 +140,10 @@ func runGenerateCmd(cmd *cobra.Command, flags *generateCmdFlags) error {
 	box, err := devbox.Open(&devopt.Opts{
 		Dir:    flags.config.path,
 		Writer: cmd.ErrOrStderr(),
+		GenerateOpts: devopt.GenerateOpts{
+			Force:    flags.force,
+			RootUser: flags.rootUser,
+		},
 	})
 	if err != nil {
 		return errors.WithStack(err)
@@ -148,9 +152,9 @@ func runGenerateCmd(cmd *cobra.Command, flags *generateCmdFlags) error {
 	case "debug":
 		return box.Generate(cmd.Context())
 	case "devcontainer":
-		return box.GenerateDevcontainer(cmd.Context(), flags.force, flags.rootUser)
+		return box.GenerateDevcontainer(cmd.Context())
 	case "dockerfile":
-		return box.GenerateDockerfile(cmd.Context(), flags.force, flags.rootUser)
+		return box.GenerateDockerfile(cmd.Context())
 	}
 	return nil
 }

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -434,7 +434,7 @@ func (d *Devbox) GenerateDockerfile(ctx context.Context, force bool, rootUser bo
 
 	// Setup Generate parameters
 	g := generate.Open(
-		ctx, dockerfilePath, rootUser, isDevcontainer, d.Packages(), d.getLocalFlakesDirs(),
+		ctx, d.projectDir, rootUser, isDevcontainer, d.Packages(), d.getLocalFlakesDirs(),
 	)
 
 	// generate dockerfile

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -401,7 +401,7 @@ func (d *Devbox) GenerateDevcontainer(ctx context.Context) error {
 	}
 
 	// Setup generate parameters
-	g := &generate.Options{
+	gen := &generate.Options{
 		Path:           devContainerPath,
 		RootUser:       d.GenerateOpts.RootUser,
 		IsDevcontainer: true,
@@ -410,13 +410,13 @@ func (d *Devbox) GenerateDevcontainer(ctx context.Context) error {
 	}
 
 	// generate dockerfile
-	err = g.CreateDockerfile(ctx)
+	err = gen.CreateDockerfile(ctx)
 	if err != nil {
 		return redact.Errorf("error generating dev container Dockerfile in <project>/%s: %w",
 			redact.Safe(filepath.Base(devContainerPath)), err)
 	}
 	// generate devcontainer.json
-	err = g.CreateDevcontainer(ctx)
+	err = gen.CreateDevcontainer(ctx)
 	if err != nil {
 		return redact.Errorf("error generating devcontainer.json in <project>/%s: %w",
 			redact.Safe(filepath.Base(devContainerPath)), err)
@@ -440,7 +440,7 @@ func (d *Devbox) GenerateDockerfile(ctx context.Context) error {
 	}
 
 	// Setup Generate parameters
-	g := &generate.Options{
+	gen := &generate.Options{
 		Path:           d.projectDir,
 		RootUser:       d.GenerateOpts.RootUser,
 		IsDevcontainer: false,
@@ -449,7 +449,7 @@ func (d *Devbox) GenerateDockerfile(ctx context.Context) error {
 	}
 
 	// generate dockerfile
-	return errors.WithStack(g.CreateDockerfile(ctx))
+	return errors.WithStack(gen.CreateDockerfile(ctx))
 }
 
 func PrintEnvrcContent(w io.Writer, envFlags devopt.EnvFlags) error {

--- a/internal/impl/devopt/devboxopts.go
+++ b/internal/impl/devopt/devboxopts.go
@@ -4,6 +4,11 @@ import (
 	"io"
 )
 
+type GenerateOpts struct {
+	Force    bool
+	RootUser bool
+}
+
 type Opts struct {
 	AllowInsecureAdds        bool
 	Dir                      string
@@ -12,6 +17,7 @@ type Opts struct {
 	IgnoreWarnings           bool
 	CustomProcessComposeFile string
 	Writer                   io.Writer
+	GenerateOpts             GenerateOpts
 }
 
 type EnvFlags struct {

--- a/internal/impl/devopt/devboxopts.go
+++ b/internal/impl/devopt/devboxopts.go
@@ -4,11 +4,6 @@ import (
 	"io"
 )
 
-type GenerateOpts struct {
-	Force    bool
-	RootUser bool
-}
-
 type Opts struct {
 	AllowInsecureAdds        bool
 	Dir                      string
@@ -17,7 +12,11 @@ type Opts struct {
 	IgnoreWarnings           bool
 	CustomProcessComposeFile string
 	Writer                   io.Writer
-	GenerateOpts             GenerateOpts
+}
+
+type GenerateOpts struct {
+	Force    bool
+	RootUser bool
 }
 
 type EnvFlags struct {

--- a/internal/impl/generate/devcontainer_util.go
+++ b/internal/impl/generate/devcontainer_util.go
@@ -25,8 +25,7 @@ import (
 //go:embed tmpl/*
 var tmplFS embed.FS
 
-type Generate struct {
-	Ctx            context.Context
+type Options struct {
 	Path           string
 	RootUser       bool
 	IsDevcontainer bool
@@ -61,28 +60,9 @@ type dockerfileData struct {
 	LocalFlakeDirs []string
 }
 
-func Open(
-	ctx context.Context,
-	path string,
-	rootUser bool,
-	isDevcontainer bool,
-	pkgs []string,
-	localFlakeDirs []string,
-) *Generate {
-
-	return &Generate{
-		Ctx:            ctx,
-		Path:           path,
-		RootUser:       rootUser,
-		IsDevcontainer: isDevcontainer,
-		Pkgs:           pkgs,
-		LocalFlakeDirs: localFlakeDirs,
-	}
-}
-
 // CreateDockerfile creates a Dockerfile in path and writes devcontainerDockerfile.tmpl's content into it
-func (g *Generate) CreateDockerfile() error {
-	defer trace.StartRegion(g.Ctx, "createDockerfile").End()
+func (g *Options) CreateDockerfile(ctx context.Context) error {
+	defer trace.StartRegion(ctx, "createDockerfile").End()
 
 	// create dockerfile
 	file, err := os.Create(filepath.Join(g.Path, "Dockerfile"))
@@ -102,8 +82,8 @@ func (g *Generate) CreateDockerfile() error {
 }
 
 // CreateDevcontainer creates a devcontainer.json in path and writes getDevcontainerContent's output into it
-func (g *Generate) CreateDevcontainer() error {
-	defer trace.StartRegion(g.Ctx, "createDevcontainer").End()
+func (g *Options) CreateDevcontainer(ctx context.Context) error {
+	defer trace.StartRegion(ctx, "createDevcontainer").End()
 
 	// create devcontainer.json file
 	file, err := os.Create(filepath.Join(g.Path, "devcontainer.json"))
@@ -151,7 +131,7 @@ func CreateEnvrc(ctx context.Context, path string, envFlags devopt.EnvFlags) err
 	})
 }
 
-func (g *Generate) getDevcontainerContent() *devcontainerObject {
+func (g *Options) getDevcontainerContent() *devcontainerObject {
 	// object that gets written in devcontainer.json
 	devcontainerContent := &devcontainerObject{
 		// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
@@ -172,7 +152,6 @@ func (g *Generate) getDevcontainerContent() *devcontainerObject {
 				},
 			},
 		},
-		// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 		RemoteUser: "devbox",
 	}
 	if g.RootUser {

--- a/internal/impl/generate/devcontainer_util.go
+++ b/internal/impl/generate/devcontainer_util.go
@@ -25,6 +25,15 @@ import (
 //go:embed tmpl/*
 var tmplFS embed.FS
 
+type Generate struct {
+	Ctx            context.Context
+	Path           string
+	RootUser       bool
+	IsDevcontainer bool
+	Pkgs           []string
+	LocalFlakeDirs []string
+}
+
 type devcontainerObject struct {
 	Name           string          `json:"name"`
 	Build          *build          `json:"build"`
@@ -48,15 +57,35 @@ type vscode struct {
 
 type dockerfileData struct {
 	IsDevcontainer bool
+	RootUser       bool
 	LocalFlakeDirs []string
 }
 
+func Open(
+	ctx context.Context,
+	path string,
+	rootUser bool,
+	isDevcontainer bool,
+	pkgs []string,
+	localFlakeDirs []string,
+) *Generate {
+
+	return &Generate{
+		Ctx:            ctx,
+		Path:           path,
+		RootUser:       rootUser,
+		IsDevcontainer: isDevcontainer,
+		Pkgs:           pkgs,
+		LocalFlakeDirs: localFlakeDirs,
+	}
+}
+
 // CreateDockerfile creates a Dockerfile in path and writes devcontainerDockerfile.tmpl's content into it
-func CreateDockerfile(ctx context.Context, path string, localFlakeDirs []string, isDevcontainer bool) error {
-	defer trace.StartRegion(ctx, "createDockerfile").End()
+func (g *Generate) CreateDockerfile() error {
+	defer trace.StartRegion(g.Ctx, "createDockerfile").End()
 
 	// create dockerfile
-	file, err := os.Create(filepath.Join(path, "Dockerfile"))
+	file, err := os.Create(g.Path)
 	if err != nil {
 		return err
 	}
@@ -66,23 +95,24 @@ func CreateDockerfile(ctx context.Context, path string, localFlakeDirs []string,
 	t := template.Must(template.ParseFS(tmplFS, "tmpl/"+tmplName))
 	// write content into file
 	return t.Execute(file, &dockerfileData{
-		IsDevcontainer: isDevcontainer,
-		LocalFlakeDirs: localFlakeDirs,
+		IsDevcontainer: g.IsDevcontainer,
+		RootUser:       g.RootUser,
+		LocalFlakeDirs: g.LocalFlakeDirs,
 	})
 }
 
 // CreateDevcontainer creates a devcontainer.json in path and writes getDevcontainerContent's output into it
-func CreateDevcontainer(ctx context.Context, path string, pkgs []string) error {
-	defer trace.StartRegion(ctx, "createDevcontainer").End()
+func (g *Generate) CreateDevcontainer() error {
+	defer trace.StartRegion(g.Ctx, "createDevcontainer").End()
 
 	// create devcontainer.json file
-	file, err := os.Create(filepath.Join(path, "devcontainer.json"))
+	file, err := os.Create(filepath.Join(g.Path, "devcontainer.json"))
 	if err != nil {
 		return err
 	}
 	defer file.Close()
 	// get devcontainer.json's content
-	devcontainerContent := getDevcontainerContent(pkgs)
+	devcontainerContent := g.getDevcontainerContent()
 	devcontainerFileBytes, err := json.MarshalIndent(devcontainerContent, "", "  ")
 	if err != nil {
 		return err
@@ -121,7 +151,7 @@ func CreateEnvrc(ctx context.Context, path string, envFlags devopt.EnvFlags) err
 	})
 }
 
-func getDevcontainerContent(pkgs []string) *devcontainerObject {
+func (g *Generate) getDevcontainerContent() *devcontainerObject {
 	// object that gets written in devcontainer.json
 	devcontainerContent := &devcontainerObject{
 		// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
@@ -143,7 +173,10 @@ func getDevcontainerContent(pkgs []string) *devcontainerObject {
 			},
 		},
 		// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-		RemoteUser: "root",
+		RemoteUser: "devbox",
+	}
+	if g.RootUser {
+		devcontainerContent.RemoteUser = "root"
 	}
 
 	// match only python3 or python3xx as package names
@@ -152,7 +185,7 @@ func getDevcontainerContent(pkgs []string) *devcontainerObject {
 		debug.Log("Failed to compile regex")
 		return nil
 	}
-	for _, pkg := range pkgs {
+	for _, pkg := range g.Pkgs {
 		if py3pattern.MatchString(pkg) {
 			// Setup python3 interpreter path to devbox in the container
 			devcontainerContent.Customizations.Vscode.Settings = map[string]any{

--- a/internal/impl/generate/devcontainer_util.go
+++ b/internal/impl/generate/devcontainer_util.go
@@ -85,7 +85,7 @@ func (g *Generate) CreateDockerfile() error {
 	defer trace.StartRegion(g.Ctx, "createDockerfile").End()
 
 	// create dockerfile
-	file, err := os.Create(g.Path)
+	file, err := os.Create(filepath.Join(g.Path, "Dockerfile"))
 	if err != nil {
 		return err
 	}

--- a/internal/impl/generate/tmpl/devcontainerDockerfile.tmpl
+++ b/internal/impl/generate/tmpl/devcontainerDockerfile.tmpl
@@ -4,18 +4,38 @@ FROM debian:stable-slim
 RUN apt-get update
 RUN apt-get -y install bash binutils git{{if .IsDevcontainer}} gnupg2{{- end}} xz-utils wget sudo
 
+{{- if not .RootUser }}
+
+# Step 1.5: Setting up devbox user
+ENV DEVBOX_USER=devbox
+RUN adduser $DEVBOX_USER
+RUN usermod -aG sudo $DEVBOX_USER
+RUN echo "devbox ALL=(ALL:ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/$DEVBOX_USER
+USER $DEVBOX_USER
+{{- end}}
+
 # Step 2: Installing Nix
-RUN wget --output-document=/dev/stdout https://nixos.org/nix/install | sh -s -- --daemon
+RUN wget --output-document=/dev/stdout https://nixos.org/nix/install | sh -s -- --{{if not .RootUser}}no-{{- end}}daemon
 RUN . ~/.nix-profile/etc/profile.d/nix.sh
+{{ if .RootUser }}
 ENV PATH="/root/.nix-profile/bin:$PATH"
+{{ else }}
+ENV PATH="/home/${DEVBOX_USER}/.nix-profile/bin:$PATH"
+{{- end}}
 
 # Step 3: Installing devbox
 RUN wget --quiet --output-document=/dev/stdout https://get.jetpack.io/devbox   | bash -s -- -f
+{{- if not .RootUser }}
+RUN chown -R "${DEVBOX_USER}:${DEVBOX_USER}" /usr/local/bin/devbox
+{{- end}}
 
 # Step 4: Installing your devbox project
 WORKDIR /code
 COPY devbox.json devbox.json
 COPY devbox.lock devbox.lock
+{{- if not .RootUser }}
+RUN sudo chown -R "${DEVBOX_USER}:${DEVBOX_USER}" /code
+{{- end}}
 {{if len .LocalFlakeDirs}}
 # Step 6: Copying local flakes directories
 {{- end}}


### PR DESCRIPTION
## Summary
follow up for #1325 
This also potentially fixes an issue reported for users having permission issues with `.devbox/` directory inside devcontainer because of `root` user inside the container.

Added a `--root-user` flag to allow both single user installation and multi user installation for nix as well as setup for Dockerfile and devcontainer.json.

This allows users to choose either `devbox` as a user in the container environment (default) or `root` as a user in the container environment (passing `--root-user` flag).

## How was it tested?
`devbox generate dockerfile -f -r`
compare content of Dockerfile with 
`devbox generate dockerfile -f`
