### PR TITLE
[easy][global] global push/pull should not require login for github

### DIFF
--- a/internal/boxcli/pull.go
+++ b/internal/boxcli/pull.go
@@ -17,6 +17,7 @@ import (
 	"go.jetpack.io/devbox/internal/goutil"
 	"go.jetpack.io/devbox/internal/impl/devopt"
 	"go.jetpack.io/devbox/internal/pullbox/s3"
+	"go.jetpack.io/pkg/sandbox/auth"
 )
 
 type pullCmdFlags struct {
@@ -63,9 +64,9 @@ func pullCmdFunc(cmd *cobra.Command, url string, flags *pullCmdFlags) error {
 
 	var creds devopt.Credentials
 	t, err := genSession(cmd.Context())
-	if err != nil {
+	if err != nil && !errors.Is(err, auth.ErrNotLoggedIn) {
 		return errors.WithStack(err)
-	} else if t != nil {
+	} else if t != nil && err == nil {
 		creds = devopt.Credentials{
 			IDToken: t.IDToken,
 			Email:   t.IDClaims().Email,

--- a/internal/boxcli/push.go
+++ b/internal/boxcli/push.go
@@ -6,6 +6,7 @@ package boxcli
 import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"go.jetpack.io/pkg/sandbox/auth"
 
 	"go.jetpack.io/devbox"
 	"go.jetpack.io/devbox/internal/goutil"
@@ -43,9 +44,9 @@ func pushCmdFunc(cmd *cobra.Command, url string, flags pushCmdFlags) error {
 	}
 	t, err := genSession(cmd.Context())
 	var creds devopt.Credentials
-	if err != nil {
+	if err != nil && !errors.Is(err, auth.ErrNotLoggedIn) {
 		return errors.WithStack(err)
-	} else if t != nil {
+	} else if t != nil && err == nil {
 		creds = devopt.Credentials{
 			IDToken: t.IDToken,
 			Email:   t.IDClaims().Email,


### PR DESCRIPTION
## Summary

Login should not be required for push/pull to github.

Fixes https://github.com/jetpack-io/devbox/issues/1580

## How was it tested?

```
devbox global push git@github.com:mikeland73/global.git
devbox global pull git@github.com:mikeland73/global.git
```