### PR TITLE
examples/insecure: modernize devbox.json

### DIFF
--- a/examples/insecure/devbox.json
+++ b/examples/insecure/devbox.json
@@ -1,15 +1,14 @@
 {
-  "packages": [
-    "nodejs@16"
-  ],
+  "packages": {
+    "nodejs": {
+      "version":        "16",
+      "allow_insecure": ["nodejs-16.20.2"]
+    }
+  },
   "shell": {
-    "init_hook": [
-      "echo 'Welcome to devbox!' > /dev/null"
-    ],
+    "init_hook": "echo 'Welcome to devbox!' > /dev/null",
     "scripts": {
-      "run_test": [
-        "node --version"
-      ]
+      "run_test": "node --version"
     }
   }
 }

--- a/examples/insecure/devbox.lock
+++ b/examples/insecure/devbox.lock
@@ -2,7 +2,6 @@
   "lockfile_version": "1",
   "packages": {
     "nodejs@16": {
-      "allow_insecure": true,
       "last_modified": "2023-08-30T00:25:28Z",
       "resolved": "github:NixOS/nixpkgs/a63a64b593dcf2fe05f7c5d666eb395950f36bc9#nodejs_16",
       "source": "devbox-search",


### PR DESCRIPTION
Whenever the example tests run, Devbox updates the devbox.json to use the newer `allow_insecure` syntax. Commit those changes so they stop showing up as diffs.