### PR TITLE
[per-OS Packages] Error if adding --platform, when `excluded_platforms` is defined

### DIFF
--- a/internal/devconfig/packages.go
+++ b/internal/devconfig/packages.go
@@ -87,7 +87,13 @@ func (pkgs *Packages) AddPlatforms(versionedname string, platforms []string) err
 
 			// Adding any platform will restrict installation to it, so
 			// the ExcludedPlatforms are no longer needed
-			pkg.ExcludedPlatforms = nil
+			if len(pkg.ExcludedPlatforms) > 0 {
+				return usererr.New(
+					"cannot add any platform for package %s because it already has `excluded_platforms` defined. "+
+						"Please delete the `excludedPlatforms` for this package from devbox.json and re-try.",
+					pkg.VersionedName(),
+				)
+			}
 
 			pkgs.jsonKind = jsonMap
 			pkg.kind = regular

--- a/testscripts/add/add_platforms.test.txt
+++ b/testscripts/add/add_platforms.test.txt
@@ -26,6 +26,14 @@ json.superset devbox.json expected_devbox3.json
 exec devbox add cowsay --exclude-platform x86_64-darwin,x86_64-linux --exclude-platform aarch64-darwin
 json.superset devbox.json expected_devbox4.json
 
+### Part 3: Ensure we error to prevent inconsistent state
+
+! exec devbox add cowsay --platform x86_64-darwin
+stderr 'Error: cannot add any platform for package cowsay@latest because it already has `excluded_platforms` defined'
+
+! exec devbox add hello --exclude-platform x86_64-darwin
+stderr 'Error: cannot exclude any platform for package hello@latest because it already has `platforms` defined'
+
 -- devbox.json --
 {
   "packages": [


### PR DESCRIPTION
## Summary

Background:
for a package, `platforms` and `excluded_platforms` should be defined mutually-exclusively.

Previously, we were being "clever" by dropping "excluded_platforms" when a user
does `devbox add <package> --platform <platform>`. But I think we should:
1. Ensure the user explicitly makes the change to their devbox config.
2. Be consistent with how the inverse is handled: using `--exclude-platform` when `platform` is defined.

## How was it tested?

added testscript unit-tests
