### PR TITLE
[poetry plugin] ensure initHook runs with /bin/sh

### DIFF
--- a/examples/development/python/poetry/poetry-demo/devbox.lock
+++ b/examples/development/python/poetry/poetry-demo/devbox.lock
@@ -3,7 +3,7 @@
   "packages": {
     "poetry@1.4": {
       "last_modified": "2023-05-19T19:44:39Z",
-      "plugin_version": "0.0.1",
+      "plugin_version": "0.0.2",
       "resolved": "github:NixOS/nixpkgs/4a22f6f0a4b4354778f786425babce9a56f6b5d8#poetry",
       "source": "devbox-search",
       "version": "1.4.2",

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -766,7 +766,6 @@ func (d *Devbox) computeNixEnv(ctx context.Context, usePrintDevEnvCache bool) (m
 	// Append variables from current env if --pure is not passed
 	currentEnv := os.Environ()
 	env, err := d.parseEnvAndExcludeSpecialCases(currentEnv)
-
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/poetry.json
+++ b/plugins/poetry.json
@@ -1,15 +1,18 @@
 {
     "name": "poetry",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "readme": "This plugin automatically configures poetry to use the version of python installed in your Devbox shell, instead of the Python version that it is bundled with. Your pyproject.toml must be in the same directory as your devbox.json.",
     "env": {
         "POETRY_VIRTUALENVS_IN_PROJECT": "true",
         "POETRY_VIRTUALENVS_CREATE": "true",
         "POETRY_VIRTUALENVS_PATH": "{{.Virtenv}}/.virtualenvs"
     },
+    "create_files": {
+        "{{ .Virtenv }}/bin/initHook.sh": "poetry/initHook.sh"
+    },
     "shell": {
         "init_hook": [
-            "poetry env use $(command -v python) --no-interaction"
+            "{{ .Virtenv }}/bin/initHook.sh"
         ]
     }
 }

--- a/plugins/poetry/initHook.sh
+++ b/plugins/poetry/initHook.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+poetry env use $(command -v python) --no-interaction
+


### PR DESCRIPTION
## Summary

A user is saying that the poetry plugin's init-hook was failing for them with Fish 
shell. While the init-hook's command does work with modern fish shells, it fails
for older versions of fish. 

In this case, the user is on Ubuntu whose package manager seems to use an older
version of fish.

Regardless, we can ensure the plugin's init-hooks work for consistently if we
ensure that they are written as posix scripts executed via /bin/sh. This PR
seeks to do that.

Fixes #1550


## How was it tested?

```
cd examples/development/poetry/poetry_demo
devbox run run_test
```


