### PR TITLE
[golangci-lint] bump action to latest release

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -67,7 +67,7 @@ jobs:
         with:
           go-version-file: ./go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.4.0
+        uses: golangci/golangci-lint-action@v3.7.0
         with:
           args: "--out-${NO_FUTURE}format colored-line-number --timeout=10m"
           skip-cache: true


### PR DESCRIPTION
## Summary

seeing odd errors in another PR, so seeing if we can bump the lint action

## How was it tested?

cicd cli-test should pass
