### PR TITLE
[envsec] Initial envsec integration

### DIFF
--- a/internal/boxcli/featureflag/envsec.go
+++ b/internal/boxcli/featureflag/envsec.go
@@ -1,0 +1,6 @@
+// Copyright 2023 Jetpack Technologies Inc and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package featureflag
+
+var Envsec = disable("ENVSEC")

--- a/internal/devconfig/config.go
+++ b/internal/devconfig/config.go
@@ -26,6 +26,10 @@ type Config struct {
 
 	// Env allows specifying env variables
 	Env map[string]string `json:"env,omitempty"`
+
+	// Only allows "envsec" for now
+	FromEnv string `json:"from_env,omitempty"`
+
 	// Shell configures the devbox shell environment.
 	Shell *shellConfig `json:"shell,omitempty"`
 	// Nixpkgs specifies the repository to pull packages from

--- a/internal/devconfig/env.go
+++ b/internal/devconfig/env.go
@@ -1,0 +1,26 @@
+package devconfig
+
+import (
+	"go.jetpack.io/devbox/internal/boxcli/featureflag"
+	"go.jetpack.io/devbox/internal/boxcli/usererr"
+	"go.jetpack.io/devbox/internal/integrations/envsec"
+)
+
+func (c *Config) ComputedEnv(projectDir string) (map[string]string, error) {
+	env := map[string]string{}
+	var err error
+	if featureflag.Envsec.Enabled() {
+		if c.FromEnv == "envsec" {
+			env, err = envsec.Env(projectDir)
+			if err != nil {
+				return nil, err
+			}
+		} else if c.FromEnv != "" {
+			return nil, usererr.New("unknown from_env value: %s", c.FromEnv)
+		}
+	}
+	for k, v := range c.Env {
+		env[k] = v
+	}
+	return env, nil
+}

--- a/internal/integrations/envsec/envsec.go
+++ b/internal/integrations/envsec/envsec.go
@@ -1,0 +1,63 @@
+package envsec
+
+import (
+	"encoding/json"
+	"os/exec"
+
+	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/internal/boxcli/usererr"
+	"go.jetpack.io/devbox/internal/cmdutil"
+)
+
+func Env(projectDir string) (map[string]string, error) {
+
+	if err := ensureEnvsecInstalled(); err != nil {
+		return nil, err
+	}
+
+	if err := ensureEnvsecInitialized(); err != nil {
+		return nil, err
+	}
+
+	return envsecList(projectDir)
+}
+
+func ensureEnvsecInstalled() error {
+	if !cmdutil.Exists("envsec") {
+		return usererr.New("envsec is not installed or not in path")
+	}
+	return nil
+}
+
+func ensureEnvsecInitialized() error {
+	cmd := exec.Command("envsec", "init")
+	// TODO handle user not logged in
+	// envsec init is currently broken in that it exits with 0 even if the user is not logged in
+	return cmd.Run()
+}
+
+func envsecList(projectDir string) (map[string]string, error) {
+	cmd := exec.Command(
+		"envsec", "ls", "--show",
+		"--format", "json",
+		"--environment", "dev")
+	cmd.Dir = projectDir
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	var values []struct {
+		Name  string `json:"name"`
+		Value string `json:"value"`
+	}
+
+	if err := json.Unmarshal(out, &values); err != nil {
+		return nil, errors.Wrap(err, "failed to parse envsec output")
+	}
+
+	m := map[string]string{}
+	for _, v := range values {
+		m[v.Name] = v.Value
+	}
+	return m, nil
+}


### PR DESCRIPTION
## Summary

This pre-mvp integration is mostly just to get something working. It's missing a lot of stuff. Specifically:

* envsec auto-install
* error handling (this requires new envsec `--json` output so we don't have to do clever parsing). 
* Performance. Currently `envsec.Env` gets called a few times and not cached.

One open question is how generic we want to make the integration. This implementation is pretty coupled. 

## How was it tested?

```bash
envsec set FOO=BAR
devbox run echo \$FOO
```
