### PR TITLE
Use `envsubst` in our NGINX plugin

### DIFF
--- a/examples/servers/nginx/devbox.d/nginx/nginx.template
+++ b/examples/servers/nginx/devbox.d/nginx/nginx.template
@@ -1,10 +1,10 @@
 events {}
 http{
 server {
-         listen       $NGINX_WEB_PORT;
-         listen       [::]:$NGINX_WEB_PORT;
-         server_name  localhost;
-         root         ../../../devbox.d/web;
+         listen       $WEB_PORT;
+         listen       [::]:$WEB_PORT;
+         server_name  $WEB_SERVER_NAME;
+         root         $WEB_ROOT;
 
          error_log error.log error;
          access_log access.log;

--- a/examples/servers/nginx/devbox.d/nginx/nginx.template
+++ b/examples/servers/nginx/devbox.d/nginx/nginx.template
@@ -1,0 +1,20 @@
+events {}
+http{
+server {
+         listen       $NGINX_WEB_PORT;
+         listen       [::]:$NGINX_WEB_PORT;
+         server_name  localhost;
+         root         ../../../devbox.d/web;
+
+         error_log error.log error;
+         access_log access.log;
+         client_body_temp_path temp/client_body;
+         proxy_temp_path temp/proxy;
+         fastcgi_temp_path temp/fastcgi;
+         uwsgi_temp_path temp/uwsgi;
+         scgi_temp_path temp/scgi;
+
+         index index.html;
+         server_tokens off;
+    }
+}

--- a/examples/servers/nginx/devbox.d/nginx/nginx.template
+++ b/examples/servers/nginx/devbox.d/nginx/nginx.template
@@ -1,10 +1,10 @@
 events {}
 http{
 server {
-         listen       $WEB_PORT;
-         listen       [::]:$WEB_PORT;
-         server_name  $WEB_SERVER_NAME;
-         root         $WEB_ROOT;
+         listen       $NGINX_WEB_PORT;
+         listen       [::]:$NGINX_WEB_PORT;
+         server_name  $NGINX_WEB_SERVER_NAME;
+         root         $NGINX_WEB_ROOT;
 
          error_log error.log error;
          access_log access.log;

--- a/examples/servers/nginx/devbox.json
+++ b/examples/servers/nginx/devbox.json
@@ -2,7 +2,5 @@
   "packages": [
     "nginx@latest"
   ],
-  "shell": {
-    "init_hook": null
-  }
+  "shell": {}
 }

--- a/examples/servers/nginx/devbox.lock
+++ b/examples/servers/nginx/devbox.lock
@@ -2,9 +2,10 @@
   "lockfile_version": "1",
   "packages": {
     "nginx@latest": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "plugin_version": "0.0.1",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#nginx",
+      "last_modified": "2023-07-06T12:20:10Z",
+      "plugin_version": "0.0.3",
+      "resolved": "github:NixOS/nixpkgs/5daaa32204e9c46b05cd709218b7ba733d07e80c#nginx",
+      "source": "devbox-search",
       "version": "1.24.0"
     }
   }

--- a/examples/servers/nginx/devbox.lock
+++ b/examples/servers/nginx/devbox.lock
@@ -2,9 +2,9 @@
   "lockfile_version": "1",
   "packages": {
     "nginx@latest": {
-      "last_modified": "2023-07-06T12:20:10Z",
+      "last_modified": "2023-08-30T00:25:28Z",
       "plugin_version": "0.0.3",
-      "resolved": "github:NixOS/nixpkgs/5daaa32204e9c46b05cd709218b7ba733d07e80c#nginx",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#nginx",
       "source": "devbox-search",
       "version": "1.24.0"
     }

--- a/examples/stacks/lepp-stack/devbox.d/nginx/nginx.template
+++ b/examples/stacks/lepp-stack/devbox.d/nginx/nginx.template
@@ -1,10 +1,10 @@
 events {}
 http{
 server {
-         listen       $NGINX_WEB_PORT;
-         listen       [::]:$NGINX_WEB_PORT;
-         server_name  localhost;
-         root         ../../../devbox.d/web;
+         listen       $WEB_PORT;
+         listen       [::]:$WEB_PORT;
+         server_name  $WEB_SERVER_NAME;
+         root         $WEB_ROOT;
 
          error_log error.log error;
          access_log access.log;

--- a/examples/stacks/lepp-stack/devbox.d/nginx/nginx.template
+++ b/examples/stacks/lepp-stack/devbox.d/nginx/nginx.template
@@ -1,10 +1,10 @@
 events {}
 http{
 server {
-         listen       $WEB_PORT;
-         listen       [::]:$WEB_PORT;
-         server_name  $WEB_SERVER_NAME;
-         root         $WEB_ROOT;
+         listen       $NGINX_WEB_PORT;
+         listen       [::]:$NGINX_WEB_PORT;
+         server_name  $NGINX_WEB_SERVER_NAME;
+         root         $NGINX_WEB_ROOT;
 
          error_log error.log error;
          access_log access.log;

--- a/examples/stacks/lepp-stack/devbox.d/nginx/nginx.template
+++ b/examples/stacks/lepp-stack/devbox.d/nginx/nginx.template
@@ -1,8 +1,8 @@
 events {}
 http{
 server {
-         listen       8089;
-         listen       [::]:8089;
+         listen       $NGINX_WEB_PORT;
+         listen       [::]:$NGINX_WEB_PORT;
          server_name  localhost;
          root         ../../../devbox.d/web;
 

--- a/examples/stacks/lepp-stack/devbox.json
+++ b/examples/stacks/lepp-stack/devbox.json
@@ -1,34 +1,35 @@
 {
-    "packages": [
-        "curl@8.0",
-        "postgresql@14",
-        "php@8.1",
-        "php81Extensions.pgsql@latest",
-        "nginx@1.24"
-    ],
-    "env": {
-        "PGPORT": "5433"
-    },
-    "shell": {
-        "scripts": {
-            "init_db": "initdb",
-            "create_db": [
-                "dropdb --if-exists devbox_lepp",
-                "createdb devbox_lepp",
-                "psql devbox_lepp < setup_postgres_db.sql"
-            ],
-            "run_test": [
-                "mkdir -p /tmp/devbox/lepp",
-                "export PGHOST=/tmp/devbox/lepp",
-                "initdb",
-                "devbox services up -b",
-                "echo 'sleep 2 second for the postgres server to initialize.' && sleep 2",
-                "dropdb --if-exists devbox_lepp",
-                "createdb devbox_lepp",
-                "psql devbox_lepp < setup_postgres_db.sql",
-                "curl localhost:8089",
-                "devbox services stop"
-            ]
-        }
+  "packages": [
+    "curl@8.0",
+    "postgresql@14",
+    "php@8.1",
+    "php81Extensions.pgsql@latest",
+    "nginx@1.24"
+  ],
+  "env": {
+    "NGINX_WEB_PORT": "8089",
+    "PGPORT": "5433"
+  },
+  "shell": {
+    "scripts": {
+      "create_db": [
+        "dropdb --if-exists devbox_lepp",
+        "createdb devbox_lepp",
+        "psql devbox_lepp < setup_postgres_db.sql"
+      ],
+      "init_db": "initdb",
+      "run_test": [
+        "mkdir -p /tmp/devbox/lepp",
+        "export PGHOST=/tmp/devbox/lepp",
+        "initdb",
+        "devbox services up -b",
+        "echo 'sleep 2 second for the postgres server to initialize.' && sleep 2",
+        "dropdb --if-exists devbox_lepp",
+        "createdb devbox_lepp",
+        "psql devbox_lepp < setup_postgres_db.sql",
+        "curl localhost:$NGINX_WEB_PORT",
+        "devbox services stop"
+      ]
     }
+  }
 }

--- a/examples/stacks/lepp-stack/devbox.json
+++ b/examples/stacks/lepp-stack/devbox.json
@@ -7,7 +7,7 @@
     "nginx@1.24"
   ],
   "env": {
-    "NGINX_WEB_PORT": "8089",
+    "WEB_PORT": "8089",
     "PGPORT": "5433"
   },
   "shell": {
@@ -27,7 +27,7 @@
         "dropdb --if-exists devbox_lepp",
         "createdb devbox_lepp",
         "psql devbox_lepp < setup_postgres_db.sql",
-        "curl localhost:$NGINX_WEB_PORT",
+        "curl localhost:$WEB_PORT",
         "devbox services stop"
       ]
     }

--- a/examples/stacks/lepp-stack/devbox.json
+++ b/examples/stacks/lepp-stack/devbox.json
@@ -7,7 +7,7 @@
     "nginx@1.24"
   ],
   "env": {
-    "WEB_PORT": "8089",
+    "NGINX_WEB_PORT": "8089",
     "PGPORT": "5433"
   },
   "shell": {
@@ -27,7 +27,7 @@
         "dropdb --if-exists devbox_lepp",
         "createdb devbox_lepp",
         "psql devbox_lepp < setup_postgres_db.sql",
-        "curl localhost:$WEB_PORT",
+        "curl localhost:$NGINX_WEB_PORT",
         "devbox services stop"
       ]
     }

--- a/examples/stacks/lepp-stack/devbox.lock
+++ b/examples/stacks/lepp-stack/devbox.lock
@@ -7,9 +7,10 @@
       "version": "8.0.1"
     },
     "nginx@1.24": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "plugin_version": "0.0.1",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#nginx",
+      "last_modified": "2023-07-06T12:20:10Z",
+      "plugin_version": "0.0.3",
+      "resolved": "github:NixOS/nixpkgs/5daaa32204e9c46b05cd709218b7ba733d07e80c#nginx",
+      "source": "devbox-search",
       "version": "1.24.0"
     },
     "php81Extensions.pgsql@latest": {
@@ -19,13 +20,13 @@
     },
     "php@8.1": {
       "last_modified": "2023-05-01T16:53:22Z",
-      "plugin_version": "0.0.1",
+      "plugin_version": "0.0.2",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#php",
       "version": "8.1.18"
     },
     "postgresql@14": {
       "last_modified": "2023-05-01T16:53:22Z",
-      "plugin_version": "0.0.1",
+      "plugin_version": "0.0.2",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#postgresql",
       "version": "14.7"
     }

--- a/plugins/nginx.json
+++ b/plugins/nginx.json
@@ -1,7 +1,7 @@
 {
   "name": "nginx",
   "version": "0.0.3",
-  "readme": "nginx can be configured with env variables\n\nTo customize:\n* Use $NGINX_CONFDIR to change the configuration directory\n* Use $NGINX_LOGDIR to change the log directory\n* Use $NGINX_PIDDIR to change the pid directory\n* Use $NGINX_RUNDIR to change the run directory\n* Use $NGINX_SITESDIR to change the sites directory\n* Use $NGINX_TMPDIR to change the tmp directory. Use $NGINX_USER to change the user\n* Use $NGINX_GROUP to customize.",
+  "readme": "nginx can be configured with env variables\n\nTo customize:\n* Use $NGINX_CONFDIR to change the configuration directory\n* Use $NGINX_TMPDIR to change the tmp directory. Use $NGINX_USER to change the user\n* Use $NGINX_WEB_PORT to change the port NGINX runs on. \n Note: This plugin uses envsubst when running `devbox services` to generate the nginx.conf file from the nginx.template file. To customize the nginx.conf file, edit the nginx.template file.\n",
   "__packages": ["envsubst"],
   "env": {
     "NGINX_CONFDIR": "{{ .DevboxDir }}",

--- a/plugins/nginx.json
+++ b/plugins/nginx.json
@@ -4,11 +4,13 @@
   "readme": "nginx can be configured with env variables\n\nTo customize:\n* Use $NGINX_CONFDIR to change the configuration directory\n* Use $NGINX_TMPDIR to change the tmp directory. Use $NGINX_USER to change the user\n* Use $NGINX_WEB_PORT to change the port NGINX runs on. \n Note: This plugin uses envsubst when running `devbox services` to generate the nginx.conf file from the nginx.template file. To customize the nginx.conf file, edit the nginx.template file.\n",
   "__packages": ["envsubst"],
   "env": {
-    "NGINX_CONFDIR": "{{ .DevboxDir }}",
     "NGINX_CONF": "{{ .DevboxDir }}/nginx.conf",
+    "NGINX_CONFDIR": "{{ .DevboxDir }}",
     "NGINX_PATH_PREFIX": "{{ .Virtenv }}",
     "NGINX_TMPDIR": "{{ .Virtenv }}/temp",
-    "NGINX_WEB_PORT": "8081"
+    "WEB_PORT": "8081",
+    "WEB_ROOT": "../../../devbox.d/web",
+    "WEB_SERVER_NAME": "localhost"
   },
   "create_files": {
     "{{ .Virtenv }}/temp": "",

--- a/plugins/nginx.json
+++ b/plugins/nginx.json
@@ -2,7 +2,7 @@
   "name": "nginx",
   "version": "0.0.3",
   "readme": "nginx can be configured with env variables\n\nTo customize:\n* Use $NGINX_CONFDIR to change the configuration directory\n* Use $NGINX_TMPDIR to change the tmp directory. Use $NGINX_USER to change the user\n* Use $NGINX_WEB_PORT to change the port NGINX runs on. \n Note: This plugin uses envsubst when running `devbox services` to generate the nginx.conf file from the nginx.template file. To customize the nginx.conf file, edit the nginx.template file.\n",
-  "__packages": ["envsubst"],
+  "__packages": ["envsubst@latest"],
   "env": {
     "NGINX_CONF": "{{ .DevboxDir }}/nginx.conf",
     "NGINX_CONFDIR": "{{ .DevboxDir }}",

--- a/plugins/nginx.json
+++ b/plugins/nginx.json
@@ -1,15 +1,19 @@
 {
   "name": "nginx",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "readme": "nginx can be configured with env variables\n\nTo customize:\n* Use $NGINX_CONFDIR to change the configuration directory\n* Use $NGINX_LOGDIR to change the log directory\n* Use $NGINX_PIDDIR to change the pid directory\n* Use $NGINX_RUNDIR to change the run directory\n* Use $NGINX_SITESDIR to change the sites directory\n* Use $NGINX_TMPDIR to change the tmp directory. Use $NGINX_USER to change the user\n* Use $NGINX_GROUP to customize.",
+  "__packages": ["envsubst"],
   "env": {
-    "NGINX_CONFDIR": "{{ .DevboxDir }}/nginx.conf",
+    "NGINX_CONFDIR": "{{ .DevboxDir }}",
+    "NGINX_CONF": "{{ .DevboxDir }}/nginx.conf",
     "NGINX_PATH_PREFIX": "{{ .Virtenv }}",
-    "NGINX_TMPDIR": "{{ .Virtenv }}/temp"
+    "NGINX_TMPDIR": "{{ .Virtenv }}/temp",
+    "NGINX_WEB_PORT": "8081"
   },
   "create_files": {
     "{{ .Virtenv }}/temp": "",
     "{{ .Virtenv }}/process-compose.yaml": "nginx/process-compose.yaml",
+    "{{ .DevboxDir }}/nginx.template": "nginx/nginx.template",
     "{{ .DevboxDir }}/nginx.conf": "nginx/nginx.conf",
     "{{ .DevboxDir }}/fastcgi.conf": "nginx/fastcgi.conf",
     "{{ .DevboxDirRoot }}/web/index.html": "web/index.html"

--- a/plugins/nginx.json
+++ b/plugins/nginx.json
@@ -8,9 +8,9 @@
     "NGINX_CONFDIR": "{{ .DevboxDir }}",
     "NGINX_PATH_PREFIX": "{{ .Virtenv }}",
     "NGINX_TMPDIR": "{{ .Virtenv }}/temp",
-    "WEB_PORT": "8081",
-    "WEB_ROOT": "../../../devbox.d/web",
-    "WEB_SERVER_NAME": "localhost"
+    "NGINX_WEB_PORT": "8081",
+    "NGINX_WEB_ROOT": "../../../devbox.d/web",
+    "NGINX_WEB_SERVER_NAME": "localhost"
   },
   "create_files": {
     "{{ .Virtenv }}/temp": "",

--- a/plugins/nginx/nginx.template
+++ b/plugins/nginx/nginx.template
@@ -1,10 +1,10 @@
 events {}
 http{
 server {
-         listen       $NGINX_WEB_PORT;
-         listen       [::]:$NGINX_WEB_PORT;
-         server_name  localhost;
-         root         ../../../devbox.d/web;
+         listen       $WEB_PORT;
+         listen       [::]:$WEB_PORT;
+         server_name  $WEB_SERVER_NAME;
+         root         $WEB_ROOT;
 
          error_log error.log error;
          access_log access.log;

--- a/plugins/nginx/nginx.template
+++ b/plugins/nginx/nginx.template
@@ -1,0 +1,20 @@
+events {}
+http{
+server {
+         listen       $NGINX_WEB_PORT;
+         listen       [::]:$NGINX_WEB_PORT;
+         server_name  localhost;
+         root         ../../../devbox.d/web;
+
+         error_log error.log error;
+         access_log access.log;
+         client_body_temp_path temp/client_body;
+         proxy_temp_path temp/proxy;
+         fastcgi_temp_path temp/fastcgi;
+         uwsgi_temp_path temp/uwsgi;
+         scgi_temp_path temp/scgi;
+
+         index index.html;
+         server_tokens off;
+    }
+}

--- a/plugins/nginx/nginx.template
+++ b/plugins/nginx/nginx.template
@@ -1,10 +1,10 @@
 events {}
 http{
 server {
-         listen       $WEB_PORT;
-         listen       [::]:$WEB_PORT;
-         server_name  $WEB_SERVER_NAME;
-         root         $WEB_ROOT;
+         listen       $NGINX_WEB_PORT;
+         listen       [::]:$NGINX_WEB_PORT;
+         server_name  $NGINX_WEB_SERVER_NAME;
+         root         $NGINX_WEB_ROOT;
 
          error_log error.log error;
          access_log access.log;

--- a/plugins/nginx/process-compose.yaml
+++ b/plugins/nginx/process-compose.yaml
@@ -2,7 +2,8 @@ version: "0.5"
 
 processes:
   nginx:
-    command: "nginx -p $NGINX_PATH_PREFIX -c $NGINX_CONFDIR -e error.log -g \"pid nginx.pid;daemon off;\""
+    command: >
+      envsubst < $NGINX_CONFDIR/nginx.template > $NGINX_CONFDIR/nginx.conf && nginx -p $NGINX_PATH_PREFIX -c $NGINX_CONFDIR/nginx.conf -e error.log -g "pid nginx.pid;daemon off;"
     availability:
       restart: on_failure
       max_restarts: 5

--- a/plugins/nginx/process-compose.yaml
+++ b/plugins/nginx/process-compose.yaml
@@ -2,8 +2,9 @@ version: "0.5"
 
 processes:
   nginx:
-    command: >
-      envsubst < $NGINX_CONFDIR/nginx.template > $NGINX_CONFDIR/nginx.conf && nginx -p $NGINX_PATH_PREFIX -c $NGINX_CONFDIR/nginx.conf -e error.log -g "pid nginx.pid;daemon off;"
+    command: |
+      if [ -f $NGINX_CONFDIR/nginx.template ]; then envsubst < $NGINX_CONFDIR/nginx.template > $NGINX_CONFDIR/nginx.conf; fi
+      nginx -p $NGINX_PATH_PREFIX -c $NGINX_CONFDIR/nginx.conf -e error.log -g "pid nginx.pid;daemon off;"
     availability:
       restart: on_failure
       max_restarts: 5


### PR DESCRIPTION
## Summary
NGINX does not support using environment variables in it's configuration file, which makes it difficult for our plugin to configure NGINX to run in a local devbox shell.

This update to the NGINX plugin installs envsubst, and then uses it to generate a valid `nginx.conf` from an `nginx.template` file. Developers can further customize their nginx.conf by adding environment variables to the `nginx.template` file. 

Envsubst will generate the nginx.conf whenever `devbox services up` or `devbox service start` is run. 

## How was it tested?

Using the nginx example:

1. Change the NGINX_WEB_PORT variable
2. Run `devbox services up`
3. NGINX should generate a valid nginx.conf in the `devbox.d/nginx` folder, and run on the NGINX_WEB_PORT