### PR TITLE
examples/development/zig: update to 0.11.0 and fix for macOS

### DIFF
--- a/examples/development/zig/zig-hello-world/build.zig
+++ b/examples/development/zig/zig-hello-world/build.zig
@@ -1,34 +1,32 @@
 const std = @import("std");
 
-pub fn build(b: *std.build.Builder) void {
-    // Standard target options allows the person running `zig build` to choose
-    // what target to build for. Here we do not override the defaults, which
-    // means any target is allowed, and the default is native. Other options
-    // for restricting supported target set are available.
+pub fn build(b: *std.Build) void {
+    // Standard target options allows the person running zig build to choose what
+    // target to build for. By default, any target is allowed, and no choice means to
+    // target the host system. Other options for restricting supported target set are
+    // available.
     const target = b.standardTargetOptions(.{});
 
-    // Standard release options allow the person running `zig build` to select
-    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
-    const mode = b.standardReleaseOptions();
+    // Standard optimization options allow the person running zig build to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. By default none of
+    // the release options are considered the preferable choice by the build script,
+    // and the user must make a decision in order to create a release build.
+    const optimize = b.standardOptimizeOption(.{});
 
-    const exe = b.addExecutable("zig-hello-world", "src/main.zig");
-    exe.setTarget(target);
-    exe.setBuildMode(mode);
-    exe.install();
+    const exe = b.addExecutable(.{
+        .name = "zig-hello-world",
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+    b.installArtifact(exe);
 
-    const run_cmd = exe.run();
-    run_cmd.step.dependOn(b.getInstallStep());
-    if (b.args) |args| {
-        run_cmd.addArgs(args);
-    }
-
-    const run_step = b.step("run", "Run the app");
-    run_step.dependOn(&run_cmd.step);
-
-    const exe_tests = b.addTest("src/main.zig");
-    exe_tests.setTarget(target);
-    exe_tests.setBuildMode(mode);
+    const run_exe = b.addRunArtifact(exe);
+    const run_step = b.step("run", "Run the application");
+    run_step.dependOn(&run_exe.step);
 
     const test_step = b.step("test", "Run unit tests");
-    test_step.dependOn(&exe_tests.step);
+    const unit_tests = b.addTest(.{ .root_source_file = .{ .path = "src/main.zig" }, .target = target, .optimize = optimize });
+    const run_unit_tests = b.addRunArtifact(unit_tests);
+    test_step.dependOn(&run_unit_tests.step);
 }

--- a/examples/development/zig/zig-hello-world/devbox.json
+++ b/examples/development/zig/zig-hello-world/devbox.json
@@ -1,14 +1,10 @@
 {
-    "packages": [
-        "zig@0.10"
-    ],
-    "shell": {
-        "init_hook": null,
-        "scripts": {
-            "run_test": [
-                "zig build install",
-                "zig build run"
-            ]
-        }
+  "packages": {
+    "zig": "latest"
+  },
+  "shell": {
+    "scripts": {
+      "run_test": "zig build run test --summary all"
     }
+  }
 }

--- a/examples/development/zig/zig-hello-world/devbox.lock
+++ b/examples/development/zig/zig-hello-world/devbox.lock
@@ -1,23 +1,23 @@
 {
   "lockfile_version": "1",
   "packages": {
-    "zig@0.10": {
-      "last_modified": "2023-08-09T23:50:43Z",
-      "resolved": "github:NixOS/nixpkgs/3d6ebeb283be256f008541ce2b089eb5fb0e4e01#zig",
+    "zig@latest": {
+      "last_modified": "2024-01-27T14:55:31Z",
+      "resolved": "github:NixOS/nixpkgs/160b762eda6d139ac10ae081f8f78d640dd523eb#zig",
       "source": "devbox-search",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "systems": {
         "aarch64-darwin": {
-          "store_path": "/nix/store/wdl373cbxsbsgkbrhcm8rsjxf1nyzda5-zig-0.10.1"
+          "store_path": "/nix/store/l7jy40r7xqzjyijq4p4jw5bvpxcnqx6h-zig-0.11.0"
         },
         "aarch64-linux": {
-          "store_path": "/nix/store/kffa3f61affmlms4r8xmmrq7ksz7lx7k-zig-0.10.1"
+          "store_path": "/nix/store/vysivb9bazavcq994cn4k044mlickyd0-zig-0.11.0"
         },
         "x86_64-darwin": {
-          "store_path": "/nix/store/0a267lbl7hy45rlg5i9azxb3s5jggnkm-zig-0.10.1"
+          "store_path": "/nix/store/dh721al3vdr3akb6zsjykjr6qv65fqwj-zig-0.11.0"
         },
         "x86_64-linux": {
-          "store_path": "/nix/store/rg6yk06fhxbnq9xm32v1ccfrdilwhx17-zig-0.10.1"
+          "store_path": "/nix/store/g3ndnazkx9brkyindbiq8zan942mcsvg-zig-0.11.0"
         }
       }
     }


### PR DESCRIPTION
The zig example is out-of-date and isn't working on macOS. Updating to the latest version of Zig seems to fix it. I don't think we run these tests on macOS, so this bug was never caught.

The bug was caused by https://github.com/ziglang/zig/issues/12069 which has been fixed in 0.11.0.