### PR TITLE
[python] use posix-compatible dot instead of bashism source

### DIFF
--- a/docs/app/docs/devbox_examples/languages/python.md
+++ b/docs/app/docs/devbox_examples/languages/python.md
@@ -29,7 +29,7 @@ This will install Python 3.10 in your shell. You can find other versions of Pyth
 
 The `python` package automatically comes bundled with `pip`, and the `python` plugin for Devbox will automatically create a virtual environment for installing your packages locally
 
-Your virtual environment is created in the `.devbox/virtenv/python` directory by default, and can be activated by running `source $VENV_DIR/bin/activate` in your devbox shell. You can activate the virtual environment automatically using the init_hook of your `devbox.json`:
+Your virtual environment is created in the `.devbox/virtenv/python` directory by default, and can be activated by running `. $VENV_DIR/bin/activate` in your devbox shell. You can activate the virtual environment automatically using the init_hook of your `devbox.json`:
 
 ```json
 {

--- a/docs/app/docs/devbox_examples/stacks/django.md
+++ b/docs/app/docs/devbox_examples/stacks/django.md
@@ -25,7 +25,7 @@ This example demonstrates how to configure and run a Django app using Devbox. It
 1. Start a devbox shell with `devbox shell`, then activate your virtual environment and install your requirements using the commands below.
 
    ```bash
-   source $VENV_DIR/bin/activate
+   . $VENV_DIR/bin/activate
    pip install -r requirements.txt
    ```
 

--- a/examples/cloud_development/temporal/devbox.json
+++ b/examples/cloud_development/temporal/devbox.json
@@ -14,7 +14,7 @@
             "echo 'Setting flags to allow Python C extension compilation'",
             "export NIX_CFLAGS_COMPILE=\"$NIX_CFLAGS_COMPILE $(cat $(dirname $(command -v clang))/../nix-support/libcxx-cxxflags)\"",
             "echo 'Setting up virtual environment'",
-            "source $VENV_DIR/bin/activate"
+            ". $VENV_DIR/bin/activate"
         ],
         "scripts": {
             "start-temporal": "temporalite start --namespace default --log-level warn --log-format pretty --ephemeral"

--- a/examples/data_science/pytorch/gradio/devbox.json
+++ b/examples/data_science/pytorch/gradio/devbox.json
@@ -7,7 +7,7 @@
     "env": {},
     "shell": {
         "init_hook": [
-            "source $VENV_DIR/bin/activate",
+            ". $VENV_DIR/bin/activate",
             "pip install -r requirements.txt"
         ]
     },

--- a/examples/data_science/tensorflow/devbox.json
+++ b/examples/data_science/tensorflow/devbox.json
@@ -6,7 +6,7 @@
   ],
   "shell": {
     "init_hook": [
-      "source $VENV_DIR/bin/activate",
+      ". $VENV_DIR/bin/activate",
       "pip install -r requirements.txt"
     ]
   },

--- a/examples/development/python/pip/README.md
+++ b/examples/development/python/pip/README.md
@@ -26,7 +26,7 @@ This will install Python 3.10 in your shell. You can find other versions of Pyth
 
 You can install `pip` by running `devbox add python3xxPackages.pip`, where `3xx` is the version of Python you want to install. This will also install the pip plugin for Devbox, which automatically creates a virtual environment for installing your packages locally
 
-Your virtual environment is created in the `.devbox/virtenv/pip` directory by default, and can be activated by running `source $VENV_DIR/bin/activate` in your devbox shell. You can activate the virtual environment automatically using the init_hook of your `devbox.json`:
+Your virtual environment is created in the `.devbox/virtenv/pip` directory by default, and can be activated by running `. $VENV_DIR/bin/activate` in your devbox shell. You can activate the virtual environment automatically using the init_hook of your `devbox.json`:
 
 ```json
 {

--- a/examples/stacks/django/README.md
+++ b/examples/stacks/django/README.md
@@ -23,7 +23,7 @@
 1. Start a devbox shell with `devbox shell`. This will activate your virtual environment and install your requirements using the commands below.
 
    ```bash
-   source $VENV_DIR/bin/activate
+   . $VENV_DIR/bin/activate
    pip install -r requirements.txt
    ```
 

--- a/plugins/pip.json
+++ b/plugins/pip.json
@@ -1,7 +1,7 @@
 {
     "name": "pip",
     "version": "0.0.2",
-    "readme": "This plugin adds a script for automatically creating a virtual environment using `venv` for python3 projects, so you can install packages with pip as normal.\nTo activate the environment, run `source $VENV_DIR/bin/activate` or add it to the init_hook of your devbox.json\nTo change where your virtual environment is created, modify the $VENV_DIR environment variable in your init_hook",
+    "readme": "This plugin adds a script for automatically creating a virtual environment using `venv` for python3 projects, so you can install packages with pip as normal.\nTo activate the environment, run `. $VENV_DIR/bin/activate` or add it to the init_hook of your devbox.json\nTo change where your virtual environment is created, modify the $VENV_DIR environment variable in your init_hook",
     "env": {
         "VENV_DIR": "{{ .Virtenv }}/.venv"
     },

--- a/plugins/python.json
+++ b/plugins/python.json
@@ -1,7 +1,7 @@
 {
   "name": "python",
   "version": "0.0.3",
-  "readme": "Python in Devbox works best when used with a virtual environment (vent, virtualenv, etc.). Devbox will automatically create a virtual environment using `venv` for python3 projects, so you can install packages with pip as normal.\nTo activate the environment, run `source $VENV_DIR/bin/activate` or add it to the init_hook of your devbox.json\nTo change where your virtual environment is created, modify the $VENV_DIR environment variable in your init_hook",
+  "readme": "Python in Devbox works best when used with a virtual environment (vent, virtualenv, etc.). Devbox will automatically create a virtual environment using `venv` for python3 projects, so you can install packages with pip as normal.\nTo activate the environment, run `. $VENV_DIR/bin/activate` or add it to the init_hook of your devbox.json\nTo change where your virtual environment is created, modify the $VENV_DIR environment variable in your init_hook",
   "env": {
       "VENV_DIR": "{{ .Virtenv }}/.venv"
   },


### PR DESCRIPTION
## Summary

Think its a bit nice to be posix compatible where we can.

The downside is that `source` is more recognizable, perhaps, compared to `dot`.

## How was it tested?

cicd tests
