### PR TITLE
[envsec] Add envsec to path if used in config

### DIFF
--- a/internal/boxcli/featureflag/envsec.go
+++ b/internal/boxcli/featureflag/envsec.go
@@ -1,6 +1,0 @@
-// Copyright 2023 Jetpack Technologies Inc and contributors. All rights reserved.
-// Use of this source code is governed by the license in the LICENSE file.
-
-package featureflag
-
-var Envsec = disable("ENVSEC")

--- a/internal/devconfig/env.go
+++ b/internal/devconfig/env.go
@@ -1,7 +1,6 @@
 package devconfig
 
 import (
-	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/integrations/envsec"
 )
@@ -9,18 +8,20 @@ import (
 func (c *Config) ComputedEnv(projectDir string) (map[string]string, error) {
 	env := map[string]string{}
 	var err error
-	if featureflag.Envsec.Enabled() {
-		if c.EnvFrom == "envsec" {
-			env, err = envsec.Env(projectDir)
-			if err != nil {
-				return nil, err
-			}
-		} else if c.EnvFrom != "" {
-			return nil, usererr.New("unknown from_env value: %s", c.EnvFrom)
+	if c.IsEnvsecEnabled() {
+		env, err = envsec.Env(projectDir)
+		if err != nil {
+			return nil, err
 		}
+	} else if c.EnvFrom != "" {
+		return nil, usererr.New("unknown from_env value: %s", c.EnvFrom)
 	}
 	for k, v := range c.Env {
 		env[k] = v
 	}
 	return env, nil
+}
+
+func (c *Config) IsEnvsecEnabled() bool {
+	return c.EnvFrom == "envsec"
 }

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -871,6 +871,11 @@ func (d *Devbox) computeNixEnv(ctx context.Context, usePrintDevEnvCache bool) (m
 		)
 	}
 
+	env["PATH"], err = d.addUtilitiesToPath(env["PATH"])
+	if err != nil {
+		return nil, err
+	}
+
 	// Include env variables in devbox.json
 	configEnv, err := d.configEnvs(env)
 	if err != nil {

--- a/internal/impl/util.go
+++ b/internal/impl/util.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/internal/integrations/envsec"
 	"go.jetpack.io/devbox/internal/nix/nixprofile"
 
 	"go.jetpack.io/devbox/internal/xdg"
@@ -31,6 +32,21 @@ func (d *Devbox) addDevboxUtilityPackage(ctx context.Context, pkg string) error 
 		ProfilePath: profilePath,
 		Writer:      d.writer,
 	})
+}
+
+// addDevboxUtilityPackages adds binaries that we want the user to have access
+// to (e.g. envsec).
+// Question: Should we add utilityBinPath here? That would allow user to use
+// process-compose, etc
+func (d *Devbox) addUtilitiesToPath(path string) (string, error) {
+	if d.cfg.IsEnvsecEnabled() {
+		envsecPath, err := envsec.EnsureInstalled()
+		if err != nil {
+			return "", err
+		}
+		path = path + string(os.PathListSeparator) + filepath.Dir(envsecPath)
+	}
+	return path, nil
 }
 
 func utilityLookPath(binName string) (string, error) {


### PR DESCRIPTION
## Summary

This PR adds envsec to devbox env $PATH if it is used in config. This allows user to use envsec without explicitly installing it and without adding any envsec specific commands to devbox. e.g.

`devbox run envsec ls`

and `devbox shell` followed by `envsec ls` 

will both work.

Other improvements:

* Don't modify current process path when adding envsec (it's best to avoid `os.Setenv` if we can so that environment is more consistent trough run and now longer depends on when `envsec.EnsureInstalled` is called.)
* Remove feature flag (this feature is gated anyway by requiring explicit opt-in in the config) 

## How was it tested?

``` 
devbox run envsec ls
```
