### PR TITLE
[fish] use fish hooks file for devbox.EnvExports (used in shellenv)

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -325,7 +325,13 @@ func (d *Devbox) EnvExports(ctx context.Context, opts devopt.EnvExportsOpts) (st
 	envStr := exportify(envs)
 
 	if opts.RunHooks {
-		hooksStr := ". " + shellgen.ScriptPath(d.ProjectDir(), shellgen.HooksFilename)
+		hooksFilename := shellgen.HooksFilename
+		if isFishShell() {
+			hooksFilename = shellgen.HooksFishFilename
+		}
+
+		hooksStr := ". " + shellgen.ScriptPath(d.ProjectDir(), hooksFilename)
+
 		envStr = fmt.Sprintf("%s\n%s;\n", envStr, hooksStr)
 	}
 


### PR DESCRIPTION
## Summary

I was getting shell script parsing errors when doing
`devbox global shellenv --init-hook | source`
in fish

Turns out, we were sourcing the init-hook file for non-fish. This PR fixes that

## How was it tested?

Ran the above command succesfully in a fish shell
