### PR TITLE
[init-hooks] Prevent init hook recursion

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -338,7 +338,7 @@ func (d *Devbox) EnvVars(ctx context.Context) ([]string, error) {
 
 func (d *Devbox) shellEnvHashKey() string {
 	// Don't make this a const so we don't use it by itself accidentally
-	return "__DEVBOX_SHELLENV_HASH_" + d.projectDirHash()
+	return "__DEVBOX_SHELLENV_HASH_" + d.ProjectDirHash()
 }
 
 func (d *Devbox) Info(ctx context.Context, pkg string, markdown bool) (string, error) {
@@ -949,7 +949,7 @@ func (d *Devbox) computeEnv(ctx context.Context, usePrintDevEnvCache bool) (map[
 	devboxEnvPath = envpath.JoinPathLists(devboxEnvPath, runXPaths)
 
 	pathStack := envpath.Stack(env, originalEnv)
-	pathStack.Push(env, d.projectDirHash(), devboxEnvPath, d.preservePathStack)
+	pathStack.Push(env, d.ProjectDirHash(), devboxEnvPath, d.preservePathStack)
 	env["PATH"] = pathStack.Path(env)
 	debug.Log("New path stack is: %s", pathStack)
 
@@ -1170,7 +1170,7 @@ func (d *Devbox) setCommonHelperEnvVars(env map[string]string) {
 	env["LIBRARY_PATH"] = envpath.JoinPathLists(profileLibDir, env["LIBRARY_PATH"])
 }
 
-func (d *Devbox) projectDirHash() string {
+func (d *Devbox) ProjectDirHash() string {
 	h, _ := cachehash.Bytes([]byte(d.projectDir))
 	return h
 }

--- a/internal/devbox/devbox_test.go
+++ b/internal/devbox/devbox_test.go
@@ -88,7 +88,7 @@ func TestComputeDevboxPathIsIdempotent(t *testing.T) {
 	t.Setenv("PATH", path)
 	t.Setenv(envpath.InitPathEnv, env[envpath.InitPathEnv])
 	t.Setenv(envpath.PathStackEnv, env[envpath.PathStackEnv])
-	t.Setenv(envpath.Key(devbox.projectDirHash()), env[envpath.Key(devbox.projectDirHash())])
+	t.Setenv(envpath.Key(devbox.ProjectDirHash()), env[envpath.Key(devbox.ProjectDirHash())])
 
 	env, err = devbox.computeEnv(ctx, false /*use cache*/)
 	require.NoError(t, err, "computeEnv should not fail")
@@ -110,7 +110,7 @@ func TestComputeDevboxPathWhenRemoving(t *testing.T) {
 	t.Setenv("PATH", path)
 	t.Setenv(envpath.InitPathEnv, env[envpath.InitPathEnv])
 	t.Setenv(envpath.PathStackEnv, env[envpath.PathStackEnv])
-	t.Setenv(envpath.Key(devbox.projectDirHash()), env[envpath.Key(devbox.projectDirHash())])
+	t.Setenv(envpath.Key(devbox.ProjectDirHash()), env[envpath.Key(devbox.ProjectDirHash())])
 
 	devbox.nix.(*testNix).path = ""
 	env, err = devbox.computeEnv(ctx, false /*use cache*/)

--- a/internal/devbox/envvars.go
+++ b/internal/devbox/envvars.go
@@ -76,5 +76,5 @@ func (d *Devbox) IsEnvEnabled() bool {
 	fakeEnv := map[string]string{}
 	// the Stack is initialized in the fakeEnv, from the state in the real os.Environ
 	pathStack := envpath.Stack(fakeEnv, envir.PairsToMap(os.Environ()))
-	return pathStack.Has(d.projectDirHash())
+	return pathStack.Has(d.ProjectDirHash())
 }

--- a/internal/devbox/refresh.go
+++ b/internal/devbox/refresh.go
@@ -15,7 +15,7 @@ func (d *Devbox) isRefreshAliasSet() bool {
 }
 
 func (d *Devbox) refreshAliasEnvVar() string {
-	return "DEVBOX_REFRESH_ALIAS_" + d.projectDirHash()
+	return "DEVBOX_REFRESH_ALIAS_" + d.ProjectDirHash()
 }
 
 func (d *Devbox) isGlobal() bool {

--- a/internal/shellgen/tmpl/init-hook.tmpl
+++ b/internal/shellgen/tmpl/init-hook.tmpl
@@ -1,0 +1,15 @@
+
+{{/* if hash is set, we're in recursive loop, just exit */ -}}
+if [ -n "${{ .InitHookHash }}" ]; then
+    return
+fi
+
+export {{ .InitHookHash }}=true
+
+{{ .Body }}
+
+{{ if .IsFish }}
+    set -e {{ .InitHookHash }}
+{{ else }}
+    unset {{ .InitHookHash }}
+{{ end }}


### PR DESCRIPTION
## Summary

Fixes https://github.com/jetpack-io/devbox/issues/1651

## How was it tested?

Added a `devbox run echo foobar` into our init hook. Tested with

```
devbox run echo 123
SHELL=fish devbox run echo 123
```

