### PR TITLE
[cli-test] Use pinned nixpkgs commit that has pre-built yarn

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -95,7 +95,7 @@ jobs:
           - run-devbox-json-tests: true
             os: macos-latest
     runs-on: ${{ matrix.os }}
-    timeout-minutes: ${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && 37 || 25 }}
+    timeout-minutes: ${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && 37 || 40 }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -125,7 +125,7 @@ jobs:
           DEVBOX_DEBUG: ${{ (!matrix.run-devbox-json-tests || inputs.example-debug) && '1' || '0' }}
           DEVBOX_RUN_DEVBOX_JSON_TESTS: ${{ matrix.run-devbox-json-tests }}
           # Used in `go test -timeout` flag. Needs a value that time.ParseDuration can parse.
-          DEVBOX_GOLANG_TEST_TIMEOUT: "${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && '35m' || '25m' }}"
+          DEVBOX_GOLANG_TEST_TIMEOUT: "${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && '35m' || '40m' }}"
         run: |
           echo "::group::Nix version"
           nix --version

--- a/examples/development/nodejs/nodejs-yarn/devbox.lock
+++ b/examples/development/nodejs/nodejs-yarn/devbox.lock
@@ -9,7 +9,7 @@
     },
     "yarn@1.22": {
       "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#yarn",
+      "resolved": "github:NixOS/nixpkgs/9356eead97d8d16956b0226d78f76bd66e06cb60#yarn",
       "version": "1.22.19"
     }
   }


### PR DESCRIPTION
## Summary

Ran `curl 'https://search.devbox.sh/v1/search?q=yarn' | jq | less`
and picked the nixpkgs commit hash that was listed in each platform.

## How was it tested?

doing `devbox shell` locally loaded yarn quickly. No building.

will observe testscripts...
