### PR TITLE
[minor cleanup] use flake dir instead of flake-file-path in nix print-dev-env

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -773,7 +773,7 @@ func (d *Devbox) computeNixEnv(ctx context.Context, usePrintDevEnvCache bool) (m
 	maps.Copy(originalEnv, env)
 
 	vaf, err := d.nix.PrintDevEnv(ctx, &nix.PrintDevEnvArgs{
-		FlakesFilePath:       d.nixFlakesFilePath(),
+		FlakeDir:             d.flakeDir(),
 		PrintDevEnvCachePath: d.nixPrintDevEnvCachePath(),
 		UsePrintDevEnvCache:  usePrintDevEnvCache,
 	})
@@ -928,8 +928,8 @@ func (d *Devbox) nixPrintDevEnvCachePath() string {
 	return filepath.Join(d.projectDir, ".devbox/.nix-print-dev-env-cache")
 }
 
-func (d *Devbox) nixFlakesFilePath() string {
-	return filepath.Join(d.projectDir, ".devbox/gen/flake/flake.nix")
+func (d *Devbox) flakeDir() string {
+	return filepath.Join(d.projectDir, ".devbox/gen/flake")
 }
 
 // ConfigPackageNames returns the package names as defined in devbox.json

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -36,7 +36,7 @@ type Variable struct {
 }
 
 type PrintDevEnvArgs struct {
-	FlakesFilePath       string
+	FlakeDir             string
 	PrintDevEnvCachePath string
 	UsePrintDevEnvCache  bool
 }
@@ -65,7 +65,7 @@ func (*Nix) PrintDevEnv(ctx context.Context, args *PrintDevEnvArgs) (*PrintDevEn
 		cmd := exec.CommandContext(
 			ctx,
 			"nix", "print-dev-env",
-			args.FlakesFilePath,
+			args.FlakeDir,
 		)
 		cmd.Args = append(cmd.Args, ExperimentalFlags()...)
 		cmd.Args = append(cmd.Args, "--json")


### PR DESCRIPTION
## Summary

This has been bugging me for many months. Previously, with DEVBOX_DEBUG=1 and doing
some command that evaluated `nix print-dev-env`, we'd see output like:
```
path '/Users/savil/code/jetpack/devbox-projects/lagoja-global/.devbox/gen/flake/flake.nix' does not contain a 'flake.nix', searching up
```

This is because `nix print-dev-env` expects the path to the flake directory but not including the flake.nix itself.

## How was it tested?

changed devbox.json to trigger a re-evaluation of `nix print-dev-env`, and then
`DEVBOX_DEBUG=1 devbox install` and didn't see such output
