### PR TITLE
Added schema validation to devbox vscode extension

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "devbox" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.1.3]
+
+- Added json validation for devbox.json files.
+
 ## [0.1.2]
 
 - Fixed error handling when using `Reopen in Devbox shell` command in Windows and WSL

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -42,6 +42,10 @@ NOTE: Requires devbox CLI v0.5.5 and above
   reopen VSCode in devbox environment. Note: It requires devbox CLI v0.5.5 and above
   installed and in PATH.
 
+### JSON validation when writing a devbox.json file
+
+No need to take any action for this feature. When writing a devbox.json, if this extension is installed, it will validate and highlight any disallowed fields or values on a devbox.json file.
+
 ---
 
 ## Following extension guidelines

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -113,6 +113,12 @@
         }
       ]
     },
+    "jsonValidation": [
+      {
+        "fileMatch": "devbox.json",
+        "url": "https://json.schemastore.org/devbox"
+      }
+    ],
     "configuration": {
       "title": "devbox",
       "properties": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "devbox",
   "displayName": "devbox by jetpack.io",
   "description": "devbox integration for VSCode",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "icon": "assets/icon.png",
   "repository": {
     "type": "git",
@@ -21,7 +21,9 @@
     "onStartupFinished"
   ],
   "main": "./out/extension.js",
-  "extensionDependencies": ["ms-vscode-remote.remote-ssh"],
+  "extensionDependencies": [
+    "ms-vscode-remote.remote-ssh"
+  ],
   "contributes": {
     "commands": [
       {
@@ -116,7 +118,7 @@
     "jsonValidation": [
       {
         "fileMatch": "devbox.json",
-        "url": "https://json.schemastore.org/devbox"
+        "url": "https://raw.githubusercontent.com/jetpack-io/devbox/main/.schema/devbox.schema.json"
       }
     ],
     "configuration": {


### PR DESCRIPTION
## Summary

tasks:
- [x] Schemastore merges this pull request: SchemaStore/schemastore/pull/3386
- [x] devbox schema becomes available in [schemastore.org/json](https://www.schemastore.org/json/)
- [ ] This PR gets merged
- [ ] New devbox vscode extension gets published

addresses #1576

## How was it tested?
- follow steps to generate custom vsix file and install it on vscode
- or after the extension is published, update the extension to 0.1.3