### PR TITLE
[UX] Show add (nix build) stdout

### DIFF
--- a/internal/devbox/packages.go
+++ b/internal/devbox/packages.go
@@ -443,7 +443,8 @@ func (d *Devbox) installNixPackagesToStore(ctx context.Context) error {
 		args := &nix.BuildArgs{
 			AllowInsecure: pkg.HasAllowInsecure(),
 			// --no-link to avoid generating the result objects
-			Flags: []string{"--no-link"},
+			Flags:  []string{"--no-link"},
+			Writer: d.stderr,
 		}
 		err = nix.Build(ctx, args, installable)
 		if err != nil {

--- a/internal/nix/build.go
+++ b/internal/nix/build.go
@@ -25,7 +25,7 @@ func Build(ctx context.Context, args *BuildArgs, installables ...string) error {
 		cmd.Env = allowInsecureEnv(cmd.Env)
 	}
 
-	// If nix profile install runs as tty, the output is much nicer. If we ever
+	// If nix build runs as tty, the output is much nicer. If we ever
 	// need to change this to our own writers, consider that you may need
 	// to implement your own nicer output. --print-build-logs flag may be useful.
 	cmd.Stdin = os.Stdin

--- a/internal/nix/build.go
+++ b/internal/nix/build.go
@@ -2,17 +2,16 @@ package nix
 
 import (
 	"context"
-	"fmt"
+	"io"
 	"os"
-	"os/exec"
 
-	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/internal/debug"
 )
 
 type BuildArgs struct {
 	AllowInsecure bool
 	Flags         []string
+	Writer        io.Writer
 }
 
 func Build(ctx context.Context, args *BuildArgs, installables ...string) error {
@@ -26,14 +25,13 @@ func Build(ctx context.Context, args *BuildArgs, installables ...string) error {
 		cmd.Env = allowInsecureEnv(cmd.Env)
 	}
 
+	// If nix profile install runs as tty, the output is much nicer. If we ever
+	// need to change this to our own writers, consider that you may need
+	// to implement your own nicer output. --print-build-logs flag may be useful.
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = args.Writer
+	cmd.Stderr = args.Writer
+
 	debug.Log("Running cmd: %s\n", cmd)
-	_, err := cmd.Output()
-	if err != nil {
-		if exitErr := (&exec.ExitError{}); errors.As(err, &exitErr) {
-			debug.Log("Nix build exit code: %d, output: %s\n", exitErr.ExitCode(), exitErr.Stderr)
-			return fmt.Errorf("nix build exit code: %d, output: %s, err: %w", exitErr.ExitCode(), exitErr.Stderr, err)
-		}
-		return err
-	}
-	return nil
+	return cmd.Run()
 }


### PR DESCRIPTION
## Summary

I mostly copied over what we have from `nix.ProfileInstall`. I thinks this is OK? It will pipe all output and errors to stderr so user can see progress and if anything breaks it will show up there as well.

## How was it tested?

Tried installing something slow:
<img width="756" alt="image" src="https://github.com/jetpack-io/devbox/assets/544948/bab51a0a-b167-4a9d-ae95-b2b1a9f2179a">

