### PR TITLE
[add] Print messages about actions taken, or not taken.

### DIFF
--- a/internal/devconfig/packages.go
+++ b/internal/devconfig/packages.go
@@ -2,7 +2,10 @@ package devconfig
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
 	"slices"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
@@ -70,7 +73,7 @@ func (pkgs *Packages) Remove(versionedName string) {
 }
 
 // AddPlatforms adds a platform to the list of platforms for a given package
-func (pkgs *Packages) AddPlatforms(versionedname string, platforms []string) error {
+func (pkgs *Packages) AddPlatforms(writer io.Writer, versionedname string, platforms []string) error {
 	if len(platforms) == 0 {
 		return nil
 	}
@@ -94,6 +97,10 @@ func (pkgs *Packages) AddPlatforms(versionedname string, platforms []string) err
 					pkg.VersionedName(),
 				)
 			}
+			fmt.Fprintf(writer,
+				"Added platform %s to package %s\n", strings.Join(platforms, ", "),
+				pkg.VersionedName(),
+			)
 
 			pkgs.jsonKind = jsonMap
 			pkg.kind = regular
@@ -105,7 +112,7 @@ func (pkgs *Packages) AddPlatforms(versionedname string, platforms []string) err
 }
 
 // ExcludePlatforms adds a platform to the list of excluded platforms for a given package
-func (pkgs *Packages) ExcludePlatforms(versionedName string, platforms []string) error {
+func (pkgs *Packages) ExcludePlatforms(writer io.Writer, versionedName string, platforms []string) error {
 	if len(platforms) == 0 {
 		return nil
 	}
@@ -127,6 +134,8 @@ func (pkgs *Packages) ExcludePlatforms(versionedName string, platforms []string)
 					pkg.VersionedName(),
 				)
 			}
+			fmt.Fprintf(writer, "Excluded platform %s for package %s\n", strings.Join(platforms, ", "),
+				pkg.VersionedName())
 
 			pkgs.jsonKind = jsonMap
 			pkg.kind = regular

--- a/internal/devconfig/packages.go
+++ b/internal/devconfig/packages.go
@@ -2,7 +2,6 @@ package devconfig
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"slices"
 	"strings"
@@ -13,6 +12,7 @@ import (
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/nix"
 	"go.jetpack.io/devbox/internal/searcher"
+	"go.jetpack.io/devbox/internal/ux"
 )
 
 type jsonKind int
@@ -97,7 +97,7 @@ func (pkgs *Packages) AddPlatforms(writer io.Writer, versionedname string, platf
 					pkg.VersionedName(),
 				)
 			}
-			fmt.Fprintf(writer,
+			ux.Finfo(writer,
 				"Added platform %s to package %s\n", strings.Join(platforms, ", "),
 				pkg.VersionedName(),
 			)
@@ -134,7 +134,7 @@ func (pkgs *Packages) ExcludePlatforms(writer io.Writer, versionedName string, p
 					pkg.VersionedName(),
 				)
 			}
-			fmt.Fprintf(writer, "Excluded platform %s for package %s\n", strings.Join(platforms, ", "),
+			ux.Finfo(writer, "Excluded platform %s for package %s\n", strings.Join(platforms, ", "),
 				pkg.VersionedName())
 
 			pkgs.jsonKind = jsonMap

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -57,7 +57,7 @@ func (d *Devbox) Add(ctx context.Context, platforms, excludePlatforms []string, 
 			// But we still need to add to addedPackageNames. See its comment.
 			addedPackageNames = append(addedPackageNames, pkg.Versioned())
 			unchangedPackageNames = append(unchangedPackageNames, pkg.Versioned())
-			fmt.Fprintf(d.stderr, "Package %q already in devbox.json\n", pkg.Versioned())
+			ux.Finfo(d.stderr, "Package %q already in devbox.json\n", pkg.Versioned())
 			continue
 		}
 
@@ -93,7 +93,7 @@ func (d *Devbox) Add(ctx context.Context, platforms, excludePlatforms []string, 
 			return usererr.New("Package %s not found", pkg.Raw)
 		}
 
-		fmt.Fprintf(d.stderr, "Adding package %q to devbox.json\n", packageNameForConfig)
+		ux.Finfo(d.stderr, "Adding package %q to devbox.json\n", packageNameForConfig)
 		d.cfg.Packages.Add(packageNameForConfig)
 		addedPackageNames = append(addedPackageNames, packageNameForConfig)
 	}
@@ -147,9 +147,9 @@ func (d *Devbox) Add(ctx context.Context, platforms, excludePlatforms []string, 
 
 	if len(platforms) == 0 && len(excludePlatforms) == 0 && !d.allowInsecureAdds {
 		if len(unchangedPackageNames) == 1 {
-			fmt.Fprintf(d.stderr, "Package %q was already in devbox.json and was not modified\n", unchangedPackageNames[0])
+			ux.Finfo(d.stderr, "Package %q was already in devbox.json and was not modified\n", unchangedPackageNames[0])
 		} else if len(unchangedPackageNames) > 1 {
-			fmt.Fprintf(d.stderr, "Packages %s were already in devbox.json and were not modified\n",
+			ux.Finfo(d.stderr, "Packages %s were already in devbox.json and were not modified\n",
 				strings.Join(unchangedPackageNames, ", "),
 			)
 		}

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -38,6 +38,9 @@ func (d *Devbox) Add(ctx context.Context, platforms, excludePlatforms []string, 
 	ctx, task := trace.NewTask(ctx, "devboxAdd")
 	defer task.End()
 
+	// Track which packages had no changes so we can report that to the user.
+	unchangedPackageNames := []string{}
+
 	// Only add packages that are not already in config. If same canonical exists,
 	// replace it.
 	pkgs := devpkg.PackageFromStrings(lo.Uniq(pkgsNames), d.lockfile)
@@ -53,6 +56,8 @@ func (d *Devbox) Add(ctx context.Context, platforms, excludePlatforms []string, 
 		if slices.Contains(existingPackageNames, pkg.Versioned()) {
 			// But we still need to add to addedPackageNames. See its comment.
 			addedPackageNames = append(addedPackageNames, pkg.Versioned())
+			unchangedPackageNames = append(unchangedPackageNames, pkg.Versioned())
+			fmt.Fprintf(d.stderr, "Package %q already in devbox.json\n", pkg.Versioned())
 			continue
 		}
 
@@ -88,15 +93,16 @@ func (d *Devbox) Add(ctx context.Context, platforms, excludePlatforms []string, 
 			return usererr.New("Package %s not found", pkg.Raw)
 		}
 
+		fmt.Fprintf(d.stderr, "Adding package %q to devbox.json\n", packageNameForConfig)
 		d.cfg.Packages.Add(packageNameForConfig)
 		addedPackageNames = append(addedPackageNames, packageNameForConfig)
 	}
 
 	for _, pkg := range addedPackageNames {
-		if err := d.cfg.Packages.AddPlatforms(pkg, platforms); err != nil {
+		if err := d.cfg.Packages.AddPlatforms(d.stderr, pkg, platforms); err != nil {
 			return err
 		}
-		if err := d.cfg.Packages.ExcludePlatforms(pkg, excludePlatforms); err != nil {
+		if err := d.cfg.Packages.ExcludePlatforms(d.stderr, pkg, excludePlatforms); err != nil {
 			return err
 		}
 	}
@@ -109,6 +115,11 @@ func (d *Devbox) Add(ctx context.Context, platforms, excludePlatforms []string, 
 			p, err := d.lockfile.Resolve(name)
 			if err != nil {
 				return err
+			}
+			// TODO: Now that config packages can have fields,
+			// we should set this in the config, not the lockfile.
+			if !p.AllowInsecure {
+				fmt.Fprintf(d.stderr, "Allowing insecure for %s\n", name)
 			}
 			p.AllowInsecure = true
 		}
@@ -131,6 +142,16 @@ func (d *Devbox) Add(ctx context.Context, platforms, excludePlatforms []string, 
 			return err
 		} else if readme != "" {
 			fmt.Fprintf(d.stderr, "%s\n", readme)
+		}
+	}
+
+	if len(platforms) == 0 && len(excludePlatforms) == 0 && !d.allowInsecureAdds {
+		if len(unchangedPackageNames) == 1 {
+			fmt.Fprintf(d.stderr, "Package %q was already in devbox.json and was not modified\n", unchangedPackageNames[0])
+		} else if len(unchangedPackageNames) > 1 {
+			fmt.Fprintf(d.stderr, "Packages %s were already in devbox.json and were not modified\n",
+				strings.Join(unchangedPackageNames, ", "),
+			)
 		}
 	}
 


### PR DESCRIPTION
## Summary

@Lagoja pointed out that `devbox add <existing package>` would exit with a no-op.

In this PR, I print messages during the execution of `devbox add` about changes made to each package.
If no changes were made for a package, then I explicitly print that at the end.

## How was it tested?


```
# Add new package
> devbox add vim
Adding package "vim@latest" to devbox.json

Installing package: vim@latest.

[1/1] vim@latest
[1/1] vim@latest: Success
Recomputing the devbox environment.

# Add --platform to existing package
> devbox add vim --platform x86_64-darwin
Package "vim@latest" already in devbox.json
Added platform x86_64-darwin to package vim@latest

# Add multiple existing packages
> devbox add vim go@1.19.8
Package "vim@latest" already in devbox.json
Package "go@1.19.8" already in devbox.json
Packages vim@latest, go@1.19.8 were already in devbox.json and were not modified

# Add a mix of existing and new packages
> devbox add vim go@1.19.8 fzf
Package "vim@latest" already in devbox.json
Package "go@1.19.8" already in devbox.json
Adding package "fzf@latest" to devbox.json

Installing package: fzf@latest.

[1/1] fzf@latest
[1/1] fzf@latest: Success
Recomputing the devbox environment.
Packages vim@latest, go@1.19.8 were already in devbox.json and were not modified
```
