### PR TITLE
[plugins] Fix init hooks for custom plugins

### DIFF
--- a/examples/plugins/local/my-plugin/my-plugin.json
+++ b/examples/plugins/local/my-plugin/my-plugin.json
@@ -10,5 +10,10 @@
     "{{ .Virtenv }}/some-file": "some-file.txt",
     "{{ .DevboxDir }}/some-file.txt": "some-file.txt",
     "{{ .Virtenv }}/process-compose.yaml": "process-compose.yaml"
+  },
+  "shell": {
+      "init_hook": [
+          "export MY_INIT_HOOK_VAR=BAR"
+      ]
   }
 }

--- a/examples/plugins/local/test.sh
+++ b/examples/plugins/local/test.sh
@@ -4,12 +4,12 @@ if [ -z "$MY_FOO_VAR" ]; then
   echo "MY_FOO_VAR environment variable is not set."
   exit 1
 else
- echo "MY_FOO_VAR is set to '$MY_FOO_VAR'"
+  echo "MY_FOO_VAR is set to '$MY_FOO_VAR'"
 fi
 
 if [ -z "$MY_INIT_HOOK_VAR" ]; then
   echo "MY_INIT_HOOK_VAR environment variable is not set."
   exit 1
 else
- echo "MY_INIT_HOOK_VAR is set to '$MY_INIT_HOOK_VAR'"
+  echo "MY_INIT_HOOK_VAR is set to '$MY_INIT_HOOK_VAR'"
 fi

--- a/examples/plugins/local/test.sh
+++ b/examples/plugins/local/test.sh
@@ -6,3 +6,10 @@ if [ -z "$MY_FOO_VAR" ]; then
 else
  echo "MY_FOO_VAR is set to '$MY_FOO_VAR'"
 fi
+
+if [ -z "$MY_INIT_HOOK_VAR" ]; then
+  echo "MY_INIT_HOOK_VAR environment variable is not set."
+  exit 1
+else
+ echo "MY_INIT_HOOK_VAR is set to '$MY_INIT_HOOK_VAR'"
+fi

--- a/internal/plugin/hooks.go
+++ b/internal/plugin/hooks.go
@@ -7,10 +7,24 @@ import (
 	"go.jetpack.io/devbox/internal/devpkg"
 )
 
-func InitHooks(pkgs []*devpkg.Package, projectDir string) ([]string, error) {
+func (m *Manager) InitHooks(
+	pkgs []*devpkg.Package,
+	includes []string,
+) ([]string, error) {
 	hooks := []string{}
+	allPkgs := []Includable{}
 	for _, pkg := range pkgs {
-		c, err := getConfigIfAny(pkg, projectDir)
+		allPkgs = append(allPkgs, pkg)
+	}
+	for _, include := range includes {
+		name, err := m.ParseInclude(include)
+		if err != nil {
+			return nil, err
+		}
+		allPkgs = append(allPkgs, name)
+	}
+	for _, pkg := range allPkgs {
+		c, err := getConfigIfAny(pkg, m.ProjectDir())
 		if err != nil {
 			return nil, err
 		}

--- a/internal/shellgen/scripts.go
+++ b/internal/shellgen/scripts.go
@@ -46,7 +46,10 @@ func WriteScriptsToFiles(devbox devboxer) error {
 
 	// Write all hooks to a file.
 	written := map[string]struct{}{} // set semantics; value is irrelevant
-	pluginHooks, err := plugin.InitHooks(devbox.InstallablePackages(), devbox.ProjectDir())
+	pluginHooks, err := devbox.PluginManager().InitHooks(
+		devbox.InstallablePackages(),
+		devbox.Config().Include,
+	)
 	if err != nil {
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
## Summary

Ensure custom plugin init hooks run. Previously they were only running for builtins.


## How was it tested?

`devbox run run_test`