### PR TITLE
[update] change Error: to Warning: for failed attempt to upgrade flake

### DIFF
--- a/internal/devbox/update.go
+++ b/internal/devbox/update.go
@@ -183,7 +183,7 @@ func (d *Devbox) attemptToUpgradeFlake(pkg *devpkg.Package) error {
 
 	err = nixprofile.ProfileUpgrade(profilePath, pkg, d.lockfile)
 	if err != nil {
-		ux.Ferror(
+		ux.Fwarning(
 			d.stderr,
 			"Failed to upgrade %s using `nix profile upgrade`: %s\n",
 			pkg.Raw,


### PR DESCRIPTION
## Summary

When I modified the `examples/flakes/php` to omit `ds` extension and did `devbox update`, then the output alarmed me at first. 

The Error made me think something drastic went wrong. But in this case, since its an "attempt", I think we should
make it a Warning or even an Info.

```
❯ devbox update
Info: Attempting to upgrade path:my-php-flake#php using `nix profile upgrade`
Error: Failed to upgrade path:my-php-flake#php using `nix profile upgrade`: php: package not found
Info: Attempting to upgrade path:my-php-flake#hello using `nix profile upgrade`
Error: Failed to upgrade path:my-php-flake#hello using `nix profile upgrade`: hello: package not found
Info: Already up-to-date ripgrep@latest 14.1.0
[1/2] php
[1/2] php: Success
[2/2] hello
[2/2] hello: Success
✓ Computed the Devbox environment.
Info: Removing php-with-extensions@8.1.19
Warning: Your shell environment may be out of date. Run `refresh` to update it.
Info: Running "nix flake update"
(devbox)
```

## How was it tested?

```
❯ devbox update
Info: Attempting to upgrade path:my-php-flake#php using `nix profile upgrade`
Warning: Failed to upgrade path:my-php-flake#php using `nix profile upgrade`: php: package not found
Info: Attempting to upgrade path:my-php-flake#hello using `nix profile upgrade`
Warning: Failed to upgrade path:my-php-flake#hello using `nix profile upgrade`: hello: package not found
Info: Already up-to-date ripgrep@latest 14.1.0
[1/2] php
[1/2] php: Success
[2/2] hello
[2/2] hello: Success
✓ Computed the Devbox environment.
Info: Removing php-with-extensions@8.1.19
Warning: Your shell environment may be out of date. Run `refresh` to update it.
Info: Running "nix flake update"
(devbox)
```
