### PR TITLE
internal/nix: fix unredacted error message

### DIFF
--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -82,14 +82,7 @@ func (*Nix) PrintDevEnv(ctx context.Context, args *PrintDevEnvArgs) (*PrintDevEn
 		if insecure, insecureErr := IsExitErrorInsecurePackage(err, "" /*installable*/); insecure {
 			return nil, insecureErr
 		} else if err != nil {
-			safeArgs := make([]string, 0, len(cmd.Args))
-			for _, a := range cmd.Args {
-				if a == args.FlakeDir {
-					a = "<redacted path>"
-				}
-				safeArgs = append(safeArgs, a)
-			}
-			return nil, redact.Errorf("nix command: %s", redact.Safe(safeArgs))
+			return nil, redact.Errorf("nix print-dev-env --json \"path:%s\": %w", flakeDirResolved, err)
 		}
 
 		if err := json.Unmarshal(data, &out); err != nil {


### PR DESCRIPTION
Don't pass a slice of already-redacted arguments to `redact.Errorf` so that they're preserved in the regular error message.

Tested by forcing an error and seeing the full message:

```
$ go run ./cmd/devbox shell
Ensuring packages are installed.
✓ Computed the Devbox environment.
Error: nix print-dev-env --json "path:/Users/gcurtis/src/devbox/.devbox/gen/flake": exit status 1

Error: There was an internal error. Run with DEVBOX_DEBUG=1 for a detailed error message, and consider reporting it at https://github.com/jetpack-io/devbox/issues
```

Gets redacted in Sentry as:

```
nix print-dev-env --json "path:<redacted string>": <redacted *exec.ExitError>
```