### PR TITLE
[plugins] Make python, pip, and poetry plugins output to stderr

### DIFF
--- a/examples/development/python/poetry/poetry-demo/devbox.lock
+++ b/examples/development/python/poetry/poetry-demo/devbox.lock
@@ -3,7 +3,7 @@
   "packages": {
     "poetry@1.4": {
       "last_modified": "2023-05-19T19:44:39Z",
-      "plugin_version": "0.0.2",
+      "plugin_version": "0.0.3",
       "resolved": "github:NixOS/nixpkgs/4a22f6f0a4b4354778f786425babce9a56f6b5d8#poetry",
       "source": "devbox-search",
       "version": "1.4.2",
@@ -24,7 +24,7 @@
     },
     "python@3.8": {
       "last_modified": "2023-06-30T04:44:22Z",
-      "plugin_version": "0.0.1",
+      "plugin_version": "0.0.2",
       "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#python38",
       "source": "devbox-search",
       "version": "3.8.17",

--- a/plugins/pip.json
+++ b/plugins/pip.json
@@ -1,6 +1,6 @@
 {
     "name": "pip",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "readme": "This plugin adds a script for automatically creating a virtual environment using `venv` for python3 projects, so you can install packages with pip as normal.\nTo activate the environment, run `source $VENV_DIR/bin/activate` or add it to the init_hook of your devbox.json\nTo change where your virtual environment is created, modify the $VENV_DIR environment variable in your init_hook",
     "env": {
         "VENV_DIR": "{{ .Virtenv }}/.venv"

--- a/plugins/pip/venvShellHook.sh
+++ b/plugins/pip/venvShellHook.sh
@@ -5,4 +5,4 @@ if ! [ -d "$VENV_DIR" ]; then
     python3 -m venv "$VENV_DIR"
 fi
 
-echo "You can activate the virtual environment by running 'source \$VENV_DIR/bin/activate'"
+echo "You can activate the virtual environment by running 'source \$VENV_DIR/bin/activate'" >&2

--- a/plugins/poetry.json
+++ b/plugins/poetry.json
@@ -1,6 +1,6 @@
 {
     "name": "poetry",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "readme": "This plugin automatically configures poetry to use the version of python installed in your Devbox shell, instead of the Python version that it is bundled with. The pyproject.toml location can be configured by setting DEVBOX_PYPROJECT_DIR (defaults to the devbox.json's directory).",
     "env": {
         "DEVBOX_DEFAULT_PYPROJECT_DIR": "{{ .DevboxProjectDir }}",

--- a/plugins/poetry/initHook.sh
+++ b/plugins/poetry/initHook.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-poetry env use $(command -v python) --directory="${DEVBOX_PYPROJECT_DIR:-$DEVBOX_DEFAULT_PYPROJECT_DIR}" --no-interaction
-
+poetry env use $(command -v python) --directory="${DEVBOX_PYPROJECT_DIR:-$DEVBOX_DEFAULT_PYPROJECT_DIR}" --no-interaction >&2

--- a/plugins/python.json
+++ b/plugins/python.json
@@ -1,6 +1,6 @@
 {
   "name": "python",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "readme": "Python in Devbox works best when used with a virtual environment (vent, virtualenv, etc.). Devbox will automatically create a virtual environment using `venv` for python3 projects, so you can install packages with pip as normal.\nTo activate the environment, run `source $VENV_DIR/bin/activate` or add it to the init_hook of your devbox.json\nTo change where your virtual environment is created, modify the $VENV_DIR environment variable in your init_hook",
   "env": {
       "VENV_DIR": "{{ .Virtenv }}/.venv"


### PR DESCRIPTION
## Summary

The python, pip, and poetry plugins send output to stdout in the init hooks. This breaks any script that relies on a clean std out. In general no devbox builtin plugin should ever send output to std out in init hooks or commands that where the user does not expect output. The solution in this PR is to redirect to stderr.

A separate question I'm punting on is whether `--quiet` flag should also suppress init hook output. Since init hooks are usually user code, I think the answer is no. On the other hand, built in plugins should probably respect it. This could be a follow up.

Partially addresses https://github.com/jetpack-io/devbox/issues/1632

## How was it tested?

I created a test project with poetry and confirmed there was nothing being sent to stdout when running a script.
