### PR TITLE
[rm-nixpkgs] drop warning about missing store path when updating lockfile

### DIFF
--- a/internal/lock/resolve.go
+++ b/internal/lock/resolve.go
@@ -6,7 +6,6 @@ package lock
 import (
 	"context"
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
@@ -17,7 +16,6 @@ import (
 	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/nix"
 	"go.jetpack.io/devbox/internal/searcher"
-	"go.jetpack.io/devbox/internal/ux"
 	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 )
@@ -103,12 +101,6 @@ func buildLockSystemInfos(pkg *searcher.PackageVersion) (map[string]*SystemInfo,
 			path, err := nix.StorePathFromHashPart(ctx, sysInfo.StoreHash, "https://cache.nixos.org")
 			if err != nil {
 				// Should we report this to sentry to collect data?
-				ux.Fwarning(
-					os.Stderr,
-					"Failed to resolve store path for %s with storeHash %s. Installing will be a bit slower.\n",
-					sysName,
-					sysInfo.StoreHash,
-				)
 				debug.Log(
 					"Failed to resolve store path for %s with storeHash %s. Error is %s.\n",
 					sysName,


### PR DESCRIPTION
## Summary

We'd show this warning about missing store path to users.
```
❯ time devbox add nodePackages_latest.yalc@latest
Warning: Failed to resolve store path for x86_64-darwin with storeHash h1fpdwwq2x528xwq3si97z6vny0vkjhf. Installing will be a bit slower.
Warning: Failed to resolve store path for x86_64-linux with storeHash is1ds4h8qa95s31crvgf19mlmx1990s3. Installing will be a bit slower.
Warning: Warning: Failed to resolve store path for aarch64-linux with storeHash cqjb45zk4cs4i4qzkknh5116zk7z471g. Installing will be a bit slower.
Failed to resolve store path for aarch64-darwin with storeHash 5wfxcx235xpwr5lcv29ijlpw85kb0vj0. Installing will be a bit slower.

Installing package: nodePackages_latest.yalc@latest.

[1/1] nodePackages_latest.yalc@latest
[1/1] nodePackages_latest.yalc@latest: Success
devbox add nodePackages_latest.yalc@latest  2.00s user 0.66s system 47% cpu 5.551 total
```

However, this isn't very helpful:
1. The users cannot do anything with this info.
2. The install experience will be the "slow path" but that is what users are already used to.
3. If a user complains about slow install, then we can inspect their `devbox.lock` and we'll know if the store-path is missing or not.

## How was it tested?

```
> time devbox add nodePackages_latest.yalc@latest

Installing package: nodePackages_latest.yalc@latest.

[1/1] nodePackages_latest.yalc@latest
[1/1] nodePackages_latest.yalc@latest: Success

________________________________________________________
Executed in   12.67 secs    fish           external
   usr time    4.75 secs    0.99 millis    4.75 secs
   sys time    1.72 secs    1.83 millis    1.72 secs
```
