### PR TITLE
[global] Fix global services

### DIFF
--- a/internal/boxcli/global.go
+++ b/internal/boxcli/global.go
@@ -19,8 +19,12 @@ func globalCmd() *cobra.Command {
 	globalCmd := &cobra.Command{}
 
 	*globalCmd = cobra.Command{
-		Use:                "global",
-		Short:              "Manage global devbox packages",
+		Use:   "global",
+		Short: "Manage global devbox packages",
+		// PersistentPreRunE is inherited only if children do not implement it
+		// (i.e. it's not chained). So this is fragile. Ideally we stop
+		// using PersistentPreRunE. For now a hack is to pass it down to commands
+		// that declare their own.
 		PersistentPreRunE:  setGlobalConfigForDelegatedCommands(globalCmd),
 		PersistentPostRunE: ensureGlobalEnvEnabled,
 	}
@@ -32,7 +36,10 @@ func globalCmd() *cobra.Command {
 	addCommandAndHideConfigFlag(globalCmd, pushCmd())
 	addCommandAndHideConfigFlag(globalCmd, removeCmd())
 	addCommandAndHideConfigFlag(globalCmd, runCmd())
-	addCommandAndHideConfigFlag(globalCmd, servicesCmd())
+	addCommandAndHideConfigFlag(
+		globalCmd,
+		servicesCmd(setGlobalConfigForDelegatedCommands(globalCmd)),
+	)
 	addCommandAndHideConfigFlag(globalCmd, shellEnvCmd())
 	addCommandAndHideConfigFlag(globalCmd, updateCmd())
 

--- a/internal/boxcli/global.go
+++ b/internal/boxcli/global.go
@@ -15,9 +15,8 @@ import (
 )
 
 func globalCmd() *cobra.Command {
-
 	globalCmd := &cobra.Command{}
-
+	persistentPreRunE := setGlobalConfigForDelegatedCommands(globalCmd)
 	*globalCmd = cobra.Command{
 		Use:   "global",
 		Short: "Manage global devbox packages",
@@ -25,7 +24,7 @@ func globalCmd() *cobra.Command {
 		// (i.e. it's not chained). So this is fragile. Ideally we stop
 		// using PersistentPreRunE. For now a hack is to pass it down to commands
 		// that declare their own.
-		PersistentPreRunE:  setGlobalConfigForDelegatedCommands(globalCmd),
+		PersistentPreRunE:  persistentPreRunE,
 		PersistentPostRunE: ensureGlobalEnvEnabled,
 	}
 
@@ -36,10 +35,7 @@ func globalCmd() *cobra.Command {
 	addCommandAndHideConfigFlag(globalCmd, pushCmd())
 	addCommandAndHideConfigFlag(globalCmd, removeCmd())
 	addCommandAndHideConfigFlag(globalCmd, runCmd())
-	addCommandAndHideConfigFlag(
-		globalCmd,
-		servicesCmd(setGlobalConfigForDelegatedCommands(globalCmd)),
-	)
+	addCommandAndHideConfigFlag(globalCmd, servicesCmd(persistentPreRunE))
 	addCommandAndHideConfigFlag(globalCmd, shellEnvCmd())
 	addCommandAndHideConfigFlag(globalCmd, updateCmd())
 

--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -21,6 +21,8 @@ import (
 	"go.jetpack.io/devbox/internal/vercheck"
 )
 
+type cobraFunc func(cmd *cobra.Command, args []string) error
+
 var (
 	debugMiddleware = &midcobra.DebugMiddleware{}
 	traceMiddleware = &midcobra.TraceMiddleware{}

--- a/internal/boxcli/services.go
+++ b/internal/boxcli/services.go
@@ -41,14 +41,22 @@ func (flags *serviceStopFlags) register(cmd *cobra.Command) {
 		&flags.allProjects, "all-projects", false, "Stop all running services across all your projects.\nThis flag cannot be used simultaneously with the [services] argument")
 }
 
-func servicesCmd() *cobra.Command {
+func servicesCmd(persistentPreRunE ...cobraFunc) *cobra.Command {
 	flags := servicesCmdFlags{}
 	serviceUpFlags := serviceUpFlags{}
 	serviceStopFlags := serviceStopFlags{}
 	servicesCommand := &cobra.Command{
-		Use:               "services",
-		Short:             "Interact with devbox services",
-		PersistentPreRunE: ensureNixInstalled,
+		Use:   "services",
+		Short: "Interact with devbox services",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			preruns := append([]cobraFunc{ensureNixInstalled}, persistentPreRunE...)
+			for _, fn := range preruns {
+				if err := fn(cmd, args); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
 	}
 
 	lsCommand := &cobra.Command{


### PR DESCRIPTION
## Summary

cobra doesn't chain `PersistentPreRunE`. So if a parent declares one and a child declares it as well, the parent function is ignored. `global` uses `PersistentPreRunE` to set the global project directory. The `services` command was running it to ensure nix is installed. The child replaced the parent, so we were never setting th

The fix here is a bit ugly but it solves them problem.

There's a UX issue I rediscovered while testing this. When adding global packages the environment is not automatically refreshed. This means services wont work until a new shell is opened or if the user does `eval "$(devbox global shellenv)"` manually.

## How was it tested?
```
devbox global add nginx
eval "$(devbox global shellenv)"
devbox global services up
```
