### PR TITLE
[perf] cache nix.searchSystem

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a
 	github.com/wk8/go-ordered-map/v2 v2.1.8
 	github.com/zealic/go2node v0.1.0
-	go.jetpack.io/pkg v0.0.0-20231012130632-77dcd111db2e
+	go.jetpack.io/pkg v0.0.0-20231019173032-13f60a9e32b8
 	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17
 	golang.org/x/mod v0.12.0
 	golang.org/x/sync v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -339,8 +339,8 @@ github.com/yuin/gopher-lua v0.0.0-20190514113301-1cd887cd7036/go.mod h1:gqRgreBU
 github.com/zaffka/mongodb-boltdb-mock v0.0.0-20221014194232-b4bb03fbe3a0/go.mod h1:GsDD1qsG+86MeeCG7ndi6Ei3iGthKL3wQ7PTFigDfNY=
 github.com/zealic/go2node v0.1.0 h1:ofxpve08cmLJBwFdI0lPCk9jfwGWOSD+s6216x0oAaA=
 github.com/zealic/go2node v0.1.0/go.mod h1:GrkFr+HctXwP7vzcU9RsgtAeJjTQ6Ud0IPCQAqpTfBg=
-go.jetpack.io/pkg v0.0.0-20231012130632-77dcd111db2e h1:GtqFrE5uUf6rXFk3zaIqIfLfykrqrB8gp6bDmOfH+2s=
-go.jetpack.io/pkg v0.0.0-20231012130632-77dcd111db2e/go.mod h1:m49CAcLbpZttEbzoEWC1SKD+/z5mEiFdw0dQxY6AM5Q=
+go.jetpack.io/pkg v0.0.0-20231019173032-13f60a9e32b8 h1:xzAAUVfg9uqyJhZVc+ZDTLHtFlMhj/5St5JnVfDxbpk=
+go.jetpack.io/pkg v0.0.0-20231019173032-13f60a9e32b8/go.mod h1:m49CAcLbpZttEbzoEWC1SKD+/z5mEiFdw0dQxY6AM5Q=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -270,7 +270,7 @@ func (p *Package) FullPackageAttributePath() (string, error) {
 }
 
 // NormalizedPackageAttributePath returns an attribute path normalized by nix
-// lookupNixInfo. This is useful for comparing different attribute paths that may
+// search. This is useful for comparing different attribute paths that may
 // point to the same package. Note, it may be an expensive call.
 func (p *Package) NormalizedPackageAttributePath() (string, error) {
 	if p.normalizedPackageAttributePathCache != "" {
@@ -284,7 +284,7 @@ func (p *Package) NormalizedPackageAttributePath() (string, error) {
 	return p.normalizedPackageAttributePathCache, nil
 }
 
-// normalizePackageAttributePath calls nix lookupNixInfo to find the normalized attribute
+// normalizePackageAttributePath calls nix search to find the normalized attribute
 // path. It may be an expensive call (~100ms).
 func (p *Package) normalizePackageAttributePath() (string, error) {
 	var query string

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -44,6 +44,7 @@ type PrintDevEnvArgs struct {
 // PrintDevEnv calls `nix print-dev-env -f <path>` and returns its output. The output contains
 // all the environment variables and bash functions required to create a nix shell.
 func (*Nix) PrintDevEnv(ctx context.Context, args *PrintDevEnvArgs) (*PrintDevEnvOut, error) {
+	defer debug.FunctionTimer().End()
 	defer trace.StartRegion(ctx, "nixPrintDevEnv").End()
 
 	var data []byte

--- a/internal/nix/search.go
+++ b/internal/nix/search.go
@@ -126,7 +126,6 @@ var cache = searchSystemCache{}
 // once `nix search` returns a valid result, it will always be the very same result.
 // Hence we can cache it locally and answer future queries fast, by not calling `nix search`.
 func SearchNixpkgsAttribute(query string) (map[string]*Info, error) {
-
 	if cache.QueryToInfo == nil {
 		contents, err := readSearchSystemCacheFile()
 		if err != nil {

--- a/internal/nix/search_test.go
+++ b/internal/nix/search_test.go
@@ -13,6 +13,10 @@ func TestSearchCacheKey(t *testing.T) {
 			"github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#go_1_19",
 			"github_NixOS_nixpkgs_8670e496ffd093b60e74e7fa53526aa5920d09eb_go_1_19",
 		},
+		{
+			"github:nixos/nixpkgs/7d0ed7f2e5aea07ab22ccb338d27fbe347ed2f11#emacsPackages.@",
+			"github_nixos_nixpkgs_7d0ed7f2e5aea07ab22ccb338d27fbe347ed2f11_emacsPackages._",
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -20,6 +24,38 @@ func TestSearchCacheKey(t *testing.T) {
 			out := cacheKey(testCase.in)
 			if out != testCase.out {
 				t.Errorf("got %s, want %s", out, testCase.out)
+			}
+		})
+	}
+}
+
+func TestIsAllowableQuery(t *testing.T) {
+	testCases := []struct {
+		in       string
+		expected bool
+	}{
+		{
+			"github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#go_1_19",
+			true,
+		},
+		{
+			"github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb",
+			false,
+		},
+		{
+			"github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#",
+			false,
+		},
+		{
+			"github:NixOS/nixpkgs/nixpkgs-unstable#go_1_19",
+			false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.in, func(t *testing.T) {
+			out := isAllowableQuery(testCase.in)
+			if out != testCase.expected {
+				t.Errorf("got %t, want %t", out, testCase.expected)
 			}
 		})
 	}

--- a/internal/nix/search_test.go
+++ b/internal/nix/search_test.go
@@ -1,0 +1,26 @@
+package nix
+
+import (
+	"testing"
+)
+
+func TestSearchCacheKey(t *testing.T) {
+	testCases := []struct {
+		in  string
+		out string
+	}{
+		{
+			"github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#go_1_19",
+			"github_NixOS_nixpkgs_8670e496ffd093b60e74e7fa53526aa5920d09eb_go_1_19",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.out, func(t *testing.T) {
+			out := cacheKey(testCase.in)
+			if out != testCase.out {
+				t.Errorf("got %s, want %s", out, testCase.out)
+			}
+		})
+	}
+}

--- a/internal/nix/search_test.go
+++ b/internal/nix/search_test.go
@@ -29,7 +29,7 @@ func TestSearchCacheKey(t *testing.T) {
 	}
 }
 
-func TestIsAllowableQuery(t *testing.T) {
+func TestAllowableQuery(t *testing.T) {
 	testCases := []struct {
 		in       string
 		expected bool
@@ -53,7 +53,7 @@ func TestIsAllowableQuery(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.in, func(t *testing.T) {
-			out := isAllowableQuery(testCase.in)
+			out := allowableQuery.MatchString(testCase.in)
 			if out != testCase.expected {
 				t.Errorf("got %t, want %t", out, testCase.expected)
 			}


### PR DESCRIPTION
## Summary

From observing times for adding and removing packages, I notice that a lot of time is spent in `syncPackagesToProfile` and most of that is from `nix.Search`, which is a fairly slow operation. However, from observing the results, it seems that these should be constant. 

For example, here are some search results keyed by the queries:
https://gist.github.com/savil/584c4d9bd6c468aaa8c289265287a23a
Correct me if wrong: all these seem to be constants that won't change, because the queries we run have the nixpkgs-commit-hash in them.

The general [`nix search` command](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-search.html) seems to be slower since the query it accepts is an `installable regex`, which can match a large number of concrete queries. Furthermore, it needs to accept queries like`nixpkgs#vim` and figure out which nixpkgs commit hash this would resolve to. In our case, our queries are much more specific being of the form `nixpkgs/<commit>#attribute`

## How was it tested?

This effect is more pronounced for packages that are not using store-paths. This will affect all users who are still on nix < 2.17, which is a fairly large percentage for now.

I have a devbox global of about 43 packages. For the times below, I ran `devbox global add vim` (where vim is already in my /nix/store), and did `export DEVBOX_FEATURE_REMOVE_NIXPKGS=0`

BEFORE:
syncPackagesToProfile takes about 1 min 30+ seconds

AFTER:
syncPackagesToProfile takes 500ms

