### PR TITLE
[errors] Show better errors when user script errors out and fix poetry plugin

### DIFF
--- a/internal/boxcli/midcobra/midcobra.go
+++ b/internal/boxcli/midcobra/midcobra.go
@@ -81,6 +81,7 @@ func (ex *midcobraExecutable) Execute(ctx context.Context, args []string) int {
 		var exitErr *exec.ExitError
 		var userExecErr *usererr.ExitError
 		if errors.As(err, &userExecErr) {
+			ux.Ferror(ex.cmd.ErrOrStderr(), userExecErr.Error()+"\n")
 			return userExecErr.ExitCode()
 		}
 		if errors.As(err, &exitErr) {

--- a/plugins/poetry.json
+++ b/plugins/poetry.json
@@ -1,7 +1,7 @@
 {
     "name": "poetry",
-    "version": "0.0.1",
-    "readme": "This plugin automatically configures poetry to use the version of python installed in your Devbox shell, instead of the Python version that it is bundled with.",
+    "version": "0.0.2",
+    "readme": "This plugin automatically configures poetry to use the version of python installed in your Devbox shell, instead of the Python version that it is bundled with. Your pyproject.toml must be in the same directory as your devbox.json.",
     "env": {
         "POETRY_VIRTUALENVS_IN_PROJECT": "true",
         "POETRY_VIRTUALENVS_CREATE": "true",
@@ -9,7 +9,7 @@
     },
     "shell": {
         "init_hook": [
-            "poetry env use $(command -v python) --quiet --no-interaction"
+            "poetry env use $(command -v python) --no-interaction"
         ]
     }
 }


### PR DESCRIPTION
* When a user script errors out, show the error code (e.g. `Error: exit status 1`) This helps in cases when stderr is empty (which the previous `--quiet` was causing)
* Improve poetry plugin by removing `--quiet` flag and adding more required into in readme.

Possible future improements:
* Better error when python is not installed
* Better error when pyproject is missing
* Allow custom pyproject locations

## Summary

## How was it tested?

<img width="352" alt="image" src="https://github.com/jetpack-io/devbox/assets/544948/db93da90-d244-4a0b-bf8f-5ab5812464b7">

New implementation

<img width="381" alt="image" src="https://github.com/jetpack-io/devbox/assets/544948/e2f73145-5e24-4be9-bf5e-1299a2e72c83">

