### PR TITLE
[fish] Fix init hooks for fish

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -204,7 +204,6 @@ func (d *Devbox) Shell(ctx context.Context) error {
 	}
 
 	opts := []ShellOption{
-		WithHooksFilePath(shellgen.ScriptPath(d.ProjectDir(), shellgen.HooksFilename)),
 		WithHistoryFile(filepath.Join(d.projectDir, shellHistoryFile)),
 		WithProjectDir(d.projectDir),
 		WithEnvVariables(envs),

--- a/internal/devbox/shell_test.go
+++ b/internal/devbox/shell_test.go
@@ -67,9 +67,8 @@ func testWriteDevboxShellrc(t *testing.T, testdirs []string) {
 			s := &DevboxShell{
 				devbox:          &Devbox{projectDir: projectDir},
 				env:             test.env,
-				projectDir:      "path/to/projectDir",
+				projectDir:      "/path/to/projectDir",
 				userShellrcPath: test.shellrcPath,
-				hooksFilePath:   test.hooksFilePath,
 			}
 			gotPath, err := s.writeDevboxShellrc()
 			if err != nil {

--- a/internal/devbox/testdata/shellrc/basic/shellrc.golden
+++ b/internal/devbox/testdata/shellrc/basic/shellrc.golden
@@ -15,7 +15,7 @@ export PS1="(devbox) $PS1"
 
 # Run plugin and user init hooks from the devbox.json directory.
 working_dir="$(pwd)"
-cd "path/to/projectDir" || exit
+cd "/path/to/projectDir" || exit
 
 # Source the hooks file, which contains the project's init hooks and plugin hooks.
 . /path/to/projectDir/.devbox/gen/scripts/.hooks.sh

--- a/internal/devbox/testdata/shellrc/noshellrc/shellrc.golden
+++ b/internal/devbox/testdata/shellrc/noshellrc/shellrc.golden
@@ -9,7 +9,7 @@ export PS1="(devbox) $PS1"
 
 # Run plugin and user init hooks from the devbox.json directory.
 working_dir="$(pwd)"
-cd "path/to/projectDir" || exit
+cd "/path/to/projectDir" || exit
 
 # Source the hooks file, which contains the project's init hooks and plugin hooks.
 . /path/to/projectDir/.devbox/gen/scripts/.hooks.sh

--- a/internal/shellgen/tmpl/init-hook-fish.tmpl
+++ b/internal/shellgen/tmpl/init-hook-fish.tmpl
@@ -1,12 +1,12 @@
-
+{{/* Fish version */ -}}
 {{/* if hash is set, we're in recursive loop, just exit */ -}}
 
-if [ -n "${{ .InitHookHash }}" ]; then
+if set -q {{ .InitHookHash }}; then
     return
-fi
+end
 
 export {{ .InitHookHash }}=true
 
 {{ .Body }}
 
-unset {{ .InitHookHash }}
+set -e {{ .InitHookHash }}


### PR DESCRIPTION
## Summary

Fixes issue introduced in https://github.com/jetpack-io/devbox/pull/1709

`devbox run` uses `sh` instead of native shell. So init hooks must always be `sh` compatible for `run`. On the other hand, `devbox shell` uses native shell so init hooks must be `fish` if the native shell is fish.

This is ugly, but it's how it has always worked. 

https://github.com/jetpack-io/devbox/pull/1709 introduced recursion protection that would be `fish` or `sh` depending on native shell. This worked fine for `devbox shell` but would break `devbox run`. 

This change fixes that by creating 2 hooks files, one fish and one sh and sourcing the correct one in shellrc, while still always using the `sh` for run.

cc: @Lagoja 

## How was it tested?

```
devbox run echo 5
devbox shell
SHELL=fish devbox run echo 5
SHELL=fish devbox shell
```