### PR TITLE
[mysql plugin] use --log-error instead of 2>

### DIFF
--- a/examples/databases/mariadb/devbox.lock
+++ b/examples/databases/mariadb/devbox.lock
@@ -2,23 +2,23 @@
   "lockfile_version": "1",
   "packages": {
     "mariadb@latest": {
-      "last_modified": "2023-08-30T00:25:28Z",
-      "plugin_version": "0.0.1",
-      "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#mariadb_110",
+      "last_modified": "2024-01-14T03:55:27Z",
+      "plugin_version": "0.0.4",
+      "resolved": "github:NixOS/nixpkgs/dd5621df6dcb90122b50da5ec31c411a0de3e538#mariadb_110",
       "source": "devbox-search",
-      "version": "11.0.3",
+      "version": "11.0.4",
       "systems": {
         "aarch64-darwin": {
-          "store_path": "/nix/store/d5nb44vw8yy22lc21ld75nndmn9c3cgr-mariadb-server-11.0.3"
+          "store_path": "/nix/store/kslavfq486v9nsw6mkgxxk9njmvsi75n-mariadb-server-11.0.4"
         },
         "aarch64-linux": {
-          "store_path": "/nix/store/sz5n9bkcjxklk4jd0p5h26yi5j79wh7h-mariadb-server-11.0.3"
+          "store_path": "/nix/store/94v1z5jnk00flh0x7crhnkvkzbprh6r8-mariadb-server-11.0.4"
         },
         "x86_64-darwin": {
-          "store_path": "/nix/store/4l6h83flncplm3kmry1w08msyy7b7vdw-mariadb-server-11.0.3"
+          "store_path": "/nix/store/ykmll4wccnrw42nf4dric08g7axv60r1-mariadb-server-11.0.4"
         },
         "x86_64-linux": {
-          "store_path": "/nix/store/047g9nxp6jb2bqj1f53qk86sjzrscbmj-mariadb-server-11.0.3"
+          "store_path": "/nix/store/qx6dp64yxjazv7nkamiyy1vx9zji77k7-mariadb-server-11.0.4"
         }
       }
     }

--- a/examples/databases/mysql/devbox.lock
+++ b/examples/databases/mysql/devbox.lock
@@ -2,10 +2,25 @@
   "lockfile_version": "1",
   "packages": {
     "mysql80@latest": {
-      "last_modified": "2023-06-29T16:20:38Z",
-      "plugin_version": "0.0.1",
-      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#mysql80",
-      "version": "8.0.33"
+      "last_modified": "2024-01-14T03:55:27Z",
+      "plugin_version": "0.0.3",
+      "resolved": "github:NixOS/nixpkgs/dd5621df6dcb90122b50da5ec31c411a0de3e538#mysql80",
+      "source": "devbox-search",
+      "version": "8.0.35",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/pimnmdghivjx1xbym1p0rcqqcr522pxd-mysql-8.0.35"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/w3c48ad6didigbvahxhcjyjjda0g01vh-mysql-8.0.35"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/y4lza0lv90fggfrc5pak0q0i3x8jjav5-mysql-8.0.35"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/ca1q2q9h5k3hs8shivgmh9bfi51hw97p-mysql-8.0.35"
+        }
+      }
     }
   }
 }

--- a/plugins/mariadb.json
+++ b/plugins/mariadb.json
@@ -1,6 +1,6 @@
 {
   "name": "mariadb",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "readme": "* This plugin wraps mysqld and mysql_install_db to work in your local project\n* This plugin will create a new database for your project in MYSQL_DATADIR if one doesn't exist on shell init\n* Use mysqld to manually start the server, and `mysqladmin -u root shutdown` to manually stop it",
   "env": {
     "MYSQL_BASEDIR": "{{ .DevboxProfileDefault }}",

--- a/plugins/mariadb/process-compose.yaml
+++ b/plugins/mariadb/process-compose.yaml
@@ -2,7 +2,7 @@ version: "0.5"
 
 processes:
   mariadb:
-    command: "mysqld 2> $MYSQL_HOME/mysql.log & MYSQL_PID=$! && echo 'Starting mysqld... check mariadb_logs for details'"
+    command: "mysqld --log-error=$MYSQL_HOME/mysql.log & MYSQL_PID=$! && echo 'Starting mysqld... check mariadb_logs for details'"
     is_daemon: true
     shutdown:
       command: "mysqladmin -u root shutdown"

--- a/plugins/mysql.json
+++ b/plugins/mysql.json
@@ -1,6 +1,6 @@
 {
     "name": "mysql",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "readme": "* This plugin wraps mysqld and mysql_install_db to work in your local project\n* This plugin will create a new database for your project in MYSQL_DATADIR if one doesn't exist on shell init. This DB will be started in `insecure` mode, so be sure to add a root password after creation if needed.\n* Use mysqld to manually start the server, and `mysqladmin -u root shutdown` to manually stop it",
     "env": {
       "MYSQL_BASEDIR": "{{ .DevboxProfileDefault }}",

--- a/plugins/mysql/process-compose.yaml
+++ b/plugins/mysql/process-compose.yaml
@@ -2,7 +2,7 @@ version: "0.5"
 
 processes:
   mysql:
-    command: "mysqld 2> $MYSQL_HOME/mysql.log & MYSQL_PID=$! && echo 'Starting mysqld... check mysql_logs for details'"
+    command: "mysqld --log-error=$MYSQL_HOME/mysql.log & MYSQL_PID=$! && echo 'Starting mysqld... check mysql_logs for details'"
     is_daemon: true
     shutdown:
       command: "mysqladmin -u root shutdown"


### PR DESCRIPTION
## Summary

This PR fixes a permissions issue that can arise when running the MySQL plugin in CI. 

Previous versions of the mysql plugin were creating error logs in the virtenv directory by routing stderr to a file. While this kept the error logs local, mysql would still create a log file in `/var/logs`. This worked fine on user machines, but could hit permission errors in CI. 

This update now creates the error log using the --log-error flag. This should override any log creation in `/var`, which will avoid the permissions error. 

## How was it tested?

Tested locally, verified the service was still working and error logs were being captured