### PR TITLE
Update Docs: direnv, gen readme, FAQs

### DIFF
--- a/docs/app/docs/cli_reference/devbox_generate.md
+++ b/docs/app/docs/cli_reference/devbox_generate.md
@@ -1,6 +1,6 @@
 # devbox generate
 
-Top level command for generating Devcontainer and Dockerfiles for your Devbox Project. 
+Top level command for generating Devcontainers,  Dockerfiles, and other useful files for your Devbox Project. 
 
 ```bash
 devbox generate <devcontainer|dockerfile|direnv> [flags]
@@ -18,8 +18,9 @@ devbox generate <devcontainer|dockerfile|direnv> [flags]
 ## Subcommands
 
 * [devbox generate devcontainer](devbox_generate_devcontainer.md)	 - Generate Dockerfile and devcontainer.json files under .devcontainer/ directory
-* [devbox generate dockerfile](devbox_generate_dockerfile.md)	 - Generate a Dockerfile that replicates devbox shell
 * [devbox generate direnv](devbox_generate_direnv.md)  - Generate a .envrc file to use with direnv
+* [devbox generate dockerfile](devbox_generate_dockerfile.md)	 - Generate a Dockerfile that replicates devbox shell
+* [devbox generate readme](devbox_generate_dockerfile.md)	 -  Generate markdown readme file for your project
 
 ## SEE ALSO
 

--- a/docs/app/docs/cli_reference/devbox_generate_readme.md
+++ b/docs/app/docs/cli_reference/devbox_generate_readme.md
@@ -1,0 +1,22 @@
+# devbox generate readme
+
+Generate a markdown readme file for this project. You must specify a name for the Readme file when running the command:
+
+```bash
+devbox generate readme [filename] [flags]
+```
+
+## Options
+
+<!-- Markdown Table of Options -->
+| Option | Description |
+| --- | --- |
+| `-c, --config string` | path to directory containing a devbox.json config file |
+| `-h, --help` | help for dockerfile |
+| `-q, --quiet` | Quiet mode: Suppresses logs. |
+
+
+## SEE ALSO
+
+* [devbox generate](devbox_generate.md)	 - 
+

--- a/docs/app/docs/faq.md
+++ b/docs/app/docs/faq.md
@@ -35,13 +35,29 @@ In order to save space, Devbox and Nix only install the required components of p
 
 You can learn more about non-default outputs [here](./guides/using_flakes.md#installing-additional-outputs-from-a-flake).
 
+## I'm trying to build a project, but it says that I'm missing `libstdc++`. How do I install this library in my project?
+
+This message means that your project requires an implementation of the C++ Standard Library installed and linked within your shell. You can add the libstdc++ libraries and object files using `devbox add stdenv.cc.cc.lib`. 
+
 ## How can I use custom Nix packages or overrides with Devbox?
 
 You can add customized packages to your Devbox environment using our [Flake support](./guides/using_flakes.md). You can use these flakes to modify or override packages from nixpkgs, or to create your own custom packages.
 
 ## Can I use Devbox if I use [Fish](https://fishshell.com/)?
 
-Yes. In addition to supporting POSIX compliant shells like Zsh and Bash, Devbox also works with Fish.
+Yes. In addition to supporting POSIX compliant shells like Zsh and Bash, Devbox also works with Fish. 
+
+Note that `init_hooks` in Devbox will be run directly in your host shell, so you may have encounter some compatibility issues if you try to start a shell that uses a POSIX-compatible script in the init_hook.  
+
+## How can I rollback to a previous version of Devbox?
+
+You can use any previous version of Devbox by setting the `DEVBOX_USE_VERSION` environment variable. For example, to use version 0.8.0, you can run the following or add it to your shell's rcfile: 
+
+```bash
+export DEVBOX_USE_VERSION=0.8.0
+```
+
+You can upgrade to the latest version of Devbox by unsetting the variable, and running `devbox version update`
 
 ## How can I uninstall Devbox?
 

--- a/docs/app/docs/ide_configuration/direnv.md
+++ b/docs/app/docs/ide_configuration/direnv.md
@@ -101,6 +101,15 @@ prefix = [ "/absolute/path/to/project" ]
 
 ```
 
+### Direnv Limitations
+
+Direnv works by creating a sub-shell using your `.envrc` file, your `devbox.json`, and other direnv related files, and then exporting the diff in environment variables into your current shell. This imposes some limitations on what it can load into your shell: 
+
+1. Direnv cannot load shell aliases or shell functions that are sourced in your project's `init_hook`. If you want to use direnv and also configure custom aliases, we recommend using [Devbox Scripts](../guides/scripts.md). 
+2. Direnv does not allow modifications to the $PS1 environment variable. This means `init_hooks` that modify your prompt will not work as expected. For more information, see the [direnv wiki](https://github.com/direnv/direnv/wiki/PS1)
+
+Note that sourcing aliases, functions, and `$PS1` should work as expected when using `devbox shell`, `devbox run`, and `devbox services`
+
 ### VSCode setup with direnv
 
 To seamlessly integrate VSCode with a direnv environment, follow these steps:

--- a/docs/app/docs/installing_devbox.mdx
+++ b/docs/app/docs/installing_devbox.mdx
@@ -85,8 +85,34 @@ To install on a non NixOS:
 nix-env -iA nixpkgs.devbox
 ```
 
+or 
+
+```bash
+nix profile install nixpkgs#devbox
+```
+
 </TabItem>
 </Tabs>
+
+## Updating Devbox
+
+Devbox will notify you when a new version is available. To update to the latest released version of Devbox, you can run `devbox version update`. 
+
+If you installed Devbox with Nix, you can update Devbox via Nix using `nix-env -u devbox`, or `nix profile upgrade`.
+
+You can find release notes and details on the [Releases page](http://github.com/jetpack-io/devbox/releases) of the Devbox Github repo.
+
+## Rolling Back or Pinning a Specific Version of Devbox
+
+You can rollback or pin the version of Devbox on your system using the `DEVBOX_USE_VERSION` environment variable. For example, to use version 0.8.0: 
+
+```bash
+export DEVBOX_USE_VERSION=0.8.0
+```
+
+Setting this variable will use the specified version of Devbox even if a newer version has been installed on your machine. 
+
+If you installed Devbox with Nixpkgs, you will need to pin Devbox in your profile or Nix configuration. You can find the Nixpkg commits for previous versions of Devbox on [Nixhub](https://www.nixhub.io/packages/devbox). 
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

* Adds two FAQs around pinning Devbox Version, and handling libstdc++ libraries
* Updates Direnv docs to explain 2 limitations around aliases/functions and modifying $PS1
* Updated Installation instructions to cover updating and pinning the version
* Adds docs for `devbox generate readme`

## How was it tested?

Localhost
