### PR TITLE
[envsec] Add environment flag

### DIFF
--- a/internal/boxcli/add.go
+++ b/internal/boxcli/add.go
@@ -73,8 +73,9 @@ func addCmd() *cobra.Command {
 
 func addCmdFunc(cmd *cobra.Command, args []string, flags addCmdFlags) error {
 	box, err := devbox.Open(&devopt.Opts{
-		Dir:    flags.config.path,
-		Stderr: cmd.ErrOrStderr(),
+		Dir:         flags.config.path,
+		Environment: flags.config.environment,
+		Stderr:      cmd.ErrOrStderr(),
 	})
 	if err != nil {
 		return errors.WithStack(err)

--- a/internal/boxcli/cloud.go
+++ b/internal/boxcli/cloud.go
@@ -141,8 +141,9 @@ func runCloudShellCmd(cmd *cobra.Command, flags *cloudShellCmdFlags) error {
 	}
 
 	box, err := devbox.Open(&devopt.Opts{
-		Dir:    flags.config.path,
-		Stderr: cmd.ErrOrStderr(),
+		Dir:         flags.config.path,
+		Environment: flags.config.environment,
+		Stderr:      cmd.ErrOrStderr(),
 	})
 	if err != nil {
 		return errors.WithStack(err)
@@ -157,8 +158,9 @@ func runCloudInit(cmd *cobra.Command, flags *cloudShellCmdFlags) error {
 	}
 
 	box, err := devbox.Open(&devopt.Opts{
-		Dir:    flags.config.path,
-		Stderr: cmd.ErrOrStderr(),
+		Dir:         flags.config.path,
+		Environment: flags.config.environment,
+		Stderr:      cmd.ErrOrStderr(),
 	})
 	if err != nil {
 		return errors.WithStack(err)

--- a/internal/boxcli/config.go
+++ b/internal/boxcli/config.go
@@ -9,12 +9,16 @@ import (
 
 // to be composed into xyzCmdFlags structs
 type configFlags struct {
-	path string
+	path        string
+	environment string
 }
 
 func (flags *configFlags) register(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(
 		&flags.path, "config", "c", "", "path to directory containing a devbox.json config file",
+	)
+	cmd.Flags().StringVar(
+		&flags.environment, "environment", "dev", "environment to use, when supported (e.g. envsec supports dev, prod, preview.)",
 	)
 }
 
@@ -22,4 +26,11 @@ func (flags *configFlags) registerPersistent(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVarP(
 		&flags.path, "config", "c", "", "path to directory containing a devbox.json config file",
 	)
+	cmd.PersistentFlags().StringVar(
+		&flags.environment, "environment", "dev", "environment to use, when supported (e.g. envsec supports dev, prod, preview.)",
+	)
+}
+
+func (flags *configFlags) Environment() string {
+	return flags.environment
 }

--- a/internal/boxcli/generate.go
+++ b/internal/boxcli/generate.go
@@ -138,8 +138,9 @@ func sshConfigCmd() *cobra.Command {
 func runGenerateCmd(cmd *cobra.Command, flags *generateCmdFlags) error {
 	// Check the directory exists.
 	box, err := devbox.Open(&devopt.Opts{
-		Dir:    flags.config.path,
-		Stderr: cmd.ErrOrStderr(),
+		Dir:         flags.config.path,
+		Environment: flags.config.environment,
+		Stderr:      cmd.ErrOrStderr(),
 	})
 	if err != nil {
 		return errors.WithStack(err)
@@ -166,8 +167,9 @@ func runGenerateDirenvCmd(cmd *cobra.Command, flags *generateCmdFlags) error {
 	}
 
 	box, err := devbox.Open(&devopt.Opts{
-		Dir:    flags.config.path,
-		Stderr: cmd.ErrOrStderr(),
+		Dir:         flags.config.path,
+		Environment: flags.config.environment,
+		Stderr:      cmd.ErrOrStderr(),
 	})
 	if err != nil {
 		return errors.WithStack(err)

--- a/internal/boxcli/info.go
+++ b/internal/boxcli/info.go
@@ -37,8 +37,9 @@ func infoCmd() *cobra.Command {
 
 func infoCmdFunc(cmd *cobra.Command, pkg string, flags infoCmdFlags) error {
 	box, err := devbox.Open(&devopt.Opts{
-		Dir:    flags.config.path,
-		Stderr: cmd.ErrOrStderr(),
+		Dir:         flags.config.path,
+		Environment: flags.config.environment,
+		Stderr:      cmd.ErrOrStderr(),
 	})
 	if err != nil {
 		return errors.WithStack(err)

--- a/internal/boxcli/install.go
+++ b/internal/boxcli/install.go
@@ -33,8 +33,9 @@ func installCmd() *cobra.Command {
 func installCmdFunc(cmd *cobra.Command, flags runCmdFlags) error {
 	// Check the directory exists.
 	box, err := devbox.Open(&devopt.Opts{
-		Dir:    flags.config.path,
-		Stderr: cmd.ErrOrStderr(),
+		Dir:         flags.config.path,
+		Environment: flags.config.environment,
+		Stderr:      cmd.ErrOrStderr(),
 	})
 	if err != nil {
 		return errors.WithStack(err)

--- a/internal/boxcli/pull.go
+++ b/internal/boxcli/pull.go
@@ -50,8 +50,9 @@ func pullCmd() *cobra.Command {
 
 func pullCmdFunc(cmd *cobra.Command, url string, flags *pullCmdFlags) error {
 	box, err := devbox.Open(&devopt.Opts{
-		Dir:    flags.config.path,
-		Stderr: cmd.ErrOrStderr(),
+		Dir:         flags.config.path,
+		Environment: flags.config.environment,
+		Stderr:      cmd.ErrOrStderr(),
 	})
 	if err != nil {
 		return errors.WithStack(err)

--- a/internal/boxcli/push.go
+++ b/internal/boxcli/push.go
@@ -36,8 +36,9 @@ func pushCmd() *cobra.Command {
 
 func pushCmdFunc(cmd *cobra.Command, url string, flags pushCmdFlags) error {
 	box, err := devbox.Open(&devopt.Opts{
-		Dir:    flags.config.path,
-		Stderr: cmd.ErrOrStderr(),
+		Dir:         flags.config.path,
+		Environment: flags.config.environment,
+		Stderr:      cmd.ErrOrStderr(),
 	})
 	if err != nil {
 		return errors.WithStack(err)

--- a/internal/boxcli/rm.go
+++ b/internal/boxcli/rm.go
@@ -32,8 +32,9 @@ func removeCmd() *cobra.Command {
 
 func runRemoveCmd(cmd *cobra.Command, args []string, flags removeCmdFlags) error {
 	box, err := devbox.Open(&devopt.Opts{
-		Dir:    flags.config.path,
-		Stderr: cmd.ErrOrStderr(),
+		Dir:         flags.config.path,
+		Environment: flags.config.environment,
+		Stderr:      cmd.ErrOrStderr(),
 	})
 	if err != nil {
 		return errors.WithStack(err)

--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -59,6 +59,7 @@ func runCmd() *cobra.Command {
 func listScripts(cmd *cobra.Command, flags runCmdFlags) []string {
 	box, err := devbox.Open(&devopt.Opts{
 		Dir:            flags.config.path,
+		Environment:    flags.config.environment,
 		Stderr:         cmd.ErrOrStderr(),
 		Pure:           flags.pure,
 		IgnoreWarnings: true,
@@ -99,10 +100,11 @@ func runScriptCmd(cmd *cobra.Command, args []string, flags runCmdFlags) error {
 
 	// Check the directory exists.
 	box, err := devbox.Open(&devopt.Opts{
-		Dir:    path,
-		Stderr: cmd.ErrOrStderr(),
-		Pure:   flags.pure,
-		Env:    env,
+		Dir:         path,
+		Environment: flags.config.environment,
+		Stderr:      cmd.ErrOrStderr(),
+		Pure:        flags.pure,
+		Env:         env,
 	})
 	if err != nil {
 		return redact.Errorf("error reading devbox.json: %w", err)

--- a/internal/boxcli/services.go
+++ b/internal/boxcli/services.go
@@ -131,8 +131,9 @@ func servicesCmd(persistentPreRunE ...cobraFunc) *cobra.Command {
 
 func listServices(cmd *cobra.Command, flags servicesCmdFlags) error {
 	box, err := devbox.Open(&devopt.Opts{
-		Dir:    flags.config.path,
-		Stderr: cmd.ErrOrStderr(),
+		Dir:         flags.config.path,
+		Environment: flags.config.environment,
+		Stderr:      cmd.ErrOrStderr(),
 	})
 	if err != nil {
 		return errors.WithStack(err)
@@ -147,9 +148,10 @@ func startServices(cmd *cobra.Command, services []string, flags servicesCmdFlags
 		return err
 	}
 	box, err := devbox.Open(&devopt.Opts{
-		Dir:    flags.config.path,
-		Env:    env,
-		Stderr: cmd.ErrOrStderr(),
+		Dir:         flags.config.path,
+		Environment: flags.config.environment,
+		Env:         env,
+		Stderr:      cmd.ErrOrStderr(),
 	})
 	if err != nil {
 		return errors.WithStack(err)
@@ -169,9 +171,10 @@ func stopServices(
 		return err
 	}
 	box, err := devbox.Open(&devopt.Opts{
-		Dir:    servicesFlags.config.path,
-		Env:    env,
-		Stderr: cmd.ErrOrStderr(),
+		Dir:         servicesFlags.config.path,
+		Environment: servicesFlags.config.environment,
+		Env:         env,
+		Stderr:      cmd.ErrOrStderr(),
 	})
 	if err != nil {
 		return errors.WithStack(err)
@@ -193,9 +196,10 @@ func restartServices(
 		return err
 	}
 	box, err := devbox.Open(&devopt.Opts{
-		Dir:    flags.config.path,
-		Env:    env,
-		Stderr: cmd.ErrOrStderr(),
+		Dir:         flags.config.path,
+		Environment: flags.config.environment,
+		Env:         env,
+		Stderr:      cmd.ErrOrStderr(),
 	})
 	if err != nil {
 		return errors.WithStack(err)
@@ -217,6 +221,7 @@ func startProcessManager(
 	box, err := devbox.Open(&devopt.Opts{
 		Dir:                      servicesFlags.config.path,
 		Env:                      env,
+		Environment:              servicesFlags.config.environment,
 		CustomProcessComposeFile: flags.processComposeFile,
 		Stderr:                   cmd.ErrOrStderr(),
 	})

--- a/internal/boxcli/shell.go
+++ b/internal/boxcli/shell.go
@@ -54,10 +54,11 @@ func runShellCmd(cmd *cobra.Command, flags shellCmdFlags) error {
 	}
 	// Check the directory exists.
 	box, err := devbox.Open(&devopt.Opts{
-		Dir:    flags.config.path,
-		Env:    env,
-		Pure:   flags.pure,
-		Stderr: cmd.ErrOrStderr(),
+		Dir:         flags.config.path,
+		Env:         env,
+		Environment: flags.config.environment,
+		Pure:        flags.pure,
+		Stderr:      cmd.ErrOrStderr(),
 	})
 	if err != nil {
 		return errors.WithStack(err)

--- a/internal/boxcli/shellenv.go
+++ b/internal/boxcli/shellenv.go
@@ -78,6 +78,7 @@ func shellEnvFunc(
 	}
 	box, err := devbox.Open(&devopt.Opts{
 		Dir:               flags.config.path,
+		Environment:       flags.config.environment,
 		Stderr:            cmd.ErrOrStderr(),
 		PreservePathStack: flags.preservePathStack,
 		Pure:              flags.pure,

--- a/internal/boxcli/update.go
+++ b/internal/boxcli/update.go
@@ -66,8 +66,9 @@ func updateCmdFunc(cmd *cobra.Command, args []string, flags *updateCmdFlags) err
 	}
 
 	box, err := devbox.Open(&devopt.Opts{
-		Dir:    flags.config.path,
-		Stderr: cmd.ErrOrStderr(),
+		Dir:         flags.config.path,
+		Environment: flags.config.environment,
+		Stderr:      cmd.ErrOrStderr(),
 	})
 	if err != nil {
 		return errors.WithStack(err)

--- a/internal/devconfig/env.go
+++ b/internal/devconfig/env.go
@@ -11,12 +11,12 @@ import (
 
 func (c *Config) ComputedEnv(
 	ctx context.Context,
-	projectDir string,
+	projectDir, environment string,
 ) (map[string]string, error) {
 	env := map[string]string{}
 	var err error
 	if c.IsEnvsecEnabled() {
-		env, err = envsec.Env(ctx, projectDir)
+		env, err = envsec.Env(ctx, projectDir, environment)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error reading secrets from envsec: %s\n\n", err)
 		}

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -59,6 +59,7 @@ const (
 type Devbox struct {
 	cfg                      *devconfig.Config
 	env                      map[string]string
+	environment              string
 	lockfile                 *lock.File
 	nix                      nix.Nixer
 	projectDir               string
@@ -84,9 +85,15 @@ func Open(opts *devopt.Opts) (*Devbox, error) {
 		return nil, errors.WithStack(err)
 	}
 
+	environment, err := validateEnvironment(opts.Environment)
+	if err != nil {
+		return nil, err
+	}
+
 	box := &Devbox{
 		cfg:                      cfg,
 		env:                      opts.Env,
+		environment:              environment,
 		nix:                      &nix.Nix{},
 		projectDir:               projectDir,
 		pluginManager:            plugin.NewManager(),
@@ -1089,7 +1096,7 @@ func (d *Devbox) configEnvs(
 	ctx context.Context,
 	existingEnv map[string]string,
 ) (map[string]string, error) {
-	env, err := d.cfg.ComputedEnv(ctx, d.ProjectDir())
+	env, err := d.cfg.ComputedEnv(ctx, d.ProjectDir(), d.environment)
 	if err != nil {
 		return nil, err
 	}
@@ -1244,4 +1251,11 @@ func (d *Devbox) RunXPaths(ctx context.Context) (string, error) {
 		}
 	}
 	return runxBinPath, nil
+}
+
+func validateEnvironment(environment string) (string, error) {
+	if environment == "dev" || environment == "prod" || environment == "preview" {
+		return environment, nil
+	}
+	return "", usererr.New("invalid environment %q", environment)
 }

--- a/internal/impl/devbox.go
+++ b/internal/impl/devbox.go
@@ -1254,6 +1254,9 @@ func (d *Devbox) RunXPaths(ctx context.Context) (string, error) {
 }
 
 func validateEnvironment(environment string) (string, error) {
+	if environment == "" {
+		return "dev", nil
+	}
 	if environment == "dev" || environment == "prod" || environment == "preview" {
 		return environment, nil
 	}

--- a/internal/impl/devopt/devboxopts.go
+++ b/internal/impl/devopt/devboxopts.go
@@ -7,6 +7,7 @@ import (
 type Opts struct {
 	Dir                      string
 	Env                      map[string]string
+	Environment              string
 	PreservePathStack        bool
 	Pure                     bool
 	IgnoreWarnings           bool

--- a/internal/integrations/envsec/envsec.go
+++ b/internal/integrations/envsec/envsec.go
@@ -18,7 +18,7 @@ var (
 	binPathCache string
 )
 
-func Env(ctx context.Context, projectDir string) (map[string]string, error) {
+func Env(ctx context.Context, projectDir, environment string) (map[string]string, error) {
 	defer debug.FunctionTimer().End()
 
 	if envCache != nil {
@@ -29,8 +29,7 @@ func Env(ctx context.Context, projectDir string) (map[string]string, error) {
 		return nil, err
 	}
 
-	var err error
-	envCache, err = envsecList(ctx, projectDir)
+	envCache, err := envsecList(ctx, projectDir, environment)
 
 	return envCache, err
 }
@@ -76,7 +75,7 @@ func ensureInitialized(ctx context.Context, projectDir string) error {
 
 func envsecList(
 	ctx context.Context,
-	projectDir string,
+	projectDir, environment string,
 ) (map[string]string, error) {
 	binPath, err := EnsureInstalled(ctx)
 	if err != nil {
@@ -85,7 +84,7 @@ func envsecList(
 	cmd := exec.Command(
 		binPath, "ls", "--show",
 		"--format", "json",
-		"--environment", "dev",
+		"--environment", environment,
 		"--json-errors")
 	cmd.Dir = projectDir
 	var bufErr bytes.Buffer


### PR DESCRIPTION
## Summary

Adds new `--environment` flag that gets passed in to envsec. 

A few notes:

* This flag is present in any command that allows a custom config path. The idea is that in the future users can add per environment configuration to their `devbox.json`
* This PR validates in devbox.Open instead of CLI. This can probably be moved up to CLI code but this would have bloated this PR.
* Related, the way we pass options to devbox.Open is very brittle. It involves a lot of copy paste that is easy to mess up. We should look to refactor that, maybe in a follow up. 

## How was it tested?

```
devbox run --environment prod echo $SECRET
```
