### PR TITLE
[cli-test] speed up yarn example

### DIFF
--- a/examples/development/nodejs/nodejs-yarn/devbox.lock
+++ b/examples/development/nodejs/nodejs-yarn/devbox.lock
@@ -9,7 +9,7 @@
     },
     "yarn@1.22": {
       "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#yarn",
+      "resolved": "github:NixOS/nixpkgs/844ffa82bbe2a2779c86ab3a72ff1b4176cec467#yarn",
       "version": "1.22.19"
     }
   }


### PR DESCRIPTION
## Summary

Doing `devbox shell` would have `yarn` install try to build nodejs from scratch. Took way too long.

## How was it tested?

Ran `curl 'https://search.devbox.sh/v1/search?q=yarn' | jq | less`
Picked the top-most commit-hash
Ran `rm -rf .devbox && devbox shell` and it installed quickly
