### PR TITLE
ci: run example tests on macOS for releases

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -21,9 +21,10 @@ on:
     inputs:
       run-mac-tests:
         type: boolean
-      # run the example tests with DEVBOX_DEBUG=1
+        description: Run tests on macOS
       example-debug:
         type: boolean
+        description: Run example tests with DEVBOX_DEBUG=1 to increase verbosity
 
 permissions:
   contents: read
@@ -138,7 +139,7 @@ jobs:
           - is-main: "is-main"
             run-project-tests: "project-tests-off"
           - run-project-tests: "project-tests"
-            os: macos-latest
+            os: "${{ inputs.run-mac-tests && 'dummy' || 'macos-latest' }}"
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 37


### PR DESCRIPTION
We were accidentally excluding the example tests on macOS. Also add some descriptions to the workflow inputs to make the schema validate with the YAML language server.