### PR TITLE
[services] Fix issue where env var is ignored

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -39,7 +39,7 @@ type Devbox interface {
 	Services() (services.Services, error)
 	StartProcessManager(ctx context.Context, runInCurrentShell bool, requestedServices []string, background bool, processComposeFileOrDir string) error
 	StartServices(ctx context.Context, runInCurrentShell bool, services ...string) error
-	StopServices(ctx context.Context, runInCurrentShell bool, allProjects bool, services ...string) error
+	StopServices(ctx context.Context, runInCurrentShell, allProjects bool, services ...string) error
 
 	// Generate files
 	Generate(ctx context.Context) error

--- a/devbox.go
+++ b/devbox.go
@@ -34,12 +34,12 @@ type Devbox interface {
 	Update(ctx context.Context, opts devopt.UpdateOpts) error
 
 	// Interact with services
-	ListServices(ctx context.Context) error
-	RestartServices(ctx context.Context, services ...string) error
+	ListServices(ctx context.Context, runInCurrentShell bool) error
+	RestartServices(ctx context.Context, runInCurrentShell bool, services ...string) error
 	Services() (services.Services, error)
-	StartProcessManager(ctx context.Context, requestedServices []string, background bool, processComposeFileOrDir string) error
-	StartServices(ctx context.Context, services ...string) error
-	StopServices(ctx context.Context, allProjects bool, services ...string) error
+	StartProcessManager(ctx context.Context, runInCurrentShell bool, requestedServices []string, background bool, processComposeFileOrDir string) error
+	StartServices(ctx context.Context, runInCurrentShell bool, services ...string) error
+	StopServices(ctx context.Context, runInCurrentShell bool, allProjects bool, services ...string) error
 
 	// Generate files
 	Generate(ctx context.Context) error

--- a/examples/stacks/lapp-stack/devbox.json
+++ b/examples/stacks/lapp-stack/devbox.json
@@ -7,7 +7,8 @@
     "apache@2.4"
   ],
   "env": {
-    "PGPORT": "5432"
+    "PGPORT": "5432",
+    "PGHOST": "/tmp/devbox/lapp"
   },
   "shell": {
     "scripts": {
@@ -19,7 +20,6 @@
       "init_db": "initdb",
       "run_test": [
         "mkdir -p /tmp/devbox/lapp",
-        "export PGHOST=/tmp/devbox/lapp",
         "initdb",
         "devbox services start",
         "echo 'sleep 1 second for the postgres server to initialize.' && sleep 1",

--- a/examples/stacks/lepp-stack/devbox.json
+++ b/examples/stacks/lepp-stack/devbox.json
@@ -9,7 +9,8 @@
   "env": {
     "NGINX_WEB_PORT": "8089",
     "NGINX_WEB_ROOT": "../../../my_app",
-    "PGPORT": "5433"
+    "PGPORT": "5433",
+    "PGHOST": "/tmp/devbox/lepp"
   },
   "shell": {
     "scripts": {
@@ -22,6 +23,7 @@
       "run_test": [
         "mkdir -p /tmp/devbox/lepp",
         "export PGHOST=/tmp/devbox/lepp",
+        "rm -rf .devbox/virtenv/postgresql/data",
         "initdb",
         "devbox services up -b",
         "echo 'sleep 2 second for the postgres server to initialize.' && sleep 2",

--- a/examples/stacks/lepp-stack/devbox.json
+++ b/examples/stacks/lepp-stack/devbox.json
@@ -22,7 +22,6 @@
       "init_db": "initdb",
       "run_test": [
         "mkdir -p /tmp/devbox/lepp",
-        "export PGHOST=/tmp/devbox/lepp",
         "rm -rf .devbox/virtenv/postgresql/data",
         "initdb",
         "devbox services up -b",

--- a/examples/stacks/lepp-stack/devbox.lock
+++ b/examples/stacks/lepp-stack/devbox.lock
@@ -22,7 +22,7 @@
     },
     "nginx@latest": {
       "last_modified": "2023-09-04T16:24:30Z",
-      "plugin_version": "0.0.3",
+      "plugin_version": "0.0.4",
       "resolved": "github:NixOS/nixpkgs/3c15feef7770eb5500a4b8792623e2d6f598c9c1#nginx",
       "source": "devbox-search",
       "version": "1.24.0",

--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -5,9 +5,7 @@ package boxcli
 
 import (
 	"fmt"
-	"os"
 	"slices"
-	"strconv"
 	"strings"
 
 	"github.com/samber/lo"
@@ -99,19 +97,12 @@ func runScriptCmd(cmd *cobra.Command, args []string, flags runCmdFlags) error {
 		return err
 	}
 
-	omitBinWrappersFromPath := true
-	// This is for testing. Once we completely remove bin wrappers we can remove
-	// this. It helps simulate shell using "run".
-	if ok, _ := strconv.ParseBool(os.Getenv("DEVBOX_INCLUDE_BIN_WRAPPERS_IN_PATH")); ok {
-		omitBinWrappersFromPath = false
-	}
 	// Check the directory exists.
 	box, err := devbox.Open(&devopt.Opts{
-		Dir:                     path,
-		Stderr:                  cmd.ErrOrStderr(),
-		Pure:                    flags.pure,
-		Env:                     env,
-		OmitBinWrappersFromPath: omitBinWrappersFromPath,
+		Dir:    path,
+		Stderr: cmd.ErrOrStderr(),
+		Pure:   flags.pure,
+		Env:    env,
 	})
 	if err != nil {
 		return redact.Errorf("error reading devbox.json: %w", err)

--- a/internal/boxcli/services.go
+++ b/internal/boxcli/services.go
@@ -48,7 +48,13 @@ func servicesCmd(persistentPreRunE ...cobraFunc) *cobra.Command {
 	serviceStopFlags := serviceStopFlags{}
 	servicesCommand := &cobra.Command{
 		Use:   "services",
-		Short: "Interact with devbox services",
+		Short: "Interact with devbox services.",
+		Long: "Interact with devbox services. Services start in a new shell. " +
+			"Plugin services use envrinment variables specified by plugin unless " +
+			"overridden by the user. To override plugin environment variables, use " +
+			"the --env or --env-file flag. You may also override in devbox.json by " +
+			"using the `env` field or exporting an environment variable in the " +
+			"init hook.",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			preruns := append([]cobraFunc{ensureNixInstalled}, persistentPreRunE...)
 			for _, fn := range preruns {

--- a/internal/boxcli/services.go
+++ b/internal/boxcli/services.go
@@ -50,7 +50,7 @@ func servicesCmd(persistentPreRunE ...cobraFunc) *cobra.Command {
 		Use:   "services",
 		Short: "Interact with devbox services.",
 		Long: "Interact with devbox services. Services start in a new shell. " +
-			"Plugin services use envrinment variables specified by plugin unless " +
+			"Plugin services use environment variables specified by plugin unless " +
 			"overridden by the user. To override plugin environment variables, use " +
 			"the --env or --env-file flag. You may also override in devbox.json by " +
 			"using the `env` field or exporting an environment variable in the " +

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -30,6 +30,7 @@ import (
 	"go.jetpack.io/devbox/internal/searcher"
 	"go.jetpack.io/devbox/internal/shellgen"
 	"go.jetpack.io/devbox/internal/telemetry"
+	"go.jetpack.io/devbox/internal/wrapnix"
 
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/cmdutil"
@@ -67,7 +68,6 @@ type Devbox struct {
 	pure                     bool
 	allowInsecureAdds        bool
 	customProcessComposeFile string
-	OmitBinWrappersFromPath  bool
 
 	// This is needed because of the --quiet flag.
 	stderr io.Writer
@@ -98,7 +98,6 @@ func Open(opts *devopt.Opts) (*Devbox, error) {
 		pure:                     opts.Pure,
 		customProcessComposeFile: opts.CustomProcessComposeFile,
 		allowInsecureAdds:        opts.AllowInsecureAdds,
-		OmitBinWrappersFromPath:  opts.OmitBinWrappersFromPath,
 	}
 
 	lock, err := lock.GetFile(box)
@@ -221,6 +220,19 @@ func (d *Devbox) RunScript(ctx context.Context, cmdName string, cmdArgs []string
 	if err != nil {
 		return err
 	}
+
+	// By default we always remove bin wrappers when using `run`. This env var is
+	// for testing. Once we completely remove bin wrappers we can remove this.
+	// It helps simulate shell using "run".
+	if includeBinWrappers, _ := strconv.ParseBool(
+		os.Getenv("DEVBOX_INCLUDE_BIN_WRAPPERS_IN_PATH"),
+	); !includeBinWrappers {
+		env["PATH"] = envpath.RemoveFromPath(
+			env["PATH"],
+			wrapnix.WrapperBinPath(d.projectDir),
+		)
+	}
+
 	// Used to determine whether we're inside a shell (e.g. to prevent shell inception)
 	// This is temporary because StartServices() needs it but should be replaced with
 	// better alternative since devbox run and devbox shell are not the same.
@@ -526,15 +538,21 @@ func (d *Devbox) Services() (services.Services, error) {
 	return result, nil
 }
 
-func (d *Devbox) StartServices(ctx context.Context, serviceNames ...string) error {
-	if !d.IsEnvEnabled() {
-		return d.RunScript(ctx, "devbox", append([]string{"services", "start"}, serviceNames...))
+func (d *Devbox) StartServices(
+	ctx context.Context, runInCurrentShell bool, serviceNames ...string) error {
+	if !runInCurrentShell {
+		return d.RunScript(ctx, "devbox",
+			append(
+				[]string{"services", "start", "--run-in-current-shell"},
+				serviceNames...,
+			),
+		)
 	}
 
 	if !services.ProcessManagerIsRunning(d.projectDir) {
 		fmt.Fprintln(d.stderr, "Process-compose is not running. Starting it now...")
 		fmt.Fprintln(d.stderr, "\nNOTE: We recommend using `devbox services up` to start process-compose and your services")
-		return d.StartProcessManager(ctx, serviceNames, true, "")
+		return d.StartProcessManager(ctx, runInCurrentShell, serviceNames, true, "")
 	}
 
 	svcSet, err := d.Services()
@@ -563,9 +581,9 @@ func (d *Devbox) StartServices(ctx context.Context, serviceNames ...string) erro
 	return nil
 }
 
-func (d *Devbox) StopServices(ctx context.Context, allProjects bool, serviceNames ...string) error {
-	if !d.IsEnvEnabled() {
-		args := []string{"services", "stop"}
+func (d *Devbox) StopServices(ctx context.Context, runInCurrentShell bool, allProjects bool, serviceNames ...string) error {
+	if !runInCurrentShell {
+		args := []string{"services", "stop", "--run-in-current-shell"}
 		args = append(args, serviceNames...)
 		if allProjects {
 			args = append(args, "--all-projects")
@@ -602,9 +620,10 @@ func (d *Devbox) StopServices(ctx context.Context, allProjects bool, serviceName
 	return nil
 }
 
-func (d *Devbox) ListServices(ctx context.Context) error {
-	if !d.IsEnvEnabled() {
-		return d.RunScript(ctx, "devbox", []string{"services", "ls"})
+func (d *Devbox) ListServices(ctx context.Context, runInCurrentShell bool) error {
+	if !runInCurrentShell {
+		return d.RunScript(ctx,
+			"devbox", []string{"services", "ls", "--run-in-current-shell"})
 	}
 
 	svcSet, err := d.Services()
@@ -640,15 +659,21 @@ func (d *Devbox) ListServices(ctx context.Context) error {
 	return nil
 }
 
-func (d *Devbox) RestartServices(ctx context.Context, serviceNames ...string) error {
-	if !d.IsEnvEnabled() {
-		return d.RunScript(ctx, "devbox", append([]string{"services", "restart"}, serviceNames...))
+func (d *Devbox) RestartServices(
+	ctx context.Context, runInCurrentShell bool, serviceNames ...string) error {
+	if !runInCurrentShell {
+		return d.RunScript(ctx, "devbox",
+			append(
+				[]string{"services", "restart", "--run-in-current-shell"},
+				serviceNames...,
+			),
+		)
 	}
 
 	if !services.ProcessManagerIsRunning(d.projectDir) {
 		fmt.Fprintln(d.stderr, "Process-compose is not running. Starting it now...")
 		fmt.Fprintln(d.stderr, "\nTip: We recommend using `devbox services up` to start process-compose and your services")
-		return d.StartProcessManager(ctx, serviceNames, true, "")
+		return d.StartProcessManager(ctx, runInCurrentShell, serviceNames, true, "")
 	}
 
 	// TODO: Restart with no services should restart the _currently running_ services. This means we should get the list of running services from the process-compose, then restart them all.
@@ -674,12 +699,13 @@ func (d *Devbox) RestartServices(ctx context.Context, serviceNames ...string) er
 
 func (d *Devbox) StartProcessManager(
 	ctx context.Context,
+	runInCurrentShell bool,
 	requestedServices []string,
 	background bool,
 	processComposeFileOrDir string,
 ) error {
-	if !d.IsEnvEnabled() {
-		args := []string{"services", "up"}
+	if !runInCurrentShell {
+		args := []string{"services", "up", "--run-in-current-shell"}
 		args = append(args, requestedServices...)
 		if processComposeFileOrDir != "" {
 			args = append(args, "--process-compose-file", processComposeFileOrDir)
@@ -853,16 +879,10 @@ func (d *Devbox) computeNixEnv(ctx context.Context, usePrintDevEnvCache bool) (m
 	addEnvIfNotPreviouslySetByDevbox(env, pluginEnv)
 
 	env["PATH"] = envpath.JoinPathLists(
+		filepath.Join(d.projectDir, plugin.WrapperBinPath),
 		nix.ProfileBinPath(d.projectDir),
 		env["PATH"],
 	)
-
-	if !d.OmitBinWrappersFromPath {
-		env["PATH"] = envpath.JoinPathLists(
-			filepath.Join(d.projectDir, plugin.WrapperBinPath),
-			env["PATH"],
-		)
-	}
 
 	env["PATH"], err = d.addUtilitiesToPath(ctx, env["PATH"])
 	if err != nil {

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -539,7 +539,8 @@ func (d *Devbox) Services() (services.Services, error) {
 }
 
 func (d *Devbox) StartServices(
-	ctx context.Context, runInCurrentShell bool, serviceNames ...string) error {
+	ctx context.Context, runInCurrentShell bool, serviceNames ...string,
+) error {
 	if !runInCurrentShell {
 		return d.RunScript(ctx, "devbox",
 			append(
@@ -581,7 +582,7 @@ func (d *Devbox) StartServices(
 	return nil
 }
 
-func (d *Devbox) StopServices(ctx context.Context, runInCurrentShell bool, allProjects bool, serviceNames ...string) error {
+func (d *Devbox) StopServices(ctx context.Context, runInCurrentShell, allProjects bool, serviceNames ...string) error {
 	if !runInCurrentShell {
 		args := []string{"services", "stop", "--run-in-current-shell"}
 		args = append(args, serviceNames...)
@@ -660,7 +661,8 @@ func (d *Devbox) ListServices(ctx context.Context, runInCurrentShell bool) error
 }
 
 func (d *Devbox) RestartServices(
-	ctx context.Context, runInCurrentShell bool, serviceNames ...string) error {
+	ctx context.Context, runInCurrentShell bool, serviceNames ...string,
+) error {
 	if !runInCurrentShell {
 		return d.RunScript(ctx, "devbox",
 			append(

--- a/internal/impl/devopt/devboxopts.go
+++ b/internal/impl/devopt/devboxopts.go
@@ -12,7 +12,6 @@ type Opts struct {
 	Pure                     bool
 	IgnoreWarnings           bool
 	CustomProcessComposeFile string
-	OmitBinWrappersFromPath  bool
 	Stderr                   io.Writer
 }
 

--- a/internal/impl/envpath/pathlists.go
+++ b/internal/impl/envpath/pathlists.go
@@ -1,6 +1,7 @@
 package envpath
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -34,4 +35,23 @@ func JoinPathLists(pathLists ...string) string {
 		}
 	}
 	return strings.Join(cleaned, string(filepath.ListSeparator))
+}
+
+func RemoveFromPath(path, pathToRemove string) string {
+	paths := strings.Split(path, string(os.PathListSeparator))
+
+	// Create a new slice to store the modified paths
+	var newPaths []string
+
+	// Iterate through the paths and add them to the newPaths slice if they are not equal to pathToRemove
+	for _, p := range paths {
+		if p != pathToRemove {
+			newPaths = append(newPaths, p)
+		}
+	}
+
+	// Join the modified paths using ":" as the delimiter
+	newPath := strings.Join(newPaths, string(os.PathListSeparator))
+
+	return newPath
 }

--- a/internal/impl/envpath/pathlists.go
+++ b/internal/impl/envpath/pathlists.go
@@ -38,7 +38,7 @@ func JoinPathLists(pathLists ...string) string {
 }
 
 func RemoveFromPath(path, pathToRemove string) string {
-	paths := strings.Split(path, string(os.PathListSeparator))
+	paths := filepath.SplitList(path)
 
 	// Create a new slice to store the modified paths
 	var newPaths []string

--- a/internal/wrapnix/wrapper.go
+++ b/internal/wrapnix/wrapper.go
@@ -44,7 +44,7 @@ func CreateWrappers(ctx context.Context, args CreateWrappersArgs) error {
 	_ = os.RemoveAll(filepath.Join(args.ProjectDir, plugin.WrapperPath))
 
 	// Recreate the bin wrapper directory
-	destPath := filepath.Join(wrapperBinPath(args.ProjectDir))
+	destPath := filepath.Join(WrapperBinPath(args.ProjectDir))
 	_ = os.MkdirAll(destPath, 0o755)
 
 	bashPath := cmdutil.GetPathOrDefault("bash", "/bin/bash")
@@ -195,6 +195,6 @@ func createSymlinksForSupportDirs(projectDir string) error {
 	return nil
 }
 
-func wrapperBinPath(projectDir string) string {
+func WrapperBinPath(projectDir string) string {
 	return filepath.Join(projectDir, plugin.WrapperBinPath)
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/jetpack-io/devbox/issues/1565

The bugs:
* env vars specified via `--env-file` (and possibly via other methods) are ignored in nginx config.
* When inside a devbox shell or a direnv context, starting services would ignore env vars.

Intermediate causes:
* `envsubst` binary was a bin wrapped binary. This was resetting the env vars. Fix: Never use bin wrappers when inside a `devbox run` (This was previously only scoped to using the CLI command explicitly, but now we do it any time we use RunScript function)
* Previously we would only run services in new shell if we were not already in a shell or direnv. But this causes us to ignore environment variables that are set after the environment is created due to bin wrappers. Fix: always run services in new shell.

Root cause:
* I'm not 100% sure what caused this. It's possible the [PATH stack PR](https://github.com/jetpack-io/devbox/commit/c11031a034bf4b84aa902be64ab91f59388dffb1) did, but I don't fully understand the mechanism. I'm still confident the changes in this PR are good and simplify uncertainty about how services are called.

Sorry in advance for all the boolean params. We should move to structs, but I didn't want to make those changes here.

## How was it tested?

* Copied setup from https://github.com/jetpack-io/devbox/issues/1565. 
* Tried changing port and restarting services.
* Tested outside of devbox shell
* Tested inside of devbox shell
* Tested with direnv enabled
* Tested with direnv disabled

