### PR TITLE
[docker] fix for devbox docker image root-user build

### DIFF
--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -17,14 +17,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      # - name: Build and push default
-      #   uses: docker/build-push-action@v4
-      #   with:
-      #     context: ./internal/devbox/generate/tmpl/
-      #     file: ./internal/devbox/generate/tmpl/DevboxImageDockerfile
-      #     push: true
-      #     platforms: linux/amd64,linux/arm64
-      #     tags: jetpackio/devbox:latest
+      - name: Build and push default
+        uses: docker/build-push-action@v4
+        with:
+          context: ./internal/devbox/generate/tmpl/
+          file: ./internal/devbox/generate/tmpl/DevboxImageDockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: jetpackio/devbox:latest
       - name: Build and push root user
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -17,14 +17,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: Build and push default
-        uses: docker/build-push-action@v4
-        with:
-          context: ./internal/devbox/generate/tmpl/
-          file: ./internal/devbox/generate/tmpl/DevboxImageDockerfile
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: jetpackio/devbox:latest
+      # - name: Build and push default
+      #   uses: docker/build-push-action@v4
+      #   with:
+      #     context: ./internal/devbox/generate/tmpl/
+      #     file: ./internal/devbox/generate/tmpl/DevboxImageDockerfile
+      #     push: true
+      #     platforms: linux/amd64,linux/arm64
+      #     tags: jetpackio/devbox:latest
       - name: Build and push root user
         uses: docker/build-push-action@v4
         with:

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
@@ -5,6 +5,7 @@ RUN apt-get update
 RUN apt-get -y install bash binutils git xz-utils wget sudo
 
 # Step 2: Installing Nix
+RUN mkdir -p /etc/nix/
 RUN echo 'sandbox = false' > /etc/nix/nix.conf && wget --output-document=/dev/stdout https://nixos.org/nix/install | sh -s -- --daemon
 RUN . ~/.nix-profile/etc/profile.d/nix.sh
 

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
@@ -6,7 +6,7 @@ RUN apt-get -y install bash binutils git xz-utils wget sudo
 
 # Step 2: Installing Nix
 RUN mkdir -p /etc/nix/
-RUN echo 'sandbox = false' > /etc/nix/nix.conf && wget --output-document=/dev/stdout https://nixos.org/nix/install | sh -s -- --daemon
+RUN RUN echo "filter-syscalls = false" >> /etc/nix/nix.conf && wget --output-document=/dev/stdout https://nixos.org/nix/install | sh -s -- --daemon
 RUN . ~/.nix-profile/etc/profile.d/nix.sh
 
 ENV PATH="/root/.nix-profile/bin:$PATH"

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
@@ -5,7 +5,7 @@ RUN apt-get update
 RUN apt-get -y install bash binutils git xz-utils wget sudo
 
 # Step 2: Installing Nix
-RUN wget --output-document=/dev/stdout https://nixos.org/nix/install | sh -s -- --daemon
+RUN echo 'sandbox = false' > /etc/nix/nix.conf && wget --output-document=/dev/stdout https://nixos.org/nix/install | sh -s -- --daemon
 RUN . ~/.nix-profile/etc/profile.d/nix.sh
 
 ENV PATH="/root/.nix-profile/bin:$PATH"

--- a/internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
+++ b/internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
@@ -6,7 +6,7 @@ RUN apt-get -y install bash binutils git xz-utils wget sudo
 
 # Step 2: Installing Nix
 RUN mkdir -p /etc/nix/
-RUN RUN echo "filter-syscalls = false" >> /etc/nix/nix.conf && wget --output-document=/dev/stdout https://nixos.org/nix/install | sh -s -- --daemon
+RUN echo "filter-syscalls = false" >> /etc/nix/nix.conf && wget --output-document=/dev/stdout https://nixos.org/nix/install | sh -s -- --daemon
 RUN . ~/.nix-profile/etc/profile.d/nix.sh
 
 ENV PATH="/root/.nix-profile/bin:$PATH"


### PR DESCRIPTION
## Summary
This fix is due to customer message in discord mentioning the launcher having old version.
Nix installation in `docker-image-build-publish` workflow was failing for root-user mode.
This PR fixes it.
The fix was based on recommendation from https://github.com/LnL7/nix-docker/issues/41#issuecomment-1890873956

## How was it tested?
https://github.com/jetpack-io/devbox/actions/runs/7893709911