### PR TITLE
devbox.findPackagesByName should be constructed from Config packages

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -995,7 +995,7 @@ func (d *Devbox) HasDeprecatedPackages() bool {
 func (d *Devbox) findPackageByName(name string) (*devpkg.Package, error) {
 	results := map[*devpkg.Package]bool{}
 	for _, pkg := range d.configPackages() {
-		if pkg.String() == name || pkg.CanonicalName() == name {
+		if pkg.Raw == name || pkg.CanonicalName() == name {
 			results[pkg] = true
 		}
 	}

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -992,22 +992,22 @@ func (d *Devbox) HasDeprecatedPackages() bool {
 	return false
 }
 
-func (d *Devbox) findPackageByName(name string) (string, error) {
-	results := map[string]bool{}
+func (d *Devbox) findPackageByName(name string) (*devpkg.Package, error) {
+	results := map[*devpkg.Package]bool{}
 	for _, pkg := range d.configPackages() {
 		if pkg.String() == name || pkg.CanonicalName() == name {
-			results[pkg.String()] = true
+			results[pkg] = true
 		}
 	}
 	if len(results) > 1 {
-		return "", usererr.New(
+		return nil, usererr.New(
 			"found multiple packages with name %s: %s. Please specify version",
 			name,
 			lo.Keys(results),
 		)
 	}
 	if len(results) == 0 {
-		return "", usererr.New("no package found with name %s", name)
+		return nil, usererr.New("no package found with name %s", name)
 	}
 	return lo.Keys(results)[0], nil
 }

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -59,8 +59,7 @@ func (d *Devbox) Add(ctx context.Context, pkgsNames ...string) error {
 		// match.
 		found, _ := d.findPackageByName(pkg.CanonicalName())
 		if found != nil {
-			name := found.String() // TODO savil: should name be found.Raw?
-			if err := d.Remove(ctx, name); err != nil {
+			if err := d.Remove(ctx, found.Raw); err != nil {
 				return err
 			}
 		}
@@ -137,9 +136,8 @@ func (d *Devbox) Remove(ctx context.Context, pkgs ...string) error {
 	for _, pkg := range lo.Uniq(pkgs) {
 		found, _ := d.findPackageByName(pkg)
 		if found != nil {
-			name := found.String() // TODO savil. should this be found.Raw?
-			packagesToUninstall = append(packagesToUninstall, name)
-			d.cfg.Packages.Remove(name)
+			packagesToUninstall = append(packagesToUninstall, found.Raw)
+			d.cfg.Packages.Remove(found.Raw)
 		} else {
 			missingPkgs = append(missingPkgs, pkg)
 		}

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -57,7 +57,9 @@ func (d *Devbox) Add(ctx context.Context, pkgsNames ...string) error {
 		// it. Ignore error (which is either missing or more than one). We search by
 		// CanonicalName so any legacy or versioned packages will be removed if they
 		// match.
-		if name, _ := d.findPackageByName(pkg.CanonicalName()); name != "" {
+		found, _ := d.findPackageByName(pkg.CanonicalName())
+		// TODO savil: should name be found.Raw?
+		if name := found.String(); name != "" {
 			if err := d.Remove(ctx, name); err != nil {
 				return err
 			}
@@ -134,9 +136,10 @@ func (d *Devbox) Remove(ctx context.Context, pkgs ...string) error {
 	missingPkgs := []string{}
 	for _, pkg := range lo.Uniq(pkgs) {
 		found, _ := d.findPackageByName(pkg)
-		if found != "" {
-			packagesToUninstall = append(packagesToUninstall, found)
-			d.cfg.Packages.Remove(found)
+		if found != nil {
+			name := found.String() // TODO savil. should this be found.Raw?
+			packagesToUninstall = append(packagesToUninstall, name)
+			d.cfg.Packages.Remove(name)
 		} else {
 			missingPkgs = append(missingPkgs, pkg)
 		}

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -58,8 +58,8 @@ func (d *Devbox) Add(ctx context.Context, pkgsNames ...string) error {
 		// CanonicalName so any legacy or versioned packages will be removed if they
 		// match.
 		found, _ := d.findPackageByName(pkg.CanonicalName())
-		// TODO savil: should name be found.Raw?
-		if name := found.String(); name != "" {
+		if found != nil {
+			name := found.String() // TODO savil: should name be found.Raw?
 			if err := d.Remove(ctx, name); err != nil {
 				return err
 			}

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -66,7 +66,11 @@ func (d *Devbox) Update(ctx context.Context, pkgs ...string) error {
 }
 
 func (d *Devbox) inputsToUpdate(pkgs ...string) ([]*devpkg.Package, error) {
-	var pkgsToUpdate []string
+	if len(pkgs) == 0 {
+		return d.configPackages(), nil
+	}
+
+	var pkgsToUpdate []*devpkg.Package
 	for _, pkg := range pkgs {
 		found, err := d.findPackageByName(pkg)
 		if err != nil {
@@ -74,11 +78,7 @@ func (d *Devbox) inputsToUpdate(pkgs ...string) ([]*devpkg.Package, error) {
 		}
 		pkgsToUpdate = append(pkgsToUpdate, found)
 	}
-	if len(pkgsToUpdate) == 0 {
-		pkgsToUpdate = d.PackageNames()
-	}
-
-	return devpkg.PackageFromStrings(pkgsToUpdate, d.lockfile), nil
+	return pkgsToUpdate, nil
 }
 
 func (d *Devbox) updateDevboxPackage(


### PR DESCRIPTION
## Summary

This PR refactors `devbox.findPackagesByName` to be constructed from `devconfig.Package`.

**Motivation**
`devbox.Update` calls `findPackageByName` and needs to call `devbox.Add` again with the Platform and ExcludedPlatforms. (see #1370)

## How was it tested?

compiles


