### PR TITLE
[cli-tests] fix by pinning dependencies in rails examples

### DIFF
--- a/examples/stacks/rails/blog/Gemfile.lock
+++ b/examples/stacks/rails/blog/Gemfile.lock
@@ -127,6 +127,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.14.3-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.14.3-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.3-x86_64-linux)
       racc (~> 1.4)
     public_suffix (5.0.1)
@@ -180,6 +182,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.6.2-arm64-darwin)
+    sqlite3 (1.6.2-x86_64-darwin)
     sqlite3 (1.6.2-x86_64-linux)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
@@ -213,6 +216,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/examples/stacks/rails/devbox.json
+++ b/examples/stacks/rails/devbox.json
@@ -3,7 +3,7 @@
         "ruby@3.1",
         "bundler@latest",
         "nodejs@19",
-        "yarn@latest",
+        "yarn@1.22",
         "curl@latest",
         "sqlite@latest"
     ],

--- a/examples/stacks/rails/devbox.lock
+++ b/examples/stacks/rails/devbox.lock
@@ -2,34 +2,39 @@
   "lockfile_version": "1",
   "packages": {
     "bundler@latest": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#bundler",
-      "version": "2.4.12"
+      "last_modified": "2023-07-30T12:29:02Z",
+      "resolved": "github:NixOS/nixpkgs/3acb5c4264c490e7714d503c7166a3fde0c51324#bundler",
+      "source": "devbox-search",
+      "version": "2.4.17"
     },
     "curl@latest": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#curl",
-      "version": "8.0.1"
+      "last_modified": "2023-08-08T03:07:33Z",
+      "resolved": "github:NixOS/nixpkgs/844ffa82bbe2a2779c86ab3a72ff1b4176cec467#curl",
+      "source": "devbox-search",
+      "version": "8.1.2"
     },
     "nodejs@19": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#nodejs_19",
+      "last_modified": "2023-05-14T19:13:12Z",
+      "resolved": "github:NixOS/nixpkgs/3007746b3f5bfcb49e102b517bca891822a41b31#nodejs-19_x",
+      "source": "devbox-search",
       "version": "19.9.0"
     },
     "ruby@3.1": {
       "last_modified": "2023-05-01T16:53:22Z",
-      "plugin_version": "0.0.1",
+      "plugin_version": "0.0.2",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#ruby",
       "version": "3.1.4"
     },
     "sqlite@latest": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#sqlite",
-      "version": "3.41.2"
+      "last_modified": "2023-06-30T04:44:22Z",
+      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#sqlite",
+      "source": "devbox-search",
+      "version": "3.42.0"
     },
-    "yarn@latest": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#yarn",
+    "yarn@1.22": {
+      "last_modified": "2023-05-21T19:52:09Z",
+      "resolved": "github:NixOS/nixpkgs/9356eead97d8d16956b0226d78f76bd66e06cb60#yarn",
+      "source": "devbox-search",
       "version": "1.22.19"
     }
   }


### PR DESCRIPTION
## Summary

We pin yarn to a version that has pre-built binaries.
We also update the nodejs version so it is pinned to a nixpkgs hash commit that has pre-built binaries.

From my tests (see PRs stacked from #1388), I think this should fix the cli-tests that were timing out for nix 2.17

## How was it tested?

tested locally via running `devbox shell`.
