### PR TITLE
[eval symlinks] eval symlinks in print-dev-env

### DIFF
--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -64,11 +64,16 @@ func (*Nix) PrintDevEnv(ctx context.Context, args *PrintDevEnvArgs) (*PrintDevEn
 		}
 	}
 
+	flakeDirResolved, err := filepath.EvalSymlinks(args.FlakeDir)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
 	if len(data) == 0 {
 		cmd := exec.CommandContext(
 			ctx,
 			"nix", "print-dev-env",
-			args.FlakeDir,
+			"path:"+flakeDirResolved,
 		)
 		cmd.Args = append(cmd.Args, ExperimentalFlags()...)
 		cmd.Args = append(cmd.Args, "--json")


### PR DESCRIPTION
## Summary

On MacOS, in nix 2.20, I am seeing the following error with the `global_add` testscript. This also repros in CICD:
```
 Error: Command: /nix/var/nix/profiles/default/bin/nix print-dev-env /var/folders/zv/r3sx92_94gq86_rq3yn1ky2h0000gn/T/TestScripts3021118989/001/.local/share/devbox/global/default/.devbox/gen/flake --extra-experimental-features ca-derivations --option experimental-features nix-command flakes fetch-closure --json: exit status 1

        2024/02/02 16:44:15 Command stderr: error (ignored): error: end of string reached
        error:
               … while fetching the input 'path:/var/folders/zv/r3sx92_94gq86_rq3yn1ky2h0000gn/T/TestScripts3021118989/001/.local/share/devbox/global/default/.devbox/gen/flake'

               error: path '«unknown»/var' is a symlink
```

I'm not sure why this is now failing. Possibly (but low confidence) as a side-effect of this nix PR https://github.com/NixOS/nix/commit/83c067c0fa0cc5a2dca440e5c986afe40b163802. Not sure if its intentional or not.

To workaround this, I am preemptively calling `EvalSymlink` in our golang prior to invoke `nix print-dev-env`.

## How was it tested?

CICD run including our MacOS tests:
https://github.com/jetpack-io/devbox/actions/runs/7763452308

NOTE: I manually cancelled the run below in this PR, so the above CICD including MacOS could run.
