### PR TITLE
[docs] update docs to highlight restrictions for direnv integration

### DIFF
--- a/docs/app/docs/ide_configuration/direnv.md
+++ b/docs/app/docs/ide_configuration/direnv.md
@@ -11,6 +11,8 @@ ___
 Devbox 0.5.0 makes changes to how the environment is sourced in order to ensure better compatibility with the user's host shell. This may raise some errors if you generated your `.envrc` file with an older version of devbox.
 
 If you see any errors when activating your `.envrc` file, you will need to run `devbox generate direnv --force`, and then re-run `devbox shell` to apply the latest changes. Be sure to back up your old `.envrc` file before running this command.
+
+Direnv only supports modifying environment variables, so your `init_hook` functionality will be restricted. In particular, aliases, functions, and command completions will not work. If you use these, stick with the manual `devbox shell`.
 :::
 
 ### Prerequisites


### PR DESCRIPTION
## Summary
Based on conversation in [discord](https://discord.com/channels/903306922852245526/1140685982673416273/1140710781390954606), we want to highlight the restrictions on direnv integration in docs as requested.

<img width="1446" alt="Screenshot 2023-08-15 at 2 15 41 PM" src="https://github.com/jetpack-io/devbox/assets/2292093/f3cc16a0-1699-40ef-96d0-4e0dd3016ded">


## How was it tested?
`yarn build`
`yarn start`