### PR TITLE
Envsec errors do not block devbox

### DIFF
--- a/internal/devconfig/env.go
+++ b/internal/devconfig/env.go
@@ -2,6 +2,8 @@ package devconfig
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/integrations/envsec"
@@ -16,7 +18,7 @@ func (c *Config) ComputedEnv(
 	if c.IsEnvsecEnabled() {
 		env, err = envsec.Env(ctx, projectDir)
 		if err != nil {
-			return nil, err
+			fmt.Fprintf(os.Stderr, "Error reading secrets from envsec: %s\n\n", err)
 		}
 	} else if c.EnvFrom != "" {
 		return nil, usererr.New("unknown from_env value: %s", c.EnvFrom)


### PR DESCRIPTION
## Summary

I've encountered a few scenarios when testing envsec + Jetpack secrets where an issue with authentication of the envsec server prevented me from starting my shell. Since envsec errors also require an internet connection, an unstable connection can prevent me from starting my local dev environment

This PR changes a line in env.go so that Envsec errors will be logged, instead of causing Devbox to fail

## How was it tested?

Tested on a local new project, with the following scenarios:

- User not logged in
- Project missing a github repo
- Project has a repo but no remote