### PR TITLE
[profile remove] if package was not found, change message from error to info

### DIFF
--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -376,9 +376,8 @@ func (d *Devbox) removePackagesFromProfile(ctx context.Context, pkgs []string) e
 			ProfileDir: profileDir,
 		})
 		if err != nil {
-			ux.Ferror(
-				d.writer,
-				"Package %s not found in profile. Skipping.\n",
+			debug.Log(
+				"Info: Package %s not found in nix profile. Skipping removing from profile.\n",
 				pkg.Raw,
 			)
 			continue


### PR DESCRIPTION
## Summary

When trying to remove a package, or update a package, we'd print a message
like below if the package was not found in the profile.
```
Error: Package uxn@latest not found in profile. Skipping.
```
This is confusing for a few reasons:
1. Devbox users are not usually aware of a concept called "profile". This is a nix-ism that is seeping through our messaging.
2. Even if they understand "nix profile", there's nothing actionable about this message. Their package is still removed from devbox.json and the shell environment (which is what they care about).

Instead, we can make this a debug.Log, and not bother users with it.


## How was it tested?

didn't explicitly test. Compiles.
