### PR TITLE
[CICD] Fix nix command and unbreak CICD

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -143,7 +143,7 @@ jobs:
           cat /etc/nix/nix.conf || true
           echo "::endgroup::"
           echo "::group::Resolved Nix config"
-          nix show-config
+          nix show-config --extra-experimental-features nix-command
           echo "::endgroup::"
           go test -v -timeout $DEVBOX_GOLANG_TEST_TIMEOUT ./...
 
@@ -202,7 +202,7 @@ jobs:
           cat /etc/nix/nix.conf || true
           echo "::endgroup::"
           echo "::group::Resolved Nix config"
-          nix show-config
+          nix show-config --extra-experimental-features nix-command
           echo "::endgroup::"
           devbox install
           devbox run -- echo "Hello from devbox!"


### PR DESCRIPTION
## Summary

New version of det sys installer seems to have removed this flag?

## How was it tested?

Testing on CICD