### PR TITLE
[cicd] Fix build

### DIFF
--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -766,7 +766,6 @@ func (d *Devbox) computeNixEnv(ctx context.Context, usePrintDevEnvCache bool) (m
 	// Append variables from current env if --pure is not passed
 	currentEnv := os.Environ()
 	env, err := d.parseEnvAndExcludeSpecialCases(currentEnv)
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

New stricter linter was introduced and a commit snuck a violation because PRs were not rebased on main.

## How was it tested?
CICD