### PR TITLE
[cicd] Unify lint, add caching

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -208,7 +208,10 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: devbox-${{ runner.os }}
-      - run: chmod +x ./devbox
+      - name: Add devbox to path
+        run: |
+          chmod +x ./devbox
+          sudo mv ./devbox /usr/local/bin/
       - name: Install nix and devbox packages
         run: |
           export NIX_INSTALLER_NO_CHANNEL_ADD=1
@@ -237,7 +240,10 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: devbox-${{ runner.os }}
-      - run: chmod +x ./devbox
+      - name: Add devbox to path
+        run: |
+          chmod +x ./devbox
+          sudo mv ./devbox /usr/local/bin/
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v4
         with:

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -85,13 +85,7 @@ jobs:
           key: go-${{ runner.os }}-${{ hashFiles('go.sum') }}
 
       # Use main devbox for now to ensure it supports runx
-      - run:  go run ./cmd/devbox run fmt
-      
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.7.0
-        with:
-          args: "--out-${NO_FUTURE}format colored-line-number --timeout=10m"
-          skip-cache: true
+      - run:  go run ./cmd/devbox run lint
 
   test:
     strategy:
@@ -133,6 +127,13 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: ./go.mod
+      - name: Mount golang cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg
+          key: go-devbox-tests-${{ runner.os }}-${{ hashFiles('go.sum') }}
       - name: Build devbox
         run: go install ./cmd/devbox
       - name: Install additional shells (dash, zsh)
@@ -180,6 +181,13 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: ./go.mod
+      - name: Mount golang cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg
+          key: go-devbox-tests-${{ runner.os }}-${{ hashFiles('go.sum') }}
       - name: Build devbox
         run: go install ./cmd/devbox
       - name: Install nix and devbox packages

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Upload devbox artifact
         uses: actions/upload-artifact@v3  
         with:
-          name: devbox-${{ runner.os }}
+          name: devbox-${{ runner.os }}-${{ runner.arch }}
           path: ./dist/devbox
           retention-days: 7
 
@@ -95,11 +95,7 @@ jobs:
           go-version-file: ./go.mod
           cache: false
 
-      # This can be reanabled once released version supports runx
-      # - name: Install devbox
-      #   uses: jetpack-io/devbox-install-action@v0.7.0
-      #   with:
-      #     enable-cache: true
+      # TODO ADD nix only cache
 
       - name: Mount golang cache
         uses: actions/cache@v3
@@ -110,8 +106,16 @@ jobs:
             ~/go/pkg
           key: go-${{ runner.os }}-${{ hashFiles('go.sum') }}
 
-      # Use main devbox for now to ensure it supports runx
-      - run:  go run ./cmd/devbox run lint
+      - name: Download devbox
+        uses: actions/download-artifact@v3
+        with:
+          name: devbox-${{ runner.os }}-${{ runner.arch }}
+      - name: Add devbox to path
+        run: |
+          chmod +x ./devbox
+          sudo mv ./devbox /usr/local/bin/
+          
+      - run:  devbox run lint
 
   test:
     needs: build-devbox
@@ -207,7 +211,7 @@ jobs:
       - name: Download devbox
         uses: actions/download-artifact@v3
         with:
-          name: devbox-${{ runner.os }}
+          name: devbox-${{ runner.os }}-${{ runner.arch }}
       - name: Add devbox to path
         run: |
           chmod +x ./devbox
@@ -239,7 +243,7 @@ jobs:
       - name: Download devbox
         uses: actions/download-artifact@v3
         with:
-          name: devbox-${{ runner.os }}
+          name: devbox-${{ runner.os }}-${{ runner.arch }}
       - name: Add devbox to path
         run: |
           chmod +x ./devbox

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -96,7 +96,12 @@ jobs:
           go-version-file: ./go.mod
           cache: false
 
-      # TODO ADD nix only cache
+      # This can be reanabled once released version supports runx
+      # and we can remove needs: build-devbox
+      # - name: Install devbox
+      #   uses: jetpack-io/devbox-install-action@v0.7.0
+      #   with:
+      #     enable-cache: true
 
       - name: Mount golang cache
         uses: actions/cache@v3

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -81,6 +81,7 @@ jobs:
       - uses: crate-ci/typos@v1.13.16
 
   golangci-lint:
+    needs: build-devbox
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -148,7 +148,7 @@ jobs:
             os: macos-latest
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: ${{ (github.ref == 'refs/heads/main' || inputs.run-mac-tests) && 37 || 25 }}
+    timeout-minutes: 37
     steps:
       - name: Maximize build disk space
         uses: easimon/maximize-build-space@v8

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -46,6 +46,31 @@ env:
   DEVBOX_DEBUG: 1
 
 jobs:
+  build-devbox:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: ./go.mod
+      - name: Mount golang cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg
+          key: go-devbox-build-${{ runner.os }}-${{ hashFiles('go.sum') }}
+      - name: Build devbox
+        run: go build -o dist/devbox ./cmd/devbox
+      - name: Upload compiled binary as artifact
+        uses: actions/upload-artifact@v3  
+        with:
+          name: devbox-${{ runner.os }}
+          path: ./dist/devbox
+
   typos:
     name: Spell Check with Typos
     if: github.ref != 'refs/heads/main'
@@ -88,6 +113,7 @@ jobs:
       - run:  go run ./cmd/devbox run lint
 
   test:
+    needs: build-devbox
     strategy:
       matrix:
         is-main:
@@ -134,8 +160,6 @@ jobs:
             ~/.cache/go-build
             ~/go/pkg
           key: go-devbox-tests-${{ runner.os }}-${{ hashFiles('go.sum') }}
-      - name: Build devbox
-        run: go install ./cmd/devbox
       - name: Install additional shells (dash, zsh)
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
@@ -172,6 +196,7 @@ jobs:
           go test -v -timeout $DEVBOX_GOLANG_TEST_TIMEOUT ./...
 
   auto-nix-install: # ensure Devbox installs nix and works properly after installation.
+    needs: build-devbox 
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -181,15 +206,11 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: ./go.mod
-      - name: Mount golang cache
-        uses: actions/cache@v3
+      - name: Download devbox
+        uses: actions/download-artifact@v3
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg
-          key: go-devbox-tests-${{ runner.os }}-${{ hashFiles('go.sum') }}
-      - name: Build devbox
-        run: go install ./cmd/devbox
+          name: devbox-${{ runner.os }}
+      - run: chmod +x ./devbox
       - name: Install nix and devbox packages
         run: |
           export NIX_INSTALLER_NO_CHANNEL_ADD=1
@@ -206,6 +227,7 @@ jobs:
   # Run a sanity test to make sure Devbox can install and remove packages with
   # the last 3 Nix releases.
   test-nix-versions:
+    needs: build-devbox
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -213,11 +235,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - name: Download devbox
+        uses: actions/download-artifact@v3
         with:
-          go-version-file: ./go.mod
-      - name: Build devbox
-        run: go install ./cmd/devbox
+          name: devbox-${{ runner.os }}
+      - run: chmod +x ./devbox
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v4
         with:

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -65,11 +65,12 @@ jobs:
           key: go-devbox-build-${{ runner.os }}-${{ hashFiles('go.sum') }}
       - name: Build devbox
         run: go build -o dist/devbox ./cmd/devbox
-      - name: Upload compiled binary as artifact
+      - name: Upload devbox artifact
         uses: actions/upload-artifact@v3  
         with:
           name: devbox-${{ runner.os }}
           path: ./dist/devbox
+          retention-days: 7
 
   typos:
     name: Spell Check with Typos
@@ -203,9 +204,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
-        with:
-          go-version-file: ./go.mod
       - name: Download devbox
         uses: actions/download-artifact@v3
         with:

--- a/devbox.json
+++ b/devbox.json
@@ -21,8 +21,7 @@
         "GOOS=linux GOARCH=arm64 go build -o dist/devbox-linux-arm64 ./cmd/devbox"
       ],
       "code": "code .",
-      "fmt": "scripts/gofumpt.sh",
-      "lint": "golangci-lint run",
+      "lint": "golangci-lint run && scripts/gofumpt.sh",
       "test": "go test -race -cover ./...",
       "update-examples": "devbox run build && go run testscripts/testrunner/updater/main.go"
     }

--- a/devbox.json
+++ b/devbox.json
@@ -21,7 +21,7 @@
         "GOOS=linux GOARCH=arm64 go build -o dist/devbox-linux-arm64 ./cmd/devbox"
       ],
       "code": "code .",
-      "lint": "golangci-lint run && scripts/gofumpt.sh",
+      "lint": "golangci-lint run --timeout 5m && scripts/gofumpt.sh",
       "test": "go test -race -cover ./...",
       "update-examples": "devbox run build && go run testscripts/testrunner/updater/main.go"
     }


### PR DESCRIPTION
## Summary

* unified gofumpt and lint
* Added go caching to tests
* Added pre-building devbox binary to be shared between tests

## How was it tested?
CICD
