### PR TITLE
[fish] do not print hash -r in shellenv

### DIFF
--- a/internal/boxcli/shellenv.go
+++ b/internal/boxcli/shellenv.go
@@ -5,6 +5,8 @@ package boxcli
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"go.jetpack.io/devbox"
@@ -32,7 +34,9 @@ func shellEnvCmd() *cobra.Command {
 				return err
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), s)
-			fmt.Fprintln(cmd.OutOrStdout(), "hash -r")
+			if !strings.HasSuffix(os.Getenv("SHELL"), "fish") {
+				fmt.Fprintln(cmd.OutOrStdout(), "hash -r")
+			}
 			return nil
 		},
 	}


### PR DESCRIPTION
## Summary

I started receiving errors about `hash: command not found` in my fish shell.

I'm not quite sure why this didn't error earlier.

## How was it tested?

No longer receive these errors doing `devbox global shellenv | source` in my fishrc file
