### PR TITLE
 introduce testscript-examples updater, and update the examples

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -16,7 +16,8 @@
       "build-linux-amd64": "GOOS=linux GOARCH=amd64 go build -o dist/devbox-linux-amd64 cmd/devbox/main.go",
       "code": "code .",
       "lint": "golangci-lint run",
-      "test": "go test -race -cover ./..."
+      "test": "go test -race -cover ./...",
+      "update-examples": "devbox run build && go run testscripts/testrunner/updater/main.go"
     }
   },
   "nixpkgs": {

--- a/examples/development/csharp/hello-world/devbox.lock
+++ b/examples/development/csharp/hello-world/devbox.lock
@@ -2,9 +2,24 @@
   "lockfile_version": "1",
   "packages": {
     "dotnet-sdk@latest": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#dotnet-sdk",
-      "version": "6.0.408"
+      "last_modified": "2023-08-30T00:25:28Z",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#dotnet-sdk",
+      "source": "devbox-search",
+      "version": "6.0.412",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/36llvbismbz4xkjv98m20pm2hlabhyq6-dotnet-sdk-6.0.412"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/8ym2xmbqrqb9cy7axicnp510dc5wp5nf-dotnet-sdk-6.0.412"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/bbn41r9yb1df9hdx6in34yn4wjh0s8dy-dotnet-sdk-6.0.412"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/cfwscwh904f689glcgsslghl1svapbn6-dotnet-sdk-6.0.412"
+        }
+      }
     }
   }
 }

--- a/examples/development/elixir/elixir_hello/devbox.lock
+++ b/examples/development/elixir/elixir_hello/devbox.lock
@@ -2,9 +2,24 @@
   "lockfile_version": "1",
   "packages": {
     "elixir@latest": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#elixir",
-      "version": "1.14.4"
+      "last_modified": "2023-08-30T00:25:28Z",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#elixir",
+      "source": "devbox-search",
+      "version": "1.14.5",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/bf8ck0j68kqxzlgxqf1cpqbyc9j2yhp6-elixir-1.14.5"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/v1lc7mljzi37b0fp1b787ybk2m45jsxd-elixir-1.14.5"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/07kcigpi96l15b09ydp4q9iwx4h0hkr0-elixir-1.14.5"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/y8ys05axra38n4my5x4c3fgs35c0glb1-elixir-1.14.5"
+        }
+      }
     }
   }
 }

--- a/examples/development/fsharp/hello-world/devbox.lock
+++ b/examples/development/fsharp/hello-world/devbox.lock
@@ -2,9 +2,24 @@
   "lockfile_version": "1",
   "packages": {
     "dotnet-sdk@latest": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#dotnet-sdk",
-      "version": "6.0.408"
+      "last_modified": "2023-08-30T00:25:28Z",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#dotnet-sdk",
+      "source": "devbox-search",
+      "version": "6.0.412",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/36llvbismbz4xkjv98m20pm2hlabhyq6-dotnet-sdk-6.0.412"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/8ym2xmbqrqb9cy7axicnp510dc5wp5nf-dotnet-sdk-6.0.412"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/bbn41r9yb1df9hdx6in34yn4wjh0s8dy-dotnet-sdk-6.0.412"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/cfwscwh904f689glcgsslghl1svapbn6-dotnet-sdk-6.0.412"
+        }
+      }
     }
   }
 }

--- a/examples/development/go/hello-world/devbox.lock
+++ b/examples/development/go/hello-world/devbox.lock
@@ -4,7 +4,21 @@
     "go@1.19.8": {
       "last_modified": "2023-05-01T16:53:22Z",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#go_1_19",
-      "version": "1.19.8"
+      "version": "1.19.8",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/7m99ip3616l3z670y83p34r3plwd4iq1-go-1.19.8"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/zpaj1y4iwmkk3ci43ab9k10rr9ilpa3a-go-1.19.8"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/m0fkw6wi5m73y78yqmwhd15y0fjfx5vq-go-1.19.8"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/r0x0agq0vwn0p6z99vkkvn8l8a8idzsb-go-1.19.8"
+        }
+      }
     }
   }
 }

--- a/examples/development/haskell/devbox.lock
+++ b/examples/development/haskell/devbox.lock
@@ -1,10 +1,126 @@
 {
   "lockfile_version": "1",
   "packages": {
+    "cabal-install@latest": {
+      "last_modified": "2023-08-30T00:25:28Z",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#cabal-install",
+      "source": "devbox-search",
+      "version": "3.10.1.0",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/zx8c6zy7k4fvkzxbnz1gj4d9ib0slxcb-cabal-install-3.10.1.0"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/i2cfjzfivkd6qvgjhhb1wzj7wgrhzac6-cabal-install-3.10.1.0"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/j1i22rivhlqra7ajkzwnlw4rdv63p5sp-cabal-install-3.10.1.0"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/nb96882yc1jlx8li5m4xwyhr94n7nb21-cabal-install-3.10.1.0"
+        }
+      }
+    },
     "ghc@latest": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#ghc",
-      "version": "9.2.7"
+      "last_modified": "2023-08-30T00:25:28Z",
+      "plugin_version": "0.0.1",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#ghc",
+      "source": "devbox-search",
+      "version": "9.4.6",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/1k85b7faqm8pc0k3y553zr8bfhb2dv2z-ghc-9.4.6"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/kw8dna2428nizqcij9rxcg8wdiyviiql-ghc-9.4.6"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/fdlmpnichh72gbvqxqib5dglsgqldyfp-ghc-9.4.6"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/kzn0hhns3y7khx6zjsnm9vdgnasc475j-ghc-9.4.6"
+        }
+      }
+    },
+    "gmp@latest": {
+      "last_modified": "2023-08-30T00:25:28Z",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#gmp",
+      "source": "devbox-search",
+      "version": "6.3.0",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/9v3j47bhq570p5mxb3qliakwxkimh6i9-gmp-with-cxx-6.3.0"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/kyxfqavfj53kmlmza9wlshc21v7vfvx3-gmp-with-cxx-6.3.0"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/75psalhvv51afhchymk9vn32f16qxb6b-gmp-with-cxx-6.3.0"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/44bqlp05nq9ymdjvngjx8fdjrfmgj63h-gmp-with-cxx-6.3.0"
+        }
+      }
+    },
+    "hpack@latest": {
+      "last_modified": "2023-08-30T00:25:28Z",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#hpack",
+      "source": "devbox-search",
+      "version": "0.35.2",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/b7snhj7r0fh1sl71cw93pbhissln6k9x-hpack-0.35.2"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/chm820695sg2cgaydmdz2a4mfpf3xhin-hpack-0.35.2"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/9376qjb2q0ivhgbgjagbdwgw1y3ap1j1-hpack-0.35.2"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/hm6h9vfhbg28vxphldz2czmr2iygz2bw-hpack-0.35.2"
+        }
+      }
+    },
+    "stack@latest": {
+      "last_modified": "2023-08-30T00:25:28Z",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#stack",
+      "source": "devbox-search",
+      "version": "2.11.1",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/vnrlr792q350sh9vdd9za6dd41d4iizg-stack-2.11.1"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/8xqxnhjq9x1cnbq5gmlx9c0sqzvnnf8y-stack-2.11.1"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/2nb8nvaydd6sv7cnb1yvyf31l8zwipmi-stack-2.11.1"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/57zyr8q733kksfd82f9fqlnl28s3c48m-stack-2.11.1"
+        }
+      }
+    },
+    "zlib@latest": {
+      "last_modified": "2023-08-30T00:25:28Z",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#zlib",
+      "source": "devbox-search",
+      "version": "1.2.13",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/j7a8wqyszcg3vlw0m9ra2jwiyl4hskwj-zlib-1.2.13"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/6ry5810krihf58jqm21zcn578km564kv-zlib-1.2.13"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/zlk4993fq3zbd23js5xziykz63a0iiyr-zlib-1.2.13"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/i039srr9s4li309rclbm3421ifavgl0g-zlib-1.2.13"
+        }
+      }
     }
   }
 }

--- a/examples/development/java/gradle/hello-world/devbox.lock
+++ b/examples/development/java/gradle/hello-world/devbox.lock
@@ -4,17 +4,55 @@
     "binutils@latest": {
       "last_modified": "2023-05-01T16:53:22Z",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#binutils",
-      "version": "2.40"
+      "version": "2.40",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/9s260h7wxnb6lc5sdpm3mnkvnln9pymd-binutils-wrapper-2.40"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/1j5h9v08436jjm9lxpqyrcqbp40d13xi-binutils-wrapper-2.40"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/7bac4s1gyclv2sxczqqvj6bmdg0h4xz2-binutils-wrapper-2.40"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/cyb4bb44krf4ghw8qasa03sxi2k4g6a4-binutils-wrapper-2.40"
+        }
+      }
     },
     "gradle@latest": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#gradle",
-      "version": "8.0.1"
+      "last_modified": "2023-08-30T00:25:28Z",
+      "plugin_version": "0.0.1",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#gradle",
+      "source": "devbox-search",
+      "version": "8.3",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/4xjjls354jr8w7083qxsrpfs1fgl80fj-gradle-8.3"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/f0l5fscvcl9yand9jfpk5icr2ac8qx2v-gradle-8.3"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/rxm9mpxswrd77fd6lafqcxaxizjlk1l4-gradle-8.3"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/qvp5jiik6q27qwlgiq80fx96wyh0r0nb-gradle-8.3"
+        }
+      }
     },
     "jdk@19": {
       "last_modified": "2023-05-01T16:53:22Z",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#jdk",
-      "version": "19.0.2+7"
+      "version": "19.0.2+7",
+      "systems": {
+        "aarch64-linux": {
+          "store_path": "/nix/store/bdqk85ckifa9xjnz6p2hznc6y54156nn-openjdk-19.0.2+7"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/i2j4s6qcjzlya4ssi2dpf7qnxw2vsaxm-openjdk-19.0.2+7"
+        }
+      }
     }
   }
 }

--- a/examples/development/java/maven/hello-world/devbox.lock
+++ b/examples/development/java/maven/hello-world/devbox.lock
@@ -4,17 +4,54 @@
     "binutils@latest": {
       "last_modified": "2023-05-01T16:53:22Z",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#binutils",
-      "version": "2.40"
+      "version": "2.40",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/9s260h7wxnb6lc5sdpm3mnkvnln9pymd-binutils-wrapper-2.40"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/1j5h9v08436jjm9lxpqyrcqbp40d13xi-binutils-wrapper-2.40"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/7bac4s1gyclv2sxczqqvj6bmdg0h4xz2-binutils-wrapper-2.40"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/cyb4bb44krf4ghw8qasa03sxi2k4g6a4-binutils-wrapper-2.40"
+        }
+      }
     },
     "jdk@19": {
       "last_modified": "2023-05-01T16:53:22Z",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#jdk",
-      "version": "19.0.2+7"
+      "version": "19.0.2+7",
+      "systems": {
+        "aarch64-linux": {
+          "store_path": "/nix/store/bdqk85ckifa9xjnz6p2hznc6y54156nn-openjdk-19.0.2+7"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/i2j4s6qcjzlya4ssi2dpf7qnxw2vsaxm-openjdk-19.0.2+7"
+        }
+      }
     },
     "maven@latest": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#maven",
-      "version": "3.8.6"
+      "last_modified": "2023-08-30T00:25:28Z",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#maven",
+      "source": "devbox-search",
+      "version": "3.9.4",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/a9mn00rx76fhipjd6mvh1wpww94lwrnj-apache-maven-3.9.4"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/k3b451zvvcrwkj60ghnsn12vrdx6za2r-apache-maven-3.9.4"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/idjx4zav3bn5ykdb63k3n1z1jcraprzm-apache-maven-3.9.4"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/8a5s443s3hyzikd2jkgpfa7289xgd01z-apache-maven-3.9.4"
+        }
+      }
     }
   }
 }

--- a/examples/development/nodejs/nodejs-npm/devbox.lock
+++ b/examples/development/nodejs/nodejs-npm/devbox.lock
@@ -2,10 +2,24 @@
   "lockfile_version": "1",
   "packages": {
     "nodejs@18": {
-      "last_modified": "2023-06-29T16:20:38Z",
-      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#nodejs_18",
+      "last_modified": "2023-08-30T00:25:28Z",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#nodejs_18",
       "source": "devbox-search",
-      "version": "18.16.1"
+      "version": "18.17.1",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/xpqj3zg5lx25abv9qybiqd7gcs8b81fp-nodejs-18.17.1"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/svc3bwhi6i1jd5387w8dwps23s7d4a62-nodejs-18.17.1"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/kjsf1qk9w4rknr02silyfq4lxlkh53xq-nodejs-18.17.1"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/51nhk6ycfnj895q07v94jsrwmk2jmz8j-nodejs-18.17.1"
+        }
+      }
     }
   }
 }

--- a/examples/development/nodejs/nodejs-pnpm/devbox.lock
+++ b/examples/development/nodejs/nodejs-pnpm/devbox.lock
@@ -5,13 +5,41 @@
       "last_modified": "2023-06-01T03:57:58Z",
       "resolved": "github:NixOS/nixpkgs/8d4d822bc0efa9de6eddc79cb0d82897a9baa750#nodePackages.pnpm",
       "source": "devbox-search",
-      "version": "8.6.0"
+      "version": "8.6.0",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/p83zbijcjc367avc7jw7jf31f42fqq0p-pnpm-8.6.0"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/lav7giwdqmz06696z55sg80340m6wl7a-pnpm-8.6.0"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/2rs4rx6zh4pgp7chiiccg7ax4f88anr1-pnpm-8.6.0"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/3sawj11il6grz4xjhbqj8bij5qh38p7a-pnpm-8.6.0"
+        }
+      }
     },
     "nodejs@18": {
-      "last_modified": "2023-06-29T16:20:38Z",
-      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#nodejs_18",
+      "last_modified": "2023-08-30T00:25:28Z",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#nodejs_18",
       "source": "devbox-search",
-      "version": "18.16.1"
+      "version": "18.17.1",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/xpqj3zg5lx25abv9qybiqd7gcs8b81fp-nodejs-18.17.1"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/svc3bwhi6i1jd5387w8dwps23s7d4a62-nodejs-18.17.1"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/kjsf1qk9w4rknr02silyfq4lxlkh53xq-nodejs-18.17.1"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/51nhk6ycfnj895q07v94jsrwmk2jmz8j-nodejs-18.17.1"
+        }
+      }
     }
   }
 }

--- a/examples/development/nodejs/nodejs-typescript/devbox.lock
+++ b/examples/development/nodejs/nodejs-typescript/devbox.lock
@@ -2,10 +2,24 @@
   "lockfile_version": "1",
   "packages": {
     "nodejs@18": {
-      "last_modified": "2023-06-29T16:20:38Z",
-      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#nodejs_18",
+      "last_modified": "2023-08-30T00:25:28Z",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#nodejs_18",
       "source": "devbox-search",
-      "version": "18.16.1"
+      "version": "18.17.1",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/xpqj3zg5lx25abv9qybiqd7gcs8b81fp-nodejs-18.17.1"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/svc3bwhi6i1jd5387w8dwps23s7d4a62-nodejs-18.17.1"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/kjsf1qk9w4rknr02silyfq4lxlkh53xq-nodejs-18.17.1"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/51nhk6ycfnj895q07v94jsrwmk2jmz8j-nodejs-18.17.1"
+        }
+      }
     }
   }
 }

--- a/examples/development/nodejs/nodejs-yarn/devbox.lock
+++ b/examples/development/nodejs/nodejs-yarn/devbox.lock
@@ -2,15 +2,43 @@
   "lockfile_version": "1",
   "packages": {
     "nodejs@18": {
-      "last_modified": "2023-06-29T16:20:38Z",
-      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#nodejs_18",
+      "last_modified": "2023-08-30T00:25:28Z",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#nodejs_18",
       "source": "devbox-search",
-      "version": "18.16.1"
+      "version": "18.17.1",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/xpqj3zg5lx25abv9qybiqd7gcs8b81fp-nodejs-18.17.1"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/svc3bwhi6i1jd5387w8dwps23s7d4a62-nodejs-18.17.1"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/kjsf1qk9w4rknr02silyfq4lxlkh53xq-nodejs-18.17.1"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/51nhk6ycfnj895q07v94jsrwmk2jmz8j-nodejs-18.17.1"
+        }
+      }
     },
     "yarn@1.22": {
       "last_modified": "2023-05-01T16:53:22Z",
       "resolved": "github:NixOS/nixpkgs/844ffa82bbe2a2779c86ab3a72ff1b4176cec467#yarn",
-      "version": "1.22.19"
+      "version": "1.22.19",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/4k8ij2dd4aq8hc6ifd1qjjibb94vv229-yarn-1.22.19"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/i9f46zs96v0qn439wznhkw8gg2ah69hb-yarn-1.22.19"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/l7h13xlijmzr8zkmm5qzs77z23c1dzyj-yarn-1.22.19"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/516xqbhfpvsjypq9gjwjngq20syyc1rh-yarn-1.22.19"
+        }
+      }
     }
   }
 }

--- a/examples/development/php/php8.1/devbox.lock
+++ b/examples/development/php/php8.1/devbox.lock
@@ -4,23 +4,82 @@
     "php81Extensions.imagick@latest": {
       "last_modified": "2023-05-01T16:53:22Z",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#php81Extensions.imagick",
-      "version": "3.7.0"
+      "version": "3.7.0",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/3n0837726vzr2yn5lfl0p42sxz7qdgiv-php-imagick-3.7.0"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/9llz7ih1agz0ch2qhyawv0islbjdl266-php-imagick-3.7.0"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/kmqym77xc1f7mk3k3xl48vc0dikgj9pj-php-imagick-3.7.0"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/a165li19iqbf0rzb195hq1ffhjmhg2my-php-imagick-3.7.0"
+        }
+      }
     },
     "php81Extensions.xdebug@latest": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#php81Extensions.xdebug",
-      "version": "3.2.1"
+      "last_modified": "2023-08-30T00:25:28Z",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#php81Extensions.xdebug",
+      "source": "devbox-search",
+      "version": "3.2.2",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/isd181vs56d55xarvlzqr0cl2c65skq7-php-xdebug-3.2.2"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/c0ij58mr8mqcbx6kkrs1wa6x0m433hzc-php-xdebug-3.2.2"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/v4i2qbb7aivj3x4i7ipjg1vnfdc3ynvw-php-xdebug-3.2.2"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/vb8vyyjzjx5c0d71n1bqds19yncdwb1z-php-xdebug-3.2.2"
+        }
+      }
     },
     "php81Packages.composer@latest": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#php81Packages.composer",
-      "version": "2.5.5"
+      "last_modified": "2023-08-30T00:25:28Z",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#php81Packages.composer",
+      "source": "devbox-search",
+      "version": "2.5.8",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/7hxmkxa9bmaplyy1ixl0yxv3j0qvxvc3-php-composer-2.5.8"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/r9jy712s0bnjv6i8qxwrnm099im9ypir-php-composer-2.5.8"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/fjy357jpj9q2bfahsgnak4mrh8y07izw-php-composer-2.5.8"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/awwdg6ysllx23j7brikl7wxwaglkyr0i-php-composer-2.5.8"
+        }
+      }
     },
     "php@8.1": {
-      "last_modified": "2023-05-01T16:53:22Z",
+      "last_modified": "2023-08-30T00:25:28Z",
       "plugin_version": "0.0.2",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#php",
-      "version": "8.1.18"
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#php81",
+      "source": "devbox-search",
+      "version": "8.1.22",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/24facqh0lqq9swy51xyvc763jvlwnylb-php-with-extensions-8.1.22"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/ic9rcrsfx0d9w84iz5sahin898zzkf0v-php-with-extensions-8.1.22"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/651lzjnchj12ngdf4hzldb71grbzzvhk-php-with-extensions-8.1.22"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/14icl7q3qwkcjl80a50bl06n8wn3yk1i-php-with-extensions-8.1.22"
+        }
+      }
     }
   }
 }

--- a/examples/development/python/pip/devbox.json
+++ b/examples/development/python/pip/devbox.json
@@ -1,6 +1,6 @@
 {
     "packages": [
-        "python310",
+        "python@3.10",
         "python310Packages.pip@23.0.1"
     ],
     "shell": {

--- a/examples/development/python/pip/devbox.lock
+++ b/examples/development/python/pip/devbox.lock
@@ -1,15 +1,43 @@
 {
   "lockfile_version": "1",
   "packages": {
-    "python310": {
-      "plugin_version": "0.0.1",
-      "resolved": "github:NixOS/nixpkgs/f80ac848e3d6f0c12c52758c0f25c10c97ca3b62#python310"
-    },
     "python310Packages.pip@23.0.1": {
       "last_modified": "2023-05-01T16:53:22Z",
       "plugin_version": "0.0.1",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#python310Packages.pip",
-      "version": "23.0.1"
+      "version": "23.0.1",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/idd0pswjhxrqp7mdgrhw6rmpmlkrya8r-python3.10-pip-23.0.1"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/ma7lp6a1gbss1aa2mzp2jkxgsvp9m0pg-python3.10-pip-23.0.1"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/77sd3ym5f7p5zn7bmfz36wrnklfq4ic9-python3.10-pip-23.0.1"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/gxb4vyiqip38lzhjsa2ijhb3wjf4sp4b-python3.10-pip-23.0.1"
+        }
+      }
+    },
+    "python@3.10": {
+      "last_modified": "2023-02-24T18:08:35Z",
+      "plugin_version": "0.0.1",
+      "resolved": "github:NixOS/nixpkgs/806075be2bdde71895359ed18cb530c4d323e6f6#python3",
+      "source": "devbox-search",
+      "version": "3.10.9",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/n3qask6wrby75704dz3vcwnd3f9vkab8-python3-3.10.9"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/4msj4kpnvqdg2a75x9m44xspas5ynzrd-python3-3.10.9"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/0pyymzxf7n0fzpaqnvwv92ab72v3jq8d-python3-3.10.9"
+        }
+      }
     }
   }
 }

--- a/examples/development/python/pipenv/devbox.lock
+++ b/examples/development/python/pipenv/devbox.lock
@@ -1,15 +1,43 @@
 {
   "lockfile_version": "1",
   "packages": {
-    "pipenv": {
-      "last_modified": "",
-      "resolved": "github:NixOS/nixpkgs/f80ac848e3d6f0c12c52758c0f25c10c97ca3b62#pipenv",
-      "version": ""
+    "pipenv@latest": {
+      "last_modified": "2023-08-30T00:25:28Z",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#pipenv",
+      "source": "devbox-search",
+      "version": "2023.2.4",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/g527dbv9jgbb0sic9rz299ig6lgsrwmg-pipenv-2023.2.4"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/iacwcnxblzzavig2mas067ia4w6bxhdw-pipenv-2023.2.4"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/87bq994xzv54yd48wkc7i8g023nxq4ql-pipenv-2023.2.4"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/98j571c7pd6c02yl2afg5q5305rd633q-pipenv-2023.2.4"
+        }
+      }
     },
-    "python310": {
-      "last_modified": "",
-      "resolved": "github:NixOS/nixpkgs/f80ac848e3d6f0c12c52758c0f25c10c97ca3b62#python310",
-      "version": ""
+    "python@3.10": {
+      "last_modified": "2023-02-24T18:08:35Z",
+      "plugin_version": "0.0.1",
+      "resolved": "github:NixOS/nixpkgs/806075be2bdde71895359ed18cb530c4d323e6f6#python3",
+      "source": "devbox-search",
+      "version": "3.10.9",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/n3qask6wrby75704dz3vcwnd3f9vkab8-python3-3.10.9"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/4msj4kpnvqdg2a75x9m44xspas5ynzrd-python3-3.10.9"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/0pyymzxf7n0fzpaqnvwv92ab72v3jq8d-python3-3.10.9"
+        }
+      }
     }
   }
 }

--- a/examples/development/python/poetry/poetry-demo/devbox.lock
+++ b/examples/development/python/poetry/poetry-demo/devbox.lock
@@ -6,14 +6,42 @@
       "plugin_version": "0.0.1",
       "resolved": "github:NixOS/nixpkgs/4a22f6f0a4b4354778f786425babce9a56f6b5d8#poetry",
       "source": "devbox-search",
-      "version": "1.4.2"
+      "version": "1.4.2",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/9v48hs0ik9gjkh83jg200471famf746h-poetry-1.4.2"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/qg6jnzqszzph0563hp7ikwf8xjwvl135-poetry-1.4.2"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/ras7zc64ggfppc4lzbwyg97qkjkxsdlz-poetry-1.4.2"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/maiysyji5xzns2ycqakgzxdq0isqgl6y-poetry-1.4.2"
+        }
+      }
     },
     "python@3.8": {
       "last_modified": "2023-06-30T04:44:22Z",
       "plugin_version": "0.0.1",
       "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#python38",
       "source": "devbox-search",
-      "version": "3.8.17"
+      "version": "3.8.17",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/5y3lvwg1rjlqhk0bp0dsw1110g58ilv3-python3-3.8.17"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/v27rjp2p98w4kxaf34ljifn0jgl8wafk-python3-3.8.17"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/ax6w8p37xk4hzr6f382l31y7rflp4byv-python3-3.8.17"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/lz49cng3q6qwa43c9dcs0j3alwc3vp5x-python3-3.8.17"
+        }
+      }
     }
   }
 }

--- a/examples/development/ruby/devbox.lock
+++ b/examples/development/ruby/devbox.lock
@@ -1,19 +1,45 @@
 {
   "lockfile_version": "1",
   "packages": {
-    "bundler": {
-      "resolved": "github:NixOS/nixpkgs/f80ac848e3d6f0c12c52758c0f25c10c97ca3b62#bundler"
-    },
     "bundler@2.4": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#bundler",
-      "version": "2.4.12"
+      "last_modified": "2023-08-30T00:25:28Z",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#bundler",
+      "source": "devbox-search",
+      "version": "2.4.19",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/m0nc4b4sfk69k7592djvc9s2wff4437b-bundler-2.4.19"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/97g2pzvkmazra1gylk822gk7rcp3wj37-bundler-2.4.19"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/xz56ndp380slpv27r5xnm414fhflm71h-bundler-2.4.19"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/g37467pm0imf73z2wwrz30d0q8nzv0p4-bundler-2.4.19"
+        }
+      }
     },
     "ruby@3.1": {
       "last_modified": "2023-05-01T16:53:22Z",
-      "plugin_version": "0.0.1",
+      "plugin_version": "0.0.2",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#ruby",
-      "version": "3.1.4"
+      "version": "3.1.4",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/2m9i5zrjir7j19lynyasliyv6ki27f9a-ruby-3.1.4"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/cym9rarnys76wi1gb6j77yh2j68jiam7-ruby-3.1.4"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/h6ac2glaif1iiy3ykdhisv4yysrm5niv-ruby-3.1.4"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/6iynbmq1yzx4ywicizda4g3q3fhmdf2k-ruby-3.1.4"
+        }
+      }
     }
   }
 }

--- a/examples/development/rust/rust-stable-hello-world/devbox.lock
+++ b/examples/development/rust/rust-stable-hello-world/devbox.lock
@@ -2,14 +2,39 @@
   "lockfile_version": "1",
   "packages": {
     "libiconv@latest": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#libiconv",
-      "version": "2.37"
+      "last_modified": "2023-08-30T00:25:28Z",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#libiconv",
+      "source": "devbox-search",
+      "version": "50",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/43jk41xdl1z3f96yskrc6i7y8i0bp2dn-libiconv-50"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/lbz6562d7h0bnrab89pa9s6r1igw54ir-libiconv-50"
+        }
+      }
     },
     "rustup@latest": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#rustup",
-      "version": "1.25.2"
+      "last_modified": "2023-08-30T00:25:28Z",
+      "plugin_version": "0.0.1",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#rustup",
+      "source": "devbox-search",
+      "version": "1.26.0",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/czgq818h808rv819mq84rj74b7kqxli6-rustup-1.26.0"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/fjpdncxs4bzhd2a46xc0khydj737zpgi-rustup-1.26.0"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/8ca304imc6101rii0l4vjfpfywc2vacq-rustup-1.26.0"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/hpjl2zcps8l0h928z0xmhzawanrks22j-rustup-1.26.0"
+        }
+      }
     }
   }
 }

--- a/examples/development/zig/zig-hello-world/devbox.lock
+++ b/examples/development/zig/zig-hello-world/devbox.lock
@@ -1,0 +1,25 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "zig@0.10": {
+      "last_modified": "2023-08-09T23:50:43Z",
+      "resolved": "github:NixOS/nixpkgs/3d6ebeb283be256f008541ce2b089eb5fb0e4e01#zig",
+      "source": "devbox-search",
+      "version": "0.10.1",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/wdl373cbxsbsgkbrhcm8rsjxf1nyzda5-zig-0.10.1"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/kffa3f61affmlms4r8xmmrq7ksz7lx7k-zig-0.10.1"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/0a267lbl7hy45rlg5i9azxb3s5jggnkm-zig-0.10.1"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/rg6yk06fhxbnq9xm32v1ccfrdilwhx17-zig-0.10.1"
+        }
+      }
+    }
+  }
+}

--- a/examples/flakes/php/devbox.lock
+++ b/examples/flakes/php/devbox.lock
@@ -1,4 +1,7 @@
 {
   "lockfile_version": "1",
-  "packages": {}
+  "packages": {
+    "path:my-php-flake#hello": {},
+    "path:my-php-flake#php": {}
+  }
 }

--- a/examples/flakes/remote/devbox.lock
+++ b/examples/flakes/remote/devbox.lock
@@ -1,4 +1,8 @@
 {
   "lockfile_version": "1",
-  "packages": {}
+  "packages": {
+    "github:F1bonacc1/process-compose/v0.43.1": {},
+    "github:nixos/nixpkgs/5233fd2ba76a3accb5aaa999c00509a11fd0793c#cowsay": {},
+    "github:nixos/nixpkgs/5233fd2ba76a3accb5aaa999c00509a11fd0793c#hello": {}
+  }
 }

--- a/examples/insecure/devbox.lock
+++ b/examples/insecure/devbox.lock
@@ -2,6 +2,7 @@
   "lockfile_version": "1",
   "packages": {
     "nodejs@16": {
+      "allow_insecure": true,
       "last_modified": "2023-08-30T00:25:28Z",
       "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#nodejs_16",
       "source": "devbox-search",

--- a/examples/insecure/devbox.lock
+++ b/examples/insecure/devbox.lock
@@ -2,11 +2,24 @@
   "lockfile_version": "1",
   "packages": {
     "nodejs@16": {
-      "allow_insecure": true,
-      "last_modified": "2023-06-29T16:20:38Z",
-      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#nodejs_16",
+      "last_modified": "2023-08-30T00:25:28Z",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#nodejs_16",
       "source": "devbox-search",
-      "version": "16.20.1"
+      "version": "16.20.2",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/xps0q3f7xbxqpdm4xmlz1drv6qyyb4a5-nodejs-16.20.2"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/qvxwbmwxacc1jlsnqyy45vnzdfbagns0-nodejs-16.20.2"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/6fipdgsh4vmixx3zficbknjmw7k4n4hm-nodejs-16.20.2"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/ds8p6kc8n165gy4f3x72dkpx4aizxjaw-nodejs-16.20.2"
+        }
+      }
     }
   }
 }

--- a/examples/plugins/local/devbox.d/my-plugin/some-file.txt
+++ b/examples/plugins/local/devbox.d/my-plugin/some-file.txt
@@ -1,0 +1,1 @@
+some data

--- a/examples/stacks/drupal/devbox.lock
+++ b/examples/stacks/drupal/devbox.lock
@@ -2,32 +2,106 @@
   "lockfile_version": "1",
   "packages": {
     "git@latest": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#git",
-      "version": "2.40.1"
+      "last_modified": "2023-08-30T00:25:28Z",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#git",
+      "source": "devbox-search",
+      "version": "2.41.0",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/pr1wzd22phjv7h0vbmfdjn382axlw760-git-2.41.0"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/x1j8jz0db9v69h84p5immwg1529nsh5g-git-2.41.0"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/c433w6hab06q8jpnilng1vwzpf3hv06b-git-2.41.0"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/73mc3hjk8c0fa5njc9ynm5ngqmv04ysx-git-2.41.0"
+        }
+      }
     },
     "mariadb@latest": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "plugin_version": "0.0.1",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#mariadb",
-      "version": "10.6.12"
+      "last_modified": "2023-08-30T00:25:28Z",
+      "plugin_version": "0.0.2",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#mariadb_110",
+      "source": "devbox-search",
+      "version": "11.0.3",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/d5nb44vw8yy22lc21ld75nndmn9c3cgr-mariadb-server-11.0.3"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/sz5n9bkcjxklk4jd0p5h26yi5j79wh7h-mariadb-server-11.0.3"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/4l6h83flncplm3kmry1w08msyy7b7vdw-mariadb-server-11.0.3"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/047g9nxp6jb2bqj1f53qk86sjzrscbmj-mariadb-server-11.0.3"
+        }
+      }
     },
     "nginx@latest": {
       "last_modified": "2023-05-01T16:53:22Z",
-      "plugin_version": "0.0.1",
+      "plugin_version": "0.0.2",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#nginx",
-      "version": "1.24.0"
+      "version": "1.24.0",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/prz9lx44d3hicpmsri5rm9qk44r79ng8-nginx-1.24.0"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/b2v5yw11gmywahlyhbqajml7hjdkhsar-nginx-1.24.0"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/1nyjvgj3hbhck80wkwi0h18561xbp3sy-nginx-1.24.0"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/vc66rk5b86lx1myxr18qkgzha0fjx2ks-nginx-1.24.0"
+        }
+      }
     },
     "php81Packages.composer@latest": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#php81Packages.composer",
-      "version": "2.5.5"
+      "last_modified": "2023-08-30T00:25:28Z",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#php81Packages.composer",
+      "source": "devbox-search",
+      "version": "2.5.8",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/7hxmkxa9bmaplyy1ixl0yxv3j0qvxvc3-php-composer-2.5.8"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/r9jy712s0bnjv6i8qxwrnm099im9ypir-php-composer-2.5.8"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/fjy357jpj9q2bfahsgnak4mrh8y07izw-php-composer-2.5.8"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/awwdg6ysllx23j7brikl7wxwaglkyr0i-php-composer-2.5.8"
+        }
+      }
     },
     "php@8.1": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "plugin_version": "0.0.1",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#php",
-      "version": "8.1.18"
+      "last_modified": "2023-08-30T00:25:28Z",
+      "plugin_version": "0.0.2",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#php81",
+      "source": "devbox-search",
+      "version": "8.1.22",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/24facqh0lqq9swy51xyvc763jvlwnylb-php-with-extensions-8.1.22"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/ic9rcrsfx0d9w84iz5sahin898zzkf0v-php-with-extensions-8.1.22"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/651lzjnchj12ngdf4hzldb71grbzzvhk-php-with-extensions-8.1.22"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/14icl7q3qwkcjl80a50bl06n8wn3yk1i-php-with-extensions-8.1.22"
+        }
+      }
     }
   }
 }

--- a/examples/stacks/jekyll/devbox.lock
+++ b/examples/stacks/jekyll/devbox.lock
@@ -2,19 +2,63 @@
   "lockfile_version": "1",
   "packages": {
     "bundler@latest": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#bundler",
-      "version": "2.4.12"
+      "last_modified": "2023-08-30T00:25:28Z",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#bundler",
+      "source": "devbox-search",
+      "version": "2.4.19",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/m0nc4b4sfk69k7592djvc9s2wff4437b-bundler-2.4.19"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/97g2pzvkmazra1gylk822gk7rcp3wj37-bundler-2.4.19"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/xz56ndp380slpv27r5xnm414fhflm71h-bundler-2.4.19"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/g37467pm0imf73z2wwrz30d0q8nzv0p4-bundler-2.4.19"
+        }
+      }
     },
     "libffi@latest": {
       "last_modified": "2023-05-01T16:53:22Z",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#libffi",
-      "version": "3.4.4"
+      "version": "3.4.4",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/9n2blbganavvhzjhn9pdc0sbrsil5gcd-libffi-3.4.4"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/d29cj7v0w0c18ynfbab577v78kfbyqi8-libffi-3.4.4"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/pkg5ama5n22yx7gkp8c0mazrda0bv7zk-libffi-3.4.4"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/86wfcbx4zg1dmgrfs2d54flvsdadgb0p-libffi-3.4.4"
+        }
+      }
     },
     "ruby@3.1": {
       "last_modified": "2023-05-01T16:53:22Z",
+      "plugin_version": "0.0.2",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#ruby",
-      "version": "3.1.4"
+      "version": "3.1.4",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/2m9i5zrjir7j19lynyasliyv6ki27f9a-ruby-3.1.4"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/cym9rarnys76wi1gb6j77yh2j68jiam7-ruby-3.1.4"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/h6ac2glaif1iiy3ykdhisv4yysrm5niv-ruby-3.1.4"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/6iynbmq1yzx4ywicizda4g3q3fhmdf2k-ruby-3.1.4"
+        }
+      }
     }
   }
 }

--- a/examples/stacks/lapp-stack/devbox.lock
+++ b/examples/stacks/lapp-stack/devbox.lock
@@ -5,29 +5,102 @@
       "last_modified": "2023-05-01T16:53:22Z",
       "plugin_version": "0.0.2",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#apacheHttpd",
-      "version": "2.4.57"
+      "version": "2.4.57",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/qr58izm7hncylf5zn66kghy3109rva4j-apache-httpd-2.4.57"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/iggdl8972rj3h6bm3mv4cqnjwvzi4p59-apache-httpd-2.4.57"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/b1xlj47n5pvassli9ggph09kk9xjmip6-apache-httpd-2.4.57"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/w0cbd5djp6ib3jyikqb2k06gzb9lp1hj-apache-httpd-2.4.57"
+        }
+      }
     },
     "curl@8.0": {
       "last_modified": "2023-05-01T16:53:22Z",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#curl",
-      "version": "8.0.1"
+      "version": "8.0.1",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/7qwsslwdrjyg8hs654nsqpq7lly6dhq5-curl-8.0.1"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/g9g1p4l9146kclnx4lv0hfbzhr9hk7n7-curl-8.0.1"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/bbkz21vmx16wl0h3xk36g7gxpbymnm6d-curl-8.0.1"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/0xyi7w3cm3g7gzwfpwqzx0n7xks2sdc6-curl-8.0.1"
+        }
+      }
     },
     "php81Extensions.pgsql@latest": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#php81Extensions.pgsql",
-      "version": "8.1.18"
+      "last_modified": "2023-08-30T00:25:28Z",
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#php81Extensions.pgsql",
+      "source": "devbox-search",
+      "version": "8.1.22",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/cp5m956xcqp9wnjkfkgx233sc2was375-php-pgsql-8.1.22"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/spfhyjimzzxv11b7b6hfawbl15p3rb86-php-pgsql-8.1.22"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/y6wgphymmrk800zmxmy7s1j360yzmdqz-php-pgsql-8.1.22"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/rhc05fbdkq52ms8xdh6fil3la0p21lq1-php-pgsql-8.1.22"
+        }
+      }
     },
     "php@8.1": {
-      "last_modified": "2023-05-01T16:53:22Z",
+      "last_modified": "2023-08-30T00:25:28Z",
       "plugin_version": "0.0.2",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#php",
-      "version": "8.1.18"
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#php81",
+      "source": "devbox-search",
+      "version": "8.1.22",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/24facqh0lqq9swy51xyvc763jvlwnylb-php-with-extensions-8.1.22"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/ic9rcrsfx0d9w84iz5sahin898zzkf0v-php-with-extensions-8.1.22"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/651lzjnchj12ngdf4hzldb71grbzzvhk-php-with-extensions-8.1.22"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/14icl7q3qwkcjl80a50bl06n8wn3yk1i-php-with-extensions-8.1.22"
+        }
+      }
     },
     "postgresql@14": {
-      "last_modified": "2023-05-01T16:53:22Z",
+      "last_modified": "2023-08-30T00:25:28Z",
       "plugin_version": "0.0.2",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#postgresql",
-      "version": "14.7"
+      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#postgresql",
+      "source": "devbox-search",
+      "version": "14.9",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/x6058p5djhvn57fqyqfs4hvf193m847j-postgresql-14.9"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/0gfagnjbaqlgzf17hrc5pzfr170s6wdl-postgresql-14.9"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/hd25shwpmqcki920ii1cxhh95qa51kfh-postgresql-14.9"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/vfcdf4n8f7mxx4rby11f7vhhpi62474m-postgresql-14.9"
+        }
+      }
     }
   }
 }

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -124,6 +124,7 @@ func (d *Devbox) mergeResolvedPackageToLockfile(
 			// sync the profile so we don't need to do this manually.
 			ux.Fwarning(d.writer, "Failed to remove %s from profile: %s\n", pkg, err)
 		}
+		resolved.AllowInsecure = existing.AllowInsecure
 		lockfile.Packages[pkg.Raw] = resolved
 		return nil
 	}

--- a/testscripts/testrunner/updater/main.go
+++ b/testscripts/testrunner/updater/main.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/samber/lo"
+)
+
+func main() {
+
+	if err := run(); err != nil {
+		panic(err)
+	}
+}
+
+func run() error {
+
+	// loop over all examples that have run_test script
+	// run `devbox update` on each such example
+
+	devboxRepoDir, err := devboxRepoDir()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	examplesDir := filepath.Join(devboxRepoDir, "examples")
+
+	err = filepath.WalkDir(examplesDir, func(path string, d fs.DirEntry, err error) error {
+		return walkExampleDir(devboxRepoDir, path, d, err)
+	})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+var examplesToTry = 0
+
+func walkExampleDir(devboxRepoDir, path string, d fs.DirEntry, err error) error {
+	fmt.Printf("checking %s with name: %s\n", path, d.Name())
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	if examplesToTry > 3 {
+		return nil
+	}
+
+	if d.IsDir() {
+		skippedDirs := []string{".devbox", "node_modules"}
+		if lo.Contains(skippedDirs, d.Name()) {
+			return filepath.SkipDir
+		}
+		return nil
+	}
+
+	if d.Name() != "devbox.json" {
+		return nil
+	}
+	contentBytes, err := os.ReadFile(path)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	content := string(contentBytes)
+	if !strings.Contains(content, "run_test") {
+		fmt.Printf("Skipping config at %s\n", path)
+		return nil
+	}
+
+	// run `devbox update` on this example
+	devboxExecutable := filepath.Join(devboxRepoDir, "dist", "devbox")
+	cmd := exec.Command(devboxExecutable, "update", "-c", filepath.Dir(path))
+	if err := cmd.Run(); err != nil {
+		return errors.WithStack(err)
+	}
+	fmt.Printf("Ran `devbox update` on %s\n", path)
+	examplesToTry++
+
+	return nil
+}
+
+func devboxRepoDir() (string, error) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", errors.New("unable to get the current filename")
+	}
+	// This file's directory
+	fileDir := filepath.Dir(filename)
+	// devbox repo directory is 3 levels up
+	return filepath.Join(fileDir, "..", "..", ".."), nil
+}

--- a/testscripts/testrunner/updater/main.go
+++ b/testscripts/testrunner/updater/main.go
@@ -31,9 +31,11 @@ func run() error {
 	}
 	examplesDir := filepath.Join(devboxRepoDir, "examples")
 
-	err = filepath.WalkDir(examplesDir, func(path string, d fs.DirEntry, err error) error {
-		return walkExampleDir(devboxRepoDir, path, d, err)
-	})
+	err = filepath.WalkDir(
+		examplesDir, func(path string, d fs.DirEntry, err error) error {
+			return walkExampleDir(devboxRepoDir, path, d, err)
+		},
+	)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -42,25 +44,27 @@ func run() error {
 
 var examplesToTry = 0
 
-func walkExampleDir(devboxRepoDir, path string, d fs.DirEntry, err error) error {
-	fmt.Printf("checking %s with name: %s\n", path, d.Name())
+func walkExampleDir(devboxRepoDir, path string, dirEntry fs.DirEntry, err error) error {
+	// fmt.Printf("checking %s with name: %s\n", path, dirEntry.Name())
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	if examplesToTry > 3 {
-		return nil
-	}
+	// Uncomment to try out changes
+	// if examplesToTry > 3 {
+	//	return nil
+	// }
+	_ = examplesToTry // silence linter
 
-	if d.IsDir() {
+	if dirEntry.IsDir() {
 		skippedDirs := []string{".devbox", "node_modules"}
-		if lo.Contains(skippedDirs, d.Name()) {
+		if lo.Contains(skippedDirs, dirEntry.Name()) {
 			return filepath.SkipDir
 		}
 		return nil
 	}
 
-	if d.Name() != "devbox.json" {
+	if dirEntry.Name() != "devbox.json" {
 		return nil
 	}
 	contentBytes, err := os.ReadFile(path)
@@ -70,7 +74,7 @@ func walkExampleDir(devboxRepoDir, path string, d fs.DirEntry, err error) error 
 
 	content := string(contentBytes)
 	if !strings.Contains(content, "run_test") {
-		fmt.Printf("Skipping config at %s\n", path)
+		fmt.Printf("SKIP: config at %s lacks run_test\n", path)
 		return nil
 	}
 

--- a/testscripts/testrunner/updater/main.go
+++ b/testscripts/testrunner/updater/main.go
@@ -13,17 +13,16 @@ import (
 	"github.com/samber/lo"
 )
 
+// updater is a tool that updates all examples/ in the devbox repo.
 func main() {
-
 	if err := run(); err != nil {
 		panic(err)
 	}
 }
 
+// run will loop over all examples that have run_test script
+// run `devbox update` on each such example
 func run() error {
-
-	// loop over all examples that have run_test script
-	// run `devbox update` on each such example
 
 	devboxRepoDir, err := devboxRepoDir()
 	if err != nil {
@@ -42,10 +41,10 @@ func run() error {
 	return nil
 }
 
+// examplesToTry is a counter for the number of examples to try. Useful for debugging.
 var examplesToTry = 0
 
 func walkExampleDir(devboxRepoDir, path string, dirEntry fs.DirEntry, err error) error {
-	// fmt.Printf("checking %s with name: %s\n", path, dirEntry.Name())
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -56,7 +55,9 @@ func walkExampleDir(devboxRepoDir, path string, dirEntry fs.DirEntry, err error)
 	// }
 	_ = examplesToTry // silence linter
 
+	// If it is a directory, then we don't continue.
 	if dirEntry.IsDir() {
+		// Skip if it is a directory that we don't want to process at all.
 		skippedDirs := []string{".devbox", "node_modules"}
 		if lo.Contains(skippedDirs, dirEntry.Name()) {
 			return filepath.SkipDir
@@ -64,15 +65,19 @@ func walkExampleDir(devboxRepoDir, path string, dirEntry fs.DirEntry, err error)
 		return nil
 	}
 
+	// If it is not a devbox.json file, then we don't continue.
 	if dirEntry.Name() != "devbox.json" {
 		return nil
 	}
+
+	// Read the devbox.json file
 	contentBytes, err := os.ReadFile(path)
 	if err != nil {
 		return errors.WithStack(err)
 	}
-
 	content := string(contentBytes)
+
+	// Skip if it doesn't have a run_test script
 	if !strings.Contains(content, "run_test") {
 		fmt.Printf("SKIP: config at %s lacks run_test\n", path)
 		return nil


### PR DESCRIPTION
## Summary

This PR adds `testscripts/testrunner/updater/main.go` that walks the `examples/`
directory and updates projects that have a `run_test` script defined. 

In the future, perhaps we want this to run on other (non run_test) projects as 
well, but that is left as an exercise for future contributors.

Also includes a fix for `devbox update` for insecure packages.

## How was it tested?

```
export DEVBOX_FEATURE_REMOVE_NIXPKGS=1

devbox run update-examples
```

Note: this adds info to devbox.lock for the Remove Nixpkgs feature that 
is not turned on. However, things should continue to work.

