### PR TITLE
fix: allow github plugins with slash in rev name

### DIFF
--- a/internal/plugin/github.go
+++ b/internal/plugin/github.go
@@ -28,9 +28,9 @@ func newGithubPlugin(rawURL string) (*githubPlugin, error) {
 		return nil, err
 	}
 
-	parts := strings.Split(pluginURL.Path, "/")
+	parts := strings.SplitN(pluginURL.Path, "/", 3)
 
-	if len(parts) < 2 || len(parts) > 3 {
+	if len(parts) < 2 {
 		return nil, usererr.New(
 			"invalid github plugin url %q. Must be of the form org/repo/[revision]",
 			rawURL,

--- a/internal/plugin/github_test.go
+++ b/internal/plugin/github_test.go
@@ -1,0 +1,51 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewGithubPlugin(t *testing.T) {
+	testCases := []struct {
+		name     string
+		expected githubPlugin
+	}{
+		{
+			name: "parse basic github plugin",
+			expected: githubPlugin{
+				raw:      "jetpack-io/devbox-plugins",
+				org:      "jetpack-io",
+				repo:     "devbox-plugins",
+				revision: "master",
+			},
+		},
+		{
+			name: "parse github plugin with dir param",
+			expected: githubPlugin{
+				raw:      "jetpack-io/devbox-plugins?dir=mongodb",
+				org:      "jetpack-io",
+				repo:     "devbox-plugins",
+				revision: "master",
+				dir:      "mongodb",
+			},
+		},
+		{
+			name: "parse github plugin with dir param and rev",
+			expected: githubPlugin{
+				raw:      "jetpack-io/devbox-plugins/my-branch?dir=mongodb",
+				org:      "jetpack-io",
+				repo:     "devbox-plugins",
+				revision: "my-branch",
+				dir:      "mongodb",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual, _ := newGithubPlugin(testCase.expected.raw)
+			assert.Equal(t, actual, &testCase.expected)
+		})
+	}
+}

--- a/internal/plugin/github_test.go
+++ b/internal/plugin/github_test.go
@@ -40,6 +40,16 @@ func TestNewGithubPlugin(t *testing.T) {
 				dir:      "mongodb",
 			},
 		},
+		{
+			name: "parse github plugin with dir param and rev",
+			expected: githubPlugin{
+				raw:      "jetpack-io/devbox-plugins/initials/my-branch?dir=mongodb",
+				org:      "jetpack-io",
+				repo:     "devbox-plugins",
+				revision: "initials/my-branch",
+				dir:      "mongodb",
+			},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
## Summary

You can't currently reference a plugin on a rev if that rev has a `/` character in it. This seems like a bug, here's a simple fix that I don't believe will cause any other issues (but I'm new to the codebase, so could be wrong).

## How was it tested?

1. Unit tests in this PR
2. Manual verification:

**verify current build breaks:**
```sh
devbox run build
./dist/devbox run echo "success"
# works fine

# add plugin with branch with slash -> `"include": ["github:jetpack-io/devbox-plugins/jl/add-readmes?dir=mongodb"]`
./dist/devbox run echo "success"
# Error: invalid github plugin url "jetpack-io/devbox-plugins/jl/add-readmes?dir=mongodb". Must be of the form org/repo/[revision]
```

**checkout this branch and verify it works again:**
```sh
git reset --hard
git checkout jdr/allow-github-plugins-with-slash-in-rev-name

# add plugin with branch with slash -> `"include": ["github:jetpack-io/devbox-plugins/jl/add-readmes?dir=mongodb"]`
./dist/devbox run echo "success"
# works fine
```
