### PR TITLE
[secrets] Renamed config value and small fixes

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -1104,6 +1104,7 @@ func (d *Devbox) configEnvs(
 	ctx context.Context,
 	existingEnv map[string]string,
 ) (map[string]string, error) {
+	defer debug.FunctionTimer().End()
 	env := map[string]string{}
 	if d.cfg.IsEnvsecEnabled() {
 		secrets, err := d.Secrets(ctx)
@@ -1129,7 +1130,9 @@ func (d *Devbox) configEnvs(
 		}
 	} else if d.cfg.EnvFrom != "" {
 		return nil, usererr.New(
-			"unknown from_env value: %s. Supported value is: envsec.", d.cfg.EnvFrom)
+			"unknown from_env value: %s. Supported value is: \"jetpack-cloud\".",
+			d.cfg.EnvFrom,
+		)
 	}
 	for k, v := range d.cfg.Env {
 		env[k] = v

--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -1130,8 +1130,9 @@ func (d *Devbox) configEnvs(
 		}
 	} else if d.cfg.EnvFrom != "" {
 		return nil, usererr.New(
-			"unknown from_env value: %s. Supported value is: \"jetpack-cloud\".",
+			"unknown from_env value: %s. Supported value is: %q.",
 			d.cfg.EnvFrom,
+			"jetpack-cloud",
 		)
 	}
 	for k, v := range d.cfg.Env {

--- a/internal/devconfig/env.go
+++ b/internal/devconfig/env.go
@@ -1,5 +1,6 @@
 package devconfig
 
 func (c *Config) IsEnvsecEnabled() bool {
-	return c.EnvFrom == "envsec"
+	// envsec for legacy.
+	return c.EnvFrom == "envsec" || c.EnvFrom == "jetpack-cloud"
 }


### PR DESCRIPTION
## Summary

* Renamed config from `envsec` to `jetpack-cloud`
* Handle edge case where directory is initialized but devbox.json is not.

## How was it tested?

`devbox secrets init`
