### PR TITLE
[perf] FillNarInfoCache during nix profile's pendingPackagesForInstallation

### DIFF
--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -420,6 +420,13 @@ func (d *Devbox) pendingPackagesForInstallation(ctx context.Context) ([]*devpkg.
 	if err != nil {
 		return nil, err
 	}
+
+	// Fill the narinfo cache for all packages so we can check if they are in the
+	// binary cache.
+	if err := devpkg.FillNarInfoCache(ctx, packages...); err != nil {
+		return nil, err
+	}
+
 	for _, pkg := range packages {
 		_, err := nixprofile.ProfileListIndex(&nixprofile.ProfileListIndexArgs{
 			Items:      items,


### PR DESCRIPTION
## Summary

@Lagoja has a healthy number of `devbox global` packages. This exposed that `devbox add <package>` had a perf regression for him:
```
❯ devbox global add procs

Exec times over 1ms:
"ensurePackagesAreInstalled" took 1.44075ms
"nixEnv" took 2.446083ms
"devbox shellenv --preserve-path-stack -c /Users/johnlago/.local/share/devbox/global/default" took 49.446834ms

Exec times over 1ms:
"devbox shellenv only-path-without-wrappers" took 45.889ms

Installing package: procs@latest.

[1/1] procs@latest
[1/1] procs@latest: Success

Exec times over 1ms:
"syncPackagesToProfile" took 31.80875375s
Recomputing the devbox environment.
"CreateWrappers" took 17.186833ms
"ensurePackagesAreInstalled" took 36.056620833s
"devbox global add procs" took 36.410408875s
```

See the `syncPackagesToProfile` taking 31 seconds!

After re-running with `--trace`, he got the `trace.out` file at: https://gist.github.com/savil/f6abd6a3adc8e7c92d1d3fd9ecbb93d7

Opening with `go tool trace -http=localhost:6060 trace.out` shows:
<img width="865" alt="Screenshot 2023-10-03 at 5 14 05 PM" src="https://github.com/jetpack-io/devbox/assets/676452/657f22e2-839a-4f02-aa0b-4d1e1081a0c5">


This reveals that we're doing 15 seconds of http requests.

The new codepath does a HEAD request to verify that the binary is _still_ cached in the nix binary cache. The problem is that it does it serially in a for-loop for each package. 

**Fix** 
We have a function `FillNarInfoCache` that spawns goroutines to do it concurrently. This should speed up the time.


## How was it tested?

I was able to do `devbox global add procs` as a sanity check.