### PR TITLE
plugins/redis: log to stdout by default

### DIFF
--- a/plugins/redis/redis.conf
+++ b/plugins/redis/redis.conf
@@ -168,7 +168,7 @@ loglevel notice
 # Specify the log file name. Also the empty string can be used to force
 # Redis to log on the standard output. Note that if you use standard
 # output for logging but daemonize, logs will be sent to /dev/null
-logfile redis.log
+# logfile redis.log
 
 # To enable logging to the system logger, just set 'syslog-enabled' to yes,
 # and optionally update the other syslog parameters to suit your needs.


### PR DESCRIPTION
The redis plugin configures redis to log to a file in `.devbox/virtenv/redis/redis.log`. This causes logs to not show up in process-compose (with `devbox services up redis`), which relies on capturing logs from stdout/stderr.

Logging to a file probably predates the process-compose integration back when there was no other way to view the logs. Today it makes more sense to default to having logs go to stdout and show up in process-compose.

The trade-off is that logs will go to /dev/null if redis is launched as a regular daemon (and therefore doesn't have a stdout). In this case, the user can always uncomment the config line to send logs to a file again.

Fixes #1727.