### PR TITLE
Update PostgreSQL example for cross-platform

### DIFF
--- a/docs/app/docs/devbox_examples/databases/postgres.md
+++ b/docs/app/docs/devbox_examples/databases/postgres.md
@@ -9,7 +9,7 @@ PostgreSQL can be automatically configured by Devbox via the built-in Postgres P
 
 ## Adding Postgres to your Shell
 
-You can install the PostgreSQL server and client by running`devbox add postgresql`. In some Linux distributions, you may also need to add `glibcLocales`, which can be added using `devbox add glibcLocales -p x86_64-linux,aarch64-linux`.
+You can install the PostgreSQL server and client by running`devbox add postgresql`. In some Linux distributions, you may also need to add `glibcLocales`, which can be added using `devbox add glibcLocales --platform=x86_64-linux,aarch64-linux`.
 
 Alternatively, you can add the following to your devbox.json:
 

--- a/docs/app/docs/devbox_examples/databases/postgres.md
+++ b/docs/app/docs/devbox_examples/databases/postgres.md
@@ -9,13 +9,18 @@ PostgreSQL can be automatically configured by Devbox via the built-in Postgres P
 
 ## Adding Postgres to your Shell
 
-`devbox add postgresql glibcLocales`, or in your `devbox.json`, add
+You can install the PostgreSQL server and client by running`devbox add postgresql`. In some Linux distributions, you may also need to add `glibcLocales`, which can be added using `devbox add glibcLocales -p x86_64-linux,aarch64-linux`.
+
+Alternatively, you can add the following to your devbox.json:
 
 ```json
-    "packages": [
-        "postgresql@latest",
-        "glibcLocales@latest"
-    ]
+  "packages": {
+    "postgresql": "latest",
+    "glibcLocales": {
+      "version":   "latest",
+      "platforms": ["x86_64-linux", "aarch64-linux"]
+    }
+  }
 ```
 
 This will install the latest version of Postgres. You can find other installable versions of Postgres by running `devbox search postgresql`. You can also view the available versions on [Nixhub](https://www.nixhub.io/packages/postgresql)

--- a/examples/databases/postgres/devbox.json
+++ b/examples/databases/postgres/devbox.json
@@ -1,7 +1,11 @@
 {
-  "packages": [
-    "postgresql@latest"
-  ],
+  "packages": {
+    "postgresql": "latest",
+    "glibcLocales": {
+      "version":   "latest",
+      "platforms": ["x86_64-linux", "aarch64-linux"]
+    }
+  },
   "shell": {
     "init_hook": null
   }

--- a/examples/databases/postgres/devbox.lock
+++ b/examples/databases/postgres/devbox.lock
@@ -1,8 +1,23 @@
 {
   "lockfile_version": "1",
   "packages": {
+    "glibcLocales@latest": {
+      "last_modified": "2024-01-14T03:55:27Z",
+      "resolved": "github:NixOS/nixpkgs/dd5621df6dcb90122b50da5ec31c411a0de3e538#glibcLocales",
+      "source": "devbox-search",
+      "version": "2.38-27",
+      "systems": {
+        "aarch64-linux": {
+          "store_path": "/nix/store/i0aff1lm1js9j9ggw7js7n5869bfxm6z-glibc-locales-2.38-27"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/wyl74hap7bh513hp3rz1j608gs7267af-glibc-locales-2.38-27"
+        }
+      }
+    },
     "postgresql@latest": {
       "last_modified": "2023-05-01T16:53:22Z",
+      "plugin_version": "0.0.2",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#postgresql",
       "version": "14.7"
     }


### PR DESCRIPTION
## Summary

Current PostgreSQL example doesn't work on MacOS because it attempts to install glibcLocales. This updates the example and documentation to only install glibcLocales on Linux

## How was it tested?

CI/CD, run example locally
