### PR TITLE
[urgent] Disable recursion guard

### DIFF
--- a/internal/boxcli/featureflag/inithookrecursion.go
+++ b/internal/boxcli/featureflag/inithookrecursion.go
@@ -1,0 +1,3 @@
+package featureflag
+
+var InitHookRecursionGuard = disable("INIT_HOOK_RECURSION_GUARD")

--- a/internal/shellgen/scripts.go
+++ b/internal/shellgen/scripts.go
@@ -113,7 +113,7 @@ func writeInitHookFile(devbox devboxer, body, tmpl, filename string) (err error)
 	// skip adding init-hook recursion guard for the
 	// default hook or any empty hook
 	// there's nothing to guard, and it introduces complexity
-	if body == devconfig.DefaultInitHook || strings.TrimSpace(body) == "" {
+	if !featureflag.InitHookRecursionGuard.Enabled() || body == devconfig.DefaultInitHook || strings.TrimSpace(body) == "" {
 		_, err = script.WriteString(body)
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
## Summary

This disables recursion guard. That means that init hooks are always written as is (fish and non fish will look the same)

Fixes https://github.com/jetpack-io/devbox/issues/1744

## How was it tested?

Inspected hook scripts. 
