### PR TITLE
Update node example to use the prebuilt binary

### DIFF
--- a/examples/development/nodejs/nodejs-pnpm/devbox.json
+++ b/examples/development/nodejs/nodejs-pnpm/devbox.json
@@ -1,7 +1,7 @@
 {
     "packages": [
         "nodejs@18",
-        "nodePackages.pnpm@latest"
+        "nodePackages.pnpm@8.6.0"
     ],
     "shell": {
         "init_hook": [

--- a/examples/development/nodejs/nodejs-pnpm/devbox.lock
+++ b/examples/development/nodejs/nodejs-pnpm/devbox.lock
@@ -1,16 +1,17 @@
 {
   "lockfile_version": "1",
   "packages": {
+    "nodePackages.pnpm@8.6.0": {
+      "last_modified": "2023-06-01T03:57:58Z",
+      "resolved": "github:NixOS/nixpkgs/8d4d822bc0efa9de6eddc79cb0d82897a9baa750#nodePackages.pnpm",
+      "source": "devbox-search",
+      "version": "8.6.0"
+    },
     "nodejs@18": {
       "last_modified": "2023-06-29T16:20:38Z",
       "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#nodejs_18",
       "source": "devbox-search",
       "version": "18.16.1"
-    },
-    "yarn@1.22": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#yarn",
-      "version": "1.22.19"
     }
   }
 }

--- a/examples/development/nodejs/nodejs-typescript/devbox.json
+++ b/examples/development/nodejs/nodejs-typescript/devbox.json
@@ -1,6 +1,6 @@
 {
     "packages": [
-        "nodejs@18.16"
+        "nodejs@18"
     ],
     "shell": {
         "init_hook": [

--- a/examples/development/nodejs/nodejs-typescript/devbox.lock
+++ b/examples/development/nodejs/nodejs-typescript/devbox.lock
@@ -1,13 +1,11 @@
 {
   "lockfile_version": "1",
   "packages": {
-    "nodePackages.typescript": {
-      "resolved": "github:NixOS/nixpkgs/f80ac848e3d6f0c12c52758c0f25c10c97ca3b62#nodePackages.typescript"
-    },
-    "nodejs@18.16": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#nodejs_18",
-      "version": "18.16.0"
+    "nodejs@18": {
+      "last_modified": "2023-06-29T16:20:38Z",
+      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#nodejs_18",
+      "source": "devbox-search",
+      "version": "18.16.1"
     }
   }
 }

--- a/examples/development/nodejs/nodejs-yarn/devbox.json
+++ b/examples/development/nodejs/nodejs-yarn/devbox.json
@@ -1,6 +1,6 @@
 {
   "packages": [
-    "nodejs@19.8",
+    "nodejs@18",
     "yarn@1.22"
   ],
   "shell": {


### PR DESCRIPTION
## Summary
Unfortunately I can't tell if the version for `nodePackages.pnpm` is prebuilt or not. Once we have that information in https://nixhub.io I will update the examples again.

## How was it tested?
devbox install