### PR TITLE
shellgen: update store paths when patching glibc

### DIFF
--- a/internal/shellgen/tmpl/glibc-patch.nix.tmpl
+++ b/internal/shellgen/tmpl/glibc-patch.nix.tmpl
@@ -37,7 +37,7 @@
         inherit pkg;
 
         # Programs needed by glibc-patch.bash.
-        inherit (nixpkgs-glibc.legacyPackages."${system}") bash coreutils file findutils glibc patchelf ripgrep;
+        inherit (nixpkgs-glibc.legacyPackages."${system}") bash coreutils file findutils glibc gnused patchelf ripgrep;
 
         builder = "${bash}/bin/bash";
         args = [ ./glibc-patch.bash ];


### PR DESCRIPTION
This addresses an issue where scripts (and other text files) could still refer to the unpatched version of a program after enabling `patch_glibc`. This is one of the reasons why Ruby would still segfault in issue #1772. For example, if you look at `bundler` (installed by default with `ruby`) it's a wrapper script with the shebang:

	#!/nix/store/vs52hm8jbwgx19plicg02dzz2vmvbyy5-ruby-2.7.8/bin/ruby

This means that commands like `bundler exec rails` would still run using the unpatched version of ruby. I suspect this was also happening with Python or other packages that rely on wrapper scripts.

The fix updates glibc-patch.bash to grep for the old store path and replace it using sed. It relies on ripgrep's ability to ignore binary files so that we only modify text files.