### PR TITLE
[RFC][update] Add --all-projects flag

### DIFF
--- a/internal/boxcli/multi/multi.go
+++ b/internal/boxcli/multi/multi.go
@@ -1,0 +1,38 @@
+package multi
+
+import (
+	"io/fs"
+	"path/filepath"
+
+	"go.jetpack.io/devbox"
+	"go.jetpack.io/devbox/internal/debug"
+	"go.jetpack.io/devbox/internal/impl/devopt"
+)
+
+func Open(opts *devopt.Opts) ([]devbox.Devbox, error) {
+	defer debug.FunctionTimer().End()
+
+	var boxes []devbox.Devbox
+	err := filepath.WalkDir(
+		".",
+		func(path string, dirEntry fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if !dirEntry.IsDir() && filepath.Base(path) == "devbox.json" {
+				optsCopy := *opts
+				optsCopy.Dir = path
+				box, err := devbox.Open(&optsCopy)
+				if err != nil {
+					return err
+				}
+				boxes = append(boxes, box)
+			}
+
+			return nil
+		},
+	)
+
+	return boxes, err
+}

--- a/internal/boxcli/update.go
+++ b/internal/boxcli/update.go
@@ -8,13 +8,15 @@ import (
 	"github.com/spf13/cobra"
 
 	"go.jetpack.io/devbox"
+	"go.jetpack.io/devbox/internal/boxcli/multi"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/impl/devopt"
 )
 
 type updateCmdFlags struct {
-	config configFlags
-	sync   bool
+	config      configFlags
+	sync        bool
+	allProjects bool
 }
 
 func updateCmd() *cobra.Command {
@@ -41,10 +43,19 @@ func updateCmd() *cobra.Command {
 		"Sync all devbox.lock dependencies in multiple projects. "+
 			"Dependencies will sync to the latest local version.",
 	)
+	command.Flags().BoolVar(
+		&flags.allProjects,
+		"all-projects",
+		false,
+		"Update all projects in the working directory, recursively.",
+	)
 	return command
 }
 
 func updateCmdFunc(cmd *cobra.Command, args []string, flags *updateCmdFlags) error {
+	if flags.allProjects {
+		return updateAllProjects(cmd, args, flags)
+	}
 	box, err := devbox.Open(&devopt.Opts{
 		Dir:    flags.config.path,
 		Stderr: cmd.ErrOrStderr(),
@@ -61,4 +72,22 @@ func updateCmdFunc(cmd *cobra.Command, args []string, flags *updateCmdFlags) err
 		Pkgs: args,
 		Sync: flags.sync,
 	})
+}
+
+func updateAllProjects(cmd *cobra.Command, args []string, flags *updateCmdFlags) error {
+	boxes, err := multi.Open(&devopt.Opts{
+		Stderr: cmd.ErrOrStderr(),
+	})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	for _, box := range boxes {
+		if err := box.Update(cmd.Context(), devopt.UpdateOpts{
+			Pkgs: args,
+			Sync: flags.sync,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/boxcli/update.go
+++ b/internal/boxcli/update.go
@@ -87,7 +87,8 @@ func updateAllProjects(cmd *cobra.Command, args []string) error {
 	}
 	for _, box := range boxes {
 		if err := box.Update(cmd.Context(), devopt.UpdateOpts{
-			Pkgs: args,
+			Pkgs:                  args,
+			IgnoreMissingPackages: true,
 		}); err != nil {
 			return err
 		}

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -1023,7 +1023,8 @@ func (d *Devbox) findPackageByName(name string) (*devpkg.Package, error) {
 		)
 	}
 	if len(results) == 0 {
-		return nil, usererr.New("no package found with name %s", name)
+		return nil, usererr.WithUserMessage(
+			searcher.ErrNotFound, "no package found with name %s", name)
 	}
 	return lo.Keys(results)[0], nil
 }

--- a/internal/impl/devopt/devboxopts.go
+++ b/internal/impl/devopt/devboxopts.go
@@ -40,5 +40,4 @@ type Credentials struct {
 
 type UpdateOpts struct {
 	Pkgs []string
-	Sync bool
 }

--- a/internal/impl/devopt/devboxopts.go
+++ b/internal/impl/devopt/devboxopts.go
@@ -39,5 +39,6 @@ type Credentials struct {
 }
 
 type UpdateOpts struct {
-	Pkgs []string
+	Pkgs                  []string
+	IgnoreMissingPackages bool
 }

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/devpkg"
 	"go.jetpack.io/devbox/internal/impl/devopt"
@@ -20,7 +21,7 @@ import (
 )
 
 func (d *Devbox) Update(ctx context.Context, opts devopt.UpdateOpts) error {
-	inputs, err := d.inputsToUpdate(opts.Pkgs...)
+	inputs, err := d.inputsToUpdate(opts)
 	if err != nil {
 		return err
 	}
@@ -73,15 +74,19 @@ func (d *Devbox) Update(ctx context.Context, opts devopt.UpdateOpts) error {
 	return nix.FlakeUpdate(shellgen.FlakePath(d))
 }
 
-func (d *Devbox) inputsToUpdate(pkgs ...string) ([]*devpkg.Package, error) {
-	if len(pkgs) == 0 {
+func (d *Devbox) inputsToUpdate(
+	opts devopt.UpdateOpts,
+) ([]*devpkg.Package, error) {
+	if len(opts.Pkgs) == 0 {
 		return d.configPackages(), nil
 	}
 
 	var pkgsToUpdate []*devpkg.Package
-	for _, pkg := range pkgs {
+	for _, pkg := range opts.Pkgs {
 		found, err := d.findPackageByName(pkg)
-		if err != nil {
+		if opts.IgnoreMissingPackages && errors.Is(err, searcher.ErrNotFound) {
+			continue
+		} else if err != nil {
 			return nil, err
 		}
 		pkgsToUpdate = append(pkgsToUpdate, found)

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -20,10 +20,6 @@ import (
 )
 
 func (d *Devbox) Update(ctx context.Context, opts devopt.UpdateOpts) error {
-	if opts.Sync {
-		return lock.SyncLockfiles()
-	}
-
 	inputs, err := d.inputsToUpdate(opts.Pkgs...)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

RFC for flag that updates all projects under a given directory (recursively) 

Also adds ability to sync specific packages via `--sync-lock` and moved sync code into `multi` package.

## How was it tested?

`devbox update --all-projects` in a few of our repos.
