### PR TITLE
[fish] unbreak init-hook

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -9,7 +9,7 @@
   },
   "shell": {
     "init_hook": [
-      "unset CGO_ENABLED GO111MODULE GOARCH GOFLAGS GOMOD GOOS GOROOT GOTOOLCHAIN GOWORK"
+      "test -z $FISH_VERSION && unset CGO_ENABLED GO111MODULE GOARCH GOFLAGS GOMOD GOOS GOROOT GOTOOLCHAIN GOWORK"
     ],
     "scripts": {
       "build": "go build -o dist/devbox ./cmd/devbox",


### PR DESCRIPTION
## Summary

I don't see any of these env-vars in my devbox shell, so didn't try unsetting
them in fish ;-)  the fish command is `set -e <name>` to "erase" the env-var.

## How was it tested?

could start devbox shell. 
before: it would break since `unset` is unrecognized.
