### PR TITLE
[nix] Fix profile list index for raw flakes

### DIFF
--- a/internal/nix/nixprofile/profile.go
+++ b/internal/nix/nixprofile/profile.go
@@ -127,7 +127,7 @@ func ProfileListIndex(args *ProfileListIndexArgs) (int, error) {
 		return -1, err
 	}
 
-	if !inCache {
+	if !inCache && args.Package.IsDevboxPackage() {
 		// This is an optimization for happy path when packages are added by flake reference. A resolved devbox
 		// package *which was added by flake reference* (not by store path) should match the unlockedReference
 		// of an existing profile item.
@@ -135,13 +135,13 @@ func ProfileListIndex(args *ProfileListIndexArgs) (int, error) {
 		if err != nil {
 			return -1, errors.Wrapf(err, "failed to get installable for %s", args.Package.String())
 		}
-		if ref != "" { // ref is empty when package is flake output (and not a devbox package)
-			for _, item := range items {
-				if ref == item.unlockedReference {
-					return item.index, nil
-				}
+
+		for _, item := range items {
+			if ref == item.unlockedReference {
+				return item.index, nil
 			}
 		}
+		return -1, errors.Wrap(nix.ErrPackageNotFound, args.Package.String())
 	}
 
 	for _, item := range items {

--- a/internal/nix/nixprofile/profile.go
+++ b/internal/nix/nixprofile/profile.go
@@ -135,12 +135,13 @@ func ProfileListIndex(args *ProfileListIndexArgs) (int, error) {
 		if err != nil {
 			return -1, errors.Wrapf(err, "failed to get installable for %s", args.Package.String())
 		}
-		for _, item := range items {
-			if ref == item.unlockedReference {
-				return item.index, nil
+		if ref != "" { // ref is empty when package is flake output (and not a devbox package)
+			for _, item := range items {
+				if ref == item.unlockedReference {
+					return item.index, nil
+				}
 			}
 		}
-		return -1, errors.Wrap(nix.ErrPackageNotFound, args.Package.String())
 	}
 
 	for _, item := range items {


### PR DESCRIPTION
## Summary

ProfileListIndex was broken for raw flakes. This would break `devbox update`

I could have left the `return -1, errors.Wrap(nix.ErrPackageNotFound, args.Package.String())` inside the if statement, but it seems safer to just to attempt the slow matching instead of returning an error and only returning an error after all matching fails.

Blame PR: https://github.com/jetpack-io/devbox/pull/1422

## How was it tested?

```bash
devbox add github:F1bonacc1/process-compose/v0.43.1
devbox update
```
