### PR TITLE
Update docker-image-release.yml to support ARM builds for newer Macbooks

### DIFF
--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to Docker Hub
@@ -21,6 +23,7 @@ jobs:
           context: ./internal/impl/generate/tmpl/
           file: ./internal/impl/generate/tmpl/DevboxImageDockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: jetpackio/devbox:latest
       - name: Build and push root user
         uses: docker/build-push-action@v4


### PR DESCRIPTION
## Summary
Add arm64 builds to the non-root image build(currently the root image cannot be built because of #1444) 
## How was it tested?
I have tested this locally and confirmed the non-root image is built successfully with this change