### PR TITLE
[per-OS Packages] omitempty for version in expanded Package json representation

### DIFF
--- a/internal/devconfig/packages.go
+++ b/internal/devconfig/packages.go
@@ -200,10 +200,9 @@ const (
 )
 
 type Package struct {
-	kind packageKind
-	name string
-	// deliberately not adding omitempty
-	Version string `json:"version"`
+	kind    packageKind
+	name    string
+	Version string `json:"version,omitempty"`
 
 	Platforms         []string `json:"platforms,omitempty"`
 	ExcludedPlatforms []string `json:"excluded_platforms,omitempty"`

--- a/testscripts/add/add_platforms_flakeref.test.txt
+++ b/testscripts/add/add_platforms_flakeref.test.txt
@@ -1,0 +1,26 @@
+# Testscript for exercising adding packages using a flake ref
+
+exec devbox install
+
+exec devbox add github:F1bonacc1/process-compose/v0.40.2 --exclude-platform x86_64-darwin
+json.superset devbox.json expected_devbox1.json
+
+-- devbox.json --
+{
+  "packages": [
+    "hello",
+    "cowsay@latest"
+  ]
+}
+
+-- expected_devbox1.json --
+{
+  "packages": {
+    "hello": "",
+    "cowsay": "latest",
+    "github:F1bonacc1/process-compose/v0.40.2": {
+      "excluded_platforms": ["x86_64-darwin"]
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary

Discussing with @lagoja, we felt that we can omit the version string if its empty

## How was it tested?

`devbox add github:F1bonacc1/process-compose --exclude-platform x86_64-darwin`:

BEFORE:
```
{
  "packages": {
    "github:F1bonacc1/process-compose/v0.40.2": {
      "version": "",
      "excluded_platforms": [
        "x86_64-darwin"
      ]
    }
  },
  ...
}
```

AFTER:
```
{
  "packages": {
    "github:F1bonacc1/process-compose/v0.40.2": {
      "excluded_platforms": [
        "x86_64-darwin"
      ]
    }
  },
  ...
}
```
