### PR TITLE
[Script Exit on Error] enable feature flag, and add stability advice to CICD docs

### DIFF
--- a/docs/app/docs/continuous_integration/github_action.md
+++ b/docs/app/docs/continuous_integration/github_action.md
@@ -45,3 +45,5 @@ jobs:
 ## Configuring the Action
 
 See the [GitHub Marketplace page](https://github.com/marketplace/actions/devbox-installer) for the latest configuration settings and an example.
+
+For stability over new features and bug fixes, consider pinning `devbox-version`. Remember to update this pinned version when you update your local Devbox via `devbox version update`.

--- a/internal/boxcli/featureflag/feature.go
+++ b/internal/boxcli/featureflag/feature.go
@@ -19,6 +19,9 @@ type feature struct {
 
 var features = map[string]*feature{}
 
+// Prevent lint complaining about unused function
+//
+//nolint:unparam
 func disable(name string) *feature {
 	if features[name] == nil {
 		features[name] = &feature{name: name}
@@ -27,6 +30,9 @@ func disable(name string) *feature {
 	return features[name]
 }
 
+// Prevent lint complaining about unused function
+//
+//nolint:unparam
 func enable(name string) *feature {
 	if features[name] == nil {
 		features[name] = &feature{name: name}

--- a/internal/boxcli/featureflag/script_exit_on_error.go
+++ b/internal/boxcli/featureflag/script_exit_on_error.go
@@ -5,4 +5,4 @@ package featureflag
 
 // ScriptExitOnError controls whether scripts defined in devbox.json
 // and executed via `devbox run` should exit if any command within them errors.
-var ScriptExitOnError = disable("SCRIPT_EXIT_ON_ERROR")
+var ScriptExitOnError = enable("SCRIPT_EXIT_ON_ERROR")


### PR DESCRIPTION
## Summary

Fixes #1457

This feature enables `set -e` in the generated shell files for the "scripts" and "init hooks" of Devbox.
This feature has been running internally for a long time to power our CICD tests for the projects in `examples/`,
and has been very useful in ensuring correctness.

This may expose bugs in user code. While this results in `devbox version update` possibly leading to 
code that used to seemingly work previously now needing some fixes, we feel this is acceptable because:

1. We no longer auto-update Devbox. Users are intentionally updating when they are ready.
2. For CICD, they can pin the devbox-version for additional Stability. This PR updates the CICD docs
to call this out.

## How was it tested?

testscripts should pass
