### PR TITLE
[state] Ignore shell mismatch for run

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -233,6 +233,7 @@ func (d *Devbox) RunScript(ctx context.Context, cmdName string, cmdArgs []string
 		return err
 	}
 
+	lock.SetIgnoreShellMismatch(true)
 	env, err := d.ensureStateIsUpToDateAndComputeEnv(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

This is a bit hacky, but was smallest, safest I could come up with. This fixes the following case:

* User uses fish as shell
* User adds `devbox run` in their init hook
*  User gets warning that environment is stale. This happens because shell doesn't match, but we don't really care that shell doesn't match for `run`. We only care for `shell` because we use different shellrc for fish vs POSIX.

## How was it tested?

Added `devbox run echo foo` to init hook. Then ran

```
SHELL=fish devbox run echo bar
```
