### PR TITLE
[bug fix] do not check version for devbox log, and for commands whose prefix is in the skip-list

### DIFF
--- a/internal/vercheck/vercheck.go
+++ b/internal/vercheck/vercheck.go
@@ -69,7 +69,11 @@ func CheckVersion(w io.Writer, commandPath string) {
 		return
 	}
 
-	if lo.Contains(commandSkipList, commandPath) {
+	hasSkipPrefix := lo.ContainsBy(
+		commandSkipList,
+		func(skipPath string) bool { return strings.HasPrefix(commandPath, skipPath) },
+	)
+	if hasSkipPrefix {
 		return
 	}
 

--- a/internal/vercheck/vercheck.go
+++ b/internal/vercheck/vercheck.go
@@ -48,6 +48,7 @@ var commandSkipList = []string{
 	"devbox global shellenv",
 	"devbox shellenv",
 	"devbox version update",
+	"devbox log",
 }
 
 // CheckVersion checks the launcher and binary versions and prints a notice if


### PR DESCRIPTION
## Summary

In the generated shellrc file, we invoke `devbox log` to track shell start times.
```
> git grep "devbox log"
internal/impl/shellrc.tmpl:devbox log shell-ready {{ .ShellStartTime }}
internal/impl/shellrc.tmpl:devbox log shell-interactive {{ .ShellStartTime }}
internal/impl/shellrc_fish.tmpl:devbox log shell-ready {{ .ShellStartTime }}
internal/impl/shellrc_fish.tmpl:devbox log shell-interactive {{ .ShellStartTime }}
```

We should skip checking if devbox version is up-to-date for this case.

Also, made a change to check if the commandPath matches the prefix of the commandSkipList items. This will #1420 

## How was it tested?

Did not test. It compiles.