### PR TITLE
[rm-nixpkgs] Fix profile list bug for packages added by store path

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -134,7 +134,7 @@ jobs:
           DEVBOX_DEBUG: ${{ (!matrix.run-devbox-json-tests || inputs.example-debug) && '1' || '0' }}
           DEVBOX_RUN_DEVBOX_JSON_TESTS: ${{ matrix.run-devbox-json-tests }}
           # Used in `go test -timeout` flag. Needs a value that time.ParseDuration can parse.
-          DEVBOX_GOLANG_TEST_TIMEOUT: "${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && '35m' || '25m' }}"
+          DEVBOX_GOLANG_TEST_TIMEOUT: "${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && '35m' || '30m' }}"
         run: |
           echo "::group::Nix version"
           nix --version

--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -372,6 +372,9 @@ func (p *Package) Hash() string {
 	return shortHash
 }
 
+// Equals compares two Packages. This may be an expensive operation since it
+// may have to normalize a Package's attribute path, which may require a network
+// call.
 func (p *Package) Equals(other *Package) bool {
 	if p.String() == other.String() {
 		return true

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -974,7 +974,7 @@ func (d *Devbox) InstallablePackages() []*devpkg.Package {
 	})
 }
 
-// InstallableAndPluginPackages returns installable user packages and plugin
+// AllInstallablePackages returns installable user packages and plugin
 // packages concatenated in correct order
 func (d *Devbox) AllInstallablePackages() ([]*devpkg.Package, error) {
 	userPackages := d.InstallablePackages()

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -352,18 +352,18 @@ func (d *Devbox) removePackagesFromProfile(ctx context.Context, pkgs []string) e
 		return err
 	}
 
-	for _, input := range packages {
+	for _, pkg := range packages {
 		index, err := nixprofile.ProfileListIndex(&nixprofile.ProfileListIndexArgs{
 			Lockfile:   d.lockfile,
 			Writer:     d.writer,
-			Input:      input,
+			DevPkg:     pkg,
 			ProfileDir: profileDir,
 		})
 		if err != nil {
 			ux.Ferror(
 				d.writer,
 				"Package %s not found in profile. Skipping.\n",
-				input.Raw,
+				pkg.Raw,
 			)
 			continue
 		}
@@ -415,7 +415,7 @@ func (d *Devbox) pendingPackagesForInstallation(ctx context.Context) ([]*devpkg.
 	}
 
 	pending := []*devpkg.Package{}
-	list, err := nixprofile.ProfileListItems(d.writer, profileDir)
+	items, err := nixprofile.ProfileListItems(d.writer, profileDir)
 	if err != nil {
 		return nil, err
 	}
@@ -428,10 +428,10 @@ func (d *Devbox) pendingPackagesForInstallation(ctx context.Context) ([]*devpkg.
 	}
 	for _, pkg := range packages {
 		_, err := nixprofile.ProfileListIndex(&nixprofile.ProfileListIndexArgs{
-			List:       list,
+			Items:      items,
 			Lockfile:   d.lockfile,
 			Writer:     d.writer,
-			Input:      pkg,
+			DevPkg:     pkg,
 			ProfileDir: profileDir,
 		})
 		if err != nil {
@@ -444,7 +444,7 @@ func (d *Devbox) pendingPackagesForInstallation(ctx context.Context) ([]*devpkg.
 	return pending, nil
 }
 
-// extraPkgsInProfile returns a list of packages that are in the nix profile,
+// extraPackagesInProfile returns a list of packages that are in the nix profile,
 // but are NOT in devbox.json or global devbox.json.
 //
 // NOTE: as an optimization, this implementation assumes that all packages in

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -356,7 +356,7 @@ func (d *Devbox) removePackagesFromProfile(ctx context.Context, pkgs []string) e
 		index, err := nixprofile.ProfileListIndex(&nixprofile.ProfileListIndexArgs{
 			Lockfile:   d.lockfile,
 			Writer:     d.writer,
-			DevPkg:     pkg,
+			Package:    pkg,
 			ProfileDir: profileDir,
 		})
 		if err != nil {
@@ -431,7 +431,7 @@ func (d *Devbox) pendingPackagesForInstallation(ctx context.Context) ([]*devpkg.
 			Items:      items,
 			Lockfile:   d.lockfile,
 			Writer:     d.writer,
-			DevPkg:     pkg,
+			Package:    pkg,
 			ProfileDir: profileDir,
 		})
 		if err != nil {

--- a/internal/nix/nixprofile/item.go
+++ b/internal/nix/nixprofile/item.go
@@ -1,0 +1,67 @@
+package nixprofile
+
+import (
+	"fmt"
+	"strings"
+
+	"go.jetpack.io/devbox/internal/devpkg"
+	"go.jetpack.io/devbox/internal/lock"
+	"go.jetpack.io/devbox/internal/redact"
+)
+
+// NixProfileListItem is a go-struct of a line of printed output from `nix profile list`
+// docs: https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-profile-list.html
+type NixProfileListItem struct {
+	// An integer that can be used to unambiguously identify the package in
+	// invocations of nix profile remove and nix profile upgrade.
+	index int
+
+	// The original ("unlocked") flake reference and output attribute path used at installation time.
+	// NOTE that this can be "#" if the package was added to the nix profile via store path.
+	unlockedReference string
+
+	// The locked flake reference to which the unlocked flake reference was resolved.
+	// NOTE that this can be "#" if the package was added to the nix profile via store path.
+	lockedReference string
+
+	// The store path(s) of the package.
+	nixStorePath []string
+}
+
+// AttributePath parses the package attribute from the NixProfileListItem.lockedReference
+//
+// For example:
+// if NixProfileListItem.lockedReference = github:NixOS/nixpkgs/52e3e80afff4b16ccb7c52e9f0f5220552f03d04#legacyPackages.x86_64-darwin.go_1_19
+// then AttributePath = legacyPackages.x86_64-darwin.go_1_19
+func (item *NixProfileListItem) AttributePath() (string, error) {
+	// lockedReference example:
+	// github:NixOS/nixpkgs/52e3e80afff4b16ccb7c52e9f0f5220552f03d04#legacyPackages.x86_64-darwin.go_1_19
+
+	// AttributePath example:
+	// legacyPackages.x86_64.go_1_19
+	_ /*nixpkgs*/, attrPath, found := strings.Cut(item.lockedReference, "#")
+	if !found {
+		return "", redact.Errorf(
+			"expected to find # in lockedReference: %s from NixProfileListItem: %s",
+			redact.Safe(item.lockedReference),
+			item,
+		)
+	}
+	return attrPath, nil
+}
+
+// ToPackage constructs a nix.Package using the unlocked reference.
+// TODO: this doesn't handle well the case where item.unlockedReference == "#"
+func (item *NixProfileListItem) ToPackage(locker lock.Locker) *devpkg.Package {
+	return devpkg.PackageFromString(item.unlockedReference, locker)
+}
+
+// String serializes the NixProfileListItem back into the format printed by `nix profile list`
+func (item *NixProfileListItem) String() string {
+	return fmt.Sprintf("%d %s %s %s",
+		item.index,
+		item.unlockedReference,
+		item.lockedReference,
+		item.nixStorePath,
+	)
+}

--- a/internal/nix/nixprofile/item.go
+++ b/internal/nix/nixprofile/item.go
@@ -25,7 +25,7 @@ type NixProfileListItem struct {
 	lockedReference string
 
 	// The store path(s) of the package.
-	nixStorePath []string
+	nixStorePath string // TODO: change to slice
 }
 
 // AttributePath parses the package attribute from the NixProfileListItem.lockedReference

--- a/internal/nix/nixprofile/profile.go
+++ b/internal/nix/nixprofile/profile.go
@@ -25,7 +25,7 @@ import (
 func ProfileListItems(
 	writer io.Writer,
 	profileDir string,
-) (map[string]*NixProfileListItem, error) {
+) ([]*NixProfileListItem, error) {
 
 	output, err := nix.ProfileList(writer, profileDir, true /*useJSON*/)
 	if err == nil {
@@ -47,23 +47,28 @@ func ProfileListItems(
 			return nil, err
 		}
 
-		result := map[string]*NixProfileListItem{}
+		items := []*NixProfileListItem{}
 		for index, element := range structOutput.Elements {
-			// We use the unlocked reference as the key, since that is the format
-			// used for the `nix profile list` output of older nix versions
-			// (pre 2.17), which our code is designed to support.
-			unlockedReference := element.OriginalURL + "#" + element.AttrPath
-			result[unlockedReference] = &NixProfileListItem{
+			items = append(items, &NixProfileListItem{
 				index:             index,
-				unlockedReference: unlockedReference,
+				unlockedReference: element.OriginalURL + "#" + element.AttrPath,
 				lockedReference:   element.URL + "#" + element.AttrPath,
-				nixStorePath:      element.StorePaths[0],
-			}
+				nixStorePath:      element.StorePaths[0], // TODO: add all paths
+			})
 		}
-		return result, nil
+		return items, nil
+	} else { // fallback to legacy profile list
+		// NOTE: maybe we should check the nix version first, instead of falling back on _any_ error.
+		return profileListLegacy(writer, profileDir)
 	}
+}
 
-	output, err = nix.ProfileList(writer, profileDir, false /*useJSON*/)
+// profileListLegacy lists the items in a nix profile before nix 2.17.0 introduced --json.
+func profileListLegacy(
+	writer io.Writer,
+	profileDir string,
+) ([]*NixProfileListItem, error) {
+	output, err := nix.ProfileList(writer, profileDir, false /*useJSON*/)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -77,7 +82,7 @@ func ProfileListItems(
 	// 0 github:NixOS/nixpkgs/52e3e80afff4b16ccb7c52e9f0f5220552f03d04#legacyPackages.x86_64-darwin.go_1_19 github:NixOS/nixpkgs/52e3e80afff4b16ccb7c52e9f0f5220552f03d04#legacyPackages.x86_64-darwin.go_1_19 /nix/store/w0lyimyyxxfl3gw40n46rpn1yjrl3q85-go-1.19.3
 	// 1 github:NixOS/nixpkgs/52e3e80afff4b16ccb7c52e9f0f5220552f03d04#legacyPackages.x86_64-darwin.vim github:NixOS/nixpkgs/52e3e80afff4b16ccb7c52e9f0f5220552f03d04#legacyPackages.x86_64-darwin.vim /nix/store/gapbqxx1d49077jk8ay38z11wgr12p23-vim-9.0.0609
 
-	items := map[string]*NixProfileListItem{}
+	items := []*NixProfileListItem{}
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -88,83 +93,75 @@ func ProfileListItems(
 			return nil, err
 		}
 
-		items[item.unlockedReference] = item
+		items = append(items, item)
 	}
 	return items, nil
 }
 
 type ProfileListIndexArgs struct {
-	// For performance you can reuse the same list in multiple operations if you
+	// For performance, you can reuse the same list in multiple operations if you
 	// are confident index has not changed.
-	List       map[string]*NixProfileListItem
+	Items      []*NixProfileListItem
 	Lockfile   *lock.File
 	Writer     io.Writer
-	Input      *devpkg.Package
+	DevPkg     *devpkg.Package
 	ProfileDir string
 }
 
+// ProfileListIndex returns the index of args.DevPkg in the nix profile specified by args.ProfileDir,
+// or -1 if it's not found. Callers can pass in args.Items to avoid having to call `nix-profile list` again.
 func ProfileListIndex(args *ProfileListIndexArgs) (int, error) {
 	var err error
-	list := args.List
-	if list == nil {
-		list, err = ProfileListItems(args.Writer, args.ProfileDir)
+	items := args.Items
+	if items == nil {
+		items, err = ProfileListItems(args.Writer, args.ProfileDir)
 		if err != nil {
 			return -1, err
 		}
 	}
 
-	inCache, err := args.Input.IsInBinaryCache()
+	inCache, err := args.DevPkg.IsInBinaryCache()
 	if err != nil {
 		return -1, err
 	}
 	if inCache {
-		pathInStore, err := args.Input.Installable()
+		// Packages in cache are added by store path, which means we only need to check
+		// for store path equality to find it.
+		pathInStore, err := args.DevPkg.Installable()
 		if err != nil {
-			return -1, err
+			return -1, errors.Wrapf(err, "failed to get installable for %s", args.DevPkg.String())
 		}
-		for _, item := range list {
+		for _, item := range items {
 			if pathInStore == item.nixStorePath {
 				return item.index, nil
 			}
 		}
+		return -1, errors.Wrap(nix.ErrPackageNotFound, args.DevPkg.String())
 	}
-	// else: fallback to checking if the Input matches an item's unlockedReference
 
-	// This is an optimization for happy path. A resolved devbox package
-	// should match the unlockedReference of an existing profile item.
-	ref, err := args.Input.NormalizedDevboxPackageReference()
+	// else: check if the DevPkg matches an item's unlockedReference.
+	// This is an optimization for happy path. A resolved devbox package *which was added by
+	// flake reference* (not by store path) should match the unlockedReference of an existing
+	// profile item.
+	ref, err := args.DevPkg.NormalizedDevboxPackageReference()
 	if err != nil {
 		return -1, err
 	}
-	if item, found := list[ref]; found {
-		return item.index, nil
-	}
-
-	for _, item := range list {
-		existing := item.ToPackage(args.Lockfile)
-
-		if args.Input.Equals(existing) {
+	for _, item := range items {
+		if ref == item.unlockedReference {
 			return item.index, nil
 		}
 	}
-	return -1, errors.Wrap(nix.ErrPackageNotFound, args.Input.String())
-}
 
-// NixProfileListItem is a go-struct of a line of printed output from `nix profile list`
-// docs: https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-profile-list.html
-type NixProfileListItem struct {
-	// An integer that can be used to unambiguously identify the package in
-	// invocations of nix profile remove and nix profile upgrade.
-	index int
+	// Still not found? Check for full pkg equality (may be expensive).
+	for _, item := range items {
+		existing := item.ToPackage(args.Lockfile)
 
-	// The original ("unlocked") flake reference and output attribute path used at installation time.
-	unlockedReference string
-
-	// The locked flake reference to which the unlocked flake reference was resolved.
-	lockedReference string
-
-	// The store path(s) of the package.
-	nixStorePath string
+		if args.DevPkg.Equals(existing) {
+			return item.index, nil
+		}
+	}
+	return -1, errors.Wrap(nix.ErrPackageNotFound, args.DevPkg.String())
 }
 
 // parseNixProfileListItem reads each line of output (from `nix profile list`) and converts
@@ -203,43 +200,6 @@ func parseNixProfileListItem(line string) (*NixProfileListItem, error) {
 		lockedReference:   lockedReference,
 		nixStorePath:      nixStorePath,
 	}, nil
-}
-
-// AttributePath parses the package attribute from the NixProfileListItem.lockedReference
-//
-// For example:
-// if NixProfileListItem.lockedReference = github:NixOS/nixpkgs/52e3e80afff4b16ccb7c52e9f0f5220552f03d04#legacyPackages.x86_64-darwin.go_1_19
-// then AttributePath = legacyPackages.x86_64-darwin.go_1_19
-func (item *NixProfileListItem) AttributePath() (string, error) {
-	// lockedReference example:
-	// github:NixOS/nixpkgs/52e3e80afff4b16ccb7c52e9f0f5220552f03d04#legacyPackages.x86_64-darwin.go_1_19
-
-	// AttributePath example:
-	// legacyPackages.x86_64.go_1_19
-	_ /*nixpkgs*/, attrPath, found := strings.Cut(item.lockedReference, "#")
-	if !found {
-		return "", redact.Errorf(
-			"expected to find # in lockedReference: %s from NixProfileListItem: %s",
-			redact.Safe(item.lockedReference),
-			item,
-		)
-	}
-	return attrPath, nil
-}
-
-// ToPackage constructs a nix.Package using the unlocked reference
-func (item *NixProfileListItem) ToPackage(locker lock.Locker) *devpkg.Package {
-	return devpkg.PackageFromString(item.unlockedReference, locker)
-}
-
-// String serializes the NixProfileListItem back into the format printed by `nix profile list`
-func (item *NixProfileListItem) String() string {
-	return fmt.Sprintf("%d %s %s %s",
-		item.index,
-		item.unlockedReference,
-		item.lockedReference,
-		item.nixStorePath,
-	)
 }
 
 type ProfileInstallArgs struct {

--- a/internal/nix/nixprofile/upgrade.go
+++ b/internal/nix/nixprofile/upgrade.go
@@ -16,7 +16,7 @@ func ProfileUpgrade(ProfileDir string, pkg *devpkg.Package, lock *lock.File) err
 		&ProfileListIndexArgs{
 			Lockfile:   lock,
 			Writer:     os.Stderr,
-			Input:      pkg,
+			DevPkg:     pkg,
 			ProfileDir: ProfileDir,
 		},
 	)

--- a/internal/nix/nixprofile/upgrade.go
+++ b/internal/nix/nixprofile/upgrade.go
@@ -16,7 +16,7 @@ func ProfileUpgrade(ProfileDir string, pkg *devpkg.Package, lock *lock.File) err
 		&ProfileListIndexArgs{
 			Lockfile:   lock,
 			Writer:     os.Stderr,
-			DevPkg:     pkg,
+			Package:    pkg,
 			ProfileDir: ProfileDir,
 		},
 	)


### PR DESCRIPTION
## Summary
When a package is added by store path, then when we query `nix profile list`, it'll look like this:
```
> nix profile list --profile .devbox/nix/profile/default
Index:              0
Store paths:        /nix/store/yjkac3v6c1v129fph0gvy9c7ndnx738b-cowsay-3.04
```

instead of this:
```
> nix profile list --profile .devbox/nix/profile/default
Index:              0
Flake attribute:    legacyPackages.x86_64-darwin.hello
Original flake URL: github:NixOS/nixpkgs/3007746b3f5bfcb49e102b517bca891822a41b31
Locked flake URL:   github:NixOS/nixpkgs/3007746b3f5bfcb49e102b517bca891822a41b31
Store paths:        /nix/store/gyh1bri77vlcs1pwxyg4x3z06aql2c6p-hello-2.12.1
```

Thus, when we read the profile items and try to build a map out of the item's unlockedRef, we were always ending up with a map of size 1.

To fix, I changed the map to a slice, and changed the callsites to handle the slice instead.

I made a few other code organization changes that are no-ops.

## How was it tested?
Tested by calling `devbox install` and inspecting the profile with `nix profile list`, with and without the rm-nixpkgs feature enabled. I attempted to add unit tests but it's not as easy as I had thought.