### PR TITLE
[plugins] Ensure plugin flakes get upgraded on every install

### DIFF
--- a/examples/development/php/php8.1/devbox.lock
+++ b/examples/development/php/php8.1/devbox.lock
@@ -42,7 +42,7 @@
     },
     "php@8.1": {
       "last_modified": "2023-09-04T16:24:30Z",
-      "plugin_version": "0.0.2",
+      "plugin_version": "0.0.3",
       "resolved": "github:NixOS/nixpkgs/3c15feef7770eb5500a4b8792623e2d6f598c9c1#php81",
       "source": "devbox-search",
       "version": "8.1.23",

--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -285,6 +285,13 @@ func (p *Package) Installable() (string, error) {
 	return installable, nil
 }
 
+// FlakeInstallable returns a flake installable. The raw string must contain
+// a valid flake reference parsable by ParseFlakeRef, optionally followed by an
+// #attrpath and/or an ^output.
+func (p *Package) FlakeInstallable() (FlakeInstallable, error) {
+	return ParseFlakeInstallable(p.Raw)
+}
+
 // urlForInstall is used during `nix profile install`.
 // The key difference with URLForFlakeInput is that it has a suffix of
 // `#attributePath`

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -392,7 +392,7 @@ func (d *Devbox) syncPackagesToProfile(ctx context.Context, mode installMode) er
 				return err
 			}
 			pending = append(pending, pkg)
-		} else if f, _ := pkg.FlakeInstallable(); d.pluginManager.PathIsInVirtenv(f.Ref.Path) {
+		} else if f, err := pkg.FlakeInstallable(); err == nil && d.pluginManager.PathIsInVirtenv(f.Ref.Path) {
 			if err := nix.ProfileUpgrade(profileDir, idx); err != nil {
 				return err
 			}

--- a/internal/impl/packages.go
+++ b/internal/impl/packages.go
@@ -375,10 +375,12 @@ func (d *Devbox) syncPackagesToProfile(ctx context.Context, mode installMode) er
 
 	// Last, find the pending packages, and ensure they are added to the nix-profile
 	// Important to maintain the order of packages as specified by
-	// Devbox.InstallablePackages() (higher priority first)
+	// Devbox.InstallablePackages() (higher priority first).
+	// We also run nix profile upgrade on any virtenv flakes. This is a bit of a
+	// blunt approach, but ensured any plugin created flakes are up-to-date.
 	pending := []*devpkg.Package{}
 	for _, pkg := range packages {
-		_, err := nixprofile.ProfileListIndex(&nixprofile.ProfileListIndexArgs{
+		idx, err := nixprofile.ProfileListIndex(&nixprofile.ProfileListIndexArgs{
 			Items:      itemsToKeep,
 			Lockfile:   d.lockfile,
 			Writer:     d.stderr,
@@ -390,6 +392,10 @@ func (d *Devbox) syncPackagesToProfile(ctx context.Context, mode installMode) er
 				return err
 			}
 			pending = append(pending, pkg)
+		} else if f, _ := pkg.FlakeInstallable(); d.pluginManager.PathIsInVirtenv(f.Ref.Path) {
+			if err := nix.ProfileUpgrade(profileDir, idx); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -4,6 +4,9 @@
 package plugin
 
 import (
+	"path/filepath"
+	"strings"
+
 	"github.com/samber/lo"
 	"go.jetpack.io/devbox/internal/devpkg"
 	"go.jetpack.io/devbox/internal/lock"
@@ -73,4 +76,8 @@ func (m *Manager) ProcessPluginPackages(
 	// if this is behavior we want for user plugins. We may need to add an optional
 	// priority field to the config.
 	return append(pluginPackages, netUserPackages...), nil
+}
+
+func (m *Manager) PathIsInVirtenv(absPath string) bool {
+	return strings.HasPrefix(absPath, filepath.Join(m.ProjectDir(), VirtenvPath))
 }


### PR DESCRIPTION
## Summary

Run `nix profile upgrade` on any virtenv (plugin) flakes after any package is installed. This is a bit blunt, but works. (ideally we determine which plugin is being touched and we only upgrade that flake, but that's a bit tricky)

Fixes https://github.com/jetpack-io/devbox/issues/1680

## How was it tested?

```bash
devbox add php
devbox add php82Extensions.xdebug
devbox run php -m | grep xdebug
```