### PR TITLE
[nix] ensure nix is installed for generate and envsec commands

### DIFF
--- a/internal/boxcli/envsec.go
+++ b/internal/boxcli/envsec.go
@@ -18,8 +18,9 @@ type envsecInitCmdFlags struct {
 
 func envsecCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "envsec",
-		Short: "envsec commands",
+		Use:     "envsec",
+		Short:   "envsec commands",
+		PreRunE: ensureNixInstalled,
 	}
 	cmd.AddCommand(envsecInitCmd())
 	cmd.Hidden = true

--- a/internal/boxcli/generate.go
+++ b/internal/boxcli/generate.go
@@ -25,9 +25,10 @@ func generateCmd() *cobra.Command {
 	flags := &generateCmdFlags{}
 
 	command := &cobra.Command{
-		Use:   "generate",
-		Short: "Generate supporting files for your project",
-		Args:  cobra.MaximumNArgs(0),
+		Use:               "generate",
+		Short:             "Generate supporting files for your project",
+		Args:              cobra.MaximumNArgs(0),
+		PersistentPreRunE: ensureNixInstalled,
 	}
 	command.AddCommand(devcontainerCmd())
 	command.AddCommand(dockerfileCmd())

--- a/internal/boxcli/setup.go
+++ b/internal/boxcli/setup.go
@@ -4,15 +4,12 @@
 package boxcli
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
-	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/nix"
 	"go.jetpack.io/devbox/internal/ux"
-	"go.jetpack.io/devbox/internal/vercheck"
 )
 
 const nixDaemonFlag = "daemon"
@@ -51,24 +48,15 @@ func runInstallNixCmd(cmd *cobra.Command) error {
 
 // ensureNixInstalled verifies that nix is installed and that it is of a supported version
 func ensureNixInstalled(cmd *cobra.Command, _args []string) error {
-	if err := nix.EnsureNixInstalled(cmd.ErrOrStderr(), nixDaemonFlagVal(cmd)); err != nil {
-		return err
-	}
-
-	ver, err := nix.Version()
-	if err != nil {
-		return fmt.Errorf("failed to get nix version: %w", err)
-	}
-
-	// ensure minimum nix version installed
-	if vercheck.SemverCompare(ver, "2.12.0") < 0 {
-		return usererr.New("Devbox requires nix of version >= 2.12. Your version is %s. Please upgrade nix and try again.\n", ver)
-	}
-	return nil
+	return nix.EnsureNixInstalled(cmd.ErrOrStderr(), nixDaemonFlagVal(cmd))
 }
 
 // We return a closure to avoid printing the warning every time and just
 // printing it if we actually need the value of the flag.
+//
+// TODO: devbox.Open should run nix.EnsureNixInstalled and do this logic
+// internally. Then setup can decide if it wants to pass in the value of the
+// nixDaemonFlag (if changed).
 func nixDaemonFlagVal(cmd *cobra.Command) func() *bool {
 	return func() *bool {
 		if !cmd.Flags().Changed(nixDaemonFlag) {

--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -481,12 +481,6 @@ func (d *Devbox) GenerateEnvrcFile(ctx context.Context, force bool, envFlags dev
 				"Remove it or use --force to overwrite it.",
 		)
 	}
-	// confirm .envrc doesn't exist and don't overwrite an existing .envrc
-	if err := nix.EnsureNixInstalled(
-		d.stderr, func() *bool { return lo.ToPtr(false) },
-	); err != nil {
-		return err
-	}
 
 	// generate all shell files to ensure we can refer to them in the .envrc script
 	if err := d.ensureStateIsUpToDate(ctx, ensure); err != nil {

--- a/internal/nix/install.go
+++ b/internal/nix/install.go
@@ -21,9 +21,13 @@ import (
 	"go.jetpack.io/devbox/internal/cmdutil"
 	"go.jetpack.io/devbox/internal/fileutil"
 	"go.jetpack.io/devbox/internal/ux"
+	"go.jetpack.io/devbox/internal/vercheck"
 )
 
-const rootError = "warning: installing Nix as root is not supported by this script!"
+const (
+	minNixVersion = "2.12.0"
+	rootError     = "warning: installing Nix as root is not supported by this script!"
+)
 
 // Install runs the install script for Nix. daemon has 3 states
 // nil is unset. false is --no-daemon. true is --daemon.
@@ -97,11 +101,29 @@ func isRoot() bool {
 
 func EnsureNixInstalled(writer io.Writer, withDaemonFunc func() *bool) (err error) {
 	defer func() {
-		if err == nil {
-			// call ComputeSystem to ensure its value is internally cached so other
-			// callers can rely on just calling System
-			err = ComputeSystem()
+		if err != nil {
+			return
 		}
+		version := ""
+		version, err = Version()
+		if err != nil {
+			err = fmt.Errorf("failed to get nix version: %w", err)
+			return
+		}
+
+		// ensure minimum nix version installed
+		if vercheck.SemverCompare(version, minNixVersion) < 0 {
+			err = usererr.New(
+				"Devbox requires nix of version >= %s. Your version is %s. "+
+					"Please upgrade nix and try again.\n",
+				minNixVersion,
+				version,
+			)
+			return
+		}
+		// call ComputeSystem to ensure its value is internally cached so other
+		// callers can rely on just calling System
+		err = ComputeSystem()
 	}()
 
 	if BinaryInstalled() {


### PR DESCRIPTION
## Summary

TSIA

## How was it tested?

ran `generate`, `envsec` commands and it worked as expected.

Tested version check by temporarily requiring minimum version above mine.