### PR TITLE
fix: typo in mysql process-compose.yml

### DIFF
--- a/plugins/mysql/process-compose.yaml
+++ b/plugins/mysql/process-compose.yaml
@@ -2,7 +2,7 @@ version: "0.5"
 
 processes:
   mysql:
-    command: "mysqld 2> $MYSQL_HOME/mysql.log & MYSQL_PID=$! && echo 'Starting mysqld... check mariadb_logs for details'"
+    command: "mysqld 2> $MYSQL_HOME/mysql.log & MYSQL_PID=$! && echo 'Starting mysqld... check mysql_logs for details'"
     is_daemon: true
     shutdown:
       command: "mysqladmin -u root shutdown"


### PR DESCRIPTION
## Summary

Fix typo in `plugins/mysql/process-compose.yaml` .

## How was it tested?
