### PR TITLE
[gen-readme] Allow custom templates

### DIFF
--- a/devbox.md
+++ b/devbox.md
@@ -36,6 +36,13 @@ Scripts are custom commands that can be run using this project's environment. Th
 * [tidy](#devbox-run-tidy)
 * [update-examples](#devbox-run-update-examples)
 
+## Environment
+
+```sh
+GOENV="off"
+PATH="$PATH:$PWD/dist"
+```
+
 ## Shell Init Hook
 The Shell Init Hook is a script that runs whenever the devbox environment is instantiated. It runs 
 on `devbox shell` and on `devbox run`.

--- a/internal/devbox/docgen/readme.tmpl
+++ b/internal/devbox/docgen/readme.tmpl
@@ -33,11 +33,11 @@ Scripts are custom commands that can be run using this project's environment. Th
 {{- end }}
 {{ end }}
 
-{{- if .Env }}
+{{- if .EnvVars }}
 ## Environment
 
 ```sh
-{{- range $key, $value := .Env }}
+{{- range $key, $value := .EnvVars }}
 {{ $key }}="{{ $value }}"
 {{- end }}
 ```


### PR DESCRIPTION
## Summary

This adds:

Flag that saves default template
```
devbox generate readme [path] --save-template
```

Flag that uses custom template
```
devbox generate readme [path] --template <custom-template>
```

It also:

* defaults readme [path] to `README.md`
* defaults template [path] to `readme.tmpl`
* If there is `readme.tmpl` in root, then `devbox generate readme` will use it automatically.
* Fixed missing env vars from default template

## How was it tested?

```
devbox generate readme --save-template # generate template
vi readme.tmpl # modified template
devbox generate readme devbox.md # tested creating new readme
```

