### PR TITLE
[lockfile] When updating store-paths, we should update all fields

### DIFF
--- a/devbox.lock
+++ b/devbox.lock
@@ -3,21 +3,21 @@
   "packages": {
     "go@latest": {
       "last_modified": "2023-09-10T10:53:27Z",
-      "resolved": "github:NixOS/nixpkgs/78058d810644f5ed276804ce7ea9e82d92bee293#go_1_21",
+      "resolved": "github:NixOS/nixpkgs/46688f8eb5cd6f1298d873d4d2b9cf245e09e88e#go_1_21",
       "source": "devbox-search",
       "version": "1.21.1",
       "systems": {
         "aarch64-darwin": {
-          "store_path": "/nix/store/0xy4l28cjaji04jp2la3s5wzh0n4yb5y-go-1.21.1"
+          "store_path": "/nix/store/jkhg33806wygpwpix47d2h5scfgn01i8-go-1.21.1"
         },
         "aarch64-linux": {
-          "store_path": "/nix/store/mji19qaxy6xd8vlk5j0jk83yslq0lqil-go-1.21.1"
+          "store_path": "/nix/store/sgkkfw6saficch0mviqyqyw6nj64kzf9-go-1.21.1"
         },
         "x86_64-darwin": {
-          "store_path": "/nix/store/7rgm1xhrmf9ygdk0c1qcgjsraxhzjj3g-go-1.21.1"
+          "store_path": "/nix/store/w67nj5iqgnz0msi8i12kyh9nhsp2ci9n-go-1.21.1"
         },
         "x86_64-linux": {
-          "store_path": "/nix/store/vnbz45plc7is6j5pk33dbcq14fbvb658-go-1.21.1"
+          "store_path": "/nix/store/jk0bqfsjijia52vks1wxqnn4s6dxaiqp-go-1.21.1"
         }
       }
     },

--- a/devbox.lock
+++ b/devbox.lock
@@ -2,7 +2,7 @@
   "lockfile_version": "1",
   "packages": {
     "go@latest": {
-      "last_modified": "2023-09-10T10:53:27Z",
+      "last_modified": "2023-09-15T06:49:28Z",
       "resolved": "github:NixOS/nixpkgs/46688f8eb5cd6f1298d873d4d2b9cf245e09e88e#go_1_21",
       "source": "devbox-search",
       "version": "1.21.1",

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -135,7 +135,6 @@ func (d *Devbox) mergeResolvedPackageToLockfile(
 		userSystem := nix.System()
 		updated := false
 		for sysName, newSysInfo := range resolved.Systems {
-
 			// Check whether we are actually updating any system info.
 			if sysName == userSystem {
 				// The resolved pkg has a system info for the user's system, so add/overwrite it.

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -132,11 +132,9 @@ func (d *Devbox) mergeResolvedPackageToLockfile(
 			lockfile.Packages[pkg.Raw].Systems = map[string]*lock.SystemInfo{}
 		}
 
-		newSystems := map[string]*lock.SystemInfo{}
 		userSystem := nix.System()
 		updated := false
 		for sysName, newSysInfo := range resolved.Systems {
-			newSystems[sysName] = newSysInfo
 
 			// Check whether we are actually updating any system info.
 			if sysName == userSystem {
@@ -158,7 +156,6 @@ func (d *Devbox) mergeResolvedPackageToLockfile(
 		if updated {
 			// if we are updating the system info, then we should also update the other fields
 			useResolvedPackageInLockfile(lockfile, pkg, resolved, existing)
-			lockfile.Packages[pkg.Raw].Systems = newSystems
 
 			ux.Finfo(d.stderr, "Updated system information for %s\n", pkg)
 			return nil

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -121,8 +121,7 @@ func (d *Devbox) mergeResolvedPackageToLockfile(
 			// sync the profile so we don't need to do this manually.
 			ux.Fwarning(d.stderr, "Failed to remove %s from profile: %s\n", pkg, err)
 		}
-		resolved.AllowInsecure = existing.AllowInsecure
-		lockfile.Packages[pkg.Raw] = resolved
+		useResolvedPackageInLockfile(lockfile, pkg, resolved, existing)
 		return nil
 	}
 
@@ -133,30 +132,33 @@ func (d *Devbox) mergeResolvedPackageToLockfile(
 			lockfile.Packages[pkg.Raw].Systems = map[string]*lock.SystemInfo{}
 		}
 
+		newSystems := map[string]*lock.SystemInfo{}
 		userSystem := nix.System()
 		updated := false
 		for sysName, newSysInfo := range resolved.Systems {
+			newSystems[sysName] = newSysInfo
+
+			// Check whether we are actually updating any system info.
 			if sysName == userSystem {
 				// The resolved pkg has a system info for the user's system, so add/overwrite it.
 				if !newSysInfo.Equals(existing.Systems[userSystem]) {
 					// We only guard this so that the ux messaging is accurate. We could overwrite every time.
-					lockfile.Packages[pkg.Raw].Systems[userSystem] = newSysInfo
 					updated = true
 				}
 			} else {
 				// Add other system infos if they don't exist, or if we have a different StorePath. This may
-				// overwrite an existing CAPath, but to ensure correctness we should ensure that all StorePaths
+				// overwrite an existing StorePath, but to ensure correctness we should ensure that all StorePaths
 				// come from the same package version.
 				existingSysInfo, exists := existing.Systems[sysName]
 				if !exists || existingSysInfo.StorePath != newSysInfo.StorePath {
-					lockfile.Packages[pkg.Raw].Systems[sysName] = newSysInfo
 					updated = true
 				}
 			}
 		}
 		if updated {
-			// if we are updating the system info, then we should also update the resolved path
-			lockfile.Packages[pkg.Raw].Resolved = resolved.Resolved
+			// if we are updating the system info, then we should also update the other fields
+			useResolvedPackageInLockfile(lockfile, pkg, resolved, existing)
+			lockfile.Packages[pkg.Raw].Systems = newSystems
 
 			ux.Finfo(d.stderr, "Updated system information for %s\n", pkg)
 			return nil
@@ -192,4 +194,14 @@ func (d *Devbox) attemptToUpgradeFlake(pkg *devpkg.Package) error {
 	}
 
 	return nil
+}
+
+func useResolvedPackageInLockfile(
+	lockfile *lock.File,
+	pkg *devpkg.Package,
+	resolved *lock.Package,
+	existing *lock.Package,
+) {
+	lockfile.Packages[pkg.Raw] = resolved
+	lockfile.Packages[pkg.Raw].AllowInsecure = existing.AllowInsecure
 }

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -155,6 +155,9 @@ func (d *Devbox) mergeResolvedPackageToLockfile(
 			}
 		}
 		if updated {
+			// if we are updating the system info, then we should also update the resolved path
+			lockfile.Packages[pkg.Raw].Resolved = resolved.Resolved
+
 			ux.Finfo(d.stderr, "Updated system information for %s\n", pkg)
 			return nil
 		}


### PR DESCRIPTION
## Summary



When we update the store-paths in the lockfile, we should also update the other fields, including "resolved" for the nixpkgs commit hash, and the modified-time.

This way the exact same derivation is used whether installing the binary directly via store-path, or via relying on the derivation in the package's "resolved" field. This ensures parity for the following scenarios:
1. A team has a devbox project. Some team members are using nix >= 2.17, while others are using older nix.
2. The store-path binary is no longer in the nix binary cache, and the package is installed via the older way. This should alleviate @lagoja's concern that there may be a discrepancy between the store-path and the derivation source in "resolved" field of the package.

## How was it tested?

Did `devbox update` and saw that `go@latest` had new store-paths, and the "resolved" field was also updated.
