### PR TITLE
[per-OS Packages] Improve error message if package is uninstallable

### DIFF
--- a/internal/nix/nixprofile/profile.go
+++ b/internal/nix/nixprofile/profile.go
@@ -272,10 +272,14 @@ func ProfileInstall(ctx context.Context, args *ProfileInstallArgs) error {
 		if exists, err := input.ValidateInstallsOnSystem(); err != nil {
 			return err
 		} else if !exists {
-			platform := " " + nix.System()
+			platform := nix.System()
 			return usererr.New(
-				"package %s cannot be installed on your platform%s. "+
-					"Run `devbox add %[1]s --exclude-platform%[2]s` and re-try.",
+				"package %s cannot be installed on your platform %s.\n"+
+					"If you know this package is incompatible with %[2]s, then "+
+					"you could run `devbox add %[1]s --exclude-platform %[2]s` and re-try.\n"+
+					"If you think this package should be compatible with %[2]s, then "+
+					"it's possible this particular version is not available yet from the nix registry. "+
+					"You could try `devbox add` with a different version for this package.\n",
 				input.Raw,
 				platform,
 			)


### PR DESCRIPTION
## Summary

Instead of gating the entire per-OS packages feature due to __some__ packages
not being installable on the user's platform for that particular version, I propose
this PR.

Here, we modify the error message to be less prescriptive. We explain the two
scenarios and let the user pick.

This is obviously not the ideal UX. But a good enough measure until we can
provide firmer guidance on which version of the package may work for this 
platform?

## How was it tested?

in axiom on mac, did `devbox update` and saw:
```
Ensuring packages are installed.

Installing package: gotty@latest.


Error: package gotty@latest cannot be installed on your platform x86_64-darwin.
If you know this package is incompatible with x86_64-darwin, then you could run `devbox add gotty@latest --exclude-platform x86_64-darwin` and re-try.
If you think this package should be compatible with x86_64-darwin, then it's possible this particular version is not available yet from the nix registry. You could try `devbox add` with a different version for this package.


```
