### PR TITLE
Fix envsubst issues

### DIFF
--- a/examples/servers/nginx/devbox.lock
+++ b/examples/servers/nginx/devbox.lock
@@ -2,11 +2,25 @@
   "lockfile_version": "1",
   "packages": {
     "nginx@latest": {
-      "last_modified": "2023-08-30T00:25:28Z",
+      "last_modified": "2023-09-04T16:24:30Z",
       "plugin_version": "0.0.3",
-      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#nginx",
+      "resolved": "github:NixOS/nixpkgs/3c15feef7770eb5500a4b8792623e2d6f598c9c1#nginx",
       "source": "devbox-search",
-      "version": "1.24.0"
+      "version": "1.24.0",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/prz9lx44d3hicpmsri5rm9qk44r79ng8-nginx-1.24.0"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/b2v5yw11gmywahlyhbqajml7hjdkhsar-nginx-1.24.0"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/1nyjvgj3hbhck80wkwi0h18561xbp3sy-nginx-1.24.0"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/vc66rk5b86lx1myxr18qkgzha0fjx2ks-nginx-1.24.0"
+        }
+      }
     }
   }
 }

--- a/examples/stacks/drupal/devbox.d/nginx/nginx.template
+++ b/examples/stacks/drupal/devbox.d/nginx/nginx.template
@@ -1,10 +1,10 @@
 events {}
 http{
 server {
-         listen       8081;
-         listen       [::]:8081;
-         server_name  localhost;
-         root         ../../../devbox.d/web;
+         listen       $NGINX_WEB_PORT;
+         listen       [::]:$NGINX_WEB_PORT;
+         server_name  $NGINX_WEB_SERVER_NAME;
+         root         $NGINX_WEB_ROOT;
 
          error_log error.log error;
          access_log access.log;
@@ -31,7 +31,7 @@ server {
         location ~ \.php$ {
             include fastcgi.conf;
             fastcgi_split_path_info ^(.+\.php)(/.+)$;
-            fastcgi_pass 127.0.0.1:8082;
+            fastcgi_pass 127.0.0.1:$PHPFPM_PORT;
             fastcgi_param PATH_INFO $fastcgi_path_info;
             fastcgi_index index.php;
         }

--- a/examples/stacks/drupal/devbox.json
+++ b/examples/stacks/drupal/devbox.json
@@ -3,8 +3,8 @@
     "git@latest",
     "php@8.1",
     "php81Packages.composer@latest",
-    "nginx@latest",
-    "mariadb@latest"
+    "mariadb@latest",
+    "nginx@latest"
   ],
   "shell": {
     "init_hook": [],

--- a/examples/stacks/drupal/devbox.lock
+++ b/examples/stacks/drupal/devbox.lock
@@ -43,9 +43,10 @@
       }
     },
     "nginx@latest": {
-      "last_modified": "2023-05-01T16:53:22Z",
+      "last_modified": "2023-09-04T16:24:30Z",
       "plugin_version": "0.0.3",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#nginx",
+      "resolved": "github:NixOS/nixpkgs/3c15feef7770eb5500a4b8792623e2d6f598c9c1#nginx",
+      "source": "devbox-search",
       "version": "1.24.0",
       "systems": {
         "aarch64-darwin": {

--- a/examples/stacks/lepp-stack/devbox.d/nginx/nginx.conf
+++ b/examples/stacks/lepp-stack/devbox.d/nginx/nginx.conf
@@ -4,7 +4,7 @@ server {
          listen       8089;
          listen       [::]:8089;
          server_name  localhost;
-         root         ../../../devbox.d/web;
+         root         ../../../my_app;
 
          error_log error.log error;
          access_log access.log;
@@ -14,7 +14,17 @@ server {
          uwsgi_temp_path temp/uwsgi;
          scgi_temp_path temp/scgi;
 
-         index index.html;
-         server_tokens off;
+         index index.php index.htm index.html;
+
+         location / {
+                      try_files $uri $uri/ /index.php$is_args$args;
+         }
+
+         location ~ \.php$ {
+            include fastcgi.conf;
+            fastcgi_split_path_info ^(.+\.php)(/.+)$;
+            fastcgi_pass 127.0.0.1:8082;
+            fastcgi_index index.php;
+        }
     }
 }

--- a/examples/stacks/lepp-stack/devbox.d/nginx/nginx.template
+++ b/examples/stacks/lepp-stack/devbox.d/nginx/nginx.template
@@ -14,7 +14,17 @@ server {
          uwsgi_temp_path temp/uwsgi;
          scgi_temp_path temp/scgi;
 
-         index index.html;
-         server_tokens off;
+         index index.php index.htm index.html;
+
+         location / {
+                      try_files $uri $uri/ /index.php$is_args$args;
+         }
+
+         location ~ \.php$ {
+            include fastcgi.conf;
+            fastcgi_split_path_info ^(.+\.php)(/.+)$;
+            fastcgi_pass 127.0.0.1:$PHPFPM_PORT;
+            fastcgi_index index.php;
+        }
     }
 }

--- a/examples/stacks/lepp-stack/devbox.json
+++ b/examples/stacks/lepp-stack/devbox.json
@@ -4,10 +4,11 @@
     "postgresql@14",
     "php@8.1",
     "php81Extensions.pgsql@latest",
-    "nginx@1.24"
+    "nginx@latest"
   ],
   "env": {
     "NGINX_WEB_PORT": "8089",
+    "NGINX_WEB_ROOT": "../../../my_app",
     "PGPORT": "5433"
   },
   "shell": {

--- a/examples/stacks/lepp-stack/devbox.lock
+++ b/examples/stacks/lepp-stack/devbox.lock
@@ -20,10 +20,11 @@
         }
       }
     },
-    "nginx@1.24": {
-      "last_modified": "2023-05-01T16:53:22Z",
+    "nginx@latest": {
+      "last_modified": "2023-09-04T16:24:30Z",
       "plugin_version": "0.0.3",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#nginx",
+      "resolved": "github:NixOS/nixpkgs/3c15feef7770eb5500a4b8792623e2d6f598c9c1#nginx",
+      "source": "devbox-search",
       "version": "1.24.0",
       "systems": {
         "aarch64-darwin": {

--- a/plugins/nginx.json
+++ b/plugins/nginx.json
@@ -1,8 +1,8 @@
 {
   "name": "nginx",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "readme": "nginx can be configured with env variables\n\nTo customize:\n* Use $NGINX_CONFDIR to change the configuration directory\n* Use $NGINX_TMPDIR to change the tmp directory. Use $NGINX_USER to change the user\n* Use $NGINX_WEB_PORT to change the port NGINX runs on. \n Note: This plugin uses envsubst when running `devbox services` to generate the nginx.conf file from the nginx.template file. To customize the nginx.conf file, edit the nginx.template file.\n",
-  "__packages": ["envsubst@latest"],
+  "__packages": ["gettext@latest", "gawk@latest"],
   "env": {
     "NGINX_CONF": "{{ .DevboxDir }}/nginx.conf",
     "NGINX_CONFDIR": "{{ .DevboxDir }}",

--- a/plugins/nginx/process-compose.yaml
+++ b/plugins/nginx/process-compose.yaml
@@ -3,7 +3,7 @@ version: "0.5"
 processes:
   nginx:
     command: |
-      if [ -f $NGINX_CONFDIR/nginx.template ]; then envsubst < $NGINX_CONFDIR/nginx.template > $NGINX_CONFDIR/nginx.conf; fi
+      if [ -f $NGINX_CONFDIR/nginx.template ]; then envsubst $(awk 'BEGIN {for (k in ENVIRON) {printf "$"k","}}') < $NGINX_CONFDIR/nginx.template > $NGINX_CONFDIR/nginx.conf; fi
       nginx -p $NGINX_PATH_PREFIX -c $NGINX_CONFDIR/nginx.conf -e error.log -g "pid nginx.pid;daemon off;"
     availability:
       restart: on_failure


### PR DESCRIPTION
## Summary

Ugh.

Fixes a few envsubst related issues in the Nginx plugin: 

1. The `envsubst` package seemed to have a different version of envsubst than what I expected. I replaced this package with `gettext` to get the GNU version
2. `envsubst` was replacing all the nginx variables with blanks if they weren't included in the environment, which caused Drupal and PHP related examples to stop working. This update uses `gawk` to get a list of all the current environment variables and pass them as arguments to envsubst, which will make envsubst skip any unset variables. 
3. Fixed Drupal and LEPP examples to use the plugin correctly

## How was it tested?

Ran `runtest` for the examples, verified that the generated nginx.conf matched previous versions.