### PR TITLE
[fish] use exit instead of return in init-hook recursion guard

### DIFF
--- a/internal/shellgen/tmpl/init-hook-fish.tmpl
+++ b/internal/shellgen/tmpl/init-hook-fish.tmpl
@@ -2,7 +2,7 @@
 {{/* if hash is set, we're in recursive loop, just exit */ -}}
 
 if set -q {{ .InitHookHash }}; then
-    return
+    exit
 end
 
 export {{ .InitHookHash }}=true

--- a/internal/shellgen/tmpl/init-hook-fish.tmpl
+++ b/internal/shellgen/tmpl/init-hook-fish.tmpl
@@ -2,7 +2,7 @@
 {{/* if hash is set, we're in recursive loop, just exit */ -}}
 
 if set -q {{ .InitHookHash }}; then
-    exit
+    exit 0
 end
 
 export {{ .InitHookHash }}=true


### PR DESCRIPTION
## Summary

Problem:
```
❯ SHELL=$(which fish) devbox shell
Starting a devbox shell...
~/code/jetpack/devbox/.devbox/gen/scripts/.hooks.fish.sh (line 2): 'return' outside of function definition
    return
    ^
from sourcing file ~/code/jetpack/devbox/.devbox/gen/scripts/.hooks.fish.sh
	called on line 164 of file /var/folders/zv/r3sx92_94gq86_rq3yn1ky2h0000gn/T/devbox340516573/config.fish
from sourcing file /var/folders/zv/r3sx92_94gq86_rq3yn1ky2h0000gn/T/devbox340516573/config.fish
source: Error while reading file “/Users/savil/code/jetpack/devbox/.devbox/gen/scripts/.hooks.fish.sh”
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish
(devbox) savil@Savil-Srivastavas-MacBook-Pro ~/c/j/devbox (main)> exit
```

Fix: use `exit` instead of `return`

## How was it tested?

Made the following changes locally:
```
❯ git diff
diff --git a/devbox.json b/devbox.json
index cf698ebc..3ceff8fb 100644
--- a/devbox.json
+++ b/devbox.json
@@ -13,8 +13,11 @@
   "shell": {
     "init_hook": [
       "test -z $FISH_VERSION && unset CGO_ENABLED GO111MODULE GOARCH GOFLAGS GOMOD GOOS GOROOT GOTOOLCHAIN GOWORK",
+      "devbox run fishy",
+      "echo \"running after fishy\""
     ],
     "scripts": {
+      "fishy": "echo \"hello from fishy\"",
       "build":
         // Build devbox for the current platform
         "go build -o dist/devbox ./cmd/devbox",
diff --git a/internal/devbox/shellrc_fish.tmpl b/internal/devbox/shellrc_fish.tmpl
index a50b3fb2..3c8227de 100644
--- a/internal/devbox/shellrc_fish.tmpl
+++ b/internal/devbox/shellrc_fish.tmpl
@@ -61,6 +61,8 @@ cd "{{ .ProjectDir }}" || exit
 # Source the hooks file, which contains the project's init hooks and plugin hooks.
 source {{ .HooksFilePath }}

+set FOO_AFTER_HOOKS true
+
 cd "$workingDir" || exit

 {{- if .ShellStartTime }}
```

Then ran: `SHELL=$(which fish) devbox shell` and saw that:
1. `hello from fishy` and `running after fishy` were both echo'd.
2. `FOO_AFTER_HOOKS` was set to true.
No other errors.
