### PR TITLE
[script-on-error] disable for fish shell, and add testscript unit-test

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -210,6 +210,17 @@ func (d *Devbox) Shell(ctx context.Context) error {
 	return shell.Run()
 }
 
+// IsUserShellFish returns true if the user's shell is fish.
+// This wrapper function over DevboxShell enables querying from other packages that
+// make a devboxer interface.
+func (d *Devbox) IsUserShellFish() (bool, error) {
+	sh, err := NewDevboxShell(d)
+	if err != nil {
+		return false, err
+	}
+	return sh.IsFish(), nil
+}
+
 func (d *Devbox) RunScript(ctx context.Context, cmdName string, cmdArgs []string) error {
 	ctx, task := trace.NewTask(ctx, "devboxRun")
 	defer task.End()

--- a/internal/impl/shell.go
+++ b/internal/impl/shell.go
@@ -269,6 +269,12 @@ func (s *DevboxShell) Run() error {
 	return errors.WithStack(err)
 }
 
+// IsFish returns whether this DevboxShell wraps a fish shell. Fish shells are non-posix compatible,
+// and so sometimes we may need to switch logic based on this function's result.
+func (s *DevboxShell) IsFish() bool {
+	return s.name == shFish
+}
+
 func (s *DevboxShell) shellRCOverrides(shellrc string) (extraEnv map[string]string, extraArgs []string) {
 	// Shells have different ways of overriding the shellrc, so we need to
 	// look at the name to know which env vars or args to set when launching the shell.
@@ -319,7 +325,7 @@ func (s *DevboxShell) writeDevboxShellrc() (path string, err error) {
 	}()
 
 	tmpl := shellrcTmpl
-	if s.name == shFish {
+	if s.IsFish() {
 		tmpl = fishrcTmpl
 	}
 

--- a/internal/shellgen/scripts.go
+++ b/internal/shellgen/scripts.go
@@ -25,6 +25,7 @@ type devboxer interface {
 	Lockfile() *lock.File
 	AllInstallablePackages() ([]*devpkg.Package, error)
 	InstallablePackages() []*devpkg.Package
+	IsUserShellFish() (bool, error)
 	PluginManager() *plugin.Manager
 	ProjectDir() string
 }
@@ -97,7 +98,13 @@ func WriteScriptFile(d devboxer, name string, body string) (err error) {
 	}
 
 	if featureflag.ScriptExitOnError.Enabled() {
-		body = fmt.Sprintf("set -e\n\n%s", body)
+		isFish, err := d.IsUserShellFish()
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if !isFish {
+			body = fmt.Sprintf("set -e\n\n%s", body)
+		}
 	}
 	_, err = script.WriteString(body)
 	return errors.WithStack(err)

--- a/internal/shellgen/scripts.go
+++ b/internal/shellgen/scripts.go
@@ -81,8 +81,8 @@ func WriteScriptsToFiles(devbox devboxer) error {
 	return nil
 }
 
-func WriteScriptFile(d devboxer, name string, body string) (err error) {
-	script, err := os.Create(ScriptPath(d.ProjectDir(), name))
+func WriteScriptFile(devbox devboxer, name string, body string) (err error) {
+	script, err := os.Create(ScriptPath(devbox.ProjectDir(), name))
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -98,7 +98,7 @@ func WriteScriptFile(d devboxer, name string, body string) (err error) {
 	}
 
 	if featureflag.ScriptExitOnError.Enabled() {
-		isFish, err := d.IsUserShellFish()
+		isFish, err := devbox.IsUserShellFish()
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/internal/shellgen/scripts.go
+++ b/internal/shellgen/scripts.go
@@ -98,6 +98,10 @@ func WriteScriptFile(devbox devboxer, name string, body string) (err error) {
 	}
 
 	if featureflag.ScriptExitOnError.Enabled() {
+		// Fish cannot run scripts with `set -e`.
+		// NOTE: Devbox scripts will run using `sh` for consistency. However,
+		// init_hooks in a fish shell will run using `fish` shell, and need this
+		// check.
 		isFish, err := devbox.IsUserShellFish()
 		if err != nil {
 			return errors.WithStack(err)

--- a/testscripts/run/script_exit_on_error.test.txt
+++ b/testscripts/run/script_exit_on_error.test.txt
@@ -1,0 +1,20 @@
+# Testscript to ensure that the script exits on error.
+
+! exec devbox run multi_line
+stdout 'first line'
+! stdout 'second line'
+
+-- devbox.json --
+{
+  "packages": [
+  ],
+  "shell": {
+    "scripts": {
+      "multi_line": [
+        "echo \"first line\"",
+        "exit 1",
+        "echo \"second line\""
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

`set -e` can fail in fish-shells (sometimes), so we disable script-on-error for them.

I also add a testscript unit-test for script-exit-on-error, in general.

## How was it tested?

I run fish-shell, and did a sanity test that the `go/hello-world` example passes `run_test`.

BEFORE:
with this devbox.json
```
> cat devbox.json
{
    "packages": [
        "go@1.19.8"
    ],
    "shell": {
        "init_hook": [
            "export \"GOROOT=$(go env GOROOT)\"",
            "echo \"foo\""
        ],
        "scripts": {
            "run_test": "go run main.go"
        }
    }
}
```

doing `devbox shell` would give:
```
> devbox shell
Ensuring packages are installed.

Installing package: go@1.19.8.

[1/1] go@1.19.8
[1/1] go@1.19.8: Success
Starting a devbox shell...
set: -e: option requires an argument

~/code/jetpack/devbox/examples/development/go/hello-world/.devbox/gen/scripts/.hooks.sh (line 1):
set -e
^
from sourcing file ~/code/jetpack/devbox/examples/development/go/hello-world/.devbox/gen/scripts/.hooks.sh
	called on line 130 of file /var/folders/zv/r3sx92_94gq86_rq3yn1ky2h0000gn/T/devbox2997650637/config.fish
from sourcing file /var/folders/zv/r3sx92_94gq86_rq3yn1ky2h0000gn/T/devbox2997650637/config.fish

(Type 'help set' for related documentation)
foo
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish
(devbox)
```

AFTER:
```
> devbox shell
Ensuring packages are installed.

Installing package: go@1.19.8.

[1/1] go@1.19.8
[1/1] go@1.19.8: Success
Starting a devbox shell...
foo
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish
(devbox)>
```


