### PR TITLE
[error ux] print script name upon error

### DIFF
--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -118,7 +118,7 @@ func runScriptCmd(cmd *cobra.Command, args []string, flags runCmdFlags) error {
 	}
 
 	if err := box.RunScript(cmd.Context(), script, scriptArgs); err != nil {
-		return redact.Errorf("error running command in Devbox: %w", err)
+		return redact.Errorf("error running script %q in Devbox: %w", script, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Printing the name to make it easier to identify the source of the error.

## How was it tested?

Added this script

```
"hello": [
  "echo \"hello\"",
  "exit 1"
],
```
ran `devbox run hello` and got:
```
Error: error running script "hello" in Devbox: exit status 1
```
