### PR TITLE
[per-OS Packages] Suggest --platform/--exclude-platform upon error with installing package that is uninstallable on user's platform

### DIFF
--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -195,7 +195,11 @@ var nixPlatforms = []string{
 	"armv7l-linux",
 }
 
-// ensureValidPlatform returns an error if the platform is not supported by nix.
+func SupportedPlatforms() []string {
+	return nixPlatforms
+}
+
+// EnsureValidPlatform returns an error if the platform is not supported by nix.
 // https://nixos.org/manual/nix/stable/installation/supported-platforms.html
 func EnsureValidPlatform(platforms ...string) error {
 	ensureValid := func(platform string) error {

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -195,10 +195,6 @@ var nixPlatforms = []string{
 	"armv7l-linux",
 }
 
-func SupportedPlatforms() []string {
-	return nixPlatforms
-}
-
 // EnsureValidPlatform returns an error if the platform is not supported by nix.
 // https://nixos.org/manual/nix/stable/installation/supported-platforms.html
 func EnsureValidPlatform(platforms ...string) error {

--- a/internal/nix/nixprofile/profile.go
+++ b/internal/nix/nixprofile/profile.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
-	"github.com/samber/lo"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/devpkg"
 	"go.jetpack.io/devbox/internal/lock"
@@ -272,16 +271,11 @@ func ProfileInstall(args *ProfileInstallArgs) error {
 			} else {
 				platform = " " + platform
 			}
-			otherPlatforms := lo.Filter(nix.SupportedPlatforms(), func(p string, _ int) bool {
-				return p != strings.TrimSpace(platform)
-			})
 			return usererr.New(
 				"package %s cannot be installed on your platform%s. "+
-					"Consider using `--platform` or `--exclude-platform` with `devbox add` to install on a supported"+
-					" platform. Other available platforms are: %s.",
-				input.String(),
+					"Run `devbox add %[1]s --exclude-platform%[2]s` and re-try.",
+				input.Raw,
 				platform,
-				strings.Join(otherPlatforms, ", "),
 			)
 		}
 	}


### PR DESCRIPTION
## Summary

Changes the error message to suggest using `--platform/--exclude-platform` with `devbox add`.

I wish we had a way to recommend the platforms that are supported for the exact package being installed, but we don't.

The heavy lifting for this was done in #1279. Thanks @mikeland73!

## How was it tested?

```
> devbox add glibcLocales

Installing package: glibcLocales.


Error: package glibcLocales cannot be installed on your platform x86_64-darwin. Consider using `--platform` or `--exclude-platform` with `devbox add` to install on a supported platform. Other available platforms are: aarch64-darwin, aarch64-linux, i686-linux, x86_64-linux, armv7l-linux.
```

<img width="949" alt="Screenshot 2023-08-10 at 4 20 18 PM" src="https://github.com/jetpack-io/devbox/assets/676452/95ddff88-793b-4c09-9e65-be344d303c2a">
