### PR TITLE
[launcher] Bump launcher version

### DIFF
--- a/internal/vercheck/vercheck.go
+++ b/internal/vercheck/vercheck.go
@@ -28,7 +28,7 @@ import (
 
 // Keep this in-sync with latest version in launch.sh.
 // If this version is newer than the version in launch.sh, we'll print a notice.
-const expectedLauncherVersion = "v0.2.0"
+const expectedLauncherVersion = "v0.2.1"
 
 // envName determines whether the version check has already occurred.
 // We set this env-var so that this devbox command invoking other devbox commands


### PR DESCRIPTION
## Summary

Depends on https://github.com/jetpack-io/axiom/pull/3577

(that needs to be deployed before this change can be released)

## How was it tested?
