### PR TITLE
docs: Fix the `"includes"` typo

### DIFF
--- a/docs/app/docs/devbox_examples/databases/mariadb.md
+++ b/docs/app/docs/devbox_examples/databases/mariadb.md
@@ -17,10 +17,10 @@ MariaDB can be automatically configured for your dev environment by Devbox via t
     ]
 ```
 
-You can manually add the MariaDB Plugin to your `devbox.json` by adding it to your `includes` list:
+You can manually add the MariaDB Plugin to your `devbox.json` by adding it to your `include` list:
 
 ```json
-    "includes": [
+    "include": [
         "plugin:mariadb"
     ]
 ```

--- a/docs/app/docs/devbox_examples/languages/php.md
+++ b/docs/app/docs/devbox_examples/languages/php.md
@@ -37,10 +37,10 @@ For example -- to add the `ds` extension, run `devbox add php81Extensions.ds`, o
 
 ## PHP Plugin Details
 
-The PHP Plugin will provide the following configuration when you install a PHP runtime with `devbox add`. You can also manually add the PHP plugin by adding `plugin:php` to your `includes` list in `devbox.json`:
+The PHP Plugin will provide the following configuration when you install a PHP runtime with `devbox add`. You can also manually add the PHP plugin by adding `plugin:php` to your `include` list in `devbox.json`:
 
 ```json
-    "includes": [
+    "include": [
         "plugin:php"
     ]
 ```


### PR DESCRIPTION
## Summary

Some docs mentioned the `"includes"` key for `devbox.json` instead of the correct `"include"`.

## How was it tested?

Tried to use the suggested snippet for the PHP plugin in `devbox.json`, found that it does not actually work, then found the proper `"include"` key name in another part of the documentation.