### PR TITLE
[features] Turn off Remove Nixpkgs and Script Exit on Error

### DIFF
--- a/internal/boxcli/featureflag/remove_nixpkgs.go
+++ b/internal/boxcli/featureflag/remove_nixpkgs.go
@@ -4,4 +4,4 @@ package featureflag
 // It leverages the search index to directly map <package>@<version> to
 // the /nix/store/<hash>-<package>-<version> that can be fetched from
 // cache.nixpkgs.org.
-var RemoveNixpkgs = enable("REMOVE_NIXPKGS")
+var RemoveNixpkgs = disable("REMOVE_NIXPKGS")

--- a/internal/boxcli/featureflag/script_exit_on_error.go
+++ b/internal/boxcli/featureflag/script_exit_on_error.go
@@ -5,4 +5,4 @@ package featureflag
 
 // ScriptExitOnError controls whether scripts defined in devbox.json
 // and executed via `devbox run` should exit if any command within them errors.
-var ScriptExitOnError = enable("SCRIPT_EXIT_ON_ERROR")
+var ScriptExitOnError = disable("SCRIPT_EXIT_ON_ERROR")


### PR DESCRIPTION
## Summary

Turning these off to reduce scope of the next release. 

## How was it tested?

did not test. Will rely on CICD being green.
