### PR TITLE
[update] Don't update if old last_modified, fix runx update

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -2,22 +2,22 @@
   "packages": {
     "go":                          "latest",
     "runx:golangci/golangci-lint": "latest",
-    "runx:mvdan/gofumpt":          "latest"
+    "runx:mvdan/gofumpt":          "latest",
   },
   "env": {
     "GOENV": "off",
-    "PATH":  "$PATH:$PWD/dist"
+    "PATH":  "$PATH:$PWD/dist",
   },
   "shell": {
     "init_hook": [
-      "test -z $FISH_VERSION && unset CGO_ENABLED GO111MODULE GOARCH GOFLAGS GOMOD GOOS GOROOT GOTOOLCHAIN GOWORK"
+      "test -z $FISH_VERSION && unset CGO_ENABLED GO111MODULE GOARCH GOFLAGS GOMOD GOOS GOROOT GOTOOLCHAIN GOWORK",
     ],
     "scripts": {
-      "build": "go build -o dist/devbox ./cmd/devbox",
+      "build":              "go build -o dist/devbox ./cmd/devbox",
       "build-darwin-amd64": "GOOS=darwin GOARCH=amd64 go build -o dist/devbox-darwin-amd64 ./cmd/devbox",
       "build-darwin-arm64": "GOOS=darwin GOARCH=arm64 go build -o dist/devbox-darwin-arm64 ./cmd/devbox",
-      "build-linux-amd64": "GOOS=linux GOARCH=amd64 go build -o dist/devbox-linux-amd64 ./cmd/devbox",
-      "build-linux-arm64": "GOOS=linux GOARCH=arm64 go build -o dist/devbox-linux-arm64 ./cmd/devbox",
+      "build-linux-amd64":  "GOOS=linux GOARCH=amd64 go build -o dist/devbox-linux-amd64 ./cmd/devbox",
+      "build-linux-arm64":  "GOOS=linux GOARCH=arm64 go build -o dist/devbox-linux-arm64 ./cmd/devbox",
       "build-all": [
         "devbox run build-darwin-amd64",
         "devbox run build-darwin-arm64",
@@ -28,7 +28,7 @@
       "lint":            "golangci-lint run --timeout 5m && scripts/gofumpt.sh",
       "fmt":             "scripts/gofumpt.sh",
       "test":            "go test -race -cover ./...",
-      "update-examples": "devbox run build && go run testscripts/testrunner/updater/main.go"
-    }
-  }
+      "update-examples": "devbox run build && go run testscripts/testrunner/updater/main.go",
+    },
+  },
 }

--- a/devbox.lock
+++ b/devbox.lock
@@ -2,28 +2,28 @@
   "lockfile_version": "1",
   "packages": {
     "go@latest": {
-      "last_modified": "2023-09-15T06:49:28Z",
-      "resolved": "github:NixOS/nixpkgs/46688f8eb5cd6f1298d873d4d2b9cf245e09e88e#go_1_21",
+      "last_modified": "2023-11-17T14:14:56Z",
+      "resolved": "github:NixOS/nixpkgs/a71323f68d4377d12c04a5410e214495ec598d4c#go",
       "source": "devbox-search",
-      "version": "1.21.1",
+      "version": "1.21.4",
       "systems": {
         "aarch64-darwin": {
-          "store_path": "/nix/store/jkhg33806wygpwpix47d2h5scfgn01i8-go-1.21.1"
+          "store_path": "/nix/store/02cpvad60np366kmsqc3gnixbsw9jvg1-go-1.21.4"
         },
         "aarch64-linux": {
-          "store_path": "/nix/store/sgkkfw6saficch0mviqyqyw6nj64kzf9-go-1.21.1"
+          "store_path": "/nix/store/7y75b2ac80chlh6knld3943y46n3v9kf-go-1.21.4"
         },
         "x86_64-darwin": {
-          "store_path": "/nix/store/w67nj5iqgnz0msi8i12kyh9nhsp2ci9n-go-1.21.1"
+          "store_path": "/nix/store/0djljz0g4s6f55xcnw7fpzcy7af7rxid-go-1.21.4"
         },
         "x86_64-linux": {
-          "store_path": "/nix/store/jk0bqfsjijia52vks1wxqnn4s6dxaiqp-go-1.21.1"
+          "store_path": "/nix/store/y7abhs9glxfcg7lgcdc8i4ml5wg5ly92-go-1.21.4"
         }
       }
     },
     "runx:golangci/golangci-lint@latest": {
-      "resolved": "golangci/golangci-lint@v1.54.2",
-      "version": "v1.54.2"
+      "resolved": "golangci/golangci-lint@v1.55.2",
+      "version": "v1.55.2"
     },
     "runx:mvdan/gofumpt@latest": {
       "resolved": "mvdan/gofumpt@v0.5.0",

--- a/internal/impl/update.go
+++ b/internal/impl/update.go
@@ -114,6 +114,14 @@ func (d *Devbox) mergeResolvedPackageToLockfile(
 	}
 
 	if existing.Version != resolved.Version {
+		if existing.LastModified > resolved.LastModified {
+			ux.Fwarning(
+				d.stderr,
+				"Resolved version for %s has older last_modified time. Not updating\n",
+				pkg,
+			)
+			return nil
+		}
 		ux.Finfo(d.stderr, "Updating %s %s -> %s\n", pkg, existing.Version, resolved.Version)
 		useResolvedPackageInLockfile(lockfile, pkg, resolved, existing)
 		return nil

--- a/internal/lock/lockfile.go
+++ b/internal/lock/lockfile.go
@@ -73,16 +73,7 @@ func (f *File) Resolve(pkg string) (*Package, error) {
 	if !hasEntry || entry.Resolved == "" {
 		locked := &Package{}
 		var err error
-		if pkgtype.IsRunX(pkg) {
-			ref, err := ResolveRunXPackage(context.TODO(), pkg)
-			if err != nil {
-				return nil, err
-			}
-			locked = &Package{
-				Resolved: ref.String(),
-				Version:  ref.Version,
-			}
-		} else if _, _, versioned := searcher.ParseVersionedPackage(pkg); versioned {
+		if _, _, versioned := searcher.ParseVersionedPackage(pkg); pkgtype.IsRunX(pkg) || versioned {
 			locked, err = f.FetchResolvedPackage(pkg)
 			if err != nil {
 				return nil, err

--- a/internal/lock/resolve.go
+++ b/internal/lock/resolve.go
@@ -14,6 +14,7 @@ import (
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/debug"
+	"go.jetpack.io/devbox/internal/devpkg/pkgtype"
 	"go.jetpack.io/devbox/internal/nix"
 	"go.jetpack.io/devbox/internal/searcher"
 	"golang.org/x/sync/errgroup"
@@ -29,6 +30,17 @@ func (f *File) FetchResolvedPackage(pkg string) (*Package, error) {
 	name, version, _ := searcher.ParseVersionedPackage(pkg)
 	if version == "" {
 		return nil, usererr.New("No version specified for %q.", name)
+	}
+
+	if pkgtype.IsRunX(pkg) {
+		ref, err := ResolveRunXPackage(context.TODO(), pkg)
+		if err != nil {
+			return nil, err
+		}
+		return &Package{
+			Resolved: ref.String(),
+			Version:  ref.Version,
+		}, nil
 	}
 
 	packageVersion, err := searcher.Client().Resolve(name, version)


### PR DESCRIPTION
## Summary

This task is one of the follow ups from https://jetpack-io.slack.com/archives/C05KDNNN0Q6/p1702320680314359

If the package we get from nixhub is old, we should not try to update.

Other fixes:

* runx update was broken (or never implemented?)

## How was it tested?

`devbox update`

Simulated old package issue by changing lock file to a future date.
