### PR TITLE
[perf] skip forcing printDevEnv when add/rm/update outside shellenv

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -259,7 +259,7 @@ func (d *Devbox) Install(ctx context.Context) error {
 	ctx, task := trace.NewTask(ctx, "devboxInstall")
 	defer task.End()
 
-	return d.ensurePackagesAreInstalled(ctx, ensure)
+	return d.ensureDevboxEnvIsUpToDate(ctx, ensure)
 }
 
 func (d *Devbox) ListScripts() []string {
@@ -477,7 +477,7 @@ func (d *Devbox) GenerateEnvrcFile(ctx context.Context, force bool, envFlags dev
 	}
 
 	// generate all shell files to ensure we can refer to them in the .envrc script
-	if err := d.ensurePackagesAreInstalled(ctx, ensure); err != nil {
+	if err := d.ensureDevboxEnvIsUpToDate(ctx, ensure); err != nil {
 		return err
 	}
 
@@ -931,9 +931,9 @@ func (d *Devbox) ensurePackagesAreInstalledAndComputeEnv(
 ) (map[string]string, error) {
 	defer debug.FunctionTimer().End()
 
-	// When ensurePackagesAreInstalled is called with ensure=true, it always
+	// When ensureDevboxEnvIsUpToDate is called with ensure=true, it always
 	// returns early if the lockfile is up to date. So we don't need to check here
-	if err := d.ensurePackagesAreInstalled(ctx, ensure); err != nil {
+	if err := d.ensureDevboxEnvIsUpToDate(ctx, ensure); err != nil {
 		return nil, err
 	}
 
@@ -1172,10 +1172,10 @@ func (d *Devbox) parseEnvAndExcludeSpecialCases(currentEnv []string) (map[string
 		if ignoreCurrentEnvVar[key] {
 			continue
 		}
-		// handling special cases to for pure shell
-		// Passing HOME for pure shell to leak through otherwise devbox binary won't work
-		// We also include PATH to find the nix installation. It is cleaned for pure mode below
-		// TERM leaking through is to enable colored text in the pure shell
+		// handling special cases for pure shell
+		// - HOME required for devbox binary to work
+		// - PATH to find the nix installation. It is cleaned for pure mode below.
+		// - TERM to enable colored text in the pure shell
 		if !d.pure || key == "HOME" || key == "PATH" || key == "TERM" {
 			env[key] = val
 		}

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -259,7 +259,7 @@ func (d *Devbox) Install(ctx context.Context) error {
 	ctx, task := trace.NewTask(ctx, "devboxInstall")
 	defer task.End()
 
-	return d.ensureDevboxEnvIsUpToDate(ctx, ensure)
+	return d.ensurePackagesAreInstalled(ctx, ensure)
 }
 
 func (d *Devbox) ListScripts() []string {
@@ -477,7 +477,7 @@ func (d *Devbox) GenerateEnvrcFile(ctx context.Context, force bool, envFlags dev
 	}
 
 	// generate all shell files to ensure we can refer to them in the .envrc script
-	if err := d.ensureDevboxEnvIsUpToDate(ctx, ensure); err != nil {
+	if err := d.ensurePackagesAreInstalled(ctx, ensure); err != nil {
 		return err
 	}
 
@@ -931,9 +931,9 @@ func (d *Devbox) ensurePackagesAreInstalledAndComputeEnv(
 ) (map[string]string, error) {
 	defer debug.FunctionTimer().End()
 
-	// When ensureDevboxEnvIsUpToDate is called with ensure=true, it always
+	// When ensurePackagesAreInstalled is called with ensure=true, it always
 	// returns early if the lockfile is up to date. So we don't need to check here
-	if err := d.ensureDevboxEnvIsUpToDate(ctx, ensure); err != nil {
+	if err := d.ensurePackagesAreInstalled(ctx, ensure); err != nil {
 		return nil, err
 	}
 

--- a/internal/impl/envvars.go
+++ b/internal/impl/envvars.go
@@ -69,8 +69,8 @@ func markEnvsAsSetByDevbox(envs ...map[string]string) {
 	}
 }
 
-// IsEnvEnabled checks if the devbox environment is enabled. We use the ogPathKey
-// as a proxy for this. This allows us to differentiate between global and
+// IsEnvEnabled checks if the devbox environment is enabled.
+// This allows us to differentiate between global and
 // individual project shells.
 func (d *Devbox) IsEnvEnabled() bool {
 	fakeEnv := map[string]string{}

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -108,7 +108,7 @@ func (d *Devbox) Add(ctx context.Context, platforms, excludePlatforms []string, 
 		}
 	}
 
-	// Resolving here ensures we allow insecure before running ensureDevboxEnvIsUpToDate
+	// Resolving here ensures we allow insecure before running ensurePackagesAreInstalled
 	// which will call print-dev-env. Resolving does not save the lockfile, we
 	// save at the end when everything has succeeded.
 	if d.allowInsecureAdds {
@@ -126,7 +126,7 @@ func (d *Devbox) Add(ctx context.Context, platforms, excludePlatforms []string, 
 		}
 	}
 
-	if err := d.ensureDevboxEnvIsUpToDate(ctx, install); err != nil {
+	if err := d.ensurePackagesAreInstalled(ctx, install); err != nil {
 		return usererr.WithUserMessage(err, "There was an error installing nix packages")
 	}
 
@@ -190,14 +190,14 @@ func (d *Devbox) Remove(ctx context.Context, pkgs ...string) error {
 	}
 
 	// this will clean up the now-extra package from nix profile and the lockfile
-	if err := d.ensureDevboxEnvIsUpToDate(ctx, uninstall); err != nil {
+	if err := d.ensurePackagesAreInstalled(ctx, uninstall); err != nil {
 		return err
 	}
 
 	return d.saveCfg()
 }
 
-// installMode is an enum for helping with ensureDevboxEnvIsUpToDate implementation
+// installMode is an enum for helping with ensurePackagesAreInstalled implementation
 type installMode string
 
 const (
@@ -208,7 +208,7 @@ const (
 	ensure installMode = "ensure"
 )
 
-// ensureDevboxEnvIsUpToDate ensures:
+// ensurePackagesAreInstalled ensures:
 //  1. Packages are installed, in nix-profile or runx.
 //     Extraneous packages are removed (references purged, not uninstalled).
 //  2. Files for devbox shellenv are generated
@@ -218,7 +218,8 @@ const (
 // The `mode` is used for:
 // 1. Skipping certain operations that may not apply.
 // 2. User messaging to explain what operations are happening, because this function may take time to execute.
-func (d *Devbox) ensureDevboxEnvIsUpToDate(ctx context.Context, mode installMode) error {
+// TODO: Rename method since it does more than just ensure packages are installed.
+func (d *Devbox) ensurePackagesAreInstalled(ctx context.Context, mode installMode) error {
 	defer trace.StartRegion(ctx, "ensurePackages").End()
 	defer debug.FunctionTimer().End()
 

--- a/internal/impl/shell_test.go
+++ b/internal/impl/shell_test.go
@@ -17,8 +17,8 @@ import (
 	"go.jetpack.io/devbox/internal/shellgen"
 )
 
-// update overwrites golden files with the new test results.
-var update = flag.Bool("update", false, "update the golden files with the test results")
+// updateFlag overwrites golden files with the new test results.
+var updateFlag = flag.Bool("update", false, "update the golden files with the test results")
 
 func TestWriteDevboxShellrc(t *testing.T) {
 	testdirs, err := filepath.Glob("testdata/shellrc/*")
@@ -83,7 +83,7 @@ func testWriteDevboxShellrc(t *testing.T, testdirs []string) {
 			// Overwrite the golden file if the -update flag was
 			// set, and then proceed normally. The test should
 			// always pass in this case.
-			if *update {
+			if *updateFlag {
 				err = os.WriteFile(test.goldShellrcPath, gotShellrc, 0o666)
 				if err != nil {
 					t.Error("Error updating golden files:", err)

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -62,7 +62,7 @@ func (d *Devbox) Update(ctx context.Context, opts devopt.UpdateOpts) error {
 		}
 	}
 
-	if err := d.ensureDevboxEnvIsUpToDate(ctx, update); err != nil {
+	if err := d.ensurePackagesAreInstalled(ctx, update); err != nil {
 		return err
 	}
 

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -62,7 +62,7 @@ func (d *Devbox) Update(ctx context.Context, opts devopt.UpdateOpts) error {
 		}
 	}
 
-	if err := d.ensurePackagesAreInstalled(ctx, ensure); err != nil {
+	if err := d.ensureDevboxEnvIsUpToDate(ctx, update); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary

In this PR, we skip forcing `computeNixEnv` if a user is adding/removing/updating packages, AND if we are not in a shellenv-enabled environment from that devbox project.

Also:
- ~rename `ensurePackagesAreInstalled` to `ensureDevboxEnvIsUpToDate`~
- some minor comment cleanups

## How was it tested?

did `devbox add vim` when:
1. in devbox project's directory, but direnv disabled => did not print "Recomputing Devbox environment."
2. in devbox project's directory with direnv enabled => did print "Recomputing Devbox environment".
3. in devbox shell => did print again

Repeated the same exercise with `devbox global`:
1. with `devbox global shellenv | source` run in shellrc => did print "Recomputing Devbox environment".
2. after commenting out that line in shellrc => did not print
NOTE: there's no special devbox-global specific code change here.
