### PR TITLE
[offline] Allow devbox to work offline if packages are already fetched

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -56,13 +56,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: ./go.mod
-      - name: Mount golang cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg
-          key: go-devbox-build-${{ runner.os }}-${{ hashFiles('go.sum') }}
       - name: Build devbox
         run: go build -o dist/devbox ./cmd/devbox
       - name: Upload devbox artifact

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -953,8 +953,10 @@ func (d *Devbox) ensurePackagesAreInstalledAndComputeEnv(
 
 	// When ensurePackagesAreInstalled is called with ensure=true, it always
 	// returns early if the lockfile is up to date. So we don't need to check here
-	if err := d.ensurePackagesAreInstalled(ctx, ensure); err != nil {
+	if err := d.ensurePackagesAreInstalled(ctx, ensure); err != nil && !strings.Contains(err.Error(), "no such host") {
 		return nil, err
+	} else if err != nil {
+		ux.Fwarning(d.stderr, "Error connecting to the internet. Will attempt to use cached environment.\n")
 	}
 
 	// Since ensurePackagesAreInstalled calls computeNixEnv when not up do date,


### PR DESCRIPTION
## Summary

Very basic fix. Doesn't handle all cases, but fixes run/shell.

Fixes https://github.com/jetpack-io/devbox/issues/1657

## How was it tested?

Turned off my wifi, modified `.local.lock` file to bust cache. Was able to run/shell.
