### PR TITLE
[vscode extension] Fixed github action workflow error

### DIFF
--- a/.github/workflows/vscode-ext-release.yaml
+++ b/.github/workflows/vscode-ext-release.yaml
@@ -18,7 +18,6 @@ jobs:
           node-version: 16
       - name: Install dependencies
         run: |
-          apt install jq
           npm install -g yarn
           npm install -g vsce
           npm install -g ovsx
@@ -30,8 +29,6 @@ jobs:
         working-directory: vscode-extension
       - name: publish-ovsx
         run: |
-          mv package.json package-temp.json
-          jq 'del(.extensionDependencies[0])' package-temp.json > package.json
-          rm package-temp.json
+          sed -i 's/"ms-vscode-remote.remote-ssh"//g' package.json
           ovsx publish --pat ${{ secrets.OVSX_MARKETPLACE_TOKEN }} --yarn --skip-duplicate
         working-directory: vscode-extension

--- a/.github/workflows/vscode-ext-release.yaml
+++ b/.github/workflows/vscode-ext-release.yaml
@@ -35,3 +35,7 @@ jobs:
           rm package-temp.json
           ovsx publish --pat ${{ secrets.OVSX_MARKETPLACE_TOKEN }} --yarn --skip-duplicate
         working-directory: vscode-extension
+      - name: publish-ovsx
+        run: |
+          ovsx publish --pat ${{ secrets.OVSX_MARKETPLACE_TOKEN }} --yarn
+        working-directory: vscode-extension

--- a/.github/workflows/vscode-ext-release.yaml
+++ b/.github/workflows/vscode-ext-release.yaml
@@ -30,12 +30,5 @@ jobs:
         working-directory: vscode-extension
       - name: publish-ovsx
         run: |
-          mv package.json package-temp.json
-          jq 'del(.extensionDependencies[0])' package-temp.json > package.json
-          rm package-temp.json
           ovsx publish --pat ${{ secrets.OVSX_MARKETPLACE_TOKEN }} --yarn --skip-duplicate
-        working-directory: vscode-extension
-      - name: publish-ovsx
-        run: |
-          ovsx publish --pat ${{ secrets.OVSX_MARKETPLACE_TOKEN }} --yarn
         working-directory: vscode-extension

--- a/.github/workflows/vscode-ext-release.yaml
+++ b/.github/workflows/vscode-ext-release.yaml
@@ -30,5 +30,8 @@ jobs:
         working-directory: vscode-extension
       - name: publish-ovsx
         run: |
+          mv package.json package-temp.json
+          jq 'del(.extensionDependencies[0])' package-temp.json > package.json
+          rm package-temp.json
           ovsx publish --pat ${{ secrets.OVSX_MARKETPLACE_TOKEN }} --yarn --skip-duplicate
         working-directory: vscode-extension

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -55,4 +55,4 @@ Ensure that you've read through the extensions guidelines and follow the best pr
 Steps:
 
 1. Bump the version in `package.json`, and add notes to `CHANGELOG.md`. Sample PR: #951.
-2. Manually trigger the [`vscode-ext-release` in Github Actions](https://github.com/jetpack-io/devbox/actions/workflows/vscode-ext-release.yaml).
+2. Manually trigger the [`vscode-ext-release` in Github Actions](https://github.com/jetpack-io/devbox/actions/workflows/vscode-ext-release.yaml) to publish to both VSCode extension Marketplace and OpenVSX extension Marketplace.

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -55,4 +55,4 @@ Ensure that you've read through the extensions guidelines and follow the best pr
 Steps:
 
 1. Bump the version in `package.json`, and add notes to `CHANGELOG.md`. Sample PR: #951.
-2. Manually trigger the [`vscode-ext-release` in Github Actions](https://github.com/jetpack-io/devbox/actions/workflows/vscode-ext-release.yaml) to publish to both VSCode extension Marketplace and OpenVSX extension Marketplace.
+2. Manually trigger the [`vscode-ext-release` in Github Actions](https://github.com/jetpack-io/devbox/actions/workflows/vscode-ext-release.yaml).


### PR DESCRIPTION
## Summary

Open-VSX does not recognize `ms-vscode-remote.remote-ssh` extension which we depend on for `Open in Desktop` feature. This stops our github actions to publish to open-vsx without removing this dependency from package.json.
I first implemented dynamic removal of this using `jq` but installing jq throws permission error, so this PR achieves the same with `sed`.

Fixed github actions so that it can automatically publish to vscode and open-vsx extension marketplaces.

## How was it tested?
N/A