### PR TITLE
[wrappers] Always use system bash and sed in bin wrappers

### DIFF
--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -17,6 +17,7 @@ import (
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/boxcli/midcobra"
 	"go.jetpack.io/devbox/internal/cloud/openssh/sshshim"
+	"go.jetpack.io/devbox/internal/cmdutil"
 	"go.jetpack.io/devbox/internal/debug"
 	"go.jetpack.io/devbox/internal/telemetry"
 	"go.jetpack.io/devbox/internal/vercheck"
@@ -113,6 +114,7 @@ func Execute(ctx context.Context, args []string) int {
 
 func Main() {
 	timer := debug.Timer(strings.Join(os.Args, " "))
+	setSystemBinaryPaths()
 	ctx := context.Background()
 	if strings.HasSuffix(os.Args[0], "ssh") ||
 		strings.HasSuffix(os.Args[0], "scp") {
@@ -144,5 +146,14 @@ func listAllCommands(cmd *cobra.Command, indent string) {
 	// Recursively list child commands with increased indentation
 	for _, childCmd := range cmd.Commands() {
 		listAllCommands(childCmd, indent+"\t")
+	}
+}
+
+func setSystemBinaryPaths() {
+	if os.Getenv("DEVBOX_SYSTEM_BASH") == "" {
+		os.Setenv("DEVBOX_SYSTEM_BASH", cmdutil.GetPathOrDefault("bash", "/bin/bash"))
+	}
+	if os.Getenv("DEVBOX_SYSTEM_SED") == "" {
+		os.Setenv("DEVBOX_SYSTEM_SED", cmdutil.GetPathOrDefault("sed", "/usr/bin/sed"))
 	}
 }

--- a/internal/wrapnix/wrapper.go
+++ b/internal/wrapnix/wrapper.go
@@ -21,6 +21,15 @@ import (
 	"go.jetpack.io/devbox/internal/xdg"
 )
 
+// Avoid wrapping bash and sed to prevent accidentally creating a recursive loop
+// We use DEVBOX_SYSTEM_BASH and DEVBOX_SYSTEM_SED so normally we won't use
+// user versions, but we want to be extra careful.
+// This also has minor performance benefits.
+var dontWrap = map[string]bool{
+	"bash": true,
+	"sed":  true,
+}
+
 type CreateWrappersArgs struct {
 	NixBins         []string
 	ShellEnvHash    string
@@ -55,6 +64,9 @@ func CreateWrappers(ctx context.Context, args CreateWrappersArgs) error {
 	}
 
 	for _, bin := range args.NixBins {
+		if dontWrap[filepath.Base(bin)] {
+			continue
+		}
 		if err := createWrapper(&createWrapperArgs{
 			WrapperBinPath:     destPath,
 			CreateWrappersArgs: args,

--- a/internal/wrapnix/wrapper.go
+++ b/internal/wrapnix/wrapper.go
@@ -21,11 +21,6 @@ import (
 	"go.jetpack.io/devbox/internal/xdg"
 )
 
-var dontWrap = map[string]bool{
-	"bash": true,
-	"sed":  true,
-}
-
 type CreateWrappersArgs struct {
 	NixBins         []string
 	ShellEnvHash    string
@@ -52,18 +47,14 @@ func CreateWrappers(ctx context.Context, args CreateWrappersArgs) error {
 	destPath := filepath.Join(wrapperBinPath(args.ProjectDir))
 	_ = os.MkdirAll(destPath, 0o755)
 
-	bashPath := cmdutil.GetPathOrDefault("bash", "/bin/bash")
-	sedPath := cmdutil.GetPathOrDefault("sed", "/usr/bin/sed")
+	bashPath := cmdutil.GetPathOrDefault(os.Getenv("DEVBOX_SYSTEM_BASH"), "/bin/bash")
+	sedPath := cmdutil.GetPathOrDefault(os.Getenv("DEVBOX_SYSTEM_SED"), "/usr/bin/sed")
 
 	if err := CreateDevboxSymlinkIfPossible(); err != nil {
 		return err
 	}
 
 	for _, bin := range args.NixBins {
-		if dontWrap[filepath.Base(bin)] {
-			continue
-		}
-
 		if err := createWrapper(&createWrapperArgs{
 			WrapperBinPath:     destPath,
 			CreateWrappersArgs: args,

--- a/internal/wrapnix/wrapper.go
+++ b/internal/wrapnix/wrapper.go
@@ -21,6 +21,11 @@ import (
 	"go.jetpack.io/devbox/internal/xdg"
 )
 
+var dontWrap = map[string]bool{
+	"bash": true,
+	"sed":  true,
+}
+
 type CreateWrappersArgs struct {
 	NixBins         []string
 	ShellEnvHash    string
@@ -48,13 +53,17 @@ func CreateWrappers(ctx context.Context, args CreateWrappersArgs) error {
 	_ = os.MkdirAll(destPath, 0o755)
 
 	bashPath := cmdutil.GetPathOrDefault("bash", "/bin/bash")
-	sedPath := cmdutil.GetPathOrDefault("sed", "sed")
+	sedPath := cmdutil.GetPathOrDefault("sed", "/usr/bin/sed")
 
 	if err := CreateDevboxSymlinkIfPossible(); err != nil {
 		return err
 	}
 
 	for _, bin := range args.NixBins {
+		if dontWrap[filepath.Base(bin)] {
+			continue
+		}
+
 		if err := createWrapper(&createWrapperArgs{
 			WrapperBinPath:     destPath,
 			CreateWrappersArgs: args,


### PR DESCRIPTION
## Summary

This feels like the safest solution to https://github.com/jetpack-io/devbox/pull/1566#discussion_r1364318788

It also avoids creating bin wrappers for `bash` and `sed` which reduces risk and improves performance.

## How was it tested?

Used setup from https://github.com/jetpack-io/devbox/pull/1566

```
devbox shell
devbox add bash
hash -r
which bash # ensure I get profile bash instead of wrapped bash
```
