### PR TITLE
[envsec] Ensure build environment is the same

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -883,7 +883,7 @@ func (d *Devbox) computeEnv(ctx context.Context, usePrintDevEnvCache bool) (map[
 		env["PATH"],
 	)
 
-	if err = d.addUtilitiesToPath(ctx, env); err != nil {
+	if err = d.addUtilitiesToEnv(ctx, env); err != nil {
 		return nil, err
 	}
 

--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -883,8 +883,7 @@ func (d *Devbox) computeEnv(ctx context.Context, usePrintDevEnvCache bool) (map[
 		env["PATH"],
 	)
 
-	env["PATH"], err = d.addUtilitiesToPath(ctx, env["PATH"])
-	if err != nil {
+	if err = d.addUtilitiesToPath(ctx, env); err != nil {
 		return nil, err
 	}
 

--- a/internal/devbox/util.go
+++ b/internal/devbox/util.go
@@ -35,11 +35,11 @@ func (d *Devbox) addDevboxUtilityPackage(ctx context.Context, pkg string) error 
 	})
 }
 
-// addDevboxUtilityPackages adds binaries that we want the user to have access
-// to (e.g. envsec).
+// addUtilitiesToEnv adds binaries that we want the user to have access
+// to (e.g. envsec) and associated env vars.
 // Question: Should we add utilityBinPath here? That would allow user to use
 // process-compose, etc
-func (d *Devbox) addUtilitiesToPath(
+func (d *Devbox) addUtilitiesToEnv(
 	ctx context.Context,
 	env map[string]string,
 ) error {

--- a/internal/integrations/envsec/envsec.go
+++ b/internal/integrations/envsec/envsec.go
@@ -87,6 +87,11 @@ func envsecList(
 		"--environment", environment,
 		"--json-errors")
 	cmd.Dir = projectDir
+	if build.IsDev {
+		// Ensure that devbox and envsec build envs are the same
+		cmd.Env = append(os.Environ(), "ENVSEC_BUILD_ENV=dev")
+	}
+
 	var bufErr bytes.Buffer
 	cmd.Stderr = &bufErr
 	out, err := cmd.Output()

--- a/internal/integrations/envsec/envsec.go
+++ b/internal/integrations/envsec/envsec.go
@@ -49,7 +49,7 @@ func EnsureInstalled(ctx context.Context) (string, error) {
 		return binPathCache, nil
 	}
 
-	paths, err := pkgtype.RunXClient().Install(ctx, "jetpack-io/envsec@v0.0.14")
+	paths, err := pkgtype.RunXClient().Install(ctx, "jetpack-io/envsec@v0.0.15")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to install envsec")
 	}


### PR DESCRIPTION
## Summary

This is combined with https://github.com/jetpack-io/opensource/pull/251 to ensure devbox and envsec environments are always the same.

Otherwise, when using dev devbox, it will install a prod envsec and environments won't match which causes issues because dev environment uses a different authentication issuer so keys are not compatible.

## How was it tested?
