### PR TITLE
[package outputs] add --outputs flag to devbox add, and save in config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 # Editors
 .idea
 .vscode
+.zed
 
 # NodeJS
 node_modules

--- a/internal/boxcli/add.go
+++ b/internal/boxcli/add.go
@@ -24,6 +24,7 @@ type addCmdFlags struct {
 	platforms        []string
 	excludePlatforms []string
 	patchGlibc       bool
+	outputs          []string
 }
 
 func addCmd() *cobra.Command {
@@ -67,6 +68,9 @@ func addCmd() *cobra.Command {
 	command.Flags().BoolVar(
 		&flags.patchGlibc, "patch-glibc", false,
 		"patch any ELF binaries to use the latest glibc version in nixpkgs")
+	command.Flags().StringSliceVarP(
+		&flags.outputs, "outputs", "o", []string{},
+		"specify the outputs to select for the nix package")
 
 	return command
 }
@@ -87,5 +91,6 @@ func addCmdFunc(cmd *cobra.Command, args []string, flags addCmdFlags) error {
 		Platforms:        flags.platforms,
 		ExcludePlatforms: flags.excludePlatforms,
 		PatchGlibc:       flags.patchGlibc,
+		Outputs:          flags.outputs,
 	})
 }

--- a/internal/devbox/devopt/devboxopts.go
+++ b/internal/devbox/devopt/devboxopts.go
@@ -48,6 +48,7 @@ type AddOpts struct {
 	ExcludePlatforms []string
 	DisablePlugin    bool
 	PatchGlibc       bool
+	Outputs          []string
 }
 
 type UpdateOpts struct {

--- a/internal/devbox/packages.go
+++ b/internal/devbox/packages.go
@@ -128,9 +128,12 @@ func (d *Devbox) setPackageOptions(pkgs []string, opts devopt.AddOpts) error {
 			pkg, opts.DisablePlugin); err != nil {
 			return err
 		}
-
 		if err := d.cfg.Packages.SetPatchGLibc(
 			pkg, opts.PatchGlibc); err != nil {
+			return err
+		}
+		if err := d.cfg.Packages.SetOutputs(
+			d.stderr, pkg, opts.Outputs); err != nil {
 			return err
 		}
 	}
@@ -175,7 +178,7 @@ func (d *Devbox) printPostAddMessage(
 		}
 	}
 
-	if len(opts.Platforms) == 0 && len(opts.ExcludePlatforms) == 0 && !opts.AllowInsecure {
+	if len(opts.Platforms) == 0 && len(opts.ExcludePlatforms) == 0 && len(opts.Outputs) == 0 && !opts.AllowInsecure {
 		if len(unchangedPackageNames) == 1 {
 			ux.Finfo(d.stderr, "Package %q was already in devbox.json and was not modified\n", unchangedPackageNames[0])
 		} else if len(unchangedPackageNames) > 1 {

--- a/internal/devconfig/ast.go
+++ b/internal/devconfig/ast.go
@@ -196,32 +196,15 @@ func (c *configAST) appendPlatforms(name, fieldName string, platforms []string) 
 		return
 	}
 
-	pkgObject := c.FindPkgObject(name)
-	if pkgObject == nil {
+	c.appendStringSliceField(name, fieldName, platforms)
+}
+
+func (c *configAST) appendOutputs(name, fieldName string, outputs []string) {
+	if len(outputs) == 0 {
 		return
 	}
 
-	var arr *hujson.Array
-	if i := c.memberIndex(pkgObject, fieldName); i == -1 {
-		arr = &hujson.Array{
-			Elements: make([]hujson.Value, 0, len(platforms)),
-		}
-		pkgObject.Members = append(pkgObject.Members, hujson.ObjectMember{
-			Name: hujson.Value{
-				Value:       hujson.String(fieldName),
-				BeforeExtra: []byte{'\n'},
-			},
-			Value: hujson.Value{Value: arr},
-		})
-	} else {
-		arr = pkgObject.Members[i].Value.Value.(*hujson.Array)
-		arr.Elements = slices.Grow(arr.Elements, len(platforms))
-	}
-
-	for _, p := range platforms {
-		arr.Elements = append(arr.Elements, hujson.Value{Value: hujson.String(p)})
-	}
-	c.root.Format()
+	c.appendStringSliceField(name, fieldName, outputs)
 }
 
 func (c *configAST) FindPkgObject(name string) *hujson.Object {
@@ -306,4 +289,33 @@ func joinNameVersion(name, version string) string {
 		return name
 	}
 	return name + "@" + version
+}
+
+func (c *configAST) appendStringSliceField(name, fieldName string, fieldValues []string) {
+	pkgObject := c.FindPkgObject(name)
+	if pkgObject == nil {
+		return
+	}
+
+	var arr *hujson.Array
+	if i := c.memberIndex(pkgObject, fieldName); i == -1 {
+		arr = &hujson.Array{
+			Elements: make([]hujson.Value, 0, len(fieldValues)),
+		}
+		pkgObject.Members = append(pkgObject.Members, hujson.ObjectMember{
+			Name: hujson.Value{
+				Value:       hujson.String(fieldName),
+				BeforeExtra: []byte{'\n'},
+			},
+			Value: hujson.Value{Value: arr},
+		})
+	} else {
+		arr = pkgObject.Members[i].Value.Value.(*hujson.Array)
+		arr.Elements = slices.Grow(arr.Elements, len(fieldValues))
+	}
+
+	for _, p := range fieldValues {
+		arr.Elements = append(arr.Elements, hujson.Value{Value: hujson.String(p)})
+	}
+	c.root.Format()
 }

--- a/internal/devconfig/packages_test.go
+++ b/internal/devconfig/packages_test.go
@@ -155,6 +155,25 @@ func TestJsonifyConfigPackages(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "map-with-platforms-and-excluded-platforms-and-outputs-nixpkgs-reference",
+			jsonConfig: `{"packages":{"github:nixos/nixpkgs/5233fd2ba76a3accb5aaa999c00509a11fd0793c#hello":` +
+				`{"version":"latest",` +
+				`"platforms":["x86_64-darwin","aarch64-linux"],` +
+				`"excluded_platforms":["x86_64-linux"],` +
+				`"outputs":["cli"]` +
+				`}}}`,
+			expected: Packages{
+				Collection: []Package{
+					NewPackage("github:nixos/nixpkgs/5233fd2ba76a3accb5aaa999c00509a11fd0793c#hello", map[string]any{
+						"version":            "latest",
+						"platforms":          []string{"x86_64-darwin", "aarch64-linux"},
+						"excluded_platforms": []string{"x86_64-linux"},
+						"outputs":            []string{"cli"},
+					}),
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
## Summary

Enables `devbox add <package-name> --outputs <output-name>` to add an `outputs` field to the config for that package.

The next PR will hook up reading this `outputs` field from the config, and changing how we generate the flake.nix to match this outputs field.

## How was it tested?

augmented unit tests

```
> devbox add prometheus --outputs out,cli
Info: Adding package "prometheus@latest" to devbox.json
Info: Added outputs out, cli to package prometheus@latest



> git diff devbox.json
diff --git a/devbox.json b/devbox.json
index 224072bc..f1a0c59c 100644
--- a/devbox.json
+++ b/devbox.json
@@ -3,6 +3,10 @@
     "go":                          "latest",
     "runx:golangci/golangci-lint": "latest",
     "runx:mvdan/gofumpt":          "latest",
+    "prometheus": {
+      "version": "latest",
+      "outputs": ["out", "cli"],
+    },
   },
   "env": {
     "GOENV": "off",
```