### PR TITLE
devpkg: use struct field values in FlakeRef.String

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,7 +41,7 @@ linters-settings:
       - name: bool-literal-in-expr
       - name: cognitive-complexity
         arguments:
-          - 30 # TODO: gradually reduce it
+          - 32 # TODO: gradually reduce it
       - name: datarace
       - name: duplicated-imports
       - name: early-return


### PR DESCRIPTION
Improve FlakeRef.String so that it reassembles the flakeref using the current field values instead of returning the original parsed string that it came from. This makes it easier to modify parsed flakerefs or to create new ones from scratch.

The strings are normalized so that when two flakerefs are equal, their strings will also be equal. The docs for FlakeRef.String go into more detail on what the normalized form looks like.

Being able to parse/modify/encode flake references is part of the work to support multiple package outputs. Having a single (well-tested type) for handling flakes should help manage the complexity as another syntax for outputs is added.