### PR TITLE
[per-OS Packages] fix devbox update for unversioned packages with platform/excluded-platform

### DIFF
--- a/internal/devconfig/packages.go
+++ b/internal/devconfig/packages.go
@@ -44,6 +44,17 @@ func (pkgs *Packages) VersionedNames() []string {
 	return result
 }
 
+// Get returns the package with the given versionedName
+func (pkgs *Packages) Get(versionedName string) (*Package, bool) {
+	name, version := parseVersionedName(versionedName)
+	for _, pkg := range pkgs.Collection {
+		if pkg.name == name && pkg.Version == version {
+			return &pkg, true
+		}
+	}
+	return nil, false
+}
+
 // Add adds a package to the list of packages
 func (pkgs *Packages) Add(versionedName string) {
 	name, version := parseVersionedName(versionedName)

--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -341,7 +341,8 @@ func (p *Package) normalizePackageAttributePath() (string, error) {
 	}
 
 	if nix.PkgExistsForAnySystem(query) {
-		return "", usererr.New(
+		return "", usererr.WithUserMessage(
+			ErrCannotBuildPackageOnSystem,
 			"Package \"%s\" was found, but we're unable to build it for your system."+
 				" You may need to choose another version or write a custom flake.",
 			p.String(),
@@ -350,6 +351,8 @@ func (p *Package) normalizePackageAttributePath() (string, error) {
 
 	return "", usererr.New("Package \"%s\" was not found", p.String())
 }
+
+var ErrCannotBuildPackageOnSystem = errors.New("unable to build for system")
 
 func (p *Package) urlWithoutFragment() string {
 	u := p.URL // get copy

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -70,8 +70,11 @@ func (d *Devbox) Add(ctx context.Context, platforms, excludePlatforms []string, 
 		versionedPkg := devpkg.PackageFromString(pkg.Versioned(), d.lockfile)
 
 		packageNameForConfig := pkg.Raw
-		if ok, err := versionedPkg.ValidateExists(); err == nil && ok {
-			// Only use versioned if it exists in search.
+		ok, err := versionedPkg.ValidateExists()
+		if (err == nil && ok) || errors.Is(err, devpkg.ErrCannotBuildPackageOnSystem) {
+			// Only use versioned if it exists in search. We can disregard the error
+			// about not building on the current system, since user's can continue
+			// via --exclude-platform flag.
 			packageNameForConfig = pkg.Versioned()
 		} else if !versionedPkg.IsDevboxPackage() {
 			// This means it didn't validate and we don't want to fallback to legacy


### PR DESCRIPTION
## Summary

This PR fixes a slightly edge-casey workflow:
1. User on macOS tries to `devbox shell` with `glibcLocales` in devbox.json. Note: unversioned package.
2. Is asked to run: `devbox add glibcLocales --exclude-platforms x86_64-darwin`
3. Running that, prints a notice to run `devbox update`.
4. Runs `devbox update`.

This should work, but was previously broken for two reasons:
1. In `update.go`, we were calling `devbox.Add` with `nil` for platforms and excluded_platforms. 
2. In `devbox.Add`, we check `versionedPkg.ValidateExists()` prior to converting the raw package name to the versioned-name.
Both are now fixed.

## How was it tested?

Ran the workflow described above. It's hard to write a testscript unit-test, since
some packages build may or may not build on whichever system is running the unit-test. And mocking is too complicated here.
