### PR TITLE
[direnv] Fix direnv fish support

### DIFF
--- a/internal/boxcli/shellenv.go
+++ b/internal/boxcli/shellenv.go
@@ -16,10 +16,11 @@ import (
 type shellEnvCmdFlags struct {
 	envFlag
 	config            configFlags
-	runInitHook       bool
 	install           bool
-	pure              bool
+	noRefreshAlias    bool
 	preservePathStack bool
+	pure              bool
+	runInitHook       bool
 }
 
 func shellEnvCmd(recomputeEnvIfNeeded *bool) *cobra.Command {
@@ -54,6 +55,11 @@ func shellEnvCmd(recomputeEnvIfNeeded *bool) *cobra.Command {
 		"Preserves existing PATH order if this project's environment is already in PATH. "+
 			"Useful if you want to avoid overshadowing another devbox project that is already active")
 	_ = command.Flags().MarkHidden("preserve-path-stack")
+	command.Flags().BoolVar(
+		&flags.noRefreshAlias, "no-refresh-alias", false,
+		"By default, devbox will add refresh alias to the environment"+
+			"Use this flag to disable this behavior.")
+	_ = command.Flags().MarkHidden("no-refresh-alias")
 
 	flags.config.register(command)
 	flags.envFlag.register(command)
@@ -89,6 +95,7 @@ func shellEnvFunc(
 
 	envStr, err := box.NixEnv(cmd.Context(), devopt.NixEnvOpts{
 		DontRecomputeEnvironment: !recomputeEnvIfNeeded,
+		NoRefreshAlias:           flags.noRefreshAlias,
 		RunHooks:                 flags.runInitHook,
 	})
 	if err != nil {

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -301,7 +301,9 @@ func (d *Devbox) NixEnv(ctx context.Context, opts devopt.NixEnvOpts) (string, er
 		envStr = fmt.Sprintf("%s\n%s;\n", envStr, hooksStr)
 	}
 
-	envStr += "\n" + d.refreshAlias()
+	if !opts.NoRefreshAlias {
+		envStr += "\n" + d.refreshAlias()
+	}
 
 	return envStr, nil
 }

--- a/internal/impl/devopt/devboxopts.go
+++ b/internal/impl/devopt/devboxopts.go
@@ -45,5 +45,6 @@ type UpdateOpts struct {
 
 type NixEnvOpts struct {
 	DontRecomputeEnvironment bool
+	NoRefreshAlias           bool
 	RunHooks                 bool
 }

--- a/internal/impl/generate/tmpl/envrcContent.tmpl
+++ b/internal/impl/generate/tmpl/envrcContent.tmpl
@@ -1,6 +1,6 @@
 use_devbox() {
     watch_file devbox.json
-    eval "$(devbox shellenv --init-hook --install{{ if .EnvFlag }} {{ .EnvFlag }}{{ end }})"
+    eval "$(devbox shellenv --init-hook --install --no-refresh-alias{{ if .EnvFlag }} {{ .EnvFlag }}{{ end }})"
 }
 use devbox
 {{ if .EnvFile }}


### PR DESCRIPTION
## Summary

Adding alias to `direnv` environment is causing problems in fish and doesn't work anyway (because direnv doesn't support aliases)

## How was it tested?

* For both zsh and fish
* Started shell
* activated direnv hook
* cd to devbox directory
* confirmed environment was actice
* installed package and tested it