### PR TITLE
[fish] Fix fish init hook

### DIFF
--- a/internal/devbox/shell.go
+++ b/internal/devbox/shell.go
@@ -402,5 +402,6 @@ func filterPathList(pathList string, keep func(string) bool) string {
 }
 
 func isFishShell() bool {
-	return filepath.Base(os.Getenv("SHELL")) == "fish"
+	return filepath.Base(os.Getenv("SHELL")) == "fish" ||
+		os.Getenv("FISH_VERSION") != ""
 }

--- a/internal/shellgen/scripts.go
+++ b/internal/shellgen/scripts.go
@@ -108,7 +108,8 @@ func writeInitHookFile(devbox devboxer, body string) (err error) {
 		"InitHookHash": "__DEVBOX_INIT_HOOK_" + devbox.ProjectDirHash(),
 		// TODO put IsFish() in common place so we can call here and in devbox package
 		// without adding more stuff to interface
-		"IsFish": filepath.Base(os.Getenv("SHELL")) == "fish",
+		"IsFish": filepath.Base(os.Getenv("SHELL")) == "fish" ||
+			os.Getenv("FISH_VERSION") != "",
 	})
 }
 

--- a/internal/shellgen/tmpl/init-hook.tmpl
+++ b/internal/shellgen/tmpl/init-hook.tmpl
@@ -1,15 +1,22 @@
 
 {{/* if hash is set, we're in recursive loop, just exit */ -}}
+
+{{ if .IsFish }}
+if set -q {{ .InitHookHash }}; then
+    return
+end
+{{ else }}
 if [ -n "${{ .InitHookHash }}" ]; then
     return
 fi
+{{ end }}
 
 export {{ .InitHookHash }}=true
 
 {{ .Body }}
 
 {{ if .IsFish }}
-    set -e {{ .InitHookHash }}
+set -e {{ .InitHookHash }}
 {{ else }}
-    unset {{ .InitHookHash }}
+unset {{ .InitHookHash }}
 {{ end }}


### PR DESCRIPTION
## Summary

Fixes an issue with https://github.com/jetpack-io/devbox/pull/1709

Also, adds a `FISH_VERSION` check which seems more reliable? (See https://github.com/fish-shell/fish-shell/issues/374) 

I think longer term it may be better to generate different init hooks (e.g. `.hooks.fish`) instead.

## How was it tested?

```
SHELL=fish devbox shell
refresh
```
