### PR TITLE
[plugins] fix info for packages with process-compose services

### DIFF
--- a/internal/plugin/info.go
+++ b/internal/plugin/info.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
 	"go.jetpack.io/devbox/internal/devpkg"
+	"go.jetpack.io/devbox/internal/services"
 )
 
 func Readme(ctx context.Context,
@@ -39,7 +40,7 @@ func Readme(ctx context.Context,
 		return "", err
 	}
 
-	if err = printServices(cfg, buf, markdown); err != nil {
+	if err = printServices(cfg, pkg, buf, markdown); err != nil {
 		return "", err
 	}
 
@@ -72,17 +73,25 @@ func printReadme(cfg *config, w io.Writer, markdown bool) error {
 	return errors.WithStack(err)
 }
 
-func printServices(cfg *config, w io.Writer, markdown bool) error {
-	svcs, err := cfg.Services()
+func printServices(cfg *config, pkg *devpkg.Package, w io.Writer, markdown bool) error {
+	contentPath, _ := cfg.ProcessComposeYaml()
+	if contentPath == "" {
+		return nil
+	}
+	content, err := pkg.FileContent(contentPath)
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	if len(svcs) == 0 {
+	serviceNames, err := services.NamesFromProcessCompose(content)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if len(serviceNames) == 0 {
 		return nil
 	}
 	services := ""
-	for _, service := range svcs {
-		services += fmt.Sprintf("* %[1]s\n", service.Name)
+	for _, serviceName := range serviceNames {
+		services += fmt.Sprintf("* %[1]s\n", serviceName)
 	}
 
 	_, err = fmt.Fprintf(

--- a/internal/plugin/info.go
+++ b/internal/plugin/info.go
@@ -74,7 +74,7 @@ func printReadme(cfg *config, w io.Writer, markdown bool) error {
 }
 
 func printServices(cfg *config, pkg *devpkg.Package, w io.Writer, markdown bool) error {
-	contentPath, _ := cfg.ProcessComposeYaml()
+	_, contentPath := cfg.ProcessComposeYaml()
 	if contentPath == "" {
 		return nil
 	}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -50,17 +50,17 @@ type config struct {
 	} `json:"shell,omitempty"`
 }
 
-func (c *config) ProcessComposeYaml() (string, bool) {
-	for file := range c.CreateFiles {
+func (c *config) ProcessComposeYaml() (string, string) {
+	for contentPath, file := range c.CreateFiles {
 		if strings.HasSuffix(file, "process-compose.yaml") || strings.HasSuffix(file, "process-compose.yml") {
-			return file, true
+			return contentPath, file
 		}
 	}
-	return "", false
+	return "", ""
 }
 
 func (c *config) Services() (services.Services, error) {
-	if file, ok := c.ProcessComposeYaml(); ok {
+	if _, file := c.ProcessComposeYaml(); file != "" {
 		return services.FromProcessCompose(file)
 	}
 	return nil, nil

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -51,16 +51,16 @@ type config struct {
 }
 
 func (c *config) ProcessComposeYaml() (string, string) {
-	for contentPath, file := range c.CreateFiles {
+	for file, contentPath := range c.CreateFiles {
 		if strings.HasSuffix(file, "process-compose.yaml") || strings.HasSuffix(file, "process-compose.yml") {
-			return contentPath, file
+			return file, contentPath
 		}
 	}
 	return "", ""
 }
 
 func (c *config) Services() (services.Services, error) {
-	if _, file := c.ProcessComposeYaml(); file != "" {
+	if file, _ := c.ProcessComposeYaml(); file != "" {
 		return services.FromProcessCompose(file)
 	}
 	return nil, nil

--- a/internal/services/config.go
+++ b/internal/services/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/f1bonacc1/process-compose/src/types"
 	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
 
 	"go.jetpack.io/devbox/internal/cuecfg"
 )
@@ -45,6 +46,18 @@ func FromProcessCompose(path string) (Services, error) {
 	}
 
 	return services, nil
+}
+
+func NamesFromProcessCompose(content []byte) ([]string, error) {
+	var processCompose types.Project
+	if err := yaml.Unmarshal(content, &processCompose); err != nil {
+		return nil, err
+	}
+	names := []string{}
+	for name := range processCompose.Processes {
+		names = append(names, name)
+	}
+	return names, nil
 }
 
 func lookupProcessCompose(projectDir, path string) string {


### PR DESCRIPTION
## Summary

We were relying on the package already being installed and in virtenv. This change ensures it works when not installed as well.

## How was it tested?

`devbox info php`
