### PR TITLE
[devbox.Open] drop ensureNixInstalled function call

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -130,10 +130,6 @@ func Open(opts *devopt.Opts) (*Devbox, error) {
 		)
 	}
 
-	if err := nix.EnsureNixInstalled(box.writer, func() *bool { return nil } /*withDaemonFunc*/); err != nil {
-		return nil, err
-	}
-
 	return box, nil
 }
 


### PR DESCRIPTION
## Summary

Problem:
Commands like `devbox version` are installing nix.

Cause:
By inserting a `debug.PrintStack()` one can [see](https://gist.github.com/savil/0fff37124abae3d1c0088404c05a73cc) that `devbox.Open` is invoked
for `devbox version` from a few places. In the latest 0.5.12 release, we added
a call to `ensureNixInstalled` in `devbox.Open`. Hence even though we don't set `PreRunE: ensureNixInstalled`
in the command, the nix install is triggered.

The original motivation for adding this call in `devbox.Open` was that `nix` is pretty widely used in the `Devbox`
library, and we should add `ensureNixInstalled` as a check.


## How was it tested?

compiles

will rely on tests to pass
