### PR TITLE
[telemetry] fix segfault

### DIFF
--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -113,8 +113,8 @@ func commandEvent(meta Metadata) (id string, msg *segment.Track) {
 }
 
 // Error reports an error to the telemetry server.
-func Error(err error, meta Metadata) {
-	if !started || err == nil {
+func Error(errToLog error, meta Metadata) {
+	if !started || errToLog == nil {
 		return
 	}
 
@@ -127,7 +127,7 @@ func Error(err error, meta Metadata) {
 		EventID:   sentry.EventID(ExecutionID),
 		Level:     sentry.LevelError,
 		User:      sentry.User{ID: deviceID},
-		Exception: newSentryException(redact.Error(err)),
+		Exception: newSentryException(redact.Error(errToLog)),
 		Contexts: map[string]map[string]any{
 			"os": {
 				"name": build.OS(),


### PR DESCRIPTION
## Summary

`newSentryException` can error [here](https://github.com/jetpack-io/devbox/blob/main/internal/telemetry/sentry.go#L55) due to `err` being `nil`.

## How was it tested?


