### PR TITLE
[devbox.json] Add and implement imports field

### DIFF
--- a/.schema/devbox-plugin.schema.json
+++ b/.schema/devbox-plugin.schema.json
@@ -17,7 +17,7 @@
       "description": "The version of the plugin.",
       "type": "string"
     },
-    "readme": {
+    "description": {
       "description": "A short description of the plugin and how it works. This will automatically display when the user first installs the plugin, or runs `devbox info`",
       "type": "string"
     },

--- a/devbox.json
+++ b/devbox.json
@@ -40,4 +40,8 @@
       "tidy":            "go mod tidy",
     },
   },
+  "imports": [
+    // "./examples/plugins/local/devbox.json",
+    // "github:jetpack-io/devbox",
+  ]
 }

--- a/devbox.json
+++ b/devbox.json
@@ -40,8 +40,4 @@
       "tidy":            "go mod tidy",
     },
   },
-  "imports": [
-    // "./examples/plugins/local/devbox.json",
-    // "github:jetpack-io/devbox",
-  ]
 }

--- a/docs/app/docs/guides/creating_plugins.md
+++ b/docs/app/docs/guides/creating_plugins.md
@@ -63,7 +63,7 @@ Plugins are defined as Go JSON Template files, using the following schema:
 {
   "name": "",
   "version": "",
-  "readme": "",
+  "description": "",
   "env": {
     "<key>": "<value>"
   },
@@ -153,7 +153,7 @@ The plugin.json below sets the environment variables and config needed to run Mo
 {
   "name": "mongodb",
   "version": "0.0.1",
-  "readme": "Plugin for the [`mongodb`](https://www.nixhub.io/packages/mongodb) package. This plugin configures MonogoDB to use a local config file and data directory for this project, and configures a mongodb service.",
+  "description": "Plugin for the [`mongodb`](https://www.nixhub.io/packages/mongodb) package. This plugin configures MonogoDB to use a local config file and data directory for this project, and configures a mongodb service.",
   "env": {
     "MONGODB_DATA": "{{.Virtenv}}/data",
     "MONGODB_CONFIG": "{{.DevboxDir}}/mongod.conf"

--- a/examples/plugins/local/my-plugin/my-plugin.json
+++ b/examples/plugins/local/my-plugin/my-plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "my-plugin",
   "version": "0.0.1",
-  "readme": "Example custom plugin",
+  "description": "Example custom plugin",
   "env": {
     "MY_FOO_VAR": "BAR"
   },

--- a/examples/tutorial/devbox.json
+++ b/examples/tutorial/devbox.json
@@ -9,7 +9,7 @@
             "clear && PAGER=cat glow README.md"
         ],
         "scripts": {
-            "readme": "clear && PAGER=cat glow README.md"
+            "description": "clear && PAGER=cat glow README.md"
         }
     }
 }

--- a/internal/devbox/packages.go
+++ b/internal/devbox/packages.go
@@ -52,7 +52,7 @@ func (d *Devbox) Add(ctx context.Context, pkgsNames []string, opts devopt.AddOpt
 	// names of added packages (even if they are already in config). We use this
 	// to know the exact name to mark as allowed insecure later on.
 	addedPackageNames := []string{}
-	existingPackageNames := d.PackageNames()
+	existingPackageNames := d.cfg.Root.PackagesVersionedNames()
 	for _, pkg := range pkgs {
 		// If exact versioned package is already in the config, we can skip the
 		// next loop that only deals with newPackages.

--- a/internal/devconfig/config.go
+++ b/internal/devconfig/config.go
@@ -14,7 +14,7 @@ import (
 	"github.com/tailscale/hujson"
 	"go.jetpack.io/devbox/internal/cachehash"
 	"go.jetpack.io/devbox/internal/devbox/shellcmd"
-	"go.jetpack.io/devbox/nix/flake"
+	"go.jetpack.io/devbox/internal/devconfig/reflike"
 )
 
 // Config represents a base devbox.json as well as any imports it may have.
@@ -93,7 +93,7 @@ func loadBytes(b []byte) (*Config, error) {
 	imports := make([]*Config, 0, len(baseConfig.Imports))
 
 	for _, importRef := range baseConfig.Imports {
-		ref, _ := flake.ParseRefLike(importRef, "devbox.json")
+		ref, _ := reflike.Parse(importRef, "devbox.json")
 		childConfig, err := ref.Fetch()
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch import %s: %w", importRef, err)

--- a/internal/devconfig/config.go
+++ b/internal/devconfig/config.go
@@ -9,7 +9,7 @@ import (
 // Config represents a base devbox.json as well as any imports it may have.
 // TODO: All the functions below will be modified to include all imported configs.
 type Config struct {
-	Root configFile
+	Root ConfigFile
 
 	// This will support imports in the future.
 	// imported []*Config

--- a/internal/devconfig/config_test.go
+++ b/internal/devconfig/config_test.go
@@ -39,11 +39,11 @@ func parseConfigTxtarTest(t *testing.T, test string) (in *ConfigFile, want []byt
 	for _, f := range ar.Files {
 		switch f.Name {
 		case "in":
-			var err error
-			in, err = loadBytes(f.Data)
+			config, err := loadBytes(f.Data)
 			if err != nil {
 				t.Fatalf("input devbox.json is invalid: %v\n%s", err, f.Data)
 			}
+			in = &config.Root
 
 		case "want":
 			want = f.Data
@@ -689,11 +689,11 @@ func TestSetAllowInsecure(t *testing.T) {
 func TestDefault(t *testing.T) {
 	path := filepath.Join(t.TempDir())
 	in := DefaultConfig()
-	inBytes := in.Bytes()
+	inBytes := in.Root.Bytes()
 	if _, err := hujson.Parse(inBytes); err != nil {
 		t.Fatalf("default config JSON is invalid: %v\n%s", err, inBytes)
 	}
-	err := in.SaveTo(path)
+	err := in.Root.SaveTo(path)
 	if err != nil {
 		t.Fatal("got save error:", err)
 	}

--- a/internal/devconfig/config_test.go
+++ b/internal/devconfig/config_test.go
@@ -29,7 +29,7 @@ Tests begin by defining their JSON with:
   { "packages": { "go": "latest" } }`)
 */
 
-func parseConfigTxtarTest(t *testing.T, test string) (in *configFile, want []byte) {
+func parseConfigTxtarTest(t *testing.T, test string) (in *ConfigFile, want []byte) {
 	t.Helper()
 
 	ar := txtar.Parse([]byte(test))
@@ -701,7 +701,7 @@ func TestDefault(t *testing.T) {
 	if err != nil {
 		t.Fatal("got load error:", err)
 	}
-	if diff := cmp.Diff(in, &out.Root, cmpopts.IgnoreUnexported(configFile{}, packagesMutator{})); diff != "" {
+	if diff := cmp.Diff(in, &out.Root, cmpopts.IgnoreUnexported(ConfigFile{}, packagesMutator{})); diff != "" {
 		t.Errorf("configs not equal (-in +out):\n%s", diff)
 	}
 
@@ -727,7 +727,7 @@ func TestNixpkgsValidation(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			err := ValidateNixpkg(&configFile{
+			err := ValidateNixpkg(&ConfigFile{
 				Nixpkgs: &NixpkgsConfig{
 					Commit: testCase.commit,
 				},

--- a/internal/devconfig/config_test.go
+++ b/internal/devconfig/config_test.go
@@ -701,7 +701,7 @@ func TestDefault(t *testing.T) {
 	if err != nil {
 		t.Fatal("got load error:", err)
 	}
-	if diff := cmp.Diff(in, &out.Root, cmpopts.IgnoreUnexported(ConfigFile{}, packagesMutator{})); diff != "" {
+	if diff := cmp.Diff(in, out, cmpopts.IgnoreUnexported(Config{}, ConfigFile{}, packagesMutator{})); diff != "" {
 		t.Errorf("configs not equal (-in +out):\n%s", diff)
 	}
 

--- a/internal/devconfig/env.go
+++ b/internal/devconfig/env.go
@@ -1,6 +1,6 @@
 package devconfig
 
-func (c *configFile) IsEnvsecEnabled() bool {
+func (c *ConfigFile) IsEnvsecEnabled() bool {
 	// envsec for legacy.
 	return c.EnvFrom == "envsec" || c.EnvFrom == "jetpack-cloud"
 }

--- a/internal/devconfig/field.go
+++ b/internal/devconfig/field.go
@@ -7,7 +7,7 @@ import (
 	"github.com/tailscale/hujson"
 )
 
-func (c *configFile) SetStringField(fieldName, val string) {
+func (c *ConfigFile) SetStringField(fieldName, val string) {
 	valueOfStruct := reflect.ValueOf(c).Elem()
 
 	field := valueOfStruct.FieldByName(fieldName)
@@ -16,7 +16,7 @@ func (c *configFile) SetStringField(fieldName, val string) {
 	c.ast.setStringField(c.jsonNameOfField(fieldName), val)
 }
 
-func (c *configFile) jsonNameOfField(fieldName string) string {
+func (c *ConfigFile) jsonNameOfField(fieldName string) string {
 	valueOfStruct := reflect.ValueOf(c).Elem()
 
 	var name string

--- a/internal/devconfig/file.go
+++ b/internal/devconfig/file.go
@@ -134,7 +134,7 @@ func (c *ConfigFile) NixPkgsCommitHash() string {
 
 func (c *ConfigFile) InitHook() *shellcmd.Commands {
 	if c == nil || c.Shell == nil {
-		return nil
+		return &shellcmd.Commands{}
 	}
 	return c.Shell.InitHook
 }

--- a/internal/devconfig/file.go
+++ b/internal/devconfig/file.go
@@ -130,6 +130,14 @@ func (c *ConfigFile) GetPackage(versionedName string) (*Package, bool) {
 	return &c.PackagesMutator.collection[i], true
 }
 
+func (c *ConfigFile) PackagesVersionedNames() []string {
+	result := make([]string, 0, len(c.PackagesMutator.collection))
+	for _, p := range c.PackagesMutator.collection {
+		result = append(result, p.VersionedName())
+	}
+	return result
+}
+
 func validateConfig(cfg *ConfigFile) error {
 	fns := []func(cfg *ConfigFile) error{
 		ValidateNixpkg,

--- a/internal/devconfig/init.go
+++ b/internal/devconfig/init.go
@@ -57,7 +57,7 @@ func initConfigFile(path string) (created bool, err error) {
 		}
 	}()
 
-	_, err = file.Write(DefaultConfig().Bytes())
+	_, err = file.Write(DefaultConfig().Root.Bytes())
 	if err != nil {
 		file.Close()
 		return false, err

--- a/internal/devconfig/packages_test.go
+++ b/internal/devconfig/packages_test.go
@@ -198,11 +198,11 @@ func TestJsonifyConfigPackages(t *testing.T) {
 			if err != nil {
 				t.Errorf("load error: %v", err)
 			}
-			if diff := diffPackages(t, config.PackagesMutator, testCase.expected); diff != "" {
+			if diff := diffPackages(t, config.Root.PackagesMutator, testCase.expected); diff != "" {
 				t.Errorf("got wrong packages (-want +got):\n%s", diff)
 			}
 
-			got, err := hujson.Minimize(config.Bytes())
+			got, err := hujson.Minimize(config.Root.Bytes())
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/devconfig/reflike/reflike.go
+++ b/internal/devconfig/reflike/reflike.go
@@ -1,4 +1,4 @@
-package flake
+package reflike
 
 import (
 	"fmt"
@@ -11,25 +11,26 @@ import (
 
 	"github.com/samber/lo"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
+	"go.jetpack.io/devbox/nix/flake"
 )
 
 // RefLike is like a flake ref, but in some ways more general. It can be used
 // to reference other types of files, e.g. devbox.json.
 type RefLike struct {
-	Ref
+	flake.Ref
 	filename string
 }
 
-func ParseRefLike(s, filename string) (RefLike, error) {
-	r, e := ParseRef(s)
+func Parse(s, filename string) (RefLike, error) {
+	r, e := flake.ParseRef(s)
 	return RefLike{r, filename}, e
 }
 
 func (r RefLike) Fetch() ([]byte, error) {
 	switch r.Type {
-	case TypePath:
+	case flake.TypePath:
 		return os.ReadFile(r.withFilename(r.Path))
-	case TypeGitHub:
+	case flake.TypeGitHub:
 		return r.fetchGithub()
 	default:
 		return nil, fmt.Errorf("unsupported ref type %q", r.Type)

--- a/internal/devconfig/scripts.go
+++ b/internal/devconfig/scripts.go
@@ -9,7 +9,7 @@ type script struct {
 
 type scripts map[string]*script
 
-func (c *configFile) Scripts() scripts {
+func (c *ConfigFile) Scripts() scripts {
 	if c == nil || c.Shell == nil {
 		return nil
 	}

--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -97,17 +97,6 @@ type Package struct {
 	normalizedPackageAttributePathCache string // memoized value from normalizedPackageAttributePath()
 }
 
-// PackagesFromStringsWithDefaults constructs Package from the list of package names provided.
-// These names correspond to devbox packages from the devbox.json config.
-func PackagesFromStringsWithDefaults(rawNames []string, l lock.Locker) []*Package {
-	packages := []*Package{}
-	for _, rawName := range rawNames {
-		pkg := PackageFromStringWithDefaults(rawName, l)
-		packages = append(packages, pkg)
-	}
-	return packages
-}
-
 func PackagesFromStringsWithOptions(rawNames []string, l lock.Locker, opts devopt.AddOpts) []*Package {
 	packages := []*Package{}
 	for _, name := range rawNames {

--- a/internal/plugin/hooks.go
+++ b/internal/plugin/hooks.go
@@ -31,7 +31,7 @@ func (m *Manager) InitHooks(
 		if c == nil {
 			continue
 		}
-		hooks = append(hooks, c.Shell.InitHook.Cmds...)
+		hooks = append(hooks, c.InitHook().Cmds...)
 	}
 	return hooks, nil
 }

--- a/internal/plugin/info.go
+++ b/internal/plugin/info.go
@@ -60,7 +60,7 @@ func Readme(ctx context.Context,
 }
 
 func printReadme(cfg *config, w io.Writer, markdown bool) error {
-	if cfg.Readme == "" {
+	if cfg.Description() == "" {
 		return nil
 	}
 	_, err := fmt.Fprintf(
@@ -68,7 +68,7 @@ func printReadme(cfg *config, w io.Writer, markdown bool) error {
 		"%s%s NOTES:\n%s\n\n",
 		lo.Ternary(markdown, "### ", ""),
 		cfg.Name,
-		cfg.Readme,
+		cfg.Description(),
 	)
 	return errors.WithStack(err)
 }

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/samber/lo"
+	"go.jetpack.io/devbox/internal/devconfig"
 	"go.jetpack.io/devbox/internal/devpkg"
 	"go.jetpack.io/devbox/internal/lock"
 )
@@ -64,7 +65,8 @@ func (m *Manager) ProcessPluginPackages(
 		}
 		pluginPackages = append(
 			pluginPackages,
-			devpkg.PackagesFromStringsWithDefaults(config.Packages, m.lockfile)...,
+			devpkg.PackagesFromConfig(
+				&devconfig.Config{Root: config.ConfigFile}, m.lockfile)...,
 		)
 		if config.RemoveTriggerPackage {
 			packagesToRemove = append(packagesToRemove, pkg)

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -13,11 +13,12 @@ import (
 	"text/template"
 
 	"github.com/pkg/errors"
+	"github.com/samber/lo"
+	"go.jetpack.io/devbox/internal/devconfig"
 	"go.jetpack.io/devbox/internal/devpkg"
 
 	"go.jetpack.io/devbox/internal/conf"
 	"go.jetpack.io/devbox/internal/debug"
-	"go.jetpack.io/devbox/internal/devbox/shellcmd"
 	"go.jetpack.io/devbox/internal/lock"
 	"go.jetpack.io/devbox/internal/nix"
 	"go.jetpack.io/devbox/internal/services"
@@ -34,20 +35,14 @@ var (
 )
 
 type config struct {
-	Name        string            `json:"name"`
-	Version     string            `json:"version"`
+	devconfig.ConfigFile
+
 	CreateFiles map[string]string `json:"create_files"`
-	Packages    []string          `json:"__packages"`
-	Env         map[string]string `json:"env"`
-	Readme      string            `json:"readme"`
+
+	DeprecatedDescription string `json:"readme"`
 	// If true, we remove the package that triggered this plugin from the environment
 	// Useful when we want to replace with flake
 	RemoveTriggerPackage bool `json:"__remove_trigger_package,omitempty"`
-
-	Shell struct {
-		// InitHook contains commands that will run at shell startup.
-		InitHook shellcmd.Commands `json:"init_hook,omitempty"`
-	} `json:"shell,omitempty"`
 }
 
 func (c *config) ProcessComposeYaml() (string, string) {
@@ -280,4 +275,15 @@ func (m *Manager) shouldCreateFile(
 	_, err := os.Stat(filePath)
 	// File doesn't exist, so we should create it.
 	return errors.Is(err, fs.ErrNotExist)
+}
+
+func (c *config) Description() string {
+	if c == nil {
+		return ""
+	}
+	return lo.Ternary(
+		c.ConfigFile.Description != "",
+		c.ConfigFile.Description,
+		c.DeprecatedDescription,
+	)
 }

--- a/internal/pullbox/config.go
+++ b/internal/pullbox/config.go
@@ -37,7 +37,7 @@ func (p *pullbox) pullTextDevboxConfig() error {
 	if err != nil {
 		return err
 	}
-	if err = cfg.SaveTo(tmpDir); err != nil {
+	if err = cfg.Root.SaveTo(tmpDir); err != nil {
 		return err
 	}
 

--- a/internal/pullbox/files.go
+++ b/internal/pullbox/files.go
@@ -76,7 +76,7 @@ func isModifiedConfig(path string) bool {
 		if err != nil {
 			return false
 		}
-		return !cfg.Root.Equals(devconfig.DefaultConfig())
+		return !cfg.Root.Equals(&devconfig.DefaultConfig().Root)
 	}
 	return false
 }

--- a/nix/flake/flakeref.go
+++ b/nix/flake/flakeref.go
@@ -239,6 +239,7 @@ func parseGitHubRef(refURL *url.URL, parsed *Ref) error {
 		}
 		parsed.Rev = qRev
 	}
+	parsed.Dir = refURL.Query().Get("dir")
 	return nil
 }
 

--- a/nix/flake/reflike.go
+++ b/nix/flake/reflike.go
@@ -1,0 +1,76 @@
+package flake
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/samber/lo"
+	"go.jetpack.io/devbox/internal/boxcli/usererr"
+)
+
+// RefLike is like a flake ref, but in some ways more general. It can be used
+// to reference other types of files, e.g. devbox.json.
+type RefLike struct {
+	Ref
+	filename string
+}
+
+func ParseRefLike(s, filename string) (RefLike, error) {
+	r, e := ParseRef(s)
+	return RefLike{r, filename}, e
+}
+
+func (r RefLike) Fetch() ([]byte, error) {
+	switch r.Type {
+	case TypePath:
+		return os.ReadFile(r.withFilename(r.Path))
+	case TypeGitHub:
+		return r.fetchGithub()
+	default:
+		return nil, fmt.Errorf("unsupported ref type %q", r.Type)
+	}
+}
+
+// TODO: This is almost copy paste of plugins/github.go. We should refactor this
+func (r RefLike) fetchGithub() ([]byte, error) {
+	// Github redirects "master" to "main" in new repos. They don't do the reverse
+	// so setting master here is better.
+	contentURL, err := url.JoinPath(
+		"https://raw.githubusercontent.com/",
+		r.Owner,
+		r.Repo,
+		lo.Ternary(r.Rev == "", "master", r.Rev),
+		r.withFilename(r.Dir),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := http.Get(contentURL)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, usererr.New(
+			"failed to fetch github import:%s (Status code %d). \nPlease make sure a "+
+				"%s file exists in the directory.",
+			contentURL,
+			res.StatusCode,
+			r.filename,
+		)
+	}
+	return io.ReadAll(res.Body)
+}
+
+func (r RefLike) withFilename(s string) string {
+	if strings.HasSuffix(s, r.filename) {
+		return s
+	}
+	return filepath.Join(s, r.filename)
+}

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -25,7 +25,7 @@ Plugins are defined as Go JSON Template files, using the following schema:
 {
   "name": "",
   "version": "",
-  "readme": "",
+  "description": "",
   "env": {
     "<key>": "<value>"
   },

--- a/plugins/apacheHttpd.json
+++ b/plugins/apacheHttpd.json
@@ -1,7 +1,7 @@
 {
   "name": "apache",
   "version": "0.0.2",
-  "readme": "If you with to edit the config file, please copy it out of the .devbox directory.",
+  "description": "If you with to edit the config file, please copy it out of the .devbox directory.",
   "env": {
     "HTTPD_DEVBOX_CONFIG_DIR": "{{ .DevboxProjectDir }}",
     "HTTPD_CONFDIR": "{{ .DevboxDir }}",

--- a/plugins/caddy.json
+++ b/plugins/caddy.json
@@ -1,7 +1,7 @@
 {
     "name": "caddy",
     "version": "0.0.3",
-    "readme": "You can customize the config used by the caddy service by modifying the Caddyfile in devbox.d/caddy, or by changing the CADDY_CONFIG environment variable to point to a custom config. The custom config must be either JSON or Caddyfile format.",
+    "description": "You can customize the config used by the caddy service by modifying the Caddyfile in devbox.d/caddy, or by changing the CADDY_CONFIG environment variable to point to a custom config. The custom config must be either JSON or Caddyfile format.",
     "env": {
         "CADDY_CONFIG": "{{ .DevboxDir }}/Caddyfile",
         "CADDY_LOG_DIR": "{{ .Virtenv }}/log",

--- a/plugins/gradle.json
+++ b/plugins/gradle.json
@@ -1,7 +1,7 @@
 {
     "name": "gradle",
     "version": "0.0.1",
-    "readme": "You can customize which JDK gradle will use by specifying the value of `org.gradle.java.home` in gradle.properties file",
+    "description": "You can customize which JDK gradle will use by specifying the value of `org.gradle.java.home` in gradle.properties file",
     "shell": {
         "init_hook": [
             "[ -s gradle.properties ] || echo org.gradle.java.home=$JAVA_HOME >> gradle.properties"

--- a/plugins/haskell.json
+++ b/plugins/haskell.json
@@ -1,7 +1,7 @@
 {
   "name": "haskell",
   "version": "0.0.2",
-  "readme": "Haskell plugin",
+  "description": "Haskell plugin",
   "packages": [
     "path:{{ .Virtenv }}/flake"
   ],

--- a/plugins/haskell.json
+++ b/plugins/haskell.json
@@ -2,7 +2,7 @@
   "name": "haskell",
   "version": "0.0.2",
   "readme": "Haskell plugin",
-  "__packages": [
+  "packages": [
     "path:{{ .Virtenv }}/flake"
   ],
   "__remove_trigger_package": true,

--- a/plugins/mariadb.json
+++ b/plugins/mariadb.json
@@ -1,7 +1,7 @@
 {
   "name": "mariadb",
   "version": "0.0.4",
-  "readme": "* This plugin wraps mysqld and mysql_install_db to work in your local project\n* This plugin will create a new database for your project in MYSQL_DATADIR if one doesn't exist on shell init\n* Use mysqld to manually start the server, and `mysqladmin -u root shutdown` to manually stop it",
+  "description": "* This plugin wraps mysqld and mysql_install_db to work in your local project\n* This plugin will create a new database for your project in MYSQL_DATADIR if one doesn't exist on shell init\n* Use mysqld to manually start the server, and `mysqladmin -u root shutdown` to manually stop it",
   "env": {
     "MYSQL_BASEDIR": "{{ .DevboxProfileDefault }}",
     "MYSQL_HOME": "{{ .Virtenv }}/run",

--- a/plugins/mariadb.json
+++ b/plugins/mariadb.json
@@ -15,7 +15,7 @@
     "{{ .Virtenv }}/setup_db.sh": "mariadb/setup_db.sh",
     "{{ .Virtenv }}/process-compose.yaml": "mariadb/process-compose.yaml"
   },
-  "__packages": [
+  "packages": [
     "path:{{ .Virtenv }}/flake"
   ],
   "__remove_trigger_package": true,

--- a/plugins/mysql.json
+++ b/plugins/mysql.json
@@ -15,7 +15,7 @@
       "{{ .Virtenv }}/setup_db.sh": "mysql/setup_db.sh",
       "{{ .Virtenv }}/process-compose.yaml": "mysql/process-compose.yaml"
     },
-    "__packages": [
+    "packages": [
       "path:{{ .Virtenv }}/flake"
     ],
     "__remove_trigger_package": true,

--- a/plugins/mysql.json
+++ b/plugins/mysql.json
@@ -1,7 +1,7 @@
 {
     "name": "mysql",
     "version": "0.0.3",
-    "readme": "* This plugin wraps mysqld and mysql_install_db to work in your local project\n* This plugin will create a new database for your project in MYSQL_DATADIR if one doesn't exist on shell init. This DB will be started in `insecure` mode, so be sure to add a root password after creation if needed.\n* Use mysqld to manually start the server, and `mysqladmin -u root shutdown` to manually stop it",
+    "description": "* This plugin wraps mysqld and mysql_install_db to work in your local project\n* This plugin will create a new database for your project in MYSQL_DATADIR if one doesn't exist on shell init. This DB will be started in `insecure` mode, so be sure to add a root password after creation if needed.\n* Use mysqld to manually start the server, and `mysqladmin -u root shutdown` to manually stop it",
     "env": {
       "MYSQL_BASEDIR": "{{ .DevboxProfileDefault }}",
       "MYSQL_HOME": "{{ .Virtenv }}/run",

--- a/plugins/nginx.json
+++ b/plugins/nginx.json
@@ -2,7 +2,7 @@
   "name": "nginx",
   "version": "0.0.4",
   "readme": "nginx can be configured with env variables\n\nTo customize:\n* Use $NGINX_CONFDIR to change the configuration directory\n* Use $NGINX_TMPDIR to change the tmp directory. Use $NGINX_USER to change the user\n* Use $NGINX_WEB_PORT to change the port NGINX runs on. \n Note: This plugin uses envsubst when running `devbox services` to generate the nginx.conf file from the nginx.template file. To customize the nginx.conf file, edit the nginx.template file.\n",
-  "__packages": ["gettext@latest", "gawk@latest"],
+  "packages": ["gettext@latest", "gawk@latest"],
   "env": {
     "NGINX_CONF": "{{ .DevboxDir }}/nginx.conf",
     "NGINX_CONFDIR": "{{ .DevboxDir }}",

--- a/plugins/nginx.json
+++ b/plugins/nginx.json
@@ -1,7 +1,7 @@
 {
   "name": "nginx",
   "version": "0.0.4",
-  "readme": "nginx can be configured with env variables\n\nTo customize:\n* Use $NGINX_CONFDIR to change the configuration directory\n* Use $NGINX_TMPDIR to change the tmp directory. Use $NGINX_USER to change the user\n* Use $NGINX_WEB_PORT to change the port NGINX runs on. \n Note: This plugin uses envsubst when running `devbox services` to generate the nginx.conf file from the nginx.template file. To customize the nginx.conf file, edit the nginx.template file.\n",
+  "description": "nginx can be configured with env variables\n\nTo customize:\n* Use $NGINX_CONFDIR to change the configuration directory\n* Use $NGINX_TMPDIR to change the tmp directory. Use $NGINX_USER to change the user\n* Use $NGINX_WEB_PORT to change the port NGINX runs on. \n Note: This plugin uses envsubst when running `devbox services` to generate the nginx.conf file from the nginx.template file. To customize the nginx.conf file, edit the nginx.template file.\n",
   "packages": ["gettext@latest", "gawk@latest"],
   "env": {
     "NGINX_CONF": "{{ .DevboxDir }}/nginx.conf",

--- a/plugins/php.json
+++ b/plugins/php.json
@@ -2,7 +2,7 @@
   "name": "php",
   "version": "0.0.3",
   "readme": "PHP is compiled with default extensions. If you would like to use non-default extensions you can add them with devbox add php81Extensions.{extension} . For example, for the memcache extension you can do `devbox add php81Extensions.memcached`.",
-  "__packages": [
+  "packages": [
     "path:{{ .Virtenv }}/flake",
     "path:{{ .Virtenv }}/flake#composer"
   ],

--- a/plugins/php.json
+++ b/plugins/php.json
@@ -1,7 +1,7 @@
 {
   "name": "php",
   "version": "0.0.3",
-  "readme": "PHP is compiled with default extensions. If you would like to use non-default extensions you can add them with devbox add php81Extensions.{extension} . For example, for the memcache extension you can do `devbox add php81Extensions.memcached`.",
+  "description": "PHP is compiled with default extensions. If you would like to use non-default extensions you can add them with devbox add php81Extensions.{extension} . For example, for the memcache extension you can do `devbox add php81Extensions.memcached`.",
   "packages": [
     "path:{{ .Virtenv }}/flake",
     "path:{{ .Virtenv }}/flake#composer"

--- a/plugins/pip.json
+++ b/plugins/pip.json
@@ -1,7 +1,7 @@
 {
     "name": "pip",
     "version": "0.0.2",
-    "readme": "This plugin adds a script for automatically creating a virtual environment using `venv` for python3 projects, so you can install packages with pip as normal.\nTo activate the environment, run `. $VENV_DIR/bin/activate` or add it to the init_hook of your devbox.json\nTo change where your virtual environment is created, modify the $VENV_DIR environment variable in your init_hook",
+    "description": "This plugin adds a script for automatically creating a virtual environment using `venv` for python3 projects, so you can install packages with pip as normal.\nTo activate the environment, run `. $VENV_DIR/bin/activate` or add it to the init_hook of your devbox.json\nTo change where your virtual environment is created, modify the $VENV_DIR environment variable in your init_hook",
     "env": {
         "VENV_DIR": "{{ .Virtenv }}/.venv"
     },

--- a/plugins/poetry.json
+++ b/plugins/poetry.json
@@ -1,7 +1,7 @@
 {
     "name": "poetry",
     "version": "0.0.4",
-    "readme": "This plugin automatically configures poetry to use the version of python installed in your Devbox shell, instead of the Python version that it is bundled with. The pyproject.toml location can be configured by setting DEVBOX_PYPROJECT_DIR (defaults to the devbox.json's directory).",
+    "description": "This plugin automatically configures poetry to use the version of python installed in your Devbox shell, instead of the Python version that it is bundled with. The pyproject.toml location can be configured by setting DEVBOX_PYPROJECT_DIR (defaults to the devbox.json's directory).",
     "env": {
         "DEVBOX_DEFAULT_PYPROJECT_DIR": "{{ .DevboxProjectDir }}",
         "POETRY_VIRTUALENVS_IN_PROJECT": "true",

--- a/plugins/postgresql.json
+++ b/plugins/postgresql.json
@@ -1,7 +1,7 @@
 {
     "name": "postgresql",
     "version": "0.0.2",
-    "readme": "To initialize the database run `initdb`.",
+    "description": "To initialize the database run `initdb`.",
     "env": {
         "PGDATA": "{{ .Virtenv }}/data",
         "PGHOST": "{{ .Virtenv }}"

--- a/plugins/python.json
+++ b/plugins/python.json
@@ -1,7 +1,7 @@
 {
   "name": "python",
   "version": "0.0.3",
-  "readme": "Python in Devbox works best when used with a virtual environment (vent, virtualenv, etc.). Devbox will automatically create a virtual environment using `venv` for python3 projects, so you can install packages with pip as normal.\nTo activate the environment, run `. $VENV_DIR/bin/activate` or add it to the init_hook of your devbox.json\nTo change where your virtual environment is created, modify the $VENV_DIR environment variable in your init_hook",
+  "description": "Python in Devbox works best when used with a virtual environment (vent, virtualenv, etc.). Devbox will automatically create a virtual environment using `venv` for python3 projects, so you can install packages with pip as normal.\nTo activate the environment, run `. $VENV_DIR/bin/activate` or add it to the init_hook of your devbox.json\nTo change where your virtual environment is created, modify the $VENV_DIR environment variable in your init_hook",
   "env": {
       "VENV_DIR": "{{ .Virtenv }}/.venv"
   },

--- a/plugins/redis.json
+++ b/plugins/redis.json
@@ -1,7 +1,7 @@
 {
     "name": "redis",
     "version": "0.0.2",
-    "readme": "Running `devbox services start redis` will start redis as a daemon in the background. \n\nYou can manually start Redis in the foreground by running `redis-server $REDIS_CONF --port $REDIS_PORT`. \n\nLogs, pidfile, and data dumps are stored in `.devbox/virtenv/redis`. You can change this by modifying the `dir` directive in `devbox.d/redis/redis.conf`",
+    "description": "Running `devbox services start redis` will start redis as a daemon in the background. \n\nYou can manually start Redis in the foreground by running `redis-server $REDIS_CONF --port $REDIS_PORT`. \n\nLogs, pidfile, and data dumps are stored in `.devbox/virtenv/redis`. You can change this by modifying the `dir` directive in `devbox.d/redis/redis.conf`",
     "env": {
         "REDIS_PORT": "6379",
         "REDIS_CONF": "{{ .DevboxDir }}/redis.conf"

--- a/plugins/rustc.json
+++ b/plugins/rustc.json
@@ -1,5 +1,5 @@
 {
   "name": "rustc",
   "version": "0.0.1",
-  "readme": "As an alternative to rustc you may add rustup to manage your rust versions."
+  "description": "As an alternative to rustc you may add rustup to manage your rust versions."
 }

--- a/plugins/rustup.json
+++ b/plugins/rustup.json
@@ -1,7 +1,7 @@
 {
   "name": "rustup",
   "version": "0.0.1",
-  "readme": "If using this on macOS you may need to install `libiconv` as well",
+  "description": "If using this on macOS you may need to install `libiconv` as well",
   "env": {
     "RUSTUP_HOME": "{{ .Virtenv }}",
     "LIBRARY_PATH": "{{ .DevboxProfileDefault }}/lib"


### PR DESCRIPTION
## Summary

Adds and implements `imports` field to devbox.json. Imports follow flake ref specs (but are limited to only path and github for now).

For example:

```json
"imports": [
  "./foobar",
  "path:./foobar2",
  "github:jetpack-io/devbox?dir=somedir",
]
```

Fields from imported configs are added to the environment. The merge algorithm is as follows:

* Imports are evaluated in order first. Base config is evaluated last.
* Slices are concatenated (init hooks, etc)
* maps are merged with later evaluation replacing previous one on conflict.
* Packages are deduped by name and concatenated. (i.e. multiple versions not allowed)

Caveats:

* This can be slow. When using remote imports, every devbox command does 1 or more HTTP requests to load the imports.
* central lock file. All dependencies are stored there. 

TODOs:

* Handle relative paths inside of imported configs
* Cycle detection

## How was it tested?

* Tested importing local devbox.json
* Tested importing github  devbox.json