### PR TITLE
[Plugin] Create a virtual environment with the `python` plugin

### DIFF
--- a/docs/app/docs/devbox_examples/languages/python.md
+++ b/docs/app/docs/devbox_examples/languages/python.md
@@ -27,14 +27,27 @@ This will install Python 3.10 in your shell. You can find other versions of Pyth
 
 [pip](https://pip.pypa.io/en/stable/) is the standard package manager for Python. Since it installs python packages globally, we strongly recommend using a virtual environment.
 
-You can install `pip` by running `devbox add python3xxPackages.pip`, where `3xx` is the version of Python you want to install. This will also install the pip plugin for Devbox, which automatically creates a virtual environment for installing your packages locally
+The `python` package automatically comes bundled with `pip`, and the `python` plugin for Devbox will automatically create a virtual environment for installing your packages locally
 
-Your virtual environment is created in the `.devbox/virtenv/pip` directory by default, and can be activated by running `source $VENV_DIR/bin/activate` in your devbox shell. You can activate the virtual environment automatically using the init_hook of your `devbox.json`:
+Your virtual environment is created in the `.devbox/virtenv/python` directory by default, and can be activated by running `source $VENV_DIR/bin/activate` in your devbox shell. You can activate the virtual environment automatically using the init_hook of your `devbox.json`:
 
 ```json
 {
     "packages": [
-        "python310",
+        "python@3.10"
+    ],
+    "shell": {
+        "init_hook": ". $VENV_DIR/bin/activate"
+    }
+}
+```
+
+If you need to install a specific version of Pip, you can run `devbox add python3xxPackages.pip`, where `3xx` is the major + minor version (e.g., python310 = python@3.10) of Python you want to install:
+
+```json
+{
+    "packages": [
+        "python@3.10"
         "python310Packages.pip"
     ],
     "shell": {

--- a/examples/development/python/pip/devbox.json
+++ b/examples/development/python/pip/devbox.json
@@ -1,15 +1,14 @@
 {
-    "packages": [
-        "python@3.10",
-        "python310Packages.pip@23.0.1"
+  "packages": [
+    "python@3.10"
+  ],
+  "shell": {
+    "init_hook": [
+      ". $VENV_DIR/bin/activate",
+      "pip install -r requirements.txt"
     ],
-    "shell": {
-        "init_hook": [
-            ". $VENV_DIR/bin/activate",
-            "pip install -r requirements.txt"
-        ],
-        "scripts": {
-            "run_test": "python main.py"
-        }
+    "scripts": {
+      "run_test": "python main.py"
     }
+  }
 }

--- a/examples/development/python/pip/devbox.lock
+++ b/examples/development/python/pip/devbox.lock
@@ -1,29 +1,9 @@
 {
   "lockfile_version": "1",
   "packages": {
-    "python310Packages.pip@23.0.1": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "plugin_version": "0.0.1",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#python310Packages.pip",
-      "version": "23.0.1",
-      "systems": {
-        "aarch64-darwin": {
-          "store_path": "/nix/store/idd0pswjhxrqp7mdgrhw6rmpmlkrya8r-python3.10-pip-23.0.1"
-        },
-        "aarch64-linux": {
-          "store_path": "/nix/store/ma7lp6a1gbss1aa2mzp2jkxgsvp9m0pg-python3.10-pip-23.0.1"
-        },
-        "x86_64-darwin": {
-          "store_path": "/nix/store/77sd3ym5f7p5zn7bmfz36wrnklfq4ic9-python3.10-pip-23.0.1"
-        },
-        "x86_64-linux": {
-          "store_path": "/nix/store/gxb4vyiqip38lzhjsa2ijhb3wjf4sp4b-python3.10-pip-23.0.1"
-        }
-      }
-    },
     "python@3.10": {
       "last_modified": "2023-02-24T18:08:35Z",
-      "plugin_version": "0.0.1",
+      "plugin_version": "0.0.2",
       "resolved": "github:NixOS/nixpkgs/806075be2bdde71895359ed18cb530c4d323e6f6#python3",
       "source": "devbox-search",
       "version": "3.10.9",

--- a/plugins/pip/venvShellHook.sh
+++ b/plugins/pip/venvShellHook.sh
@@ -1,9 +1,8 @@
 #!/bin/sh
 
-if [ -d "$VENV_DIR" ]; then
-    echo "Skipping venv creation, '${VENV_DIR}' already exists"
-else
+if ! [ -d "$VENV_DIR" ]; then
     echo "Creating new venv environment in path: '${VENV_DIR}'"
     python3 -m venv "$VENV_DIR"
 fi
+
 echo "You can activate the virtual environment by running 'source \$VENV_DIR/bin/activate'"

--- a/plugins/python.json
+++ b/plugins/python.json
@@ -1,5 +1,16 @@
 {
   "name": "python",
-  "version": "0.0.1",
-  "readme": "python on devbox works best when used with a virtual environment (vent, virtualenv, etc). For example with python3:\n\n> python -m venv .venv\n> source .venv/bin/activate\n\nPackage managers like poetry (https://python-poetry.org/) automatically create virtual environments for you."
+  "version": "0.0.2",
+  "readme": "Python in Devbox works best when used with a virtual environment (vent, virtualenv, etc.). Devbox will automatically create a virtual environment using `venv` for python3 projects, so you can install packages with pip as normal.\nTo activate the environment, run `source $VENV_DIR/bin/activate` or add it to the init_hook of your devbox.json\nTo change where your virtual environment is created, modify the $VENV_DIR environment variable in your init_hook",
+  "env": {
+      "VENV_DIR": "{{ .Virtenv }}/.venv"
+  },
+  "create_files": {
+      "{{ .Virtenv }}/bin/venvShellHook.sh": "pip/venvShellHook.sh"
+  },
+  "shell": {
+      "init_hook": [
+          "{{ .Virtenv }}/bin/venvShellHook.sh"
+      ]
+  }
 }


### PR DESCRIPTION
## Summary

The Nix Python packages come bundled with `pip`, so we can go ahead and create a virtual environment whenever a user installs a `python` package, even if they do not also install `pip`. 

This plugin reuses the `venvShellHook` and `VENV_DIR` environment variable from the `pip` plugin to create a virtual environment when the user starts their shell (assuming one has not been created). The user can activate the virtual environment by running `source $VENV_DIR/bin/activate`

A few notes

* This should not cause issues with virtual environments that have been created with `pythonPackages.pip`, meaning behavior should remain the same for existing python projects
* Devbox will use `VENV_DIR` variable and virtual environment for the package the appears last in the `packages` list.
* Going forward, we should probably recommend developers use the `pip` bundled with the python package. 

## How was it tested?

Using the modified python/pip example in this PR
