### PR TITLE
[ensure] Don't recompute environment if up to date

### DIFF
--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -228,12 +228,14 @@ func (d *Devbox) ensurePackagesAreInstalled(ctx context.Context, mode installMod
 	if err != nil {
 		return err
 	}
-	// if mode is ensure and we are up to date, then we can skip the rest
-	if mode == ensure && upToDate {
-		return nil
-	}
 
-	fmt.Fprintln(d.stderr, "Ensuring packages are installed.")
+	if mode == ensure {
+		// if mode is ensure and we are up to date, then we can skip the rest
+		if upToDate {
+			return nil
+		}
+		fmt.Fprintln(d.stderr, "Ensuring packages are installed.")
+	}
 
 	// Create plugin directories first because packages might need them
 	for _, pkg := range d.InstallablePackages() {

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -230,8 +230,10 @@ func (d *Devbox) ensurePackagesAreInstalled(ctx context.Context, mode installMod
 	}
 	// if mode is ensure and we are up to date, then we can skip the rest
 	if mode == ensure && upToDate {
-		fmt.Fprintln(d.stderr, "Ensuring packages are installed.")
+		return nil
 	}
+
+	fmt.Fprintln(d.stderr, "Ensuring packages are installed.")
 
 	// Create plugin directories first because packages might need them
 	for _, pkg := range d.InstallablePackages() {


### PR DESCRIPTION
## Summary

This bug was introduced in https://github.com/jetpack-io/devbox/pull/1584 and has at least 2 effects:

* Perf regression (because we recompute environment all the time)
* Plugins that create flakes may break if they create additional files in the same directory. (Another PR will address this issue in more depth)

## How was it tested?

```bash
devbox add mysql80
devbox services up -b
devbox services stop
```
