### PR TITLE
change nix.System back to returning error

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -90,7 +90,7 @@ jobs:
           - run-devbox-json-tests: true
             os: macos-latest
     runs-on: ${{ matrix.os }}
-    timeout-minutes: ${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && 37 || 25 }}
+    timeout-minutes: ${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && 37 || 20 }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -119,7 +119,7 @@ jobs:
           DEVBOX_DEBUG: ${{ (!matrix.run-devbox-json-tests || inputs.example-debug) && '1' || '0' }}
           DEVBOX_RUN_DEVBOX_JSON_TESTS: ${{ matrix.run-devbox-json-tests }}
           # Used in `go test -timeout` flag. Needs a value that time.ParseDuration can parse.
-          DEVBOX_GOLANG_TEST_TIMEOUT: "${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && '35m' || '25m' }}"
+          DEVBOX_GOLANG_TEST_TIMEOUT: "${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && '35m' || '20m' }}"
         run: |
           echo "::group::Nix version"
           nix --version

--- a/internal/devconfig/packages.go
+++ b/internal/devconfig/packages.go
@@ -248,22 +248,25 @@ func NewPackage(name string, values map[string]any) Package {
 // If the package has a list of platforms, it is enabled only on those platforms.
 // If the package has a list of excluded platforms, it is enabled on all platforms
 // except those.
-func (p *Package) IsEnabledOnPlatform() bool {
-	platform := nix.System()
+func (p *Package) IsEnabledOnPlatform() (bool, error) {
+	platform, err := nix.System()
+	if err != nil {
+		return false, err
+	}
 	if len(p.Platforms) > 0 {
 		for _, plt := range p.Platforms {
 			if plt == platform {
-				return true
+				return true, nil
 			}
 		}
-		return false
+		return false, nil
 	}
 	for _, plt := range p.ExcludedPlatforms {
 		if plt == platform {
-			return false
+			return false, nil
 		}
 	}
-	return true
+	return true, nil
 }
 
 func (p *Package) VersionedName() string {

--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -63,16 +63,16 @@ func PackageFromStrings(rawNames []string, l lock.Locker) []*Package {
 	return packages
 }
 
-func PackagesFromConfig(config *devconfig.Config, l lock.Locker) []*Package {
+func PackagesFromConfig(config *devconfig.Config, l lock.Locker) ([]*Package, error) {
 	result := []*Package{}
 	for _, pkg := range config.Packages.Collection {
 		isEnabled, err := pkg.IsEnabledOnPlatform()
 		if err != nil {
-			return nil
+			return nil, err
 		}
 		result = append(result, newPackage(pkg.VersionedName(), isEnabled, l))
 	}
-	return result
+	return result, nil
 }
 
 // PackageFromString constructs Package from the raw name provided.
@@ -490,7 +490,7 @@ func (p *Package) IsInBinaryCache() (bool, error) {
 
 	sys, err := nix.System()
 	if err != nil {
-		return false, nil
+		return false, err
 	}
 
 	// Check if the user's system's info is present in the lockfile

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -211,7 +211,11 @@ func (d *Devbox) ensurePackagesAreInstalled(ctx context.Context, mode installMod
 	}
 
 	// Create plugin directories first because packages might need them
-	for _, pkg := range d.InstallablePackages() {
+	installablePackages, err := d.InstallablePackages()
+	if err != nil {
+		return err
+	}
+	for _, pkg := range installablePackages {
 		if err := d.PluginManager().Create(pkg); err != nil {
 			return err
 		}
@@ -241,8 +245,13 @@ func (d *Devbox) ensurePackagesAreInstalled(ctx context.Context, mode installMod
 		return err
 	}
 
+	configPackages, err := d.configPackages()
+	if err != nil {
+		return err
+	}
+
 	// Update lockfile with new packages that are not to be installed
-	for _, pkg := range d.configPackages() {
+	for _, pkg := range configPackages {
 		if err := pkg.EnsureUninstallableIsInLockfile(); err != nil {
 			return err
 		}

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -131,7 +131,10 @@ func (d *Devbox) mergeResolvedPackageToLockfile(
 			lockfile.Packages[pkg.Raw].Systems = map[string]*lock.SystemInfo{}
 		}
 
-		userSystem := nix.System()
+		userSystem, err := nix.System()
+		if err != nil {
+			return err
+		}
 		updated := false
 		for sysName, newSysInfo := range resolved.Systems {
 			if sysName == userSystem {

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -74,7 +74,11 @@ func (d *Devbox) Update(ctx context.Context, pkgs ...string) error {
 
 func (d *Devbox) inputsToUpdate(pkgs ...string) ([]*devpkg.Package, error) {
 	if len(pkgs) == 0 {
-		return d.configPackages(), nil
+		configPackages, err := d.configPackages()
+		if err != nil {
+			return nil, err
+		}
+		return configPackages, nil
 	}
 
 	var pkgsToUpdate []*devpkg.Package

--- a/internal/impl/update_test.go
+++ b/internal/impl/update_test.go
@@ -156,7 +156,8 @@ func TestUpdateOtherSysInfoIsReplaced(t *testing.T) {
 	require.Equal(t, "store_path2", lockfile.Packages[raw].Systems[sys2].StorePath)
 }
 
-func currentSystem(_t *testing.T) string {
-	sys := nix.System() // NOTE: we could mock this too, if it helps.
+func currentSystem(t *testing.T) string {
+	sys, err := nix.System() // NOTE: we could mock this too, if it helps.
+	require.NoError(t, err, "failed to get current system")
 	return sys
 }

--- a/internal/lock/resolve.go
+++ b/internal/lock/resolve.go
@@ -61,7 +61,11 @@ func (f *File) FetchResolvedPackage(pkg string) (*Package, error) {
 }
 
 func selectForSystem(pkg *searcher.PackageVersion) (searcher.PackageInfo, error) {
-	if pi, ok := pkg.Systems[nix.System()]; ok {
+	sys, err := nix.System()
+	if err != nil {
+		return searcher.PackageInfo{}, err
+	}
+	if pi, ok := pkg.Systems[sys]; ok {
 		return pi, nil
 	}
 	if pi, ok := pkg.Systems["x86_64-linux"]; ok {

--- a/internal/nix/install.go
+++ b/internal/nix/install.go
@@ -96,14 +96,6 @@ func isRoot() bool {
 }
 
 func EnsureNixInstalled(writer io.Writer, withDaemonFunc func() *bool) (err error) {
-	defer func() {
-		if err == nil {
-			// call ComputeSystem to ensure its value is internally cached so other
-			// callers can rely on just calling System
-			err = ComputeSystem()
-		}
-	}()
-
 	if BinaryInstalled() {
 		return nil
 	}

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -122,8 +122,6 @@ var cachedSystem string
 
 func System() (string, error) {
 	if cachedSystem == "" {
-		// While this should have been initialized, we do a best-effort to avoid
-		// a panic.
 		if err := computeSystem(); err != nil {
 			return "", err
 		}

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -118,6 +118,8 @@ func ExperimentalFlags() []string {
 	}
 }
 
+var cachedSystem string
+
 func System() (string, error) {
 	if cachedSystem == "" {
 		// While this should have been initialized, we do a best-effort to avoid
@@ -128,8 +130,6 @@ func System() (string, error) {
 	}
 	return cachedSystem, nil
 }
-
-var cachedSystem string
 
 func computeSystem() error {
 	// For Savil to debug "remove nixpkgs" feature. The Search api lacks x86-darwin info.

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -118,20 +118,20 @@ func ExperimentalFlags() []string {
 	}
 }
 
-func System() string {
+func System() (string, error) {
 	if cachedSystem == "" {
 		// While this should have been initialized, we do a best-effort to avoid
 		// a panic.
-		if err := ComputeSystem(); err != nil {
-			panic("System called before being initialized by ComputeSystem")
+		if err := computeSystem(); err != nil {
+			return "", err
 		}
 	}
-	return cachedSystem
+	return cachedSystem, nil
 }
 
 var cachedSystem string
 
-func ComputeSystem() error {
+func computeSystem() error {
 	// For Savil to debug "remove nixpkgs" feature. The Search api lacks x86-darwin info.
 	// So, I need to fake that I am x86-linux and inspect the output in generated devbox.lock
 	// and flake.nix files.

--- a/internal/nix/nixprofile/profile.go
+++ b/internal/nix/nixprofile/profile.go
@@ -265,7 +265,11 @@ func ProfileInstall(args *ProfileInstallArgs) error {
 		if exists, err := input.ValidateInstallsOnSystem(); err != nil {
 			return err
 		} else if !exists {
-			platform := " " + nix.System()
+			platform := ""
+			sys, err := nix.System()
+			if err == nil {
+				platform = " " + sys
+			}
 			return usererr.New(
 				"package %s cannot be installed on your platform%s. "+
 					"Run `devbox add %[1]s --exclude-platform%[2]s` and re-try.",

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -152,6 +152,11 @@ func (m *Manager) createFile(
 		urlForInput = pkg.URLForFlakeInput()
 	}
 
+	sys, err := nix.System()
+	if err != nil {
+		return err
+	}
+
 	var buf bytes.Buffer
 	if err = tmpl.Execute(&buf, map[string]any{
 		"DevboxDir":            filepath.Join(m.ProjectDir(), devboxDirName, name),
@@ -159,7 +164,7 @@ func (m *Manager) createFile(
 		"DevboxProfileDefault": filepath.Join(m.ProjectDir(), nix.ProfilePath),
 		"PackageAttributePath": attributePath,
 		"Packages":             m.PackageNames(),
-		"System":               nix.System(),
+		"System":               sys,
 		"URLForInput":          urlForInput,
 		"Virtenv":              filepath.Join(virtenvPath, name),
 	}); err != nil {

--- a/internal/shellgen/flake_plan.go
+++ b/internal/shellgen/flake_plan.go
@@ -50,11 +50,16 @@ func newFlakePlan(ctx context.Context, devbox devboxer) (*flakePlan, error) {
 		}
 	}
 
+	sys, err := nix.System()
+	if err != nil {
+		return nil, err
+	}
+
 	return &flakePlan{
 		BinaryCache: devpkg.BinaryCache,
 		FlakeInputs: flakeInputs,
 		NixpkgsInfo: nixpkgsInfo,
 		Packages:    packages,
-		System:      nix.System(),
+		System:      sys,
 	}, nil
 }

--- a/internal/shellgen/scripts.go
+++ b/internal/shellgen/scripts.go
@@ -24,7 +24,7 @@ type devboxer interface {
 	Config() *devconfig.Config
 	Lockfile() *lock.File
 	AllInstallablePackages() ([]*devpkg.Package, error)
-	InstallablePackages() []*devpkg.Package
+	InstallablePackages() ([]*devpkg.Package, error)
 	PluginManager() *plugin.Manager
 	ProjectDir() string
 }
@@ -43,9 +43,14 @@ func WriteScriptsToFiles(devbox devboxer) error {
 		return errors.WithStack(err)
 	}
 
+	installablePackages, err := devbox.InstallablePackages()
+	if err != nil {
+		return err
+	}
+
 	// Write all hooks to a file.
 	written := map[string]struct{}{} // set semantics; value is irrelevant
-	pluginHooks, err := plugin.InitHooks(devbox.InstallablePackages(), devbox.ProjectDir())
+	pluginHooks, err := plugin.InitHooks(installablePackages, devbox.ProjectDir())
 	if err != nil {
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
## Summary

Returns `nix.System` error, rather than caching it in `ensureNixInstalled` which
was either error prone, OR had a perf regression.

## How was it tested?

will view testscripts outcome...
