### PR TITLE
internal/searcher,lock: use /v2/resolve endpoint

### DIFF
--- a/internal/boxcli/featureflag/resolvev2.go
+++ b/internal/boxcli/featureflag/resolvev2.go
@@ -1,0 +1,4 @@
+package featureflag
+
+// ResolveV2 uses the /v2/resolve endpoint when resolving packages.
+var ResolveV2 = disable("RESOLVE_V2")

--- a/internal/searcher/model.go
+++ b/internal/searcher/model.go
@@ -3,6 +3,12 @@
 
 package searcher
 
+import (
+	"time"
+
+	"go.jetpack.io/devbox/nix/flake"
+)
+
 type SearchResults struct {
 	NumResults int       `json:"num_results"`
 	Packages   []Package `json:"packages,omitempty"`
@@ -34,4 +40,57 @@ type PackageInfo struct {
 	AttrPaths    []string `json:"attr_paths"`
 	Version      string   `json:"version"`
 	Summary      string   `json:"summary"`
+}
+
+// ResolveResponse is a response from the /v2/resolve endpoint.
+type ResolveResponse struct {
+	// Name is the resolved name of the package. For packages that are
+	// identifiable by multiple names or attribute paths, this is the
+	// "canonical" name.
+	Name string `json:"name"`
+
+	// Version is the resolved package version.
+	Version string `json:"version"`
+
+	// Summary is a short package description.
+	Summary string `json:"summary,omitempty"`
+
+	// Systems contains information about the package that can vary across
+	// systems. It will always have at least one system. The keys match a
+	// Nix system identifier (aarch64-darwin, x86_64-linux, etc.).
+	Systems map[string]struct {
+		// FlakeInstallable is a Nix installable that specifies how to
+		// install the resolved package version.
+		//
+		// [Nix installable]: https://nixos.org/manual/nix/stable/command-ref/new-cli/nix#installables
+		FlakeInstallable flake.Installable `json:"flake_installable"`
+
+		// LastUpdated is the timestamp of the most recent change to the
+		// package.
+		LastUpdated time.Time `json:"last_updated"`
+
+		// Outputs provides additional information about the Nix store
+		// paths that this package installs. This field is not available
+		// for some (especially older) packages.
+		Outputs []struct {
+			// Name is the output's name. Nix appends the name to
+			// the output's store path unless it's the default name
+			// of "out". Output names can be anything, but
+			// conventionally they follow the various "make install"
+			// directories such as "bin", "lib", "src", "man", etc.
+			Name string `json:"name,omitempty"`
+
+			// Path is the absolute store path (with the /nix/store/
+			// prefix) of the output.
+			Path string `json:"path,omitempty"`
+
+			// Default indicates if Nix installs this output by
+			// default.
+			Default bool `json:"default,omitempty"`
+
+			// NAR is set to the package's NAR archive URL when the
+			// output exists in the cache.nixos.org binary cache.
+			NAR string `json:"nar,omitempty"`
+		} `json:"outputs,omitempty"`
+	} `json:"systems"`
 }

--- a/nix/flake/flakeref.go
+++ b/nix/flake/flakeref.go
@@ -456,11 +456,11 @@ const (
 // [Nix manual]: https://nixos.org/manual/nix/unstable/command-ref/new-cli/nix#installables
 type Installable struct {
 	// Ref is the flake reference portion of the installable.
-	Ref Ref
+	Ref Ref `json:"ref,omitempty"`
 
 	// AttrPath is an attribute path of the flake, encoded as a URL
 	// fragment.
-	AttrPath string
+	AttrPath string `json:"attr_path,omitempty"`
 
 	// Outputs is the installable's output spec, which is a comma-separated
 	// list of package outputs to install. The outputs spec is anything
@@ -474,7 +474,7 @@ type Installable struct {
 	// ParseInstallable cleans the list of outputs by removing empty
 	// elements and sorting the results. Lists containing a "*" are
 	// simplified to a single "*".
-	Outputs string
+	Outputs string `json:"outputs,omitempty"`
 }
 
 // ParseInstallable parses a flake installable. The raw string must contain


### PR DESCRIPTION
Add a `DEVBOX_FEATURE_RESOLVE_V2` feature flag that enables the new `/v2/resolve` endpoint when resolving packages. The new endpoint unlocks a couple of improvements:

- We no longer need to call `nix store path-from-hash-part` (which incurs a network request) for every `fetchClosure` package. The full store path is returned directly by the API.
- The resolved package response includes store paths for all known outputs, allowing us to support `fetchClosure` for non-default outputs as well.
- The new endpoint returns a flake installable rather than a nixpkgs commit hash and attribute path. This gives more flexibility, allowing the API to potentially return packages from sources other than nixpkgs.