### PR TITLE
[shell] Support zim (a zsh framework)

### DIFF
--- a/internal/impl/shell.go
+++ b/internal/impl/shell.go
@@ -358,6 +358,11 @@ func (s *DevboxShell) linkShellStartupFiles(shellSettingsDir string) {
 	if s.name == shZsh {
 		// Useful explanation of zsh startup files: https://zsh.sourceforge.io/FAQ/zshfaq03.html#l20
 		filenames := []string{".zshenv", ".zprofile", ".zlogin"}
+
+		// zim framework
+		// https://zimfw.sh/docs/install/
+		filenames = append(filenames, ".zimrc")
+
 		for _, filename := range filenames {
 			fileOld := filepath.Join(filepath.Dir(s.userShellrcPath), filename)
 			_, err := os.Stat(fileOld)


### PR DESCRIPTION
## Summary

Zim is a framework for zsh. It relies on a `.zimrc` file for its settings.
If this .zimrc file is not present in `ZDOTDIR/.zimrc`, then users
get some ugly error messages (and zim itself doesn't work).

Devbox generates a temp-dir for the new `devbox shell`'s configuration files
like .zshrc, or .bashrc, or fish.config. 

For zsh:
1. the ZDOTDIR is set to this temp dir.
2. we already symlink some other files like .zprofile. 
3. In this PR, we also symlink the .zimrc.

Fixes #1426
Note: the task title asserts that the problem is starship. However, the cause
is that zim is not supported. For good measure, in my testing below I have 
enabled starship and it works fine after the fix.

## How was it tested?

setup:
1. set zsh as the login shell
2. install zim using the curl install command.

BEFORE:
`devbox shell` output would spout the error messages from #1426

AFTER:
`devbox shell` starts without any error messages.

