### PR TITLE
[cli test] use action to maximize disk space

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -99,6 +99,11 @@ jobs:
     steps:
       - name: Maximize build disk space
         uses: easimon/maximize-build-space@v8
+        with:
+          root-reserve-mb: 10000
+          remove-dotnet: true
+          remove-android: true
+          remove-haskell: true
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -97,6 +97,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && 37 || 25 }}
     steps:
+      - name: Maximize build disk space
+        uses: easimon/maximize-build-space@v8
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -100,7 +100,7 @@ jobs:
       - name: Maximize build disk space
         uses: easimon/maximize-build-space@v8
         with:
-          root-reserve-mb: 10000
+          root-reserve-mb: 20000
           remove-dotnet: true
           remove-android: true
           remove-haskell: true

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -101,9 +101,11 @@ jobs:
         uses: easimon/maximize-build-space@v8
         with:
           root-reserve-mb: 20000
+          temp-reserve-mb: 2000
           remove-dotnet: true
           remove-android: true
           remove-haskell: true
+          remove-codeql: true
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -100,7 +100,7 @@ jobs:
       - name: Maximize build disk space
         uses: easimon/maximize-build-space@v8
         with:
-          root-reserve-mb: 20000
+          root-reserve-mb: 30000
           temp-reserve-mb: 2000
           remove-dotnet: true
           remove-android: true


### PR DESCRIPTION
## Summary

The default settings claim to get us 7-8GB of additional space. This should help with `cli-tests` erroring with `no space left on device`.

https://github.com/marketplace/actions/maximize-build-disk-space

## How was it tested?

will see if tests pass, and how long it takes. 