### PR TITLE
Update Process Compose to 0.85.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/cloudflare/ahocorasick v0.0.0-20210425175752-730270c3e184
 	github.com/creekorful/mvnparser v1.5.0
 	github.com/denisbrodbeck/machineid v1.0.1
-	github.com/f1bonacc1/process-compose v0.43.1
+	github.com/f1bonacc1/process-compose v0.85.0
 	github.com/fatih/color v1.16.0
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/getsentry/sentry-go v0.27.0

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/dsnet/compress v0.0.1/go.mod h1:Aw8dCMJ7RioblQeTqt88akK31OvO8Dhf5Jflh
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/f1bonacc1/process-compose v0.43.1 h1:XAN7ohegNfMFxYnj59g2jN7y6HfnJWhDCGtD/nN/TbE=
-github.com/f1bonacc1/process-compose v0.43.1/go.mod h1:jvg1NakjJd8V1LjGKu21HLLOVxbwkOHEgkaDjSWRXc0=
+github.com/f1bonacc1/process-compose v0.85.0 h1:BD3nRHRTLO5jqB5zG1Bu6UJ1Qh5wAkyOWQQ6OKtRRnQ=
+github.com/f1bonacc1/process-compose v0.85.0/go.mod h1:NFkS+lyAyKCokif7KvtO3H8MpjD0W4r3PReLn3x4yiQ=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -361,12 +361,8 @@ github.com/yuin/gopher-lua v0.0.0-20190514113301-1cd887cd7036/go.mod h1:gqRgreBU
 github.com/zaffka/mongodb-boltdb-mock v0.0.0-20221014194232-b4bb03fbe3a0/go.mod h1:GsDD1qsG+86MeeCG7ndi6Ei3iGthKL3wQ7PTFigDfNY=
 github.com/zealic/go2node v0.1.0 h1:ofxpve08cmLJBwFdI0lPCk9jfwGWOSD+s6216x0oAaA=
 github.com/zealic/go2node v0.1.0/go.mod h1:GrkFr+HctXwP7vzcU9RsgtAeJjTQ6Ud0IPCQAqpTfBg=
-go.jetpack.io/envsec v0.0.16-0.20240111222345-e1fd0e1204ca h1:7Ocnr+mVZTCG8MHlcAdW5d8ir7eqZTmD8S/aEskjXWk=
-go.jetpack.io/envsec v0.0.16-0.20240111222345-e1fd0e1204ca/go.mod h1:kCgRGNSHU5AgQXQGUenohPPDoUd87SRL00uOzQsa+Q8=
 go.jetpack.io/envsec v0.0.16-0.20240214025624-d233cf877eec h1:IvdOF1C8tAxvKEauWBd/4IWXZfeyXh5vmcfTrcTBPvQ=
 go.jetpack.io/envsec v0.0.16-0.20240214025624-d233cf877eec/go.mod h1:koTmI1q2QKqtxaX4P/7r5ygODwgJQ56FKoKRfzpZ0bM=
-go.jetpack.io/pkg v0.0.0-20240108193620-a28b84329d15 h1:ztX3CydpNKLePPMRmWgdi4HcxE/AXY6HViOJOmmYNiA=
-go.jetpack.io/pkg v0.0.0-20240108193620-a28b84329d15/go.mod h1:kGUL8aZ7ddvoGro0AQxXos9GKn5Qw0J18qW7d5FP4Ws=
 go.jetpack.io/pkg v0.0.0-20240213204231-ec96be3d78fb h1:ELaZEV3BL+/GDfPxWPXt6ODNig/VlywWhfAC4P8EG5A=
 go.jetpack.io/pkg v0.0.0-20240213204231-ec96be3d78fb/go.mod h1:kGUL8aZ7ddvoGro0AQxXos9GKn5Qw0J18qW7d5FP4Ws=
 go.jetpack.io/typeid v1.0.0 h1:8gQ+iYGdyiQ0Pr40ydSB/PzMOIwlXX5DTojp1CBeSPQ=

--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime/trace"
 	"slices"
 	"strconv"
@@ -31,6 +32,7 @@ import (
 	"go.jetpack.io/devbox/internal/searcher"
 	"go.jetpack.io/devbox/internal/shellgen"
 	"go.jetpack.io/devbox/internal/telemetry"
+	"go.jetpack.io/devbox/internal/vercheck"
 
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/cmdutil"
@@ -746,7 +748,7 @@ func (d *Devbox) StartProcessManager(
 	processComposePath, err := utilityLookPath("process-compose")
 	if err != nil {
 		fmt.Fprintln(d.stderr, "Installing process-compose. This may take a minute but will only happen once.")
-		if err = d.addDevboxUtilityPackage(ctx, "github:F1bonacc1/process-compose/v0.43.1"); err != nil {
+		if err = d.addDevboxUtilityPackage(ctx, "github:F1bonacc1/process-compose/v0.80.0"); err != nil {
 			return err
 		}
 
@@ -754,6 +756,27 @@ func (d *Devbox) StartProcessManager(
 		processComposePath, err = utilityLookPath("process-compose")
 		if err != nil {
 			fmt.Fprintln(d.stderr, "failed to find process-compose after installing it.")
+			return err
+		}
+	}
+	re := regexp.MustCompile(`(?m)Version:\s*(v\d*\.\d*\.\d*)`)
+	pcVersionString, err := exec.Command(processComposePath, "version").Output()
+
+	if err != nil {
+		fmt.Fprintln(d.stderr, "failed to get process-compose version")
+		return err
+	}
+
+	pcVersion := re.FindStringSubmatch(strings.TrimSpace(string(pcVersionString)))[1]
+
+	if vercheck.SemverCompare(pcVersion, "v0.85.0") < 0 {
+		fmt.Fprintln(d.stderr, "Upgrading process-compose to v0.85.0.")
+		// Find the old process Compose package
+		if err := d.removeDevboxUtilityPackage(ctx, pcVersion); err != nil {
+			return err
+		}
+
+		if err = d.addDevboxUtilityPackage(ctx, "github:F1bonacc1/process-compose/v0.85.0"); err != nil {
 			return err
 		}
 	}

--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -53,8 +53,8 @@ import (
 const (
 
 	// shellHistoryFile keeps the history of commands invoked inside devbox shell
-	shellHistoryFile = ".devbox/shell_history"
-
+	shellHistoryFile     = ".devbox/shell_history"
+	pcTargetVersion      = "v0.85.0"
 	arbitraryCmdFilename = ".cmd"
 )
 
@@ -748,7 +748,7 @@ func (d *Devbox) StartProcessManager(
 	processComposePath, err := utilityLookPath("process-compose")
 	if err != nil {
 		fmt.Fprintln(d.stderr, "Installing process-compose. This may take a minute but will only happen once.")
-		if err = d.addDevboxUtilityPackage(ctx, "github:F1bonacc1/process-compose/v0.80.0"); err != nil {
+		if err = d.addDevboxUtilityPackage(ctx, "github:F1bonacc1/process-compose/"+pcTargetVersion); err != nil {
 			return err
 		}
 
@@ -769,14 +769,14 @@ func (d *Devbox) StartProcessManager(
 
 	pcVersion := re.FindStringSubmatch(strings.TrimSpace(string(pcVersionString)))[1]
 
-	if vercheck.SemverCompare(pcVersion, "v0.85.0") < 0 {
-		fmt.Fprintln(d.stderr, "Upgrading process-compose to v0.85.0.")
+	if vercheck.SemverCompare(pcVersion, pcTargetVersion) < 0 {
+		fmt.Fprintln(d.stderr, "Upgrading process-compose to "+pcTargetVersion+"...")
 		// Find the old process Compose package
-		if err := d.removeDevboxUtilityPackage(ctx, pcVersion); err != nil {
+		if err := d.removeDevboxUtilityPackage(ctx, "github:F1bonacc1/process-compose/"+pcVersion); err != nil {
 			return err
 		}
 
-		if err = d.addDevboxUtilityPackage(ctx, "github:F1bonacc1/process-compose/v0.85.0"); err != nil {
+		if err = d.addDevboxUtilityPackage(ctx, "github:F1bonacc1/process-compose/"+pcTargetVersion); err != nil {
 			return err
 		}
 	}

--- a/internal/nix/profiles.go
+++ b/internal/nix/profiles.go
@@ -142,6 +142,15 @@ func readManifest(profilePath string) (manifest, error) {
 
 const DefaultPriority = 5
 
+type NixProfile struct {
+	Elements []struct {
+		Active      bool     `json:"active"`
+		OriginalUrl string   `json:"originalUrl"`
+		StorePaths  []string `json:"storePaths"`
+		Url         string   `json:"url"`
+	} `json:"elements"`
+}
+
 func nextPriority(profilePath string) string {
 	// error is ignored because it's ok if the file doesn't exist
 	m, _ := readManifest(profilePath)

--- a/internal/nix/profiles.go
+++ b/internal/nix/profiles.go
@@ -144,6 +144,7 @@ const DefaultPriority = 5
 
 type NixProfile struct {
 	Elements []struct {
+		AttrPath    string   `json:"attrPath"`
 		Active      bool     `json:"active"`
 		OriginalUrl string   `json:"originalUrl"`
 		StorePaths  []string `json:"storePaths"`

--- a/internal/services/client.go
+++ b/internal/services/client.go
@@ -14,7 +14,7 @@ import (
 	"github.com/f1bonacc1/process-compose/src/types"
 )
 
-type processStates = types.ProcessStates
+type processStates = types.ProcessesState
 
 type Process struct {
 	Name     string

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -219,7 +219,8 @@ func runProcessManagerInForeground(cmd *exec.Cmd, config *globalProcessComposeCo
 }
 
 func runProcessManagerInBackground(cmd *exec.Cmd, config *globalProcessComposeConfig, port int, projectDir string) error {
-	logfile, err := os.OpenFile(processComposeLogfile, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_TRUNC, 0o664)
+	logdir := projectDir + "/" + processComposeLogfile
+	logfile, err := os.OpenFile(logdir, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_TRUNC, 0o664)
 	if err != nil {
 		return fmt.Errorf("failed to open process-compose log file: %w", err)
 	}


### PR DESCRIPTION
## Summary

Devbox will now install process-compose 0.85.0 if an older version (or no version) is installed on the user's system

If an older version of process compose was installed in the utility profile, Devbox will remove that older version first. This PR provides a general way to remove packages (either from Flakes or Nixpkgs) from the utils profile

This PR also fixes a bug where using `devbox services up` with the `--config` flag would cause process compose to fail.

This PR doesn't add any new 0.85.0 features, though that could be a follow up. 

## How was it tested?

* Install an older version in the utils profile, check that this upgrades
* Remove process-compose from the utlis profile, check that 0.85.0 is installed
* This should be pre-released first, for more extensive testing