### PR TITLE
devpkg: make FlakeInstallable.Outputs a string

### DIFF
--- a/internal/devpkg/flakeref_test.go
+++ b/internal/devpkg/flakeref_test.go
@@ -237,22 +237,22 @@ func TestParseFlakeInstallable(t *testing.T) {
 
 		".":             {Ref: FlakeRef{Type: "path", Path: "."}},
 		".#app":         {AttrPath: "app", Ref: FlakeRef{Type: "path", Path: "."}},
-		".#app^out":     {AttrPath: "app", Outputs: []string{"out"}, Ref: FlakeRef{Type: "path", Path: "."}},
-		".#app^out,lib": {AttrPath: "app", Outputs: []string{"out", "lib"}, Ref: FlakeRef{Type: "path", Path: "."}},
-		".#app^*":       {AttrPath: "app", Outputs: []string{"*"}, Ref: FlakeRef{Type: "path", Path: "."}},
-		".^*":           {Outputs: []string{"*"}, Ref: FlakeRef{Type: "path", Path: "."}},
+		".#app^out":     {AttrPath: "app", Outputs: "out", Ref: FlakeRef{Type: "path", Path: "."}},
+		".#app^out,lib": {AttrPath: "app", Outputs: "lib,out", Ref: FlakeRef{Type: "path", Path: "."}},
+		".#app^*":       {AttrPath: "app", Outputs: "*", Ref: FlakeRef{Type: "path", Path: "."}},
+		".^*":           {Outputs: "*", Ref: FlakeRef{Type: "path", Path: "."}},
 
 		"./flake":             {Ref: FlakeRef{Type: "path", Path: "./flake"}},
 		"./flake#app":         {AttrPath: "app", Ref: FlakeRef{Type: "path", Path: "./flake"}},
-		"./flake#app^out":     {AttrPath: "app", Outputs: []string{"out"}, Ref: FlakeRef{Type: "path", Path: "./flake"}},
-		"./flake#app^out,lib": {AttrPath: "app", Outputs: []string{"out", "lib"}, Ref: FlakeRef{Type: "path", Path: "./flake"}},
-		"./flake^out":         {Outputs: []string{"out"}, Ref: FlakeRef{Type: "path", Path: "./flake"}},
+		"./flake#app^out":     {AttrPath: "app", Outputs: "out", Ref: FlakeRef{Type: "path", Path: "./flake"}},
+		"./flake#app^out,lib": {AttrPath: "app", Outputs: "lib,out", Ref: FlakeRef{Type: "path", Path: "./flake"}},
+		"./flake^out":         {Outputs: "out", Ref: FlakeRef{Type: "path", Path: "./flake"}},
 
 		"indirect":            {Ref: FlakeRef{Type: "indirect", ID: "indirect"}},
 		"nixpkgs#app":         {AttrPath: "app", Ref: FlakeRef{Type: "indirect", ID: "nixpkgs"}},
-		"nixpkgs#app^out":     {AttrPath: "app", Outputs: []string{"out"}, Ref: FlakeRef{Type: "indirect", ID: "nixpkgs"}},
-		"nixpkgs#app^out,lib": {AttrPath: "app", Outputs: []string{"out", "lib"}, Ref: FlakeRef{Type: "indirect", ID: "nixpkgs"}},
-		"nixpkgs^out":         {Outputs: []string{"out"}, Ref: FlakeRef{Type: "indirect", ID: "nixpkgs"}},
+		"nixpkgs#app^out":     {AttrPath: "app", Outputs: "out", Ref: FlakeRef{Type: "indirect", ID: "nixpkgs"}},
+		"nixpkgs#app^out,lib": {AttrPath: "app", Outputs: "lib,out", Ref: FlakeRef{Type: "indirect", ID: "nixpkgs"}},
+		"nixpkgs^out":         {Outputs: "out", Ref: FlakeRef{Type: "indirect", ID: "nixpkgs"}},
 
 		"%23#app":                        {AttrPath: "app", Ref: FlakeRef{Type: "indirect", ID: "#"}},
 		"./%23#app":                      {AttrPath: "app", Ref: FlakeRef{Type: "path", Path: "./#"}},
@@ -277,42 +277,6 @@ func TestParseFlakeInstallable(t *testing.T) {
 				t.Errorf("got.String() = %q != %q", got, installable)
 			}
 		})
-	}
-}
-
-func TestFlakeInstallableDefaultOutputs(t *testing.T) {
-	install := FlakeInstallable{Outputs: nil}
-	if !install.DefaultOutputs() {
-		t.Errorf("DefaultOutputs() = false for nil outputs slice, want true")
-	}
-
-	install = FlakeInstallable{Outputs: []string{}}
-	if !install.DefaultOutputs() {
-		t.Errorf("DefaultOutputs() = false for empty outputs slice, want true")
-	}
-
-	install = FlakeInstallable{Outputs: []string{"out"}}
-	if install.DefaultOutputs() {
-		t.Errorf("DefaultOutputs() = true for %v, want false", install.Outputs)
-	}
-}
-
-func TestFlakeInstallableAllOutputs(t *testing.T) {
-	install := FlakeInstallable{Outputs: []string{"*"}}
-	if !install.AllOutputs() {
-		t.Errorf("AllOutputs() = false for %v, want true", install.Outputs)
-	}
-	install = FlakeInstallable{Outputs: []string{"out", "*"}}
-	if !install.AllOutputs() {
-		t.Errorf("AllOutputs() = false for %v, want true", install.Outputs)
-	}
-	install = FlakeInstallable{Outputs: nil}
-	if install.AllOutputs() {
-		t.Errorf("AllOutputs() = true for nil outputs slice, want false")
-	}
-	install = FlakeInstallable{Outputs: []string{}}
-	if install.AllOutputs() {
-		t.Errorf("AllOutputs() = true for empty outputs slice, want false")
 	}
 }
 


### PR DESCRIPTION
Change `ParseInstallable.Outputs` from a `[]string` to a `string` and move the splitting logic to a `SplitOutputs` method. This makes installables directly comparable with `==` and usable as map keys, which is something we currently do a bunch using unparsed installable strings.