### PR TITLE
Derive nix profile from flake: attempt 2

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Build devbox
         run: go build -o dist/devbox ./cmd/devbox
       - name: Upload devbox artifact
-        uses: actions/upload-artifact@v3  
+        uses: actions/upload-artifact@v3
         with:
           name: devbox-${{ runner.os }}-${{ runner.arch }}
           path: ./dist/devbox
@@ -113,7 +113,7 @@ jobs:
         run: |
           chmod +x ./devbox
           sudo mv ./devbox /usr/local/bin/
-          
+
       - run:  devbox run lint
 
   test:
@@ -129,9 +129,8 @@ jobs:
         run-project-tests: ["project-tests", "project-tests-off"]
         # Run tests on:
         # 1. the oldest supported nix version (which is 2.9.0? But determinate-systems installer has 2.12.0)
-        # 2. nix version 2.17.0 which introduces a new code path that minimizes nixpkgs downloads.
-        # 3. latest nix version
-        nix-version: ["2.12.0", "2.17.0", "2.19.2"]
+        # 2. latest nix version
+        nix-version: ["2.12.0", "2.19.2"]
         exclude:
           - is-main: "not-main"
             os: "${{ inputs.run-mac-tests && 'dummy' || 'macos-latest' }}"
@@ -200,7 +199,7 @@ jobs:
           go test -v -timeout $DEVBOX_GOLANG_TEST_TIMEOUT ./...
 
   auto-nix-install: # ensure Devbox installs nix and works properly after installation.
-    needs: build-devbox 
+    needs: build-devbox
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]

--- a/internal/devbox/nixprofile.go
+++ b/internal/devbox/nixprofile.go
@@ -1,0 +1,86 @@
+package devbox
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/samber/lo"
+	"go.jetpack.io/devbox/internal/nix"
+	"go.jetpack.io/devbox/internal/nix/nixprofile"
+	"go.jetpack.io/devbox/internal/ux"
+)
+
+// syncNixProfileFromFlake ensures the nix profile has the packages from the buildInputs
+// from the devshell of the generated flake.
+//
+// It also removes any packages from the nix profile that are no longer in the buildInputs.
+func (d *Devbox) syncNixProfileFromFlake(ctx context.Context) error {
+	// Get the computed Devbox environment from the generated flake
+	env, err := d.computeEnv(ctx, false /*usePrintDevEnvCache*/)
+	if err != nil {
+		return err
+	}
+
+	// Get the store-paths of the packages we want installed in the nix profile
+	wantStorePaths := []string{}
+	if env["buildInputs"] != "" {
+		// env["buildInputs"] can be empty string if there are no packages in the project
+		// if buildInputs is empty, then we don't want wantStorePaths to be an array with a single "" entry
+		wantStorePaths = strings.Split(env["buildInputs"], " ")
+	}
+
+	profilePath, err := d.profilePath()
+	if err != nil {
+		return err
+	}
+
+	// Get the store-paths of the packages currently installed in the nix profile
+	items, err := nixprofile.ProfileListItems(d.stderr, profilePath)
+	if err != nil {
+		return fmt.Errorf("nix profile list: %v", err)
+	}
+	gotStorePaths := make([]string, 0, len(items))
+	for _, item := range items {
+		gotStorePaths = append(gotStorePaths, item.StorePaths()...)
+	}
+
+	// Diff the store paths and install/remove packages as needed
+	remove, add := lo.Difference(gotStorePaths, wantStorePaths)
+	if len(remove) > 0 {
+		packagesToRemove := make([]string, 0, len(remove))
+		for _, p := range remove {
+			storePath := nix.NewStorePathParts(p)
+			packagesToRemove = append(packagesToRemove, fmt.Sprintf("%s@%s", storePath.Name, storePath.Version))
+		}
+		if len(packagesToRemove) == 1 {
+			ux.Finfo(d.stderr, "Removing %s\n", strings.Join(packagesToRemove, ", "))
+		} else {
+			ux.Finfo(d.stderr, "Removing packages: %s\n", strings.Join(packagesToRemove, ", "))
+		}
+
+		if err := nix.ProfileRemove(profilePath, remove...); err != nil {
+			return err
+		}
+	}
+	if len(add) > 0 {
+		// We need to install the packages in the nix profile one-by-one because
+		// we do checks for insecure packages.
+		// TODO: move the insecure package check here, and do `nix profile install installables...`
+		// in one command for speed.
+		for _, addPath := range add {
+			if err = nix.ProfileInstall(ctx, &nix.ProfileInstallArgs{
+				Installable: addPath,
+				// Install in offline mode for speed. We know we should have all the files
+				// locally in /nix/store since we have run `nix print-dev-env` prior to this.
+				// Also avoids some "substituter not found for store-path" errors.
+				Offline:     true,
+				ProfilePath: profilePath,
+				Writer:      d.stderr,
+			}); err != nil {
+				return fmt.Errorf("error installing package in nix profile %s: %w", addPath, err)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/devbox/packages.go
+++ b/internal/devbox/packages.go
@@ -450,18 +450,33 @@ func (d *Devbox) installNixPackagesToStore(ctx context.Context) error {
 			fmt.Fprintf(d.stderr, "%s: ", stepMsg)
 			color.New(color.FgRed).Fprintf(d.stderr, "Fail\n")
 
-			platform := nix.System()
-			return usererr.WithUserMessage(
-				err,
-				"package %s cannot be installed on your platform %s.\n"+
-					"If you know this package is incompatible with %[2]s, then "+
-					"you could run `devbox add %[1]s --exclude-platform %[2]s` and re-try.\n"+
-					"If you think this package should be compatible with %[2]s, then "+
-					"it's possible this particular version is not available yet from the nix registry. "+
-					"You could try `devbox add` with a different version for this package.\n",
-				pkg.Raw,
-				platform,
-			)
+			// Check if the user is installing a package that cannot be installed on their platform.
+			// For example, glibcLocales on MacOS will give the following error:
+			// flake output attribute 'legacyPackages.x86_64-darwin.glibcLocales' is not a derivation or path
+			// This is because glibcLocales is only available on Linux.
+			// The user should try `devbox add` again with `--exclude-platform`
+			errMessage := strings.TrimSpace(err.Error())
+			fmt.Printf("errMessage is %s\n", errMessage)
+			maybePackageSystemCompatibilityError := strings.Contains(errMessage, "error: flake output attribute") &&
+				strings.Contains(errMessage, "is not a derivation or path")
+
+			if maybePackageSystemCompatibilityError {
+				platform := nix.System()
+				return usererr.WithUserMessage(
+					err,
+					"package %s cannot be installed on your platform %s.\n"+
+						"If you know this package is incompatible with %[2]s, then "+
+						"you could run `devbox add %[1]s --exclude-platform %[2]s` and re-try.\n"+
+						"If you think this package should be compatible with %[2]s, then "+
+						"it's possible this particular version is not available yet from the nix registry. "+
+						"You could try `devbox add` with a different version for this package.\n\n"+
+						"Underlying Error from nix is:",
+					pkg.Raw,
+					platform,
+				)
+			}
+
+			return usererr.WithUserMessage(err, "error installing package %s", pkg.Raw)
 		}
 
 		fmt.Fprintf(d.stderr, "%s: ", stepMsg)

--- a/internal/devbox/packages.go
+++ b/internal/devbox/packages.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
 	"go.jetpack.io/devbox/internal/devbox/devopt"
@@ -271,15 +272,15 @@ func (d *Devbox) ensureStateIsUpToDate(ctx context.Context, mode installMode) er
 		fmt.Fprintln(d.stderr, "Ensuring packages are installed.")
 	}
 
-	recomputeState := mode == ensure || d.IsEnvEnabled()
-	if recomputeState {
-		if err := d.recomputeState(ctx, mode); err != nil {
+	if mode == install || mode == update || mode == ensure {
+		if err := d.installPackages(ctx); err != nil {
 			return err
 		}
-	} else {
-		// TODO: in the next PR, we will only `nix build` the packages that are being
-		// added or updated. For now, we continue to call recomputeState here.
-		if err := d.recomputeState(ctx, mode); err != nil {
+	}
+
+	recomputeState := mode == ensure || d.IsEnvEnabled()
+	if recomputeState {
+		if err := d.recomputeState(ctx); err != nil {
 			return err
 		}
 	}
@@ -295,12 +296,30 @@ func (d *Devbox) ensureStateIsUpToDate(ctx context.Context, mode installMode) er
 		)
 	}
 
+	return d.updateLockfile(recomputeState)
+}
+
+// updateLockfile will ensure devbox.lock is up to date with the current state of the project.update
+// If recomputeState is true, then we will also update the local.lock file.
+func (d *Devbox) updateLockfile(recomputeState bool) error {
+	// Ensure we clean out packages that are no longer needed.
+	d.lockfile.Tidy()
+
+	// Update lockfile with new packages that are not to be installed
+	for _, pkg := range d.configPackages() {
+		if err := pkg.EnsureUninstallableIsInLockfile(); err != nil {
+			return err
+		}
+	}
+
+	// Save the lockfile at the very end, after all other operations were successful.
 	if err := d.lockfile.Save(); err != nil {
 		return err
 	}
 
 	// If we are recomputing state, then we need to update the local.lock file.
-	// If not, we leave the local.lock in a stale state.
+	// If not, we leave the local.lock in a stale state, so that state is recomputed
+	// on the next ensureStateIsUpToDate call with mode=ensure.
 	if recomputeState {
 		return d.lockfile.UpdateAndSaveLocalLock()
 	}
@@ -312,48 +331,18 @@ func (d *Devbox) ensureStateIsUpToDate(ctx context.Context, mode installMode) er
 // - devbox.lock file
 // - the generated flake
 // - the nix-profile
-func (d *Devbox) recomputeState(ctx context.Context, mode installMode) error {
-	// Create plugin directories first because packages might need them
-	for _, pkg := range d.InstallablePackages() {
-		if err := d.PluginManager().Create(pkg); err != nil {
-			return err
-		}
-	}
-
-	if err := d.syncPackagesToProfile(ctx, mode); err != nil {
-		return err
-	}
-
-	if err := d.InstallRunXPackages(ctx); err != nil {
-		return err
-	}
-
+func (d *Devbox) recomputeState(ctx context.Context) error {
 	if err := shellgen.GenerateForPrintEnv(ctx, d); err != nil {
 		return err
 	}
 
+	// TODO: should this be moved into GenerateForPrintEnv?
+	// OR into a plugin.GenerateFiles() along with d.pluginManager().Create()?
 	if err := plugin.RemoveInvalidSymlinks(d.projectDir); err != nil {
 		return err
 	}
 
-	// Use the printDevEnvCache if we are adding or removing or updating any package,
-	// AND we are not in the shellenv-enabled environment of the current devbox-project.
-	usePrintDevEnvCache := mode != ensure && !d.IsEnvEnabled()
-	if _, err := d.computeEnv(ctx, usePrintDevEnvCache); err != nil {
-		return err
-	}
-
-	// Ensure we clean out packages that are no longer needed.
-	d.lockfile.Tidy()
-
-	// Update lockfile with new packages that are not to be installed
-	for _, pkg := range d.configPackages() {
-		if err := pkg.EnsureUninstallableIsInLockfile(); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return d.syncNixProfileFromFlake(ctx)
 }
 
 func (d *Devbox) profilePath() (string, error) {
@@ -364,162 +353,6 @@ func (d *Devbox) profilePath() (string, error) {
 	}
 
 	return absPath, errors.WithStack(os.MkdirAll(filepath.Dir(absPath), 0o755))
-}
-
-// syncPackagesToProfile can ensure that all packages in devbox.json exist in the nix profile,
-// and no more. However, it may skip some steps depending on the `mode`.
-func (d *Devbox) syncPackagesToProfile(ctx context.Context, mode installMode) error {
-	defer debug.FunctionTimer().End()
-	defer trace.StartRegion(ctx, "syncPackagesToProfile").End()
-
-	// First, fetch the profile items from the nix-profile,
-	// and get the installable packages
-	profileDir, err := d.profilePath()
-	if err != nil {
-		return err
-	}
-	profileItems, err := nixprofile.ProfileListItems(d.stderr, profileDir)
-	if err != nil {
-		return err
-	}
-	packages, err := d.AllInstallablePackages()
-	if err != nil {
-		return err
-	}
-
-	// Remove non-nix packages from the list
-	packages = lo.Filter(packages, devpkg.IsNix)
-
-	if err := devpkg.FillNarInfoCache(ctx, packages...); err != nil {
-		return err
-	}
-
-	// Second, remove any packages from the nix-profile that are not in the config
-	itemsToKeep := profileItems
-	if mode != install {
-		itemsToKeep, err = d.removeExtraItemsFromProfile(ctx, profileDir, profileItems, packages)
-		if err != nil {
-			return err
-		}
-	}
-
-	// we are done if mode is uninstall
-	if mode == uninstall {
-		return nil
-	}
-
-	// Last, find the pending packages, and ensure they are added to the nix-profile
-	// Important to maintain the order of packages as specified by
-	// Devbox.InstallablePackages() (higher priority first).
-	// We also run nix profile upgrade on any virtenv flakes. This is a bit of a
-	// blunt approach, but ensured any plugin created flakes are up-to-date.
-	pending := []*devpkg.Package{}
-	for _, pkg := range packages {
-		idx, err := nixprofile.ProfileListIndex(&nixprofile.ProfileListIndexArgs{
-			Items:      itemsToKeep,
-			Lockfile:   d.lockfile,
-			Writer:     d.stderr,
-			Package:    pkg,
-			ProfileDir: profileDir,
-		})
-		if err != nil {
-			if !errors.Is(err, nix.ErrPackageNotFound) {
-				return err
-			}
-			pending = append(pending, pkg)
-		} else if f, err := pkg.FlakeInstallable(); err == nil && d.pluginManager.PathIsInVirtenv(f.Ref.Path) {
-			if err := nix.ProfileUpgrade(profileDir, idx); err != nil {
-				return err
-			}
-		}
-	}
-
-	return d.addPackagesToProfile(ctx, pending)
-}
-
-func (d *Devbox) removeExtraItemsFromProfile(
-	ctx context.Context,
-	profileDir string,
-	profileItems []*nixprofile.NixProfileListItem,
-	packages []*devpkg.Package,
-) ([]*nixprofile.NixProfileListItem, error) {
-	defer debug.FunctionTimer().End()
-	defer trace.StartRegion(ctx, "removeExtraPackagesFromProfile").End()
-
-	itemsToKeep := []*nixprofile.NixProfileListItem{}
-	extras := []*nixprofile.NixProfileListItem{}
-	// Note: because devpkg.Package uses memoization when normalizing attribute paths (slow operation),
-	// and since we're reusing the Package objects, this O(n*m) loop becomes O(n+m) wrt the slow operation.
-	for _, item := range profileItems {
-		found := false
-		for _, pkg := range packages {
-			if item.Matches(pkg, d.lockfile) {
-				itemsToKeep = append(itemsToKeep, item)
-				found = true
-				break
-			}
-		}
-		if !found {
-			extras = append(extras, item)
-		}
-	}
-	// Remove by index to avoid comparing nix.ProfileListItem <> nix.Inputs again.
-	if err := nixprofile.ProfileRemoveItems(profileDir, extras); err != nil {
-		return nil, err
-	}
-	return itemsToKeep, nil
-}
-
-// addPackagesToProfile inspects the packages in devbox.json, checks which of them
-// are missing from the nix profile, and then installs each package individually into the
-// nix profile.
-func (d *Devbox) addPackagesToProfile(ctx context.Context, pkgs []*devpkg.Package) error {
-	defer debug.FunctionTimer().End()
-	defer trace.StartRegion(ctx, "addPackagesToProfile").End()
-
-	if len(pkgs) == 0 {
-		return nil
-	}
-
-	// If packages are in profile but nixpkgs has been purged, the experience
-	// will be poor when we try to run print-dev-env. So we ensure nixpkgs is
-	// prefetched for all relevant packages (those not in binary cache).
-	if err := devpkg.EnsureNixpkgsPrefetched(ctx, d.stderr, pkgs); err != nil {
-		return err
-	}
-
-	var msg string
-	if len(pkgs) == 1 {
-		msg = fmt.Sprintf("Installing package: %s.", pkgs[0])
-	} else {
-		pkgNames := lo.Map(pkgs, func(p *devpkg.Package, _ int) string { return p.Raw })
-		msg = fmt.Sprintf("Installing %d packages: %s.", len(pkgs), strings.Join(pkgNames, ", "))
-	}
-	fmt.Fprintf(d.stderr, "\n%s\n\n", msg)
-
-	profileDir, err := d.profilePath()
-	if err != nil {
-		return fmt.Errorf("error getting profile path: %w", err)
-	}
-
-	total := len(pkgs)
-	for idx, pkg := range pkgs {
-		stepNum := idx + 1
-
-		stepMsg := fmt.Sprintf("[%d/%d] %s", stepNum, total, pkg)
-
-		if err = nixprofile.ProfileInstall(ctx, &nixprofile.ProfileInstallArgs{
-			CustomStepMessage: stepMsg,
-			Lockfile:          d.lockfile,
-			Package:           pkg.Raw,
-			ProfilePath:       profileDir,
-			Writer:            d.stderr,
-		}); err != nil {
-			return fmt.Errorf("error installing package %s: %w", pkg, err)
-		}
-	}
-
-	return nil
 }
 
 var resetCheckDone = false
@@ -556,6 +389,21 @@ func resetProfileDirForFlakes(profileDir string) (err error) {
 	return errors.WithStack(os.Remove(profileDir))
 }
 
+func (d *Devbox) installPackages(ctx context.Context) error {
+	// Create plugin directories first because packages might need them
+	for _, pkg := range d.InstallablePackages() {
+		if err := d.PluginManager().Create(pkg); err != nil {
+			return err
+		}
+	}
+
+	if err := d.installNixPackagesToStore(ctx); err != nil {
+		return err
+	}
+
+	return d.InstallRunXPackages(ctx)
+}
+
 func (d *Devbox) InstallRunXPackages(ctx context.Context) error {
 	for _, pkg := range lo.Filter(d.InstallablePackages(), devpkg.IsRunX) {
 		lockedPkg, err := d.lockfile.Resolve(pkg.Raw)
@@ -570,4 +418,94 @@ func (d *Devbox) InstallRunXPackages(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+// installNixPackagesToStore will install all the packages in the nix store, if
+// mode is install or update, and we're not in a devbox environment.
+// This is done by running `nix build` on the flake. We do this so that the
+// packages will be available in the nix store when computing the devbox environment
+// and installing in the nix profile (even if offline).
+func (d *Devbox) installNixPackagesToStore(ctx context.Context) error {
+	packages, err := d.packagesToInstallInProfile(ctx)
+	if err != nil {
+		return err
+	}
+
+	stepNum := 0
+	total := len(packages)
+	for _, pkg := range packages {
+		stepNum += 1
+
+		installable, err := pkg.Installable()
+		if err != nil {
+			return err
+		}
+
+		stepMsg := fmt.Sprintf("[%d/%d] %s", stepNum, total, pkg)
+		fmt.Fprintf(d.stderr, stepMsg+"\n")
+
+		// --no-link to avoid generating the result objects
+		err = nix.Build(ctx, []string{"--no-link"}, installable)
+		if err != nil {
+			fmt.Fprintf(d.stderr, "%s: ", stepMsg)
+			color.New(color.FgRed).Fprintf(d.stderr, "Fail\n")
+
+			platform := nix.System()
+			return usererr.WithUserMessage(
+				err,
+				"package %s cannot be installed on your platform %s.\n"+
+					"If you know this package is incompatible with %[2]s, then "+
+					"you could run `devbox add %[1]s --exclude-platform %[2]s` and re-try.\n"+
+					"If you think this package should be compatible with %[2]s, then "+
+					"it's possible this particular version is not available yet from the nix registry. "+
+					"You could try `devbox add` with a different version for this package.\n",
+				pkg.Raw,
+				platform,
+			)
+		}
+
+		fmt.Fprintf(d.stderr, "%s: ", stepMsg)
+		color.New(color.FgGreen).Fprintf(d.stderr, "Success\n")
+	}
+	return err
+}
+
+func (d *Devbox) packagesToInstallInProfile(ctx context.Context) ([]*devpkg.Package, error) {
+	// First, fetch the profile items from the nix-profile,
+	profileDir, err := d.profilePath()
+	if err != nil {
+		return nil, err
+	}
+	profileItems, err := nixprofile.ProfileListItems(d.stderr, profileDir)
+	if err != nil {
+		return nil, err
+	}
+
+	// Second, get and prepare all the packages that must be installed in this project
+	packages, err := d.AllInstallablePackages()
+	if err != nil {
+		return nil, err
+	}
+	packages = lo.Filter(packages, devpkg.IsNix) // Remove non-nix packages from the list
+	if err := devpkg.FillNarInfoCache(ctx, packages...); err != nil {
+		return nil, err
+	}
+
+	// Third, compute which packages need to be installed
+	packagesToInstall := []*devpkg.Package{}
+	// Note: because devpkg.Package uses memoization when normalizing attribute paths (slow operation),
+	// and since we're reusing the Package objects, this O(n*m) loop becomes O(n+m) wrt the slow operation.
+	for _, pkg := range packages {
+		found := false
+		for _, item := range profileItems {
+			if item.Matches(pkg, d.lockfile) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			packagesToInstall = append(packagesToInstall, pkg)
+		}
+	}
+	return packagesToInstall, nil
 }

--- a/internal/devbox/util.go
+++ b/internal/devbox/util.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/internal/devpkg"
 	"go.jetpack.io/devbox/internal/nix/nixprofile"
 
 	"go.jetpack.io/devbox/internal/xdg"
@@ -19,15 +20,21 @@ import (
 // It's used to install applications devbox might need, like process-compose
 // This is an alternative to a global install which would modify a user's
 // environment.
-func (d *Devbox) addDevboxUtilityPackage(ctx context.Context, pkg string) error {
+func (d *Devbox) addDevboxUtilityPackage(ctx context.Context, pkgName string) error {
+	pkg := devpkg.PackageFromStringWithDefaults(pkgName, d.lockfile)
+	installable, err := pkg.Installable()
+	if err != nil {
+		return err
+	}
+
 	profilePath, err := utilityNixProfilePath()
 	if err != nil {
 		return err
 	}
 
 	return nixprofile.ProfileInstall(ctx, &nixprofile.ProfileInstallArgs{
-		Lockfile:    d.lockfile,
-		Package:     pkg,
+		Installable: installable,
+		PackageName: pkgName,
 		ProfilePath: profilePath,
 		Writer:      d.stderr,
 	})

--- a/internal/nix/build.go
+++ b/internal/nix/build.go
@@ -1,0 +1,30 @@
+package nix
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/internal/debug"
+)
+
+func Build(ctx context.Context, flags []string, installables ...string) error {
+	// --impure is required for allowUnfreeEnv to work.
+	cmd := commandContext(ctx, "build", "--impure")
+	cmd.Args = append(cmd.Args, flags...)
+	cmd.Args = append(cmd.Args, installables...)
+	cmd.Env = allowUnfreeEnv(os.Environ())
+
+	debug.Log("Running cmd: %s\n", cmd)
+	_, err := cmd.Output()
+	if err != nil {
+		if exitErr := (&exec.ExitError{}); errors.As(err, &exitErr) {
+			debug.Log("Nix build exit code: %d, output: %s\n", exitErr.ExitCode(), exitErr.Stderr)
+			return fmt.Errorf("nix build exit code: %d, output: %s, err: %w", exitErr.ExitCode(), exitErr.Stderr, err)
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/nix/nixprofile/item.go
+++ b/internal/nix/nixprofile/item.go
@@ -83,3 +83,7 @@ func (i *NixProfileListItem) String() string {
 		i.nixStorePaths,
 	)
 }
+
+func (i *NixProfileListItem) StorePaths() []string {
+	return i.nixStorePaths
+}

--- a/internal/nix/nixprofile/profile.go
+++ b/internal/nix/nixprofile/profile.go
@@ -15,7 +15,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
-	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/devpkg"
 	"go.jetpack.io/devbox/internal/lock"
 	"go.jetpack.io/devbox/internal/nix"
@@ -191,42 +190,16 @@ func parseNixProfileListItem(line string) (*NixProfileListItem, error) {
 
 type ProfileInstallArgs struct {
 	CustomStepMessage string
-	Lockfile          *lock.File
-	Package           string
+	Installable       string
+	Offline           bool
+	PackageName       string
 	ProfilePath       string
 	Writer            io.Writer
 }
 
 // ProfileInstall calls nix profile install with default profile
 func ProfileInstall(ctx context.Context, args *ProfileInstallArgs) error {
-	input := devpkg.PackageFromStringWithDefaults(args.Package, args.Lockfile)
-
-	inCache, err := input.IsInBinaryCache()
-	if err != nil {
-		return err
-	}
-
-	if !inCache && nix.IsGithubNixpkgsURL(input.URLForFlakeInput()) {
-		if err := nix.EnsureNixpkgsPrefetched(args.Writer, input.HashFromNixPkgsURL()); err != nil {
-			return err
-		}
-		if exists, err := input.ValidateInstallsOnSystem(); err != nil {
-			return err
-		} else if !exists {
-			platform := nix.System()
-			return usererr.New(
-				"package %s cannot be installed on your platform %s.\n"+
-					"If you know this package is incompatible with %[2]s, then "+
-					"you could run `devbox add %[1]s --exclude-platform %[2]s` and re-try.\n"+
-					"If you think this package should be compatible with %[2]s, then "+
-					"it's possible this particular version is not available yet from the nix registry. "+
-					"You could try `devbox add` with a different version for this package.\n",
-				input.Raw,
-				platform,
-			)
-		}
-	}
-	stepMsg := args.Package
+	stepMsg := args.PackageName
 	if args.CustomStepMessage != "" {
 		stepMsg = args.CustomStepMessage
 		// Only print this first one if we have a custom message. Otherwise it feels
@@ -234,12 +207,12 @@ func ProfileInstall(ctx context.Context, args *ProfileInstallArgs) error {
 		fmt.Fprintf(args.Writer, "%s\n", stepMsg)
 	}
 
-	installable, err := input.Installable()
-	if err != nil {
-		return err
-	}
-
-	err = nix.ProfileInstall(args.Writer, args.ProfilePath, installable)
+	err := nix.ProfileInstall(ctx, &nix.ProfileInstallArgs{
+		Installable: args.Installable,
+		Offline:     args.Offline,
+		ProfilePath: args.ProfilePath,
+		Writer:      args.Writer,
+	})
 	if err != nil {
 		fmt.Fprintf(args.Writer, "%s: ", stepMsg)
 		color.New(color.FgRed).Fprintf(args.Writer, "Fail\n")
@@ -249,18 +222,4 @@ func ProfileInstall(ctx context.Context, args *ProfileInstallArgs) error {
 	fmt.Fprintf(args.Writer, "%s: ", stepMsg)
 	color.New(color.FgGreen).Fprintf(args.Writer, "Success\n")
 	return nil
-}
-
-// ProfileRemoveItems removes the items from the profile, in a single call, using their indexes.
-// It is up to the caller to ensure that the underlying profile has not changed since the items
-// were queried.
-func ProfileRemoveItems(profilePath string, items []*NixProfileListItem) error {
-	if len(items) == 0 {
-		return nil
-	}
-	indexes := []string{}
-	for _, item := range items {
-		indexes = append(indexes, strconv.Itoa(item.index))
-	}
-	return nix.ProfileRemove(profilePath, indexes)
 }

--- a/testscripts/add/add_platforms_flakeref.test.txt
+++ b/testscripts/add/add_platforms_flakeref.test.txt
@@ -2,8 +2,14 @@
 
 exec devbox install
 
-exec devbox add github:F1bonacc1/process-compose/v0.40.2 --exclude-platform x86_64-darwin
+# aside: choose armv7l-linux to verify that the add actually works on the
+# current host that is unlikely to be armv7l-linux
+exec devbox add github:F1bonacc1/process-compose/v0.40.2 --exclude-platform armv7l-linux
 json.superset devbox.json expected_devbox1.json
+
+# verify that the package is installed on this platform
+exec devbox run -- process-compose version
+stdout '0.40.2'
 
 -- devbox.json --
 {
@@ -19,8 +25,7 @@ json.superset devbox.json expected_devbox1.json
     "hello": "",
     "cowsay": "latest",
     "github:F1bonacc1/process-compose/v0.40.2": {
-      "excluded_platforms": ["x86_64-darwin"]
+      "excluded_platforms": ["armv7l-linux"]
     }
   }
 }
-

--- a/testscripts/add/global_add.test.txt
+++ b/testscripts/add/global_add.test.txt
@@ -4,7 +4,7 @@
 ! exec vim --version
 exec devbox global add ripgrep vim
 
-exec devbox global shellenv
+exec devbox global shellenv --recompute
 source.path
 exec rg --version
 exec vim --version

--- a/testscripts/languages/php.test.txt
+++ b/testscripts/languages/php.test.txt
@@ -1,18 +1,13 @@
 exec devbox run php index.php
 stdout 'done\n'
 
-# temporarily disable rm test until we fix. It requires ensuring that package 
-# in profile matches the flake we are installing.
-# For non-flakes, this involves comparing versions. For flakes we need to compare 
-# the content (or hash)
+exec devbox rm php81Extensions.ds
+exec devbox run php index.php
+stdout 'ds extension is not enabled'
 
-# exec devbox rm php81Extensions.ds
-# exec devbox run php index.php
-# stdout 'ds extension is not enabled'
-
-# exec devbox add php81Extensions.ds
-# exec devbox run php index.php
-# stdout 'done\n'
+exec devbox add php81Extensions.ds
+exec devbox run php index.php
+stdout 'done\n'
 
 -- devbox.json --
 {

--- a/testscripts/packages/unfree.test.txt
+++ b/testscripts/packages/unfree.test.txt
@@ -4,6 +4,6 @@ exec devbox init
 
 # we could test with slack and/or vscode. Using slack since it is lighter.
 exec devbox add slack
-stderr 'Installing package: slack.'
+stderr 'Adding package "slack@latest" to devbox.json'
 
 exec devbox rm slack


### PR DESCRIPTION
## Summary

This PR is a re-write of #1692. See motivation and discussion there.

**Motivation**
This PR seeks to unify our nix print-dev-env and nix profile steps. Other benefits:
- It will enable us to remove some hacks (example, this one [introduced for glibc-patch](https://github.com/jetpack-io/devbox/blob/d66f6ea5388adb3b90008c64a1b9b9abdc4550cd/internal/devbox/devbox.go#L938-L944))
- Re-enable some testscripts that were disabled (example, this [one for php extension removal](https://github.com/jetpack-io/devbox/blob/main/testscripts/languages/php.test.txt#L4-L15))

Previously, these would be two separate processes: we'd manually do nix profile install.
Now, we get the `buildInputPaths` from `nix print-dev-env` and install those, so the nix profile is derived from the flake.

**Implementation notes**
1. In `ensureStateIsUpToDate`, I had to modify the logic in #1724: call `d.installPackages` that creates plugin files, installs runx and nix packages. Also, move all lockfile operations to the end for _all_ modes, instead of just for `recomputeState == true`.
2. The `nix build` operation now happens with the `[1/3] go@1.21: Success` output that previously would happen with `nix profile install`.
3. Instead of `nixprofiles.NixProfileInstall`, we first install via `nix build` to ensure the package is installed in the local nix store. We then call `devbox.syncNixProfile` to get the `buildInputs` from `devbox.computeEnv` and `nix profile install $buildInputs`.



## How was it tested?

- CICD tests pass
- Did basic sanity checking with `devbox add hello cowsay` and `devbox rm hello cowsay`. 
- Used the Devbox binary for development for a while.



To verify that we can install packages in `/nix/store` during `devbox add`, and then use that during offline in `devbox shell`:
1. Do `devbox add python@3.11.6`
2. Do `devbox shell` and exit, or just `devbox install`.
3. Turn Wifi off, and then open `devbox shell` and verify that the newly installed version of `python` is used.
BEFORE: we could skip step 2, because we directly installed packages in the nix profile
AFTER: step 2 is required because we re-evaluate the flake's environment and derive nix profile from it.