### PR TITLE
devpkg: better flake references and installable parsing

### DIFF
--- a/internal/devpkg/flakeref.go
+++ b/internal/devpkg/flakeref.go
@@ -1,0 +1,261 @@
+package devpkg
+
+import (
+	"net/url"
+	"strings"
+
+	"go.jetpack.io/devbox/internal/redact"
+)
+
+// FlakeRef is a parsed Nix flake reference. A flake reference is as subset of
+// the Nix CLI "installable" syntax. Installables may specify an attribute path
+// and derivation outputs with a flake reference using the '#' and '^' characters.
+// For example, the string "nixpkgs" and "./flake" are valid flake references,
+// but "nixpkgs#hello" and "./flake#app^bin,dev" are not.
+//
+// See the [Nix manual] for details on flake references.
+//
+// [Nix manual]: https://nixos.org/manual/nix/unstable/command-ref/new-cli/nix3-flake
+type FlakeRef struct {
+	// Type is the type of flake reference. Some valid types are "indirect",
+	// "path", "file", "git", "tarball", and "github".
+	Type string `json:"type,omitempty"`
+
+	// ID is the flake's identifier when Type is "indirect". A common
+	// example is nixpkgs.
+	ID string `json:"id,omitempty"`
+
+	// Path is the path to the flake directory when Type is "path".
+	Path string `json:"path,omitempty"`
+
+	// Owner and repo are the flake repository owner and name when Type is
+	// "github".
+	Owner string `json:"owner,omitempty"`
+	Repo  string `json:"repo,omitempty"`
+
+	// Rev and ref are the git revision (commit hash) and ref
+	// (branch or tag) when Type is "github" or "git".
+	Rev string `json:"rev,omitempty"`
+	Ref string `json:"ref,omitempty"`
+
+	// Dir is non-empty when the directory containinig the flake.nix file is
+	// not at the flake root. It corresponds to the optional "dir" query
+	// parameter when Type is "github", "git", "tarball", or "file".
+	Dir string `json:"dir,omitempty"`
+
+	// Host overrides the default VCS host when Type is "github", such as
+	// when referring to a GitHub Enterprise instance. It corresponds to the
+	// optional "host" query parameter when Type is "github".
+	Host string `json:"host,omitempty"`
+
+	// URL is the URL pointing to the flake when type is "tarball", "file",
+	// or "git". Note that the URL is not the same as the raw unparsed
+	// flakeref.
+	URL string `json:"url,omitempty"`
+
+	// raw stores the original unparsed flakeref string.
+	raw string
+}
+
+// ParseFlakeRef parses a raw flake reference. Nix supports a variety of
+// flakeref formats, and isn't entirely consistent about how it parses them.
+// ParseFlakeRef attempts to mimic how Nix parses flakerefs on the command line.
+// The raw ref can be one of the following:
+//
+//   - Indirect reference such as "nixpkgs" or "nixpkgs/unstable".
+//   - Path-like reference such as "./flake" or "/path/to/flake". They must
+//     start with a '.' or '/' and not contain a '#' or '?'.
+//   - URL-like reference which must be a valid URL with any special characters
+//     encoded. The scheme can be any valid flakeref type except for mercurial,
+//     gitlab, and sourcehut.
+//
+// ParseFlakeRef does not guarantee that a parsed flakeref is valid or that an
+// error indicates an invalid flakeref. Use the "nix flake metadata" command or
+// the parseFlakeRef builtin function to validate a flakeref.
+func ParseFlakeRef(ref string) (FlakeRef, error) {
+	if ref == "" {
+		return FlakeRef{}, redact.Errorf("empty flake reference")
+	}
+
+	// Handle path-style references first.
+	parsed := FlakeRef{raw: ref}
+	if ref[0] == '.' || ref[0] == '/' {
+		if strings.ContainsAny(ref, "?#") {
+			// The Nix CLI does seem to allow paths with a '?'
+			// (contrary to the manual) but ignores everything that
+			// comes after it. This is a bit surprising, so we just
+			// don't allow it at all.
+			return FlakeRef{}, redact.Errorf("path-style flake reference %q contains a '?' or '#'", ref)
+		}
+		parsed.Type = "path"
+		parsed.Path = ref
+		return parsed, nil
+	}
+	parsed, _, err := parseFlakeURLRef(ref)
+	return parsed, err
+}
+
+func parseFlakeURLRef(ref string) (parsed FlakeRef, fragment string, err error) {
+	// A good way to test how Nix parses a flake reference is to run:
+	//
+	// 	nix eval --json --expr 'builtins.parseFlakeRef "ref"' | jq
+	parsed.raw = ref
+	refURL, err := url.Parse(ref)
+	if err != nil {
+		return FlakeRef{}, "", redact.Errorf("parse flake reference as URL: %v", err)
+	}
+
+	switch refURL.Scheme {
+	case "", "flake":
+		// [flake:]<flake-id>(/<rev-or-ref>(/rev)?)?
+
+		parsed.Type = "indirect"
+
+		// "indirect" is parsed as a path, "flake:indirect" is parsed as
+		// opaque because it has a scheme.
+		path := refURL.Path
+		if path == "" {
+			path, err = url.PathUnescape(refURL.Opaque)
+			if err != nil {
+				path = refURL.Opaque
+			}
+		}
+		split := strings.SplitN(path, "/", 3)
+		parsed.ID = split[0]
+		if len(split) > 1 {
+			if isGitHash(split[1]) {
+				parsed.Rev = split[1]
+			} else {
+				parsed.Ref = split[1]
+			}
+		}
+		if len(split) > 2 && parsed.Rev == "" {
+			parsed.Rev = split[2]
+		}
+	case "path":
+		// [path:]<path>(\?<params)?
+
+		parsed.Type = "path"
+		if refURL.Path == "" {
+			parsed.Path, err = url.PathUnescape(refURL.Opaque)
+			if err != nil {
+				parsed.Path = refURL.Opaque
+			}
+		} else {
+			parsed.Path = refURL.Path
+		}
+	case "http", "https", "file":
+		if isArchive(refURL.Path) {
+			parsed.Type = "tarball"
+		} else {
+			parsed.Type = "file"
+		}
+		parsed.URL = ref
+		parsed.Dir = refURL.Query().Get("dir")
+	case "tarball+http", "tarball+https", "tarball+file":
+		parsed.Type = "tarball"
+		parsed.Dir = refURL.Query().Get("dir")
+		parsed.URL = ref[8:] // remove tarball+
+	case "file+http", "file+https", "file+file":
+		parsed.Type = "file"
+		parsed.Dir = refURL.Query().Get("dir")
+		parsed.URL = ref[5:] // remove file+
+	case "git", "git+http", "git+https", "git+ssh", "git+git", "git+file":
+		parsed.Type = "git"
+		q := refURL.Query()
+		parsed.Dir = q.Get("dir")
+		parsed.Ref = q.Get("ref")
+		parsed.Rev = q.Get("rev")
+
+		// ref and rev get stripped from the query parameters, but dir
+		// stays.
+		q.Del("ref")
+		q.Del("rev")
+		refURL.RawQuery = q.Encode()
+		if len(refURL.Scheme) > 3 {
+			refURL.Scheme = refURL.Scheme[4:] // remove git+
+		}
+		parsed.URL = refURL.String()
+	case "github":
+		if err := parseGitHubFlakeRef(refURL, &parsed); err != nil {
+			return FlakeRef{}, "", err
+		}
+	}
+	return parsed, refURL.Fragment, nil
+}
+
+func parseGitHubFlakeRef(refURL *url.URL, parsed *FlakeRef) error {
+	// github:<owner>/<repo>(/<rev-or-ref>)?(\?<params>)?
+
+	parsed.Type = "github"
+	path := refURL.Path
+	if path == "" {
+		var err error
+		path, err = url.PathUnescape(refURL.Opaque)
+		if err != nil {
+			path = refURL.Opaque
+		}
+	}
+	path = strings.TrimPrefix(path, "/")
+
+	split := strings.SplitN(path, "/", 3)
+	parsed.Owner = split[0]
+	parsed.Repo = split[1]
+	if len(split) > 2 {
+		if revOrRef := split[2]; isGitHash(revOrRef) {
+			parsed.Rev = revOrRef
+		} else {
+			parsed.Ref = revOrRef
+		}
+	}
+
+	parsed.Host = refURL.Query().Get("host")
+	if qRef := refURL.Query().Get("ref"); qRef != "" {
+		if parsed.Rev != "" {
+			return redact.Errorf("github flake reference has a ref and a rev")
+		}
+		if parsed.Ref != "" && qRef != parsed.Ref {
+			return redact.Errorf("github flake reference has a ref in the path (%q) and a ref query parameter (%q)", parsed.Ref, qRef)
+		}
+		parsed.Ref = qRef
+	}
+	if qRev := refURL.Query().Get("rev"); qRev != "" {
+		if parsed.Ref != "" {
+			return redact.Errorf("github flake reference has a ref and a rev")
+		}
+		if parsed.Rev != "" && qRev != parsed.Rev {
+			return redact.Errorf("github flake reference has a rev in the path (%q) and a rev query parameter (%q)", parsed.Rev, qRev)
+		}
+		parsed.Rev = qRev
+	}
+	return nil
+}
+
+// String returns the raw flakeref string as given to ParseFlakeRef.
+func (f FlakeRef) String() string {
+	return f.raw
+}
+
+func isGitHash(s string) bool {
+	if len(s) != 40 {
+		return false
+	}
+	for i := range s {
+		isDigit := s[i] >= '0' && s[i] <= '9'
+		isHexLetter := s[i] >= 'a' && s[i] <= 'f'
+		if !isDigit && !isHexLetter {
+			return false
+		}
+	}
+	return true
+}
+
+func isArchive(path string) bool {
+	return strings.HasSuffix(path, ".tar") ||
+		strings.HasSuffix(path, ".tar.gz") ||
+		strings.HasSuffix(path, ".tgz") ||
+		strings.HasSuffix(path, ".tar.xz") ||
+		strings.HasSuffix(path, ".tar.zst") ||
+		strings.HasSuffix(path, ".tar.bz2") ||
+		strings.HasSuffix(path, ".zip")
+}

--- a/internal/devpkg/flakeref.go
+++ b/internal/devpkg/flakeref.go
@@ -7,7 +7,7 @@ import (
 	"go.jetpack.io/devbox/internal/redact"
 )
 
-// FlakeRef is a parsed Nix flake reference. A flake reference is as subset of
+// FlakeRef is a parsed Nix flake reference. A flake reference is a subset of
 // the Nix CLI "installable" syntax. Installables may specify an attribute path
 // and derivation outputs with a flake reference using the '#' and '^' characters.
 // For example, the string "nixpkgs" and "./flake" are valid flake references,
@@ -38,7 +38,7 @@ type FlakeRef struct {
 	Rev string `json:"rev,omitempty"`
 	Ref string `json:"ref,omitempty"`
 
-	// Dir is non-empty when the directory containinig the flake.nix file is
+	// Dir is non-empty when the directory containing the flake.nix file is
 	// not at the flake root. It corresponds to the optional "dir" query
 	// parameter when Type is "github", "git", "tarball", or "file".
 	Dir string `json:"dir,omitempty"`

--- a/internal/devpkg/flakeref_test.go
+++ b/internal/devpkg/flakeref_test.go
@@ -76,7 +76,7 @@ func TestParseFlakeRef(t *testing.T) {
 		"github:NixOS/nix?ref=v1.2.3": {Type: "github", Owner: "NixOS", Repo: "nix", Ref: "v1.2.3"},
 		"github:NixOS/nix?ref=5233fd2ba76a3accb5aaa999c00509a11fd0793c": {Type: "github", Owner: "NixOS", Repo: "nix", Ref: "5233fd2ba76a3accb5aaa999c00509a11fd0793c"},
 		"github:NixOS/nix/5233fd2ba76a3accb5aaa999c00509a11fd0793c":     {Type: "github", Owner: "NixOS", Repo: "nix", Rev: "5233fd2ba76a3accb5aaa999c00509a11fd0793c"},
-		"github:NixOS/nix/5233fd2ba76a3accb5aaa999c00509a11fd0793z":     {Type: "github", Owner: "NixOS", Repo: "nix", Ref: "5233fd2ba76a3accb5aaa999c00509a11fd0793z"},
+		"github:NixOS/nix/5233fd2bb76a3accb5aaa999c00509a11fd0793z":     {Type: "github", Owner: "NixOS", Repo: "nix", Ref: "5233fd2bb76a3accb5aaa999c00509a11fd0793z"},
 		"github:NixOS/nix?rev=5233fd2ba76a3accb5aaa999c00509a11fd0793c": {Type: "github", Owner: "NixOS", Repo: "nix", Rev: "5233fd2ba76a3accb5aaa999c00509a11fd0793c"},
 		"github:NixOS/nix?host=example.com":                             {Type: "github", Owner: "NixOS", Repo: "nix", Host: "example.com"},
 

--- a/internal/devpkg/flakeref_test.go
+++ b/internal/devpkg/flakeref_test.go
@@ -1,0 +1,166 @@
+package devpkg
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestParseFlakeRef(t *testing.T) {
+	// Test cases use the zero-value to check for invalid flakerefs because
+	// we don't care about the specific error message.
+	cases := map[string]FlakeRef{
+		// Empty string is not a valid flake reference.
+		"": {},
+
+		// Not a path and not a valid URL.
+		"://bad/url": {},
+
+		// Path-like references start with a '.' or '/'.
+		// This distinguishes them from indirect references
+		// (./nixpkgs is a directory; nixpkgs is an indirect).
+		".":                {Type: "path", Path: "."},
+		"./":               {Type: "path", Path: "./"},
+		"./flake":          {Type: "path", Path: "./flake"},
+		"./relative/flake": {Type: "path", Path: "./relative/flake"},
+		"/":                {Type: "path", Path: "/"},
+		"/flake":           {Type: "path", Path: "/flake"},
+		"/absolute/flake":  {Type: "path", Path: "/absolute/flake"},
+
+		// Path-like references can have raw unicode characters unlike
+		// path: URL references.
+		"./Ûñî©ôδ€/flake\n": {Type: "path", Path: "./Ûñî©ôδ€/flake\n"},
+		"/Ûñî©ôδ€/flake\n":  {Type: "path", Path: "/Ûñî©ôδ€/flake\n"},
+
+		// Path-like references don't allow paths with a '?' or '#'.
+		"./invalid#path": {},
+		"./invalid?path": {},
+		"/invalid#path":  {},
+		"/invalid?path":  {},
+		"/#":             {},
+		"/?":             {},
+
+		// URL-like path references.
+		"path:":                      {Type: "path", Path: ""},
+		"path:.":                     {Type: "path", Path: "."},
+		"path:./":                    {Type: "path", Path: "./"},
+		"path:./flake":               {Type: "path", Path: "./flake"},
+		"path:./relative/flake":      {Type: "path", Path: "./relative/flake"},
+		"path:./relative/my%20flake": {Type: "path", Path: "./relative/my flake"},
+		"path:/":                     {Type: "path", Path: "/"},
+		"path:/flake":                {Type: "path", Path: "/flake"},
+		"path:/absolute/flake":       {Type: "path", Path: "/absolute/flake"},
+
+		// URL-like paths can omit the "./" prefix for relative
+		// directories.
+		"path:flake":          {Type: "path", Path: "flake"},
+		"path:relative/flake": {Type: "path", Path: "relative/flake"},
+
+		// Indirect references.
+		"flake:indirect":          {Type: "indirect", ID: "indirect"},
+		"flake:indirect/ref":      {Type: "indirect", ID: "indirect", Ref: "ref"},
+		"flake:indirect/my%20ref": {Type: "indirect", ID: "indirect", Ref: "my ref"},
+		"flake:indirect/5233fd2ba76a3accb5aaa999c00509a11fd0793c":     {Type: "indirect", ID: "indirect", Rev: "5233fd2ba76a3accb5aaa999c00509a11fd0793c"},
+		"flake:indirect/ref/5233fd2ba76a3accb5aaa999c00509a11fd0793c": {Type: "indirect", ID: "indirect", Ref: "ref", Rev: "5233fd2ba76a3accb5aaa999c00509a11fd0793c"},
+
+		// Indirect references can omit their "indirect:" type prefix.
+		"indirect":     {Type: "indirect", ID: "indirect"},
+		"indirect/ref": {Type: "indirect", ID: "indirect", Ref: "ref"},
+		"indirect/5233fd2ba76a3accb5aaa999c00509a11fd0793c":     {Type: "indirect", ID: "indirect", Rev: "5233fd2ba76a3accb5aaa999c00509a11fd0793c"},
+		"indirect/ref/5233fd2ba76a3accb5aaa999c00509a11fd0793c": {Type: "indirect", ID: "indirect", Ref: "ref", Rev: "5233fd2ba76a3accb5aaa999c00509a11fd0793c"},
+
+		// GitHub references.
+		"github:NixOS/nix":            {Type: "github", Owner: "NixOS", Repo: "nix"},
+		"github:NixOS/nix/v1.2.3":     {Type: "github", Owner: "NixOS", Repo: "nix", Ref: "v1.2.3"},
+		"github:NixOS/nix?ref=v1.2.3": {Type: "github", Owner: "NixOS", Repo: "nix", Ref: "v1.2.3"},
+		"github:NixOS/nix?ref=5233fd2ba76a3accb5aaa999c00509a11fd0793c": {Type: "github", Owner: "NixOS", Repo: "nix", Ref: "5233fd2ba76a3accb5aaa999c00509a11fd0793c"},
+		"github:NixOS/nix/5233fd2ba76a3accb5aaa999c00509a11fd0793c":     {Type: "github", Owner: "NixOS", Repo: "nix", Rev: "5233fd2ba76a3accb5aaa999c00509a11fd0793c"},
+		"github:NixOS/nix/5233fd2ba76a3accb5aaa999c00509a11fd0793z":     {Type: "github", Owner: "NixOS", Repo: "nix", Ref: "5233fd2ba76a3accb5aaa999c00509a11fd0793z"},
+		"github:NixOS/nix?rev=5233fd2ba76a3accb5aaa999c00509a11fd0793c": {Type: "github", Owner: "NixOS", Repo: "nix", Rev: "5233fd2ba76a3accb5aaa999c00509a11fd0793c"},
+		"github:NixOS/nix?host=example.com":                             {Type: "github", Owner: "NixOS", Repo: "nix", Host: "example.com"},
+
+		// GitHub references with invalid ref + rev combinations.
+		"github:NixOS/nix?ref=v1.2.3&rev=5233fd2ba76a3accb5aaa999c00509a11fd0793c":                               {},
+		"github:NixOS/nix/v1.2.3?ref=v4.5.6":                                                                     {},
+		"github:NixOS/nix/5233fd2ba76a3accb5aaa999c00509a11fd0793c?rev=e486d8d40e626a20e06d792db8cc5ac5aba9a5b4": {},
+		"github:NixOS/nix/5233fd2ba76a3accb5aaa999c00509a11fd0793c?ref=v1.2.3":                                   {},
+
+		// The github type allows clone-style URLs. The username and
+		// host are ignored.
+		"github://git@github.com/NixOS/nix":                                              {Type: "github", Owner: "NixOS", Repo: "nix"},
+		"github://git@github.com/NixOS/nix/v1.2.3":                                       {Type: "github", Owner: "NixOS", Repo: "nix", Ref: "v1.2.3"},
+		"github://git@github.com/NixOS/nix?ref=v1.2.3":                                   {Type: "github", Owner: "NixOS", Repo: "nix", Ref: "v1.2.3"},
+		"github://git@github.com/NixOS/nix?ref=5233fd2ba76a3accb5aaa999c00509a11fd0793c": {Type: "github", Owner: "NixOS", Repo: "nix", Ref: "5233fd2ba76a3accb5aaa999c00509a11fd0793c"},
+		"github://git@github.com/NixOS/nix?rev=5233fd2ba76a3accb5aaa999c00509a11fd0793c": {Type: "github", Owner: "NixOS", Repo: "nix", Rev: "5233fd2ba76a3accb5aaa999c00509a11fd0793c"},
+		"github://git@github.com/NixOS/nix?host=example.com":                             {Type: "github", Owner: "NixOS", Repo: "nix", Host: "example.com"},
+
+		// Git references.
+		"git://example.com/repo/flake":         {Type: "git", URL: "git://example.com/repo/flake"},
+		"git+https://example.com/repo/flake":   {Type: "git", URL: "https://example.com/repo/flake"},
+		"git+ssh://git@example.com/repo/flake": {Type: "git", URL: "ssh://git@example.com/repo/flake"},
+		"git:/repo/flake":                      {Type: "git", URL: "git:/repo/flake"},
+		"git+file:///repo/flake":               {Type: "git", URL: "file:///repo/flake"},
+		"git://example.com/repo/flake?ref=unstable&rev=e486d8d40e626a20e06d792db8cc5ac5aba9a5b4&dir=subdir": {Type: "git", URL: "git://example.com/repo/flake?dir=subdir", Ref: "unstable", Rev: "e486d8d40e626a20e06d792db8cc5ac5aba9a5b4", Dir: "subdir"},
+
+		// Tarball references.
+		"tarball+http://example.com/flake":  {Type: "tarball", URL: "http://example.com/flake"},
+		"tarball+https://example.com/flake": {Type: "tarball", URL: "https://example.com/flake"},
+		"tarball+file:///home/flake":        {Type: "tarball", URL: "file:///home/flake"},
+
+		// Regular URLs have the tarball type if they have a known
+		// archive extension:
+		// .zip, .tar, .tgz, .tar.gz, .tar.xz, .tar.bz2 or .tar.zst
+		"http://example.com/flake.zip":            {Type: "tarball", URL: "http://example.com/flake.zip"},
+		"http://example.com/flake.tar":            {Type: "tarball", URL: "http://example.com/flake.tar"},
+		"http://example.com/flake.tgz":            {Type: "tarball", URL: "http://example.com/flake.tgz"},
+		"http://example.com/flake.tar.gz":         {Type: "tarball", URL: "http://example.com/flake.tar.gz"},
+		"http://example.com/flake.tar.xz":         {Type: "tarball", URL: "http://example.com/flake.tar.xz"},
+		"http://example.com/flake.tar.bz2":        {Type: "tarball", URL: "http://example.com/flake.tar.bz2"},
+		"http://example.com/flake.tar.zst":        {Type: "tarball", URL: "http://example.com/flake.tar.zst"},
+		"http://example.com/flake.tar?dir=subdir": {Type: "tarball", URL: "http://example.com/flake.tar?dir=subdir", Dir: "subdir"},
+		"file:///flake.zip":                       {Type: "tarball", URL: "file:///flake.zip"},
+		"file:///flake.tar":                       {Type: "tarball", URL: "file:///flake.tar"},
+		"file:///flake.tgz":                       {Type: "tarball", URL: "file:///flake.tgz"},
+		"file:///flake.tar.gz":                    {Type: "tarball", URL: "file:///flake.tar.gz"},
+		"file:///flake.tar.xz":                    {Type: "tarball", URL: "file:///flake.tar.xz"},
+		"file:///flake.tar.bz2":                   {Type: "tarball", URL: "file:///flake.tar.bz2"},
+		"file:///flake.tar.zst":                   {Type: "tarball", URL: "file:///flake.tar.zst"},
+		"file:///flake.tar?dir=subdir":            {Type: "tarball", URL: "file:///flake.tar?dir=subdir", Dir: "subdir"},
+
+		// File URL references.
+		"file+file:///flake":                           {Type: "file", URL: "file:///flake"},
+		"file+http://example.com/flake":                {Type: "file", URL: "http://example.com/flake"},
+		"file+http://example.com/flake.git":            {Type: "file", URL: "http://example.com/flake.git"},
+		"file+http://example.com/flake.tar?dir=subdir": {Type: "file", URL: "http://example.com/flake.tar?dir=subdir", Dir: "subdir"},
+
+		// Regular URLs have the file type if they don't have a known
+		// archive extension.
+		"http://example.com/flake":            {Type: "file", URL: "http://example.com/flake"},
+		"http://example.com/flake.git":        {Type: "file", URL: "http://example.com/flake.git"},
+		"http://example.com/flake?dir=subdir": {Type: "file", URL: "http://example.com/flake?dir=subdir", Dir: "subdir"},
+
+		// Interpret opaques with invalid escapes literally.
+		"path:./relative/my%flake": {Type: "path", Path: "./relative/my%flake"},
+		"flake:indirect/my%ref":    {Type: "indirect", ID: "indirect", Ref: "my%ref"},
+		"github:NixOS/nix/my%ref":  {Type: "github", Owner: "NixOS", Repo: "nix", Ref: "my%ref"},
+	}
+
+	for ref, want := range cases {
+		t.Run(ref, func(t *testing.T) {
+			got, err := ParseFlakeRef(ref)
+			if diff := cmp.Diff(want, got, cmpopts.IgnoreUnexported(FlakeRef{})); diff != "" {
+				if err != nil {
+					t.Errorf("got error: %s", err)
+				}
+				t.Errorf("wrong flakeref (-want +got):\n%s", diff)
+			}
+			if err != nil {
+				return
+			}
+			if ref != got.String() {
+				t.Errorf("got.String() = %q != %q", got, ref)
+			}
+		})
+	}
+}

--- a/internal/devpkg/flakeref_test.go
+++ b/internal/devpkg/flakeref_test.go
@@ -164,3 +164,92 @@ func TestParseFlakeRef(t *testing.T) {
 		})
 	}
 }
+
+func TestParseFlakeInstallable(t *testing.T) {
+	cases := map[string]FlakeInstallable{
+		// Empty string is not a valid installable.
+		"": {},
+
+		// Not a path and not a valid URL.
+		"://bad/url": {},
+
+		".":             {Ref: FlakeRef{Type: "path", Path: "."}},
+		".#app":         {AttrPath: "app", Ref: FlakeRef{Type: "path", Path: "."}},
+		".#app^out":     {AttrPath: "app", Outputs: []string{"out"}, Ref: FlakeRef{Type: "path", Path: "."}},
+		".#app^out,lib": {AttrPath: "app", Outputs: []string{"out", "lib"}, Ref: FlakeRef{Type: "path", Path: "."}},
+		".#app^*":       {AttrPath: "app", Outputs: []string{"*"}, Ref: FlakeRef{Type: "path", Path: "."}},
+		".^*":           {Outputs: []string{"*"}, Ref: FlakeRef{Type: "path", Path: "."}},
+
+		"./flake":             {Ref: FlakeRef{Type: "path", Path: "./flake"}},
+		"./flake#app":         {AttrPath: "app", Ref: FlakeRef{Type: "path", Path: "./flake"}},
+		"./flake#app^out":     {AttrPath: "app", Outputs: []string{"out"}, Ref: FlakeRef{Type: "path", Path: "./flake"}},
+		"./flake#app^out,lib": {AttrPath: "app", Outputs: []string{"out", "lib"}, Ref: FlakeRef{Type: "path", Path: "./flake"}},
+		"./flake^out":         {Outputs: []string{"out"}, Ref: FlakeRef{Type: "path", Path: "./flake"}},
+
+		"indirect":            {Ref: FlakeRef{Type: "indirect", ID: "indirect"}},
+		"nixpkgs#app":         {AttrPath: "app", Ref: FlakeRef{Type: "indirect", ID: "nixpkgs"}},
+		"nixpkgs#app^out":     {AttrPath: "app", Outputs: []string{"out"}, Ref: FlakeRef{Type: "indirect", ID: "nixpkgs"}},
+		"nixpkgs#app^out,lib": {AttrPath: "app", Outputs: []string{"out", "lib"}, Ref: FlakeRef{Type: "indirect", ID: "nixpkgs"}},
+		"nixpkgs^out":         {Outputs: []string{"out"}, Ref: FlakeRef{Type: "indirect", ID: "nixpkgs"}},
+
+		"%23#app":                        {AttrPath: "app", Ref: FlakeRef{Type: "indirect", ID: "#"}},
+		"./%23#app":                      {AttrPath: "app", Ref: FlakeRef{Type: "path", Path: "./#"}},
+		"/%23#app":                       {AttrPath: "app", Ref: FlakeRef{Type: "path", Path: "/#"}},
+		"path:/%23#app":                  {AttrPath: "app", Ref: FlakeRef{Type: "path", Path: "/#"}},
+		"http://example.com/%23.tar#app": {AttrPath: "app", Ref: FlakeRef{Type: "tarball", URL: "http://example.com/%23.tar#app"}},
+	}
+
+	for installable, want := range cases {
+		t.Run(installable, func(t *testing.T) {
+			got, err := ParseFlakeInstallable(installable)
+			if diff := cmp.Diff(want, got, cmpopts.IgnoreUnexported(FlakeRef{}, FlakeInstallable{})); diff != "" {
+				if err != nil {
+					t.Errorf("got error: %s", err)
+				}
+				t.Errorf("wrong installable (-want +got):\n%s", diff)
+			}
+			if err != nil {
+				return
+			}
+			if installable != got.String() {
+				t.Errorf("got.String() = %q != %q", got, installable)
+			}
+		})
+	}
+}
+
+func TestFlakeInstallableDefaultOutputs(t *testing.T) {
+	install := FlakeInstallable{Outputs: nil}
+	if !install.DefaultOutputs() {
+		t.Errorf("DefaultOutputs() = false for nil outputs slice, want true")
+	}
+
+	install = FlakeInstallable{Outputs: []string{}}
+	if !install.DefaultOutputs() {
+		t.Errorf("DefaultOutputs() = false for empty outputs slice, want true")
+	}
+
+	install = FlakeInstallable{Outputs: []string{"out"}}
+	if install.DefaultOutputs() {
+		t.Errorf("DefaultOutputs() = true for %v, want false", install.Outputs)
+	}
+}
+
+func TestFlakeInstallableAllOutputs(t *testing.T) {
+	install := FlakeInstallable{Outputs: []string{"*"}}
+	if !install.AllOutputs() {
+		t.Errorf("AllOutputs() = false for %v, want true", install.Outputs)
+	}
+	install = FlakeInstallable{Outputs: []string{"out", "*"}}
+	if !install.AllOutputs() {
+		t.Errorf("AllOutputs() = false for %v, want true", install.Outputs)
+	}
+	install = FlakeInstallable{Outputs: nil}
+	if install.AllOutputs() {
+		t.Errorf("AllOutputs() = true for nil outputs slice, want false")
+	}
+	install = FlakeInstallable{Outputs: []string{}}
+	if install.AllOutputs() {
+		t.Errorf("AllOutputs() = true for empty outputs slice, want false")
+	}
+}


### PR DESCRIPTION
In anticipation of adding support for non-default package outputs, I wanted to clean up some of the flakeref parsing in `devpkg`. This will make it easier to handle Nix's `flakeref#attrpath^outputs` installable syntax. This PR is broken up into two commits: one that handles flakeref parsing and one that handles installable parsing.

The `ParseFlakeRef` function is able to parse the more common flakerefs that devbox currently supports ("path", "flake", "indirect", etc.). It doesn't support mercurial, gitlab, and sourcehuthut for now. The `ParseFlakeInstallable` function parses Nix flake installables, which are a superset of the flake reference syntax. It allows an attribute path and/or outputs to be specified using the `flake#attrpath^outputs` syntax. The tests were validated using the nix expression `builtins.parseFlakeRef "ref"` and the `nix flake metadata <ref>` CLI.

The goal isn't to perfectly replicate Nix's parsing of flake references (which itself is sometimes inconsistent), but to make it good enough to handle flakerefs in devbox.json.