### PR TITLE
[add] migrate allow_insecure from lockfile to config

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -113,9 +113,16 @@ func Open(opts *devopt.Opts) (*Devbox, error) {
 	}
 	// if lockfile has any allow insecure, we need to set the env var to ensure
 	// all nix commands work.
-	if lock.HasAllowInsecurePackages() {
-		nix.AllowInsecurePackages()
+	if err := box.moveAllowInsecureFromLockfile(box.stderr, lock, cfg); err != nil {
+		ux.Fwarning(
+			box.stderr,
+			"Failed to move allow_insecure from devbox.lock to devbox.json. An insecure package may "+
+				"not work until you invoke `devbox add <pkg> --allow-insecure=<packages>` again: %s\n",
+			err,
+		)
+		// continue on, since we do not want to block user.
 	}
+
 	box.pluginManager.ApplyOptions(
 		plugin.WithDevbox(box),
 		plugin.WithLockfile(lock),

--- a/testscripts/testrunner/examplesrunner.go
+++ b/testscripts/testrunner/examplesrunner.go
@@ -75,12 +75,6 @@ func RunDevboxTestscripts(t *testing.T, dir string) {
 			return nil
 		}
 
-		if strings.Contains(path, "insecure") {
-			// TODO: next PR will fix this
-			t.Logf("skipping insecure, config at: %s\n", path)
-			return nil
-		}
-
 		t.Logf("running testscript for example: %s\n", path)
 		runSingleDevboxTestscript(t, dir, path)
 		return nil


### PR DESCRIPTION
## Summary

This PR migrates the `allow_insecure` setting in `devbox.lock` of existing projects to `devbox.json`.

## How was it tested?

Set up project with an insecure package `devbox add python@2.7.18 --allow-insecure` using the prod Devbox binary:
```
❯ git diff
diff --git a/devbox.json b/devbox.json
index cf698ebc..45aac7cc 100644
--- a/devbox.json
+++ b/devbox.json
@@ -5,6 +5,7 @@
     "go":                          "latest",
     "runx:golangci/golangci-lint": "latest",
     "runx:mvdan/gofumpt":          "latest",
+    "python":                      "2.7.18",
   },
   "env": {
     "GOENV": "off",
diff --git a/devbox.lock b/devbox.lock
index 7d4cb7e2..b54fd69b 100644
--- a/devbox.lock
+++ b/devbox.lock
@@ -21,6 +21,14 @@
         }
       }
     },
+    "python@2.7.18": {
+      "allow_insecure": true,
+      "last_modified": "2024-01-14T03:55:27Z",
+      "plugin_version": "0.0.3",
+      "resolved": "github:NixOS/nixpkgs/dd5621df6dcb90122b50da5ec31c411a0de3e538#python2",
+      "source": "devbox-search",
+      "version": "2.7.18.7"
+    },
     "runx:golangci/golangci-lint@latest": {
       "resolved": "golangci/golangci-lint@v1.55.2",
       "version": "v1.55.2"
```

Then, run `devbox shell`:
```
❯ devbox shell
Info: Allowed insecure python-2.7.18.7 for package python@2.7.18
Info: Modernized the allow_insecure setting for package "python@2.7.18" by moving it from devbox.lock to devbox.json. Please commit the changes.
Ensuring packages are installed.
✓ Computed the Devbox environment.
Starting a devbox shell...
Info: Your devbox environment may be out of date. Please run

eval "$(devbox global shellenv --recompute)"

You can activate the virtual environment by running 'source $VENV_DIR/bin/activate'


❯ git diff
diff --git a/devbox.json b/devbox.json
index cf698ebc..60cf203e 100644
--- a/devbox.json
+++ b/devbox.json
@@ -5,6 +5,10 @@
     "go":                          "latest",
     "runx:golangci/golangci-lint": "latest",
     "runx:mvdan/gofumpt":          "latest",
+    "python": {
+      "version":        "2.7.18",
+      "allow_insecure": ["python-2.7.18.7"],
+    },
   },
   "env": {
     "GOENV": "off",
diff --git a/devbox.lock b/devbox.lock
index 7d4cb7e2..adc9123c 100644
--- a/devbox.lock
+++ b/devbox.lock
@@ -21,6 +21,13 @@
         }
       }
     },
+    "python@2.7.18": {
+      "last_modified": "2024-01-14T03:55:27Z",
+      "plugin_version": "0.0.3",
+      "resolved": "github:NixOS/nixpkgs/dd5621df6dcb90122b50da5ec31c411a0de3e538#python2",
+      "source": "devbox-search",
+      "version": "2.7.18.7"
+    },
     "runx:golangci/golangci-lint@latest": {
       "resolved": "golangci/golangci-lint@v1.55.2",
       "version": "v1.55.2"
(devbox)
```


