### PR TITLE
[sed] Fix bin wrappers when sed is installed with devbox

### DIFF
--- a/internal/wrapnix/wrapper.go
+++ b/internal/wrapnix/wrapper.go
@@ -48,6 +48,7 @@ func CreateWrappers(ctx context.Context, args CreateWrappersArgs) error {
 	_ = os.MkdirAll(destPath, 0o755)
 
 	bashPath := cmdutil.GetPathOrDefault("bash", "/bin/bash")
+	sedPath := cmdutil.GetPathOrDefault("sed", "sed")
 
 	if err := CreateDevboxSymlinkIfPossible(); err != nil {
 		return err
@@ -58,6 +59,7 @@ func CreateWrappers(ctx context.Context, args CreateWrappersArgs) error {
 			WrapperBinPath:     destPath,
 			CreateWrappersArgs: args,
 			BashPath:           bashPath,
+			SedPath:            sedPath,
 			Command:            bin,
 			DevboxSymlinkDir:   devboxSymlinkDir,
 			destPath:           filepath.Join(destPath, filepath.Base(bin)),
@@ -128,6 +130,7 @@ func CreateDevboxSymlinkIfPossible() error {
 type createWrapperArgs struct {
 	CreateWrappersArgs
 	BashPath         string
+	SedPath          string
 	Command          string
 	destPath         string
 	DevboxSymlinkDir string

--- a/internal/wrapnix/wrapper.sh.tmpl
+++ b/internal/wrapnix/wrapper.sh.tmpl
@@ -32,6 +32,6 @@ should be in PATH.
 This is implemented in sed for efficiency. sed is POSIX so we assume it's available.
 
 */ -}}
-export PATH=$(echo $PATH | sed -e 's#:{{ .WrapperBinPath }}##' -e 's#{{ .WrapperBinPath }}:##' -e 's#{{ .WrapperBinPath }}##')
+export PATH=$(echo $PATH | {{ .SedPath }} -e 's#:{{ .WrapperBinPath }}##' -e 's#{{ .WrapperBinPath }}:##' -e 's#{{ .WrapperBinPath }}##')
 
 exec {{ .Command }} "$@"


### PR DESCRIPTION
## Summary

TSIA

## How was it tested?

Using this config: https://discord.com/channels/903306922852245526/1009933892385517619/1163763578399105064

Pre-change, could not shell in, got bash nesting error.
Post-change, could shell in.