### PR TITLE
[Remove Nixpkgs] Ensure we run cli-tests for oldest supported nix version, and 2.17

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -82,6 +82,11 @@ jobs:
         # the devbox.json tests. We can require the other tests to complete before
         # merging, while keeping the others as an additional non-required signal
         run-devbox-json-tests: [true, false]
+        # Run tests on:
+        # 1. the oldest supported nix version (which is 2.9.0? But determinate-systems installer has 2.12.0)
+        # 2. nix version 2.17.0 which introduces a new code path that minimizes nixpkgs downloads.
+        # 3. latest nix version (currently, that is 2.17.0, so omitted)
+        nix-version: ["2.12.0", "2.17.0"]
         exclude:
           - is-main: false
             os: "${{ inputs.run-mac-tests && 'dummy' || 'macos-latest' }}"
@@ -112,6 +117,7 @@ jobs:
         with:
           logger: pretty
           extra-conf: experimental-features = ca-derivations fetch-closure
+          nix-package-url: https://releases.nixos.org/nix/nix-${{ matrix.nix-version }}/nix-${{ matrix.nix-version }}-${{ runner.arch == 'X64' && 'x86_64' || 'aarch64' }}-${{ runner.os == 'macOS' && 'darwin' || 'linux' }}.tar.xz
       - name: Run tests
         env:
           # For devbox.json tests, we default to non-debug mode since the debug output is less useful than for unit testscripts.
@@ -163,7 +169,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        version: [2.15.1, 2.16.1, 2.17.0]
+        nix-version: [2.15.1, 2.16.1, 2.17.0]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -177,7 +183,7 @@ jobs:
         with:
           logger: pretty
           extra-conf: experimental-features = ca-derivations fetch-closure
-          nix-package-url: https://releases.nixos.org/nix/nix-${{ matrix.version }}/nix-${{ matrix.version }}-${{ runner.arch == 'X64' && 'x86_64' || 'aarch64' }}-${{ runner.os == 'macOS' && 'darwin' || 'linux' }}.tar.xz
+          nix-package-url: https://releases.nixos.org/nix/nix-${{ matrix.nix-version }}/nix-${{ matrix.nix-version }}-${{ runner.arch == 'X64' && 'x86_64' || 'aarch64' }}-${{ runner.os == 'macOS' && 'darwin' || 'linux' }}.tar.xz
       - name: Run devbox install, devbox run, devbox rm
         run: |
           echo "::group::Nix version"

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -95,7 +95,7 @@ jobs:
           - run-devbox-json-tests: true
             os: macos-latest
     runs-on: ${{ matrix.os }}
-    timeout-minutes: ${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && 37 || 25 }}
+    timeout-minutes: ${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && 37 || 30 }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -125,7 +125,7 @@ jobs:
           DEVBOX_DEBUG: ${{ (!matrix.run-devbox-json-tests || inputs.example-debug) && '1' || '0' }}
           DEVBOX_RUN_DEVBOX_JSON_TESTS: ${{ matrix.run-devbox-json-tests }}
           # Used in `go test -timeout` flag. Needs a value that time.ParseDuration can parse.
-          DEVBOX_GOLANG_TEST_TIMEOUT: "${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && '35m' || '25m' }}"
+          DEVBOX_GOLANG_TEST_TIMEOUT: "${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && '35m' || '30m' }}"
         run: |
           echo "::group::Nix version"
           nix --version

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -95,7 +95,7 @@ jobs:
           - run-devbox-json-tests: true
             os: macos-latest
     runs-on: ${{ matrix.os }}
-    timeout-minutes: ${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && 37 || 30 }}
+    timeout-minutes: ${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && 37 || 25 }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -125,7 +125,7 @@ jobs:
           DEVBOX_DEBUG: ${{ (!matrix.run-devbox-json-tests || inputs.example-debug) && '1' || '0' }}
           DEVBOX_RUN_DEVBOX_JSON_TESTS: ${{ matrix.run-devbox-json-tests }}
           # Used in `go test -timeout` flag. Needs a value that time.ParseDuration can parse.
-          DEVBOX_GOLANG_TEST_TIMEOUT: "${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && '35m' || '30m' }}"
+          DEVBOX_GOLANG_TEST_TIMEOUT: "${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && '35m' || '25m' }}"
         run: |
           echo "::group::Nix version"
           nix --version


### PR DESCRIPTION
## Summary

We could have more intentional test coverage with different nix versions:
1. Earliest supported nix version
2. Nix version 2.17 since that is the minimum for Remove Nixpkgs code paths and I want it tested
3. Latest nix version

## How was it tested?

testscripts should run
