### PR TITLE
Option to disable modification of the user's prompt.

### DIFF
--- a/internal/devbox/shellrc.tmpl
+++ b/internal/devbox/shellrc.tmpl
@@ -38,8 +38,11 @@ ignore the existing value of HISTFILE.
 HISTFILE="{{ .HistoryFile }}"
 {{- end }}
 
-# Prepend to the prompt to make it clear we're in a devbox shell.
-export PS1="(devbox) $PS1"
+# If the user hasn't specified they want to handle the prompt themselves,
+# prepend to the prompt to make it clear we're in a devbox shell.
+if [ -z "$DEVBOX_NO_PROMPT" ]; then
+  export PS1="(devbox) $PS1"
+fi
 
 {{- if .ShellStartTime }}
 # log that the shell is ready now!

--- a/internal/devbox/shellrc_fish.tmpl
+++ b/internal/devbox/shellrc_fish.tmpl
@@ -38,10 +38,13 @@ enough approximation for now.
 set fish_history devbox
 {{- end }}
 
-# Prepend to the prompt to make it clear we're in a devbox shell.
-functions -c fish_prompt __devbox_fish_prompt_orig
-function fish_prompt
-    echo "(devbox)" (__devbox_fish_prompt_orig)
+# If the user hasn't specified they want to handle the prompt themselves,
+# prepend to the prompt to make it clear we're in a devbox shell.
+if not set -q devbox_no_prompt
+    functions -c fish_prompt __devbox_fish_prompt_orig
+    function fish_prompt
+        echo "(devbox)" (__devbox_fish_prompt_orig)
+    end
 end
 
 {{- if .ShellStartTime }}

--- a/internal/devbox/testdata/shellrc/basic/shellrc.golden
+++ b/internal/devbox/testdata/shellrc/basic/shellrc.golden
@@ -8,8 +8,11 @@ export simple="value";
 export space="quote me";
 export special="\$\`\"\\";
 
-# Prepend to the prompt to make it clear we're in a devbox shell.
-export PS1="(devbox) $PS1"
+# If the user hasn't specified they want to handle the prompt themselves,
+# prepend to the prompt to make it clear we're in a devbox shell.
+if [ -z "$DEVBOX_NO_PROMPT" ]; then
+  export PS1="(devbox) $PS1"
+fi
 
 # End Devbox Post-init Hook
 

--- a/internal/devbox/testdata/shellrc/noshellrc/shellrc.golden
+++ b/internal/devbox/testdata/shellrc/noshellrc/shellrc.golden
@@ -2,8 +2,11 @@
 
 
 
-# Prepend to the prompt to make it clear we're in a devbox shell.
-export PS1="(devbox) $PS1"
+# If the user hasn't specified they want to handle the prompt themselves,
+# prepend to the prompt to make it clear we're in a devbox shell.
+if [ -z "$DEVBOX_NO_PROMPT" ]; then
+  export PS1="(devbox) $PS1"
+fi
 
 # End Devbox Post-init Hook
 


### PR DESCRIPTION
## Summary

Devbox prefixes the user's prompt (PS1) with `(devbox)` when inside the `devbox shell`. Unfortunately, this doesn't look great with prompts which have been customized (with starship for example). 

Disable prompt modification by setting either `DEVBOX_NO_PROMPT` or `devbox_no_prompt` (fish) in your shell. Now the user can detect devbox and display it on their PS1 using the method if their choosing.

Fixes #845.

## How was it tested?

### bash and zsh

I ran the command in these shells with `export DEVBOX_NO_PROMPT=true` and without the variable (`unset DEVBOX_NO_PROMPT`) and observed the results. 

```
if [ -z "$DEVBOX_NO_PROMPT" ]; then
  export PS1="(devbox) $PS1"
fi
```

### fish

Disclaimer, I'm not a fish user. I installed fish and read the documentation.

I added `set devbox_no_prompt true` to my `.config/fish/config.fish`, then removed it and observed the results.

```
if not set -q devbox_no_prompt
    functions -c fish_prompt __devbox_fish_prompt_orig
    function fish_prompt
        echo "(devbox)" (__devbox_fish_prompt_orig)
    end
end
```