### PR TITLE
[info] Modernize via search api

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -349,13 +349,16 @@ func (d *Devbox) Info(ctx context.Context, pkg string, markdown bool) error {
 
 	packageVersion, err := searcher.Client().Resolve(name, version)
 	if err != nil {
-		// This is not ideal. Search service should return valid response we
-		// can parse
-		return usererr.WithUserMessage(err, "No results found for %q\n", pkg)
+		if !errors.Is(err, searcher.ErrNotFound) {
+			return usererr.WithUserMessage(err, "Package %q not found\n", pkg)
+		}
+
+		packageVersion = nil
+		// fallthrough to below
 	}
 
 	if packageVersion == nil {
-		_, err := fmt.Fprintf(d.writer, "Package %s not found\n", pkg)
+		_, err := fmt.Fprintf(d.writer, "Package %q not found\n", pkg)
 		return errors.WithStack(err)
 	}
 

--- a/internal/nix/search.go
+++ b/internal/nix/search.go
@@ -19,6 +19,7 @@ type Info struct {
 	// if we know exactly which version we are using
 	AttributeKey string
 	PName        string
+	Summary      string
 	Version      string
 }
 

--- a/internal/searcher/client.go
+++ b/internal/searcher/client.go
@@ -16,6 +16,8 @@ import (
 
 const searchAPIEndpoint = "https://search.devbox.sh"
 
+var ErrNotFound = errors.New("Not found")
+
 type client struct {
 	host string
 }
@@ -67,6 +69,9 @@ func execGet[T any](url string) (*T, error) {
 	data, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, err
+	}
+	if response.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
 	}
 	var result T
 	return &result, json.Unmarshal(data, &result)

--- a/internal/searcher/model.go
+++ b/internal/searcher/model.go
@@ -33,4 +33,5 @@ type PackageInfo struct {
 	MetaVersion  []string `json:"meta_version"`
 	AttrPaths    []string `json:"attr_paths"`
 	Version      string   `json:"version"`
+	Summary      string   `json:"summary"`
 }

--- a/testscripts/info/info.test.txt
+++ b/testscripts/info/info.test.txt
@@ -1,11 +1,11 @@
 exec devbox init
 exec devbox info hello
-stdout hello-.
+stdout 'hello '
 
 exec devbox init
 exec devbox info hello@latest
-stdout hello-.
+stdout 'hello '
 
 exec devbox init
 exec devbox info notapackage
-stdout 'Package notapackage not found'
+stdout 'Package "notapackage" not found'


### PR DESCRIPTION
## Summary

The `devbox info` command is quite old and outdated. 

1. It returns results inconsistent with the `devbox search` results. It also doesn't print much useful information except a poorly formatted package-name and version.
2. Some users have asked in the past for understanding what a particular package in the search results is for.

This PR leverages the search service's API to get the package information, and also prints a summary of the package. 

## How was it tested?

BEFORE:
```
> devbox info go
go-1.20.2

> devbox info go@1.19.2
Ensuring nixpkgs registry is downloaded.
Downloaded 'github:NixOS/nixpkgs/1c6eb4876f71e8903ae9f73e6adf45fdbebc0292' to '/nix/store/y3kz7n62fwvp331na0k17xdw4dyaa66d-source' (hash 'sha256-hI7+s1UVDsJNqNn9UGV6xTBGqMC4dqOyVpeDf+su7JU=').
Ensuring nixpkgs registry is downloaded: Success
go-1.19.2

> devbox info php
php-with-extensions-8.1.17

php NOTES:
PHP is compiled with default extensions. If you would like to use non-default extensions you can add them with devbox add php81Extensions.{extension} . For example, for the memcache extension you can do `devbox add php81Extensions.memcached`.

Error: open /Users/savil/code/jetpack/devbox/.devbox/virtenv/php/process-compose.yaml: no such file or directory
```

AFTER:

```
> devbox info go
go 1.20.6
The Go Programming language

> devbox info go@1.19.2
go 1.19.2
The Go Programming language

> devbox info php
php 8.2.8
An HTML-embedded scripting language

php NOTES:
PHP is compiled with default extensions. If you would like to use non-default extensions you can add them with devbox add php81Extensions.{extension} . For example, for the memcache extension you can do `devbox add php81Extensions.memcached`.

Error: open /Users/savil/code/jetpack/devbox/.devbox/virtenv/php/process-compose.yaml: no such file or directory
```

NOTE: the error with `devbox info php` still needs fixing...
