### PR TITLE
[plugins] Implement --disable-plugin flag

### DIFF
--- a/devbox.go
+++ b/devbox.go
@@ -16,7 +16,7 @@ import (
 
 // Devbox provides an isolated development environment.
 type Devbox interface {
-	Add(ctx context.Context, platforms, excludePlatforms []string, pkgs ...string) error
+	Add(ctx context.Context, pkgs []string, opts devopt.AddOpts) error
 	Config() *devconfig.Config
 	EnvVars(ctx context.Context) ([]string, error)
 	Info(ctx context.Context, pkg string, markdown bool) (string, error)

--- a/devbox.json
+++ b/devbox.json
@@ -1,9 +1,9 @@
 {
-  "packages": [
-    "go@latest",
-    "runx:golangci/golangci-lint@latest",
-    "runx:mvdan/gofumpt@latest"
-  ],
+  "packages": {
+    "go":                          "latest",
+    "runx:golangci/golangci-lint": "latest",
+    "runx:mvdan/gofumpt":          "latest"
+  },
   "env": {
     "GOENV": "off",
     "PATH":  "$PATH:$PWD/dist"

--- a/internal/boxcli/add.go
+++ b/internal/boxcli/add.go
@@ -20,6 +20,7 @@ const toSearchForPackages = "To search for packages, use the `devbox search` com
 type addCmdFlags struct {
 	config           configFlags
 	allowInsecure    bool
+	disablePlugin    bool
 	platforms        []string
 	excludePlatforms []string
 }
@@ -53,6 +54,9 @@ func addCmd() *cobra.Command {
 	command.Flags().BoolVar(
 		&flags.allowInsecure, "allow-insecure", false,
 		"allow adding packages marked as insecure.")
+	command.Flags().BoolVar(
+		&flags.disablePlugin, "disable-plugin", false,
+		"disable plugin (if any) for this package.")
 	command.Flags().StringSliceVarP(
 		&flags.platforms, "platform", "p", []string{},
 		"add packages to run on only this platform.")
@@ -65,13 +69,17 @@ func addCmd() *cobra.Command {
 
 func addCmdFunc(cmd *cobra.Command, args []string, flags addCmdFlags) error {
 	box, err := devbox.Open(&devopt.Opts{
-		Dir:               flags.config.path,
-		Stderr:            cmd.ErrOrStderr(),
-		AllowInsecureAdds: flags.allowInsecure,
+		Dir:    flags.config.path,
+		Stderr: cmd.ErrOrStderr(),
 	})
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	return box.Add(cmd.Context(), flags.platforms, flags.excludePlatforms, args...)
+	return box.Add(cmd.Context(), args, devopt.AddOpts{
+		AllowInsecure:    flags.allowInsecure,
+		DisablePlugin:    flags.disablePlugin,
+		Platforms:        flags.platforms,
+		ExcludePlatforms: flags.excludePlatforms,
+	})
 }

--- a/internal/devconfig/ast.go
+++ b/internal/devconfig/ast.go
@@ -170,25 +170,37 @@ func (c *configAST) removePackageElement(arr *hujson.Array, name string) {
 	arr.Elements = slices.Delete(arr.Elements, i, i+1)
 }
 
-// appendPlatforms appends a platform to a package's "platforms" or
-// "excluded_platforms" field. It automatically converts the package to an
-// object if it isn't already.
+// setPackageBool sets a bool field on a package.
+func (c *configAST) setPackageBool(name, fieldName string, val bool) {
+	pkgObject := c.FindPkgObject(name)
+	if pkgObject == nil {
+		return
+	}
+	if i := c.memberIndex(pkgObject, fieldName); i == -1 {
+		pkgObject.Members = append(pkgObject.Members, hujson.ObjectMember{
+			Name: hujson.Value{
+				Value:       hujson.String(fieldName),
+				BeforeExtra: []byte{'\n'},
+			},
+			Value: hujson.Value{Value: hujson.Bool(val)},
+		})
+	} else {
+		pkgObject.Members[i].Value.Value = hujson.Bool(val)
+	}
+
+	c.root.Format()
+}
+
 func (c *configAST) appendPlatforms(name, fieldName string, platforms []string) {
 	if len(platforms) == 0 {
 		return
 	}
 
-	pkgs := c.packagesField(true).Value.Value.(*hujson.Object)
-	i := c.memberIndex(pkgs, name)
-	if i == -1 {
+	pkgObject := c.FindPkgObject(name)
+	if pkgObject == nil {
 		return
 	}
 
-	// We need to ensure that the package value is a full object
-	// (not a version string) before we can add a platform.
-	c.convertVersionToObject(&pkgs.Members[i].Value)
-
-	pkgObject := pkgs.Members[i].Value.Value.(*hujson.Object)
 	var arr *hujson.Array
 	if i := c.memberIndex(pkgObject, fieldName); i == -1 {
 		arr = &hujson.Array{
@@ -210,6 +222,21 @@ func (c *configAST) appendPlatforms(name, fieldName string, platforms []string) 
 		arr.Elements = append(arr.Elements, hujson.Value{Value: hujson.String(p)})
 	}
 	c.root.Format()
+}
+
+func (c *configAST) FindPkgObject(name string) *hujson.Object {
+	pkgs := c.packagesField(true).Value.Value.(*hujson.Object)
+	i := c.memberIndex(pkgs, name)
+	if i == -1 {
+		return nil
+	}
+
+	// We need to ensure that the package value is a full object
+	// (not a version string) before we can add a bool field.
+	c.convertVersionToObject(&pkgs.Members[i].Value)
+
+	pkgObject := pkgs.Members[i].Value.Value.(*hujson.Object)
+	return pkgObject
 }
 
 // migratePackagesArray migrates a legacy array of package versionedNames to an

--- a/internal/devconfig/ast.go
+++ b/internal/devconfig/ast.go
@@ -232,7 +232,7 @@ func (c *configAST) FindPkgObject(name string) *hujson.Object {
 	}
 
 	// We need to ensure that the package value is a full object
-	// (not a version string) before we can add a bool field.
+	// (not a version string) before we can set a custom field on it.
 	c.convertVersionToObject(&pkgs.Members[i].Value)
 
 	pkgObject := pkgs.Members[i].Value.Value.(*hujson.Object)

--- a/internal/devconfig/packages.go
+++ b/internal/devconfig/packages.go
@@ -177,6 +177,19 @@ func (pkgs *Packages) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (pkgs *Packages) DisablePlugin(versionedName string, v bool) error {
+	name, version := parseVersionedName(versionedName)
+	i := pkgs.index(name, version)
+	if i == -1 {
+		return errors.Errorf("package %s not found", versionedName)
+	}
+	if pkgs.Collection[i].DisablePlugin != v {
+		pkgs.Collection[i].DisablePlugin = v
+		pkgs.ast.setPackageBool(name, "disable_plugin", v)
+	}
+	return nil
+}
+
 func (pkgs *Packages) index(name, version string) int {
 	return slices.IndexFunc(pkgs.Collection, func(p Package) bool {
 		return p.name == name && p.Version == version
@@ -187,6 +200,7 @@ type Package struct {
 	name    string
 	Version string `json:"version,omitempty"`
 
+	DisablePlugin     bool     `json:"disable_plugin,omitempty"`
 	Platforms         []string `json:"platforms,omitempty"`
 	ExcludedPlatforms []string `json:"excluded_platforms,omitempty"`
 

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -64,7 +64,6 @@ type Devbox struct {
 	pluginManager            *plugin.Manager
 	preservePathStack        bool
 	pure                     bool
-	allowInsecureAdds        bool
 	customProcessComposeFile string
 
 	// This is needed because of the --quiet flag.
@@ -94,7 +93,6 @@ func Open(opts *devopt.Opts) (*Devbox, error) {
 		preservePathStack:        opts.PreservePathStack,
 		pure:                     opts.Pure,
 		customProcessComposeFile: opts.CustomProcessComposeFile,
-		allowInsecureAdds:        opts.AllowInsecureAdds,
 	}
 
 	lock, err := lock.GetFile(box)
@@ -103,7 +101,7 @@ func Open(opts *devopt.Opts) (*Devbox, error) {
 	}
 	// if lockfile has any allow insecure, we need to set the env var to ensure
 	// all nix commands work.
-	if opts.AllowInsecureAdds || lock.HasAllowInsecurePackages() {
+	if lock.HasAllowInsecurePackages() {
 		nix.AllowInsecurePackages()
 	}
 	box.pluginManager.ApplyOptions(

--- a/internal/impl/devopt/devboxopts.go
+++ b/internal/impl/devopt/devboxopts.go
@@ -5,7 +5,6 @@ import (
 )
 
 type Opts struct {
-	AllowInsecureAdds        bool
 	Dir                      string
 	Env                      map[string]string
 	PreservePathStack        bool
@@ -36,6 +35,13 @@ type Credentials struct {
 	// TODO We can just parse these out, but don't want to add a dependency right now
 	Email string
 	Sub   string
+}
+
+type AddOpts struct {
+	AllowInsecure    bool
+	Platforms        []string
+	ExcludePlatforms []string
+	DisablePlugin    bool
 }
 
 type UpdateOpts struct {

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -17,6 +17,7 @@ import (
 	"github.com/samber/lo"
 	"go.jetpack.io/devbox/internal/devpkg"
 	"go.jetpack.io/devbox/internal/devpkg/pkgtype"
+	"go.jetpack.io/devbox/internal/impl/devopt"
 	"go.jetpack.io/devbox/internal/nix/nixprofile"
 	"go.jetpack.io/devbox/internal/shellgen"
 
@@ -32,8 +33,7 @@ import (
 
 // Add adds the `pkgs` to the config (i.e. devbox.json) and nix profile for this
 // devbox project
-// nolint:revive // warns about cognitive complexity
-func (d *Devbox) Add(ctx context.Context, platforms, excludePlatforms []string, pkgsNames ...string) error {
+func (d *Devbox) Add(ctx context.Context, pkgsNames []string, opts devopt.AddOpts) error {
 	ctx, task := trace.NewTask(ctx, "devboxAdd")
 	defer task.End()
 
@@ -42,7 +42,7 @@ func (d *Devbox) Add(ctx context.Context, platforms, excludePlatforms []string, 
 
 	// Only add packages that are not already in config. If same canonical exists,
 	// replace it.
-	pkgs := devpkg.PackageFromStrings(lo.Uniq(pkgsNames), d.lockfile)
+	pkgs := devpkg.PackagesFromStrings(lo.Uniq(pkgsNames), d.lockfile, opts.DisablePlugin)
 
 	// addedPackageNames keeps track of the possibly transformed (versioned)
 	// names of added packages (even if they are already in config). We use this
@@ -98,11 +98,33 @@ func (d *Devbox) Add(ctx context.Context, platforms, excludePlatforms []string, 
 		addedPackageNames = append(addedPackageNames, packageNameForConfig)
 	}
 
-	for _, pkg := range addedPackageNames {
-		if err := d.cfg.Packages.AddPlatforms(d.stderr, pkg, platforms); err != nil {
+	// Options must be set before ensurePackagesAreInstalled. See comment in function
+	if err := d.setPackageOptions(addedPackageNames, opts); err != nil {
+		return err
+	}
+
+	if err := d.ensurePackagesAreInstalled(ctx, install); err != nil {
+		return usererr.WithUserMessage(err, "There was an error installing nix packages")
+	}
+
+	if err := d.saveCfg(); err != nil {
+		return err
+	}
+
+	return d.PrintPostAddMessage(ctx, pkgs, unchangedPackageNames, opts)
+}
+
+func (d *Devbox) setPackageOptions(pkgs []string, opts devopt.AddOpts) error {
+	for _, pkg := range pkgs {
+		if err := d.cfg.Packages.AddPlatforms(
+			d.stderr, pkg, opts.Platforms); err != nil {
 			return err
 		}
-		if err := d.cfg.Packages.ExcludePlatforms(d.stderr, pkg, excludePlatforms); err != nil {
+		if err := d.cfg.Packages.ExcludePlatforms(
+			d.stderr, pkg, opts.ExcludePlatforms); err != nil {
+			return err
+		}
+		if err := d.cfg.Packages.DisablePlugin(pkg, opts.DisablePlugin); err != nil {
 			return err
 		}
 	}
@@ -110,8 +132,9 @@ func (d *Devbox) Add(ctx context.Context, platforms, excludePlatforms []string, 
 	// Resolving here ensures we allow insecure before running ensurePackagesAreInstalled
 	// which will call print-dev-env. Resolving does not save the lockfile, we
 	// save at the end when everything has succeeded.
-	if d.allowInsecureAdds {
-		for _, name := range addedPackageNames {
+	if opts.AllowInsecure {
+		nix.AllowInsecurePackages()
+		for _, name := range pkgs {
 			p, err := d.lockfile.Resolve(name)
 			if err != nil {
 				return err
@@ -125,14 +148,15 @@ func (d *Devbox) Add(ctx context.Context, platforms, excludePlatforms []string, 
 		}
 	}
 
-	if err := d.ensurePackagesAreInstalled(ctx, install); err != nil {
-		return usererr.WithUserMessage(err, "There was an error installing nix packages")
-	}
+	return nil
+}
 
-	if err := d.saveCfg(); err != nil {
-		return err
-	}
-
+func (d *Devbox) PrintPostAddMessage(
+	ctx context.Context,
+	pkgs []*devpkg.Package,
+	unchangedPackageNames []string,
+	opts devopt.AddOpts,
+) error {
 	for _, input := range pkgs {
 		if readme, err := plugin.Readme(
 			ctx,
@@ -145,7 +169,7 @@ func (d *Devbox) Add(ctx context.Context, platforms, excludePlatforms []string, 
 		}
 	}
 
-	if len(platforms) == 0 && len(excludePlatforms) == 0 && !d.allowInsecureAdds {
+	if len(opts.Platforms) == 0 && len(opts.ExcludePlatforms) == 0 && !opts.AllowInsecure {
 		if len(unchangedPackageNames) == 1 {
 			ux.Finfo(d.stderr, "Package %q was already in devbox.json and was not modified\n", unchangedPackageNames[0])
 		} else if len(unchangedPackageNames) > 1 {
@@ -154,7 +178,6 @@ func (d *Devbox) Add(ctx context.Context, platforms, excludePlatforms []string, 
 			)
 		}
 	}
-
 	return nil
 }
 

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -42,7 +42,10 @@ func (d *Devbox) Update(ctx context.Context, opts devopt.UpdateOpts) error {
 			// Calling Add function with the original package names, since
 			// Add will automatically append @latest if search is able to handle that.
 			// If not, it will fallback to the nixpkg format.
-			if err := d.Add(ctx, cfgPackage.Platforms, cfgPackage.ExcludedPlatforms, pkg.Raw); err != nil {
+			if err := d.Add(ctx, []string{pkg.Raw}, devopt.AddOpts{
+				Platforms:        cfgPackage.Platforms,
+				ExcludePlatforms: cfgPackage.ExcludedPlatforms,
+			}); err != nil {
 				return err
 			}
 		} else {

--- a/internal/plugin/files.go
+++ b/internal/plugin/files.go
@@ -29,9 +29,12 @@ func getConfigIfAny(pkg Includable, projectDir string) (*config, error) {
 }
 
 func getBuiltinPluginConfigIfExists(
-	pkg Includable,
+	pkg *devpkg.Package,
 	projectDir string,
 ) (*config, error) {
+	if pkg.DisablePlugin {
+		return nil, nil
+	}
 	content, err := plugins.BuiltInForPackage(pkg.CanonicalName())
 	if errors.Is(err, fs.ErrNotExist) {
 		return nil, nil

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -61,7 +61,7 @@ func (m *Manager) ProcessPluginPackages(
 		}
 		pluginPackages = append(
 			pluginPackages,
-			devpkg.PackageFromStrings(config.Packages, m.lockfile)...,
+			devpkg.PackagesFromStrings(config.Packages, m.lockfile, false /*disable plugin*/)...,
 		)
 		if config.RemoveTriggerPackage {
 			packagesToRemove = append(packagesToRemove, pkg)

--- a/testscripts/plugin/disable-plugin.test.txt
+++ b/testscripts/plugin/disable-plugin.test.txt
@@ -1,0 +1,7 @@
+# Testscript for testing disable plugin
+
+exec devbox init
+exec devbox add python --disable-plugin
+! stderr 'This plugin' 
+
+! exec devbox run ls .devbox/virtenv/python

--- a/testscripts/plugin/plugin.test.txt
+++ b/testscripts/plugin/plugin.test.txt
@@ -1,0 +1,7 @@
+# Testscript for testing plugin
+
+exec devbox init
+exec devbox add python
+stderr 'This plugin'
+
+exec devbox run ls .devbox/virtenv/python


### PR DESCRIPTION
## Summary

This adds a new `--disable-plugin` flag to `devbox add`. It also adds a new `disable_plugin` field to the package object in the config. If this field is true packages with built in plugins will not install the plugin. If the package does not trigger a plugin, the field is ignored. The field can be added via flag or manually. It can be removed manually or by running `devbox add <pkg>` again without the flag.

Other fixes/improvements:

* Moved allowInsecure to `AddOpts` instead of devbox general options.
* Refactored Add() so it no longer violates the linter complexity rule.

Fixes: https://github.com/jetpack-io/devbox/issues/1615

cc: @Lagoja 

## How was it tested?

* Unit tests
* `devbox add python --disable-plugin` 