### PR TITLE
[plugins] Remove trigger package

### DIFF
--- a/examples/development/php/php8.1/devbox.json
+++ b/examples/development/php/php8.1/devbox.json
@@ -1,6 +1,5 @@
 {
   "packages": [
-    "php81Packages.composer@latest",
     "php81Extensions.xdebug@latest",
     "php81Extensions.imagick@latest",
     "php@8.1"

--- a/examples/development/php/php8.1/devbox.lock
+++ b/examples/development/php/php8.1/devbox.lock
@@ -40,26 +40,6 @@
         }
       }
     },
-    "php81Packages.composer@latest": {
-      "last_modified": "2023-08-30T00:25:28Z",
-      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#php81Packages.composer",
-      "source": "devbox-search",
-      "version": "2.5.8",
-      "systems": {
-        "aarch64-darwin": {
-          "store_path": "/nix/store/7hxmkxa9bmaplyy1ixl0yxv3j0qvxvc3-php-composer-2.5.8"
-        },
-        "aarch64-linux": {
-          "store_path": "/nix/store/vwrbpz9wr7blr7alx0fl3x79ym3jbdqa-php-composer-2.5.8"
-        },
-        "x86_64-darwin": {
-          "store_path": "/nix/store/fjy357jpj9q2bfahsgnak4mrh8y07izw-php-composer-2.5.8"
-        },
-        "x86_64-linux": {
-          "store_path": "/nix/store/6w2vrfjdwhr3mj1magr2rmbycln379f8-php-composer-2.5.8"
-        }
-      }
-    },
     "php@8.1": {
       "last_modified": "2023-09-04T16:24:30Z",
       "plugin_version": "0.0.2",

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -963,14 +963,7 @@ func (d *Devbox) InstallablePackages() []*devpkg.Package {
 // packages concatenated in correct order
 func (d *Devbox) AllInstallablePackages() ([]*devpkg.Package, error) {
 	userPackages := d.InstallablePackages()
-	pluginPackages, err := d.PluginManager().PluginPackages(userPackages)
-	if err != nil {
-		return nil, err
-	}
-	// We prioritize plugin packages so that the php plugin works. Not sure
-	// if this is behavior we want for user plugins. We may need to add an optional
-	// priority field to the config.
-	return append(pluginPackages, userPackages...), nil
+	return d.PluginManager().ProcessPluginPackages(userPackages)
 }
 
 func (d *Devbox) Includes() []plugin.Includable {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -43,6 +43,9 @@ type config struct {
 	Packages    []string          `json:"__packages"`
 	Env         map[string]string `json:"env"`
 	Readme      string            `json:"readme"`
+	// If true, we remove the package that triggered this plugin from the environment
+	// Useful when we want to replace with flake
+	RemoveTriggerPackage bool `json:"__remove_trigger_package,omitempty"`
 
 	Shell struct {
 		// InitHook contains commands that will run at shell startup.

--- a/plugins/haskell.json
+++ b/plugins/haskell.json
@@ -5,6 +5,7 @@
   "__packages": [
     "path:{{ .Virtenv }}"
   ],
+  "__remove_trigger_package": true,
   "create_files": {
     "{{ .Virtenv }}/flake.nix": "haskell/flake.nix"
   }

--- a/plugins/mariadb.json
+++ b/plugins/mariadb.json
@@ -18,6 +18,7 @@
   "__packages": [
     "path:{{ .Virtenv }}"
   ],
+  "__remove_trigger_package": true,
   "shell": {
     "init_hook": [
       "bash {{ .Virtenv }}/setup_db.sh"

--- a/plugins/mysql.json
+++ b/plugins/mysql.json
@@ -18,6 +18,7 @@
     "__packages": [
       "path:{{ .Virtenv }}"
     ],
+    "__remove_trigger_package": true,
     "shell": {
       "init_hook": [
         "bash {{ .Virtenv }}/setup_db.sh"

--- a/plugins/php.json
+++ b/plugins/php.json
@@ -6,6 +6,7 @@
     "path:{{ .Virtenv }}",
     "path:{{ .Virtenv }}#composer"
   ],
+  "__remove_trigger_package": true,
   "env": {
     "PHPFPM_ERROR_LOG_FILE": "{{ .Virtenv }}/php-fpm.log",
     "PHPFPM_PID_FILE": "{{ .Virtenv }}/php-fpm.pid",


### PR DESCRIPTION
## Summary

Previously, we were expecting `$buildInputs` to match the order of $PATH, specifically, packages installed first appeared first (in both $PATH and $buildInputs). This would allow us to prioritize the first binary that shows up. In a few plugins we add a flake that installs a wrapped or alternate version of the binary. We were relying on the order of `$buildInputs` to point to the correct wrapped binary.

It looks like `$buildInputs` is not deterministic, or something in the mariadb/mysql case caused the order to change.

The solution in this PR is to add a new `__remove_trigger_package` field that when set to true tells devbox to remove the package that causes the plugin to be installed. This does not affect plugins installed `include` field.

This has the additional benefit of not installing unnecessary packages in nix profile.

## How was it tested?

```bash
devbox init
devbox add mysql
devbox shell
```

Also verified that PHP plugin works as expected. Note that in the PHP case the user should avoid installing composer themselves. It is included in our php plugin.
