### PR TITLE
docs: devbox remove command not exist, only rm

### DIFF
--- a/docs/app/docs/devbox_global.md
+++ b/docs/app/docs/devbox_global.md
@@ -50,10 +50,10 @@ devbox global list
 To remove a global package, use:
 
 ```bash
-devbox global remove ripgrep
+devbox global rm ripgrep
 
 # Output:
-ripgrep was removed
+removing 'github:NixOS/nixpkgs/ripgrep'
 ```
 
 ## Using Fleek with Devbox Global


### PR DESCRIPTION
## Summary

The correct name of flag - `rm` 

## How was it tested?
```sh
$ devbox global remove nodejs

Manage global devbox packages

Usage:
  devbox global [command]

Available Commands:
  add         Add a new package to your devbox
  install     Install all packages mentioned in devbox.json
  list        List global packages
  path        Show path to [global] devbox config
  pull        Pull a config from a file or URL
  push        Push a [global] config. Leave empty to use jetpack cloud. Can be a git repo for self storage.
  rm          Remove a package from your devbox
  run         Run a script or command in a shell with access to your packages
  services    Interact with devbox services
  shellenv    Print shell commands that add Devbox packages to your PATH
  update      Update packages in your devbox

Flags:
  -h, --help   help for global

Global Flags:
  -q, --quiet   suppresses logs

Use "devbox global [command] --help" for more information about a command.
```