### PR TITLE
Give Github Actions instance more disk

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -97,6 +97,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && 37 || 25 }}
     steps:
+      - name: Maximize build disk space
+        uses: easimon/maximize-build-space@v8
+        with:
+          root-reserve-mb: 40000
+          temp-reserve-mb: 10000
+          remove-dotnet: true
+          remove-android: true
+          remove-haskell: true
+          remove-codeql: true
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:


### PR DESCRIPTION
## Summary
Actions have been failing with `no space left on device` for a few days now.

This change adds the https://github.com/marketplace/actions/maximize-build-disk-space action to leave more space available for the actual job, per @savil 's suggestion.

To choose the parameters to use, I looked at [Savil's PR's](https://github.com/jetpack-io/devbox/pull/1425) runs, for example:
https://github.com/jetpack-io/devbox/actions/runs/6005813206/job/16289263569

And noticed that before any changes:
```
Available storage:
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        84G   62G   22G  74% /          <-------- we start out with 22G and we run out
tmpfs           3.4G  172K  3.4G   1% /dev/shm
tmpfs           1.4G  1.1M  1.4G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb15      105M  6.1M   99M   6% /boot/efi
/dev/sda1        14G  4.1G  9.0G  31% /mnt       <-------- temp space is much higher than the action's default of 100mb.
tmpfs           694M   12K  694M   1% /run/user/1001
```

After the maximize space action runs (with these params):
```
Available storage:
Filesystem                   Size  Used Avail Use% Mounted on
/dev/root                     84G   45G   40G  54% /           <----- ~doubled it to 40G
tmpfs                        3.4G  172K  3.4G   1% /dev/shm
tmpfs                        1.4G  1.1M  1.4G   1% /run
tmpfs                        5.0M     0  5.0M   0% /run/lock
/dev/sdb15                   105M  6.1M   99M   6% /boot/efi
/dev/sda1                     14G  3.2G  9.8G  25% /mnt        <----- kept it the same at 10G
tmpfs                        694M   12K  694M   1% /run/user/1001
/dev/mapper/buildvg-buildlv  4.3G   24K  4.3G   1% /home/runner/work/devbox/devbox
```

## How was it tested?
Github Actions