### PR TITLE
[global] Added hardcoded region to push pull bucket

### DIFF
--- a/internal/pullbox/s3/config.go
+++ b/internal/pullbox/s3/config.go
@@ -16,6 +16,10 @@ import (
 const (
 	roleArn = "arn:aws:iam::984256416385:role/JetpackS3Federated"
 	bucket  = "devbox.sh"
+	// this is a fixed value the bucket resides in this region, otherwise,
+	// user's default region will get pulled from config and region mismatch
+	// will result in user not being able to run global push
+	region = "us-east-2"
 )
 
 func assumeRole(ctx context.Context, user *auth.User) (*aws.Config, error) {
@@ -43,6 +47,7 @@ func assumeRole(ctx context.Context, user *auth.User) (*aws.Config, error) {
 			),
 		),
 	)
+	config.Region = region
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}


### PR DESCRIPTION
## Summary
title says it.
Additional context, if you have a region other than `us-east-2` in your `~/.aws/config` specified, global push will fail due to region mismatch in s3 bucket and the s3 request we send to push the profile.

## How was it tested?
- change default region specified in ~/.aws/config to anything other than `us-east-2` 
- run `devbox auth login`
- run `devbox global push`