### PR TITLE
[github actions] changed root-reserve size

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -147,7 +147,7 @@ jobs:
         uses: easimon/maximize-build-space@v8
         if: matrix.os == 'ubuntu-latest'
         with:
-          root-reserve-mb: 40000
+          root-reserve-mb: 32768
           temp-reserve-mb: 10000
           remove-dotnet: true
           remove-android: true


### PR DESCRIPTION
## Summary
Github action ubuntu image has been reduced. This fixes the error with Maximize build disk space step.

## How was it tested?
github actions
