### PR TITLE
[remove-nixpkgs] Disable remove-nixpkgs to fix non-search fallback

### DIFF
--- a/internal/boxcli/featureflag/remove_nixpkgs.go
+++ b/internal/boxcli/featureflag/remove_nixpkgs.go
@@ -4,4 +4,4 @@ package featureflag
 // It leverages the search index to directly map <package>@<version> to
 // the /nix/store/<hash>-<package>-<version> that can be fetched from
 // cache.nixpkgs.org.
-var RemoveNixpkgs = enable("REMOVE_NIXPKGS")
+var RemoveNixpkgs = disable("REMOVE_NIXPKGS")

--- a/internal/devpkg/narinfo_cache.go
+++ b/internal/devpkg/narinfo_cache.go
@@ -62,6 +62,9 @@ func (p *Package) IsInBinaryCache() (bool, error) {
 // package in the list, and caches the result.
 // Callers of IsInBinaryCache must call this function first.
 func FillNarInfoCache(ctx context.Context, packages ...*Package) error {
+	if !featureflag.RemoveNixpkgs.Enabled() {
+		return nil
+	}
 
 	// Pre-compute values read in fillNarInfoCache
 	// so they can be read from multiple go-routines without locks


### PR DESCRIPTION
## Summary

Restores functionality implemented by https://github.com/jetpack-io/devbox/pull/1264 and refactored in https://github.com/jetpack-io/devbox/pull/1279

which was accidentally broken by https://github.com/jetpack-io/devbox/pull/1437

tldr: the `FillNarInfoCache` function breaks if packages are not in search, but we support non-search packages via fallback (.e.g. stdenv.cc.cc.lib)

I'm keeping surface area as small as possible, but as a follow up I think we can remove the `devpkg.FillNarInfoCache` calls from `impl.Add` if we simply ignore the`IsInBinaryCache` errors in [ValidateExists](https://github.com/jetpack-io/devbox/blob/main/internal/devpkg/validation.go#L10-L26)  or remove `IsInBinaryCache` from that function completely (I'm not convinced it is needed, @savil @ipince correct me if I'm wrong)

## How was it tested?
`devbox add stdenv.cc.cc.lib`