### PR TITLE
[Refactor ensureStateIsUpToDate] split into two modes for when to recompute state

### DIFF
--- a/internal/lock/lockfile.go
+++ b/internal/lock/lockfile.go
@@ -98,9 +98,10 @@ func (f *File) ForceResolve(pkg string) (*Package, error) {
 }
 
 func (f *File) Save() error {
-	if err := cuecfg.WriteFile(lockFilePath(f.devboxProject), f); err != nil {
-		return err
-	}
+	return cuecfg.WriteFile(lockFilePath(f.devboxProject), f)
+}
+
+func (f *File) UpdateAndSaveLocalLock() error {
 	return updateLocal(f.devboxProject)
 }
 

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -124,7 +124,7 @@ func (m *Manager) create(pkg Includable, locked *lock.Package) error {
 		locked.PluginVersion = cfg.Version
 	}
 
-	return m.lockfile.Save()
+	return nil
 }
 
 func (m *Manager) createFile(

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -124,7 +124,7 @@ func (m *Manager) create(pkg Includable, locked *lock.Package) error {
 		locked.PluginVersion = cfg.Version
 	}
 
-	return nil
+	return m.lockfile.Save()
 }
 
 func (m *Manager) createFile(


### PR DESCRIPTION
## Summary

Refactor the implementation of `ensureStateIsUpToDate` as per the suggestion in this comment: https://github.com/jetpack-io/devbox/pull/1692#discussion_r1449453688

1. Split `lockfile.Save` into `lockfile.Save` and `lockfile.UpdateAndSaveStateHash`
2. For now, regardless of `recomputeState` (boolean variable), we always call `recomputeState` (the function). In the next PR, this will change.

NOTE:
In `pluginManager.create`, I only do  `lockfile.Save` and not `lockfile.UpdateAndSaveLocal` (as before), because:
When I do `devbox add php81Extensions.ds` then the `lockfile.Save` in `pluginManager.Create` here is resulting in the `local.lock` being up-to-date so that the next `devbox run` is thinking everything is up to date and early returning in `ensureStateIsUpToDate`.

## How was it tested?

```
devbox shell
devbox add hello
devbox rm hello
```

tests should pass.
