### PR TITLE
[vscode-extension] Logging events in logfile

### DIFF
--- a/vscode-extension/src/devbox.ts
+++ b/vscode-extension/src/devbox.ts
@@ -64,7 +64,6 @@ export async function devboxReopen() {
           // handle CLI finishing the env and sending  "finished"
           child.on('message', function (msg: Message, handle) {
             if (msg.status === "finished") {
-              logToFile(dotdevbox, 'Finished setting up! Reloading the window');
               progress.report({ message: 'Finished setting up! Reloading the window...', increment: 100 });
               resolve();
               commands.executeCommand("workbench.action.closeWindow");


### PR DESCRIPTION
## Summary
Added capability to log sequence of events and potential errors in "Re-open in devbox shell environment" functionality of the extension. 
This involved adding a log file in `.devbox/extension.log` file which both the vscode extension process and devbox binary will output their logs into. 

## How was it tested?
TBD