### PR TITLE
nix/flake: installables exclude attribute path from URL

### DIFF
--- a/nix/flake/flakeref.go
+++ b/nix/flake/flakeref.go
@@ -103,7 +103,10 @@ func ParseRef(ref string) (Ref, error) {
 		parsed.Path = ref
 		return parsed, nil
 	}
-	parsed, _, err := parseURLRef(ref)
+	parsed, fragment, err := parseURLRef(ref)
+	if fragment != "" {
+		return Ref{}, redact.Errorf("flake reference %q contains a URL fragment", ref)
+	}
 	return parsed, err
 }
 

--- a/nix/flake/flakeref.go
+++ b/nix/flake/flakeref.go
@@ -116,6 +116,11 @@ func parseURLRef(ref string) (parsed Ref, fragment string, err error) {
 		return Ref{}, "", redact.Errorf("parse flake reference as URL: %v", err)
 	}
 
+	// ensure that the fragment is excluded from the parsed URL
+	// since those are not valid in flake references.
+	fragment = refURL.Fragment
+	refURL.Fragment = ""
+
 	switch refURL.Scheme {
 	case "", "flake":
 		// [flake:]<flake-id>(/<rev-or-ref>(/rev)?)?
@@ -191,7 +196,7 @@ func parseURLRef(ref string) (parsed Ref, fragment string, err error) {
 	default:
 		return Ref{}, "", redact.Errorf("unsupported flake reference URL scheme: %s", redact.Safe(refURL.Scheme))
 	}
-	return parsed, refURL.Fragment, nil
+	return parsed, fragment, nil
 }
 
 func parseGitHubRef(refURL *url.URL, parsed *Ref) error {

--- a/nix/flake/flakeref_test.go
+++ b/nix/flake/flakeref_test.go
@@ -288,11 +288,14 @@ func TestParseFlakeInstallable(t *testing.T) {
 		"nixpkgs#app^out,lib": {AttrPath: "app", Outputs: "lib,out", Ref: Ref{Type: TypeIndirect, ID: "nixpkgs"}},
 		"nixpkgs^out":         {Outputs: "out", Ref: Ref{Type: TypeIndirect, ID: "nixpkgs"}},
 
-		"%23#app":                        {AttrPath: "app", Ref: Ref{Type: TypeIndirect, ID: "#"}},
-		"./%23#app":                      {AttrPath: "app", Ref: Ref{Type: TypePath, Path: "./#"}},
-		"/%23#app":                       {AttrPath: "app", Ref: Ref{Type: TypePath, Path: "/#"}},
-		"path:/%23#app":                  {AttrPath: "app", Ref: Ref{Type: TypePath, Path: "/#"}},
-		"http://example.com/%23.tar#app": {AttrPath: "app", Ref: Ref{Type: TypeTarball, URL: "http://example.com/%23.tar#app"}},
+		"%23#app":       {AttrPath: "app", Ref: Ref{Type: TypeIndirect, ID: "#"}},
+		"./%23#app":     {AttrPath: "app", Ref: Ref{Type: TypePath, Path: "./#"}},
+		"/%23#app":      {AttrPath: "app", Ref: Ref{Type: TypePath, Path: "/#"}},
+		"path:/%23#app": {AttrPath: "app", Ref: Ref{Type: TypePath, Path: "/#"}},
+
+		"http://example.com/%23.tar#app":   {AttrPath: "app", Ref: Ref{Type: TypeTarball, URL: "http://example.com/%23.tar"}},
+		"file:///flake#app":                {AttrPath: "app", Ref: Ref{Type: TypeFile, URL: "file:///flake"}},
+		"git://example.com/repo/flake#app": {AttrPath: "app", Ref: Ref{Type: TypeGit, URL: "git://example.com/repo/flake"}},
 	}
 
 	for installable, want := range cases {

--- a/nix/flake/flakeref_test.go
+++ b/nix/flake/flakeref_test.go
@@ -189,6 +189,13 @@ func TestParseFlakeRefError(t *testing.T) {
 			}
 		}
 	})
+	t.Run("URLFragment", func(t *testing.T) {
+		ref := "https://github.com/NixOS/patchelf/archive/master.tar.gz#patchelf"
+		_, err := ParseRef(ref)
+		if err == nil {
+			t.Error("got nil error for flakeref with fragment:", ref)
+		}
+	})
 }
 
 func TestFlakeRefString(t *testing.T) {


### PR DESCRIPTION
## Summary
I ran into an issue causing the generated `.devbox/gen/flake` to contain an invalid flake reference when adding some installables to `devbox.json`, specifically those which pointed to a remote resource. Local files were fine.

After a quick hike around the repo, the fix seemed trivial enough to open up a PR rather than open up an issue. Interestingly, I didn't seem to find any issues around this even though this bug would've been around for some months.

As it turns out, `Installable`s returned from `ParseInstallable` included the attribute path when provided a value with any scheme aside from `<empty string>`, `flake`, `path`, or `github`. This was because the `parseURLRef` method was not separating the fragment out of the refURL. More generically, the affected branches were any of those that set `parsed.URL` to the result of `refURL.String()`, since that specific method will re-add `Fragment` unless its empty.

Additionally, the test for `ParseInstallable` with a flake was passing because the test case itself had an invalid flake reference. I corrected that, as well as adding a couple of relevant test cases for some other types as well.

## Repo steps
* Add any non-local-path flake reference **with an Installable** to `devbox.json`
e.g. `https://github.com/NixOS/patchelf/archive/master.tar.gz#patchelf`
* Execute the following
```sh
DEVBOX_DEBUG=1 devbox shell
```
* Observe the following `nix` error:
```sh
Error: nix print-dev-env --json "path:/path/to/your/.devbox/gen/flake": exit status 1

2024/02/16 18:44:09 Command stderr: error: unexpected fragment 'patchelf' in flake reference 'tarball+https://github.com/NixOS/patchelf/archive/master.tar.gz#patchelf'
```

## How was it tested?

* Updating the relevant test, then making adjustments to ensure they pass.