### PR TITLE
[plugins] flakes should be in own dir

### DIFF
--- a/plugins/haskell.json
+++ b/plugins/haskell.json
@@ -1,6 +1,6 @@
 {
   "name": "haskell",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "readme": "Haskell plugin",
   "__packages": [
     "path:{{ .Virtenv }}/flake"

--- a/plugins/haskell.json
+++ b/plugins/haskell.json
@@ -3,10 +3,10 @@
   "version": "0.0.1",
   "readme": "Haskell plugin",
   "__packages": [
-    "path:{{ .Virtenv }}"
+    "path:{{ .Virtenv }}/flake"
   ],
   "__remove_trigger_package": true,
   "create_files": {
-    "{{ .Virtenv }}/flake.nix": "haskell/flake.nix"
+    "{{ .Virtenv }}/flake/flake.nix": "haskell/flake.nix"
   }
 }

--- a/plugins/mariadb.json
+++ b/plugins/mariadb.json
@@ -11,12 +11,12 @@
   },
   "create_files": {
     "{{ .Virtenv }}/run": "",
-    "{{ .Virtenv }}/flake.nix": "mariadb/flake.nix",
+    "{{ .Virtenv }}/flake/flake.nix": "mariadb/flake.nix",
     "{{ .Virtenv }}/setup_db.sh": "mariadb/setup_db.sh",
     "{{ .Virtenv }}/process-compose.yaml": "mariadb/process-compose.yaml"
   },
   "__packages": [
-    "path:{{ .Virtenv }}"
+    "path:{{ .Virtenv }}/flake"
   ],
   "__remove_trigger_package": true,
   "shell": {

--- a/plugins/mariadb.json
+++ b/plugins/mariadb.json
@@ -1,6 +1,6 @@
 {
   "name": "mariadb",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "readme": "* This plugin wraps mysqld and mysql_install_db to work in your local project\n* This plugin will create a new database for your project in MYSQL_DATADIR if one doesn't exist on shell init\n* Use mysqld to manually start the server, and `mysqladmin -u root shutdown` to manually stop it",
   "env": {
     "MYSQL_BASEDIR": "{{ .DevboxProfileDefault }}",

--- a/plugins/mysql.json
+++ b/plugins/mysql.json
@@ -11,12 +11,12 @@
     },
     "create_files": {
       "{{ .Virtenv }}/run": "",
-      "{{ .Virtenv }}/flake.nix": "mysql/flake.nix",
+      "{{ .Virtenv }}/flake/flake.nix": "mysql/flake.nix",
       "{{ .Virtenv }}/setup_db.sh": "mysql/setup_db.sh",
       "{{ .Virtenv }}/process-compose.yaml": "mysql/process-compose.yaml"
     },
     "__packages": [
-      "path:{{ .Virtenv }}"
+      "path:{{ .Virtenv }}/flake"
     ],
     "__remove_trigger_package": true,
     "shell": {

--- a/plugins/mysql.json
+++ b/plugins/mysql.json
@@ -1,6 +1,6 @@
 {
     "name": "mysql",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "readme": "* This plugin wraps mysqld and mysql_install_db to work in your local project\n* This plugin will create a new database for your project in MYSQL_DATADIR if one doesn't exist on shell init. This DB will be started in `insecure` mode, so be sure to add a root password after creation if needed.\n* Use mysqld to manually start the server, and `mysqladmin -u root shutdown` to manually stop it",
     "env": {
       "MYSQL_BASEDIR": "{{ .DevboxProfileDefault }}",

--- a/plugins/php.json
+++ b/plugins/php.json
@@ -1,6 +1,6 @@
 {
   "name": "php",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "readme": "PHP is compiled with default extensions. If you would like to use non-default extensions you can add them with devbox add php81Extensions.{extension} . For example, for the memcache extension you can do `devbox add php81Extensions.memcached`.",
   "__packages": [
     "path:{{ .Virtenv }}/flake",

--- a/plugins/php.json
+++ b/plugins/php.json
@@ -3,8 +3,8 @@
   "version": "0.0.2",
   "readme": "PHP is compiled with default extensions. If you would like to use non-default extensions you can add them with devbox add php81Extensions.{extension} . For example, for the memcache extension you can do `devbox add php81Extensions.memcached`.",
   "__packages": [
-    "path:{{ .Virtenv }}",
-    "path:{{ .Virtenv }}#composer"
+    "path:{{ .Virtenv }}/flake",
+    "path:{{ .Virtenv }}/flake#composer"
   ],
   "__remove_trigger_package": true,
   "env": {
@@ -17,6 +17,6 @@
     "{{ .DevboxDir }}/php-fpm.conf": "php/php-fpm.conf",
     "{{ .DevboxDir }}/php.ini": "php/php.ini",
     "{{ .Virtenv }}/process-compose.yaml": "php/process-compose.yaml",
-    "{{ .Virtenv }}/flake.nix": "php/flake.nix"
+    "{{ .Virtenv }}/flake/flake.nix": "php/flake.nix"
   }
 }


### PR DESCRIPTION
## Summary

**What this fixes:**
When plugins create flake in a directory shared with other files, `nix search` can break. (We use `nix search` to determine output path). For example in the mysql plugin the flake would live side-by-side with the `run` directory which has a sock file. `nix search` would recurse in that directory and try to search for nix expressions and break because the file had an unexpected format. 

**How it was surfaced:**
This issue was previously hidden because we don't call `nix search` if a package has already been installed. The bug fixed in https://github.com/jetpack-io/devbox/pull/1625 was causing us to needlessly call `nix search` on stuff that was already 

**Solution:**
The partial solution in this PR is to always create the flake in its own dir. This is a bit fragile, e.g. someone can forget if writing their own plugin. Longer term, we need a better way to extract the output path from a custom flake. (I think `nix flake show` could do it without causing the issues surfaced by search)

## How was it tested?

CICD tests all plugins with exampels.