### PR TITLE
[generate] Updated dockerfile template to use devbox image

### DIFF
--- a/internal/impl/generate/tmpl/devcontainerDockerfile.tmpl
+++ b/internal/impl/generate/tmpl/devcontainerDockerfile.tmpl
@@ -1,35 +1,8 @@
-FROM debian:stable-slim
-
-# Step 1: Installing dependencies
-RUN apt-get update
-RUN apt-get -y install bash binutils git{{if .IsDevcontainer}} gnupg2{{- end}} xz-utils wget sudo
-
-{{- if not .RootUser }}
-
-# Step 1.5: Setting up devbox user
-ENV DEVBOX_USER=devbox
-RUN adduser $DEVBOX_USER
-RUN usermod -aG sudo $DEVBOX_USER
-RUN echo "devbox ALL=(ALL:ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/$DEVBOX_USER
-USER $DEVBOX_USER
+{{- if .RootUser }}FROM jetpackio/devbox-root-user:latest
+{{- else }}FROM jetpackio/devbox:latest
 {{- end}}
 
-# Step 2: Installing Nix
-RUN wget --output-document=/dev/stdout https://nixos.org/nix/install | sh -s -- --{{if not .RootUser}}no-{{- end}}daemon
-RUN . ~/.nix-profile/etc/profile.d/nix.sh
-{{ if .RootUser }}
-ENV PATH="/root/.nix-profile/bin:$PATH"
-{{ else }}
-ENV PATH="/home/${DEVBOX_USER}/.nix-profile/bin:$PATH"
-{{- end}}
-
-# Step 3: Installing devbox
-RUN wget --quiet --output-document=/dev/stdout https://get.jetpack.io/devbox   | bash -s -- -f
-{{- if not .RootUser }}
-RUN chown -R "${DEVBOX_USER}:${DEVBOX_USER}" /usr/local/bin/devbox
-{{- end}}
-
-# Step 4: Installing your devbox project
+# Installing your devbox project
 WORKDIR /code
 COPY devbox.json devbox.json
 COPY devbox.lock devbox.lock


### PR DESCRIPTION
## Summary
Publishing a docker image for devbox, makes it easier to use an image with devbox installed and configured. So we can use it in our generated dockerfiles for `generate dockerfile` and `generate devcontainer` commands. 

## How was it tested?
`devbox generate dockerfile`
or `devbox generate dockerfile --root-user`
`devbox generate devcontainer`
or `devbox generate devcontainer --root-user`