### PR TITLE
Bump process compose to version 0.85.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/cloudflare/ahocorasick v0.0.0-20210425175752-730270c3e184
 	github.com/creekorful/mvnparser v1.5.0
 	github.com/denisbrodbeck/machineid v1.0.1
-	github.com/f1bonacc1/process-compose v0.43.1
+	github.com/f1bonacc1/process-compose v0.85.0
 	github.com/fatih/color v1.16.0
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/getsentry/sentry-go v0.27.0


### PR DESCRIPTION
## Summary
It would be nice for the users of Devbox to be able to use new process-compose features.

## How was it tested?
No tests were done, counting on CI and hoping that the new process compose does not break its API.