### PR TITLE
impl: set SHELL environment variable

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -71,7 +71,6 @@ type Devbox struct {
 var legacyPackagesWarningHasBeenShown = false
 
 func Open(opts *devopt.Opts) (*Devbox, error) {
-
 	projectDir, err := findProjectDir(opts.Dir)
 	if err != nil {
 		return nil, err
@@ -318,7 +317,7 @@ func (d *Devbox) EnvVars(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return keyEqualsValue(envs), nil
+	return mapToPairs(envs), nil
 }
 
 func (d *Devbox) ShellEnvHash(ctx context.Context) (string, error) {
@@ -684,7 +683,6 @@ func (d *Devbox) StartProcessManager(
 	background bool,
 	processComposeFileOrDir string,
 ) error {
-
 	if !d.IsEnvEnabled() {
 		args := []string{"services", "up"}
 		args = append(args, requestedServices...)

--- a/internal/impl/shell.go
+++ b/internal/impl/shell.go
@@ -244,6 +244,7 @@ func (s *DevboxShell) Run() error {
 	for k, v := range extraEnv {
 		env[k] = v
 	}
+	env["SHELL"] = s.binPath
 
 	cmd = exec.Command(s.binPath)
 	cmd.Env = mapToPairs(env)

--- a/internal/impl/shell_test.go
+++ b/internal/impl/shell_test.go
@@ -83,7 +83,7 @@ func testWriteDevboxShellrc(t *testing.T, testdirs []string) {
 			// set, and then proceed normally. The test should
 			// always pass in this case.
 			if *update {
-				err = os.WriteFile(test.goldShellrcPath, gotShellrc, 0666)
+				err = os.WriteFile(test.goldShellrcPath, gotShellrc, 0o666)
 				if err != nil {
 					t.Error("Error updating golden files:", err)
 				}


### PR DESCRIPTION
We were assuming that most shells set `SHELL` upon startup, but this is only true for bash. Usually `SHELL` is only set by `login`, so we need to set it ourselves when launching the user's shell.

Also remove the `keyEqualsValue` which was only being used by the VSCode integration. This function escapes environment variable values for a shell, but we were setting the `code` process's environment with them directly. This was mangling the values by adding quotes and backslashes.

Fixes #1454.