### PR TITLE
[sync-lock] Add sync-lock-reference flag

### DIFF
--- a/internal/boxcli/update.go
+++ b/internal/boxcli/update.go
@@ -13,8 +13,9 @@ import (
 )
 
 type updateCmdFlags struct {
-	config configFlags
-	sync   bool
+	config                configFlags
+	sync                  bool
+	ReferenceLockFilePath string
 }
 
 func updateCmd() *cobra.Command {
@@ -39,7 +40,15 @@ func updateCmd() *cobra.Command {
 		"sync-lock",
 		false,
 		"Sync all devbox.lock dependencies in multiple projects. "+
-			"Dependencies will sync to the latest local version.",
+			"Dependencies will sync to the latest resolved local version.",
+	)
+	command.Flags().StringVar(
+		&flags.ReferenceLockFilePath,
+		"sync-lock-reference",
+		"",
+		"Path to a devbox.lock file to use as a reference when syncing lockfiles. "+
+			"If none is provided then most recent last modified dependency is used. "+
+			"Must be used with --sync-lock flag.",
 	)
 	return command
 }
@@ -58,7 +67,8 @@ func updateCmdFunc(cmd *cobra.Command, args []string, flags *updateCmdFlags) err
 	}
 
 	return box.Update(cmd.Context(), devopt.UpdateOpts{
-		Pkgs: args,
-		Sync: flags.sync,
+		Pkgs:                  args,
+		ReferenceLockFilePath: flags.ReferenceLockFilePath,
+		Sync:                  flags.sync,
 	})
 }

--- a/internal/impl/devopt/devboxopts.go
+++ b/internal/impl/devopt/devboxopts.go
@@ -39,6 +39,7 @@ type Credentials struct {
 }
 
 type UpdateOpts struct {
-	Pkgs []string
-	Sync bool
+	Pkgs                  []string
+	ReferenceLockFilePath string
+	Sync                  bool
 }

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -21,7 +21,7 @@ import (
 
 func (d *Devbox) Update(ctx context.Context, opts devopt.UpdateOpts) error {
 	if opts.Sync {
-		return lock.SyncLockfiles()
+		return lock.SyncLockfiles(opts)
 	}
 
 	inputs, err := d.inputsToUpdate(opts.Pkgs...)


### PR DESCRIPTION
## Summary

Stacked on https://github.com/jetpack-io/devbox/pull/1501

This adds a `--sync-lock-reference` flag that allows `--sync-lock` to prioritize dependencies in a lock file. This is useful when you want to enforce a repo to mimic a single lock file.

This is an alternative to introducing workspaces (e.g. yarn or golang workspaces). 

## How was it tested?

```
# modified examples/databases/mariadb/devbox.lock to have an older dependency
devbox update --sync-lock --sync-lock-reference examples/databases/mariadb/devbox.lock
# observed that all lock files now follow older dependency.
```
