### PR TITLE
[perf] Replace only-path-without-wrappers with sed

### DIFF
--- a/internal/boxcli/shellenv.go
+++ b/internal/boxcli/shellenv.go
@@ -94,13 +94,14 @@ func shellEnvFunc(cmd *cobra.Command, flags shellEnvCmdFlags) (string, error) {
 }
 
 func shellEnvOnlyPathWithoutWrappersCmd() *cobra.Command {
+	// Deprecated: will be removed after devbox 0.7.0
+	// Don't add deprecated field to avoid printing anything to stdout
 	command := &cobra.Command{
-		Use:        "only-path-without-wrappers",
-		Deprecated: "This command is deprecated and will be removed after devbox 0.7.0",
-		Hidden:     true,
-		Short:      "[internal] Print shell command that exports the system $PATH without the bin-wrappers paths.",
-		Args:       cobra.ExactArgs(0),
-		PreRunE:    ensureNixInstalled,
+		Use:     "only-path-without-wrappers",
+		Hidden:  true,
+		Short:   "[internal] Print shell command that exports the system $PATH without the bin-wrappers paths.",
+		Args:    cobra.ExactArgs(0),
+		PreRunE: ensureNixInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			s := shellEnvOnlyPathWithoutWrappersFunc()
 			fmt.Fprintln(cmd.OutOrStdout(), s)

--- a/internal/boxcli/shellenv.go
+++ b/internal/boxcli/shellenv.go
@@ -95,11 +95,12 @@ func shellEnvFunc(cmd *cobra.Command, flags shellEnvCmdFlags) (string, error) {
 
 func shellEnvOnlyPathWithoutWrappersCmd() *cobra.Command {
 	command := &cobra.Command{
-		Use:     "only-path-without-wrappers",
-		Hidden:  true,
-		Short:   "[internal] Print shell command that exports the system $PATH without the bin-wrappers paths.",
-		Args:    cobra.ExactArgs(0),
-		PreRunE: ensureNixInstalled,
+		Use:        "only-path-without-wrappers",
+		Deprecated: "This command is deprecated and will be removed after devbox 0.7.0",
+		Hidden:     true,
+		Short:      "[internal] Print shell command that exports the system $PATH without the bin-wrappers paths.",
+		Args:       cobra.ExactArgs(0),
+		PreRunE:    ensureNixInstalled,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			s := shellEnvOnlyPathWithoutWrappersFunc()
 			fmt.Fprintln(cmd.OutOrStdout(), s)

--- a/internal/wrapnix/wrapper.go
+++ b/internal/wrapnix/wrapper.go
@@ -55,6 +55,7 @@ func CreateWrappers(ctx context.Context, args CreateWrappersArgs) error {
 
 	for _, bin := range args.NixBins {
 		if err := createWrapper(&createWrapperArgs{
+			WrapperBinPath:     destPath,
 			CreateWrappersArgs: args,
 			BashPath:           bashPath,
 			Command:            bin,
@@ -130,6 +131,7 @@ type createWrapperArgs struct {
 	Command          string
 	destPath         string
 	DevboxSymlinkDir string
+	WrapperBinPath   string // This is the  directory where all bin wrappers live
 }
 
 func createWrapper(args *createWrapperArgs) error {

--- a/internal/wrapnix/wrapper.sh.tmpl
+++ b/internal/wrapnix/wrapper.sh.tmpl
@@ -25,12 +25,13 @@ eval "$(DO_NOT_TRACK=1 devbox shellenv --preserve-path-stack -c {{ .ProjectDir }
 fi
 
 {{/*
-We call only-path-without-wrappers so that we do not invoke other bin-wrappers from
+Remove wrapper bin path from PATH so that we don't call more bin-wrappers from
 this bin-wrapper. Instead, we directly invoke the binary from the nix store, which
 should be in PATH.
 
-DO_NOT_TRACK=1 can be removed once we optimize segment to queue events.
+This is implemented in sed for efficieny. sed is POSIX so we assume it's available.
+
 */ -}}
-eval "$(DO_NOT_TRACK=1 devbox shellenv only-path-without-wrappers)"
+export PATH=$(echo $PATH | sed -e 's#:{{ .WrapperBinPath }}##' -e 's#{{ .WrapperBinPath }}:##' -e 's#{{ .WrapperBinPath }}##')
 
 exec {{ .Command }} "$@"

--- a/internal/wrapnix/wrapper.sh.tmpl
+++ b/internal/wrapnix/wrapper.sh.tmpl
@@ -29,7 +29,7 @@ Remove wrapper bin path from PATH so that we don't call more bin-wrappers from
 this bin-wrapper. Instead, we directly invoke the binary from the nix store, which
 should be in PATH.
 
-This is implemented in sed for efficieny. sed is POSIX so we assume it's available.
+This is implemented in sed for efficiency. sed is POSIX so we assume it's available.
 
 */ -}}
 export PATH=$(echo $PATH | sed -e 's#:{{ .WrapperBinPath }}##' -e 's#{{ .WrapperBinPath }}:##' -e 's#{{ .WrapperBinPath }}##')


### PR DESCRIPTION
## Summary

This replaces our existing `only-path-without-wrappers` wrapper implementation to use `sed`. 

Context:

We use `only-path-without-wrappers` to remove bin wrappers in the environment of our binaries. This is particularly useful when a binary calls another binary. See https://github.com/jetpack-io/devbox/pull/1160 for more context. Unfortunately this adds a perf hit to every single binary call. In my informal experiments this cost was ~40ms. For example:

Previously, `time go version` was taking ~60ms even if environment is fully up to date.
Now, `time go version` takes ~20ms.

@Lagoja I'm getting an error in the elixer example (since that was the motivation for the original fix) but it looks like nix elixer on Sonoma is broken: https://elixirforum.com/t/bus-error-after-upgrading-to-sonoma-beta/56354/33 (Our CICD runners will test on Ubuntu and older macOS, Monterrey I believe)

## How was it tested?

* Tested time to call `go version` before and after
* Inspected PATH of shell to ensure `.wrappers` was still there. 
* Copy pasted `sed` code from one of the bin wrappers 
