### PR TITLE
set the ownership of /code to devbox user

### DIFF
--- a/internal/devbox/generate/tmpl/devcontainerDockerfile.tmpl
+++ b/internal/devbox/generate/tmpl/devcontainerDockerfile.tmpl
@@ -5,6 +5,8 @@
 # Installing your devbox project
 WORKDIR /code
 {{- if not .RootUser }}
+USER root:root
+RUN mkdir /code && chown ${DEVBOX_USER}:${DEVBOX_USER} /code
 USER ${DEVBOX_USER}:${DEVBOX_USER}
 COPY --chown=${DEVBOX_USER}:${DEVBOX_USER} devbox.json devbox.json
 COPY --chown=${DEVBOX_USER}:${DEVBOX_USER} devbox.lock devbox.lock


### PR DESCRIPTION
## Summary
When set to non `RootUser` for generating Dockerfile. We need to make sure `/code` owned by the devbox user for allowing the script to create new files / dirs in `/code` dir.

## How was it tested?
Locally, Manually