### PR TITLE
[glibc] Add patch-glibc patch and fix when package in binary cache

### DIFF
--- a/internal/boxcli/add.go
+++ b/internal/boxcli/add.go
@@ -23,6 +23,7 @@ type addCmdFlags struct {
 	disablePlugin    bool
 	platforms        []string
 	excludePlatforms []string
+	patchGlibc       bool
 }
 
 func addCmd() *cobra.Command {
@@ -63,6 +64,9 @@ func addCmd() *cobra.Command {
 	command.Flags().StringSliceVarP(
 		&flags.excludePlatforms, "exclude-platform", "e", []string{},
 		"exclude packages from a specific platform.")
+	command.Flags().BoolVar(
+		&flags.patchGlibc, "patch-glibc", false,
+		"patch any ELF binaries to use the latest glibc version in nixpkgs")
 
 	return command
 }
@@ -81,5 +85,6 @@ func addCmdFunc(cmd *cobra.Command, args []string, flags addCmdFlags) error {
 		DisablePlugin:    flags.disablePlugin,
 		Platforms:        flags.platforms,
 		ExcludePlatforms: flags.excludePlatforms,
+		PatchGlibc:       flags.patchGlibc,
 	})
 }

--- a/internal/devconfig/packages.go
+++ b/internal/devconfig/packages.go
@@ -177,7 +177,20 @@ func (pkgs *Packages) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (pkgs *Packages) DisablePlugin(versionedName string, v bool) error {
+func (pkgs *Packages) SetPatchGLibc(versionedName string, v bool) error {
+	name, version := parseVersionedName(versionedName)
+	i := pkgs.index(name, version)
+	if i == -1 {
+		return errors.Errorf("package %s not found", versionedName)
+	}
+	if pkgs.Collection[i].PatchGlibc != v {
+		pkgs.Collection[i].PatchGlibc = v
+		pkgs.ast.setPackageBool(name, "patch_glibc", v)
+	}
+	return nil
+}
+
+func (pkgs *Packages) SetDisablePlugin(versionedName string, v bool) error {
 	name, version := parseVersionedName(versionedName)
 	i := pkgs.index(name, version)
 	if i == -1 {

--- a/internal/devpkg/narinfo_cache.go
+++ b/internal/devpkg/narinfo_cache.go
@@ -25,6 +25,10 @@ const BinaryCache = "https://cache.nixos.org"
 // ALERT: Callers in a perf-sensitive code path should call FillNarInfoCache
 // before calling this function.
 func (p *Package) IsInBinaryCache() (bool, error) {
+	// Patched glibc packages are not in the binary cache.
+	if p.PatchGlibc {
+		return false, nil
+	}
 	if eligible, err := p.isEligibleForBinaryCache(); err != nil {
 		return false, err
 	} else if !eligible {

--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -127,7 +127,7 @@ func PackageFromStringWithDefaults(raw string, locker lock.Locker) *Package {
 func PackageFromStringWithOptions(raw string, locker lock.Locker, opts devopt.AddOpts) *Package {
 	pkg := PackageFromStringWithDefaults(raw, locker)
 	pkg.DisablePlugin = opts.DisablePlugin
-	// TODO: add patchGlibc flag
+	pkg.PatchGlibc = opts.PatchGlibc
 	return pkg
 }
 

--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -114,7 +114,7 @@ func PackagesFromConfig(config *devconfig.Config, l lock.Locker) []*Package {
 	for _, cfgPkg := range config.Packages.Collection {
 		pkg := newPackage(cfgPkg.VersionedName(), cfgPkg.IsEnabledOnPlatform(), l)
 		pkg.DisablePlugin = cfgPkg.DisablePlugin
-		pkg.PatchGlibc = cfgPkg.PatchGlibc
+		pkg.PatchGlibc = cfgPkg.PatchGlibc && nix.SystemIsLinux()
 		result = append(result, pkg)
 	}
 	return result

--- a/internal/impl/devopt/devboxopts.go
+++ b/internal/impl/devopt/devboxopts.go
@@ -42,6 +42,7 @@ type AddOpts struct {
 	Platforms        []string
 	ExcludePlatforms []string
 	DisablePlugin    bool
+	PatchGlibc       bool
 }
 
 type UpdateOpts struct {

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -124,7 +124,13 @@ func (d *Devbox) setPackageOptions(pkgs []string, opts devopt.AddOpts) error {
 			d.stderr, pkg, opts.ExcludePlatforms); err != nil {
 			return err
 		}
-		if err := d.cfg.Packages.DisablePlugin(pkg, opts.DisablePlugin); err != nil {
+		if err := d.cfg.Packages.SetDisablePlugin(
+			pkg, opts.DisablePlugin); err != nil {
+			return err
+		}
+
+		if err := d.cfg.Packages.SetPatchGLibc(
+			pkg, opts.PatchGlibc); err != nil {
 			return err
 		}
 	}

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -157,6 +157,10 @@ func ComputeSystem() error {
 	return nil
 }
 
+func SystemIsLinux() bool {
+	return strings.Contains(System(), "linux")
+}
+
 // version is the cached output of `nix --version`.
 var version = ""
 


### PR DESCRIPTION
## Summary

* Adds new `--patch-glibc` flag 
* Fixes glibc feature (I think) when package is in binary cache. We were previouwly always installing the cached version instead of the patched version.

## How was it tested?

* Flag was tested using `devbox add python --patch-glibc`
* I'm not 100% sure how to test the patch itself, but I did verify we are creating the patch flake
