### PR TITLE
[cleanup] remove unused nixEnv cache

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -916,16 +916,11 @@ func (d *Devbox) computeNixEnv(ctx context.Context, usePrintDevEnvCache bool) (m
 	return env, d.addHashToEnv(env)
 }
 
-var nixEnvCache map[string]string
-
 // nixEnv is a wrapper around computeNixEnv that caches the result.
 // Note that this is in-memory cache of the final environment, and not the same
 // as the nix print-dev-env cache which is stored in a file.
 func (d *Devbox) nixEnv(ctx context.Context) (map[string]string, error) {
 	defer debug.FunctionTimer().End()
-	if nixEnvCache != nil {
-		return nixEnvCache, nil
-	}
 
 	usePrintDevEnvCache := false
 


### PR DESCRIPTION
## Summary

cleanup this unused nixEnv cache.

I don't think it makes sense to re-use it just now. Reasons:
- inside `computeNixEnv` the most time intensive work is `nix print-dev-env`. The
rest happens quite quickly.
- We already rely on the lockfile state to guide us on re-using the print-dev-env cache.

Therefore, the value of this nixEnv cache is pretty marginal, and by re-introducing
code to set the cache, we may introduce correctness errors. So I propose 
removing it.

## How was it tested?

compiles.
