### PR TITLE
[telemetry] add nix.version to sentry and segment

### DIFF
--- a/internal/boxcli/midcobra/telemetry.go
+++ b/internal/boxcli/midcobra/telemetry.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-
 	"go.jetpack.io/devbox"
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/envir"
@@ -54,6 +53,7 @@ func (m *telemetryMiddleware) postRun(cmd *cobra.Command, args []string, runErr 
 	}
 	meta.Command = subcmd.CommandPath()
 	meta.CommandFlags = flags
+
 	meta.Packages, meta.NixpkgsHash = getPackagesAndCommitHash(cmd)
 	meta.InShell = envir.IsDevboxShellEnabled()
 	meta.InBrowser = envir.IsInBrowser()

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -17,8 +17,14 @@ var (
 	Commit     = "none"
 	CommitDate = "unknown"
 
-	SentryDSN    = "" // Disabled by default
-	TelemetryKey = "" // Disabled by default
+	// SentryDSN is injected in the build from
+	// https://jetpack-io.sentry.io/settings/projects/devbox/keys/
+	// It is disabled by default.
+	SentryDSN = ""
+	// TelemetryKey is the Segment Write Key
+	// https://segment.com/docs/connections/sources/catalog/libraries/server/go/quickstart/
+	// It is disabled by default.
+	TelemetryKey = ""
 )
 
 // User-presentable names of operating systems supported by Devbox.

--- a/internal/telemetry/segment.go
+++ b/internal/telemetry/segment.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	segment "github.com/segmentio/analytics-go"
+	"go.jetpack.io/devbox/internal/nix"
 
 	"go.jetpack.io/devbox/internal/build"
 	"go.jetpack.io/devbox/internal/envir"
@@ -32,6 +33,11 @@ func initSegmentClient() bool {
 }
 
 func newTrackMessage(name string, meta Metadata) *segment.Track {
+	nixVersion, err := nix.Version()
+	if err != nil {
+		nixVersion = "unknown"
+	}
+
 	dur := time.Since(procStartTime)
 	if !meta.CommandStart.IsZero() {
 		dur = time.Since(meta.CommandStart)
@@ -63,6 +69,7 @@ func newTrackMessage(name string, meta Metadata) *segment.Track {
 			"packages":     meta.Packages,
 			"shell":        os.Getenv(envir.Shell),
 			"shell_access": shellAccess(),
+			"nix_version":  nixVersion,
 		},
 	}
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	segment "github.com/segmentio/analytics-go"
+	"go.jetpack.io/devbox/internal/nix"
 
 	"go.jetpack.io/devbox/internal/build"
 	"go.jetpack.io/devbox/internal/envir"
@@ -117,6 +118,11 @@ func Error(err error, meta Metadata) {
 		return
 	}
 
+	nixVersion, err := nix.Version()
+	if err != nil {
+		nixVersion = "unknown"
+	}
+
 	event := &sentry.Event{
 		EventID:   sentry.EventID(ExecutionID),
 		Level:     sentry.LevelError,
@@ -132,6 +138,9 @@ func Error(err error, meta Metadata) {
 			"runtime": {
 				"name":    "Go",
 				"version": strings.TrimPrefix(runtime.Version(), "go"),
+			},
+			"nix": {
+				"version": nixVersion,
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Upon request by @Lagoja, this PR adds nix-version information to the sentry and segment telemetry logging.

## How was it tested?

Added a sentryDSN and telemetryKey locally, and built the binary.
Added a print-statement to verify the nix-version in the commandEvent to segment is correctly set for me.
