### PR TITLE
[process-compose] Improve port selection

### DIFF
--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -25,8 +25,6 @@ import (
 
 const (
 	processComposeLogfile = ".devbox/compose.log"
-	startingPort          = 8260
-	maxPortTries          = 10
 	fileLockTimeout       = 5 * time.Second
 )
 

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -30,7 +30,7 @@ const (
 	fileLockTimeout       = 5 * time.Second
 )
 
-func getAvailablePort(config *globalProcessComposeConfig) (int, error) {
+func getAvailablePort() (int, error) {
 	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
 	if err != nil {
 		return 0, errors.WithStack(err)
@@ -142,7 +142,7 @@ func StartProcessManager(
 	config.File = configFile
 
 	// Get the port to use for this project
-	port, err := getAvailablePort(config)
+	port, err := getAvailablePort()
 	if err != nil {
 		return err
 	}

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -27,20 +26,6 @@ const (
 	processComposeLogfile = ".devbox/compose.log"
 	fileLockTimeout       = 5 * time.Second
 )
-
-func getAvailablePort() (int, error) {
-	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
-	if err != nil {
-		return 0, errors.WithStack(err)
-	}
-
-	l, err := net.ListenTCP("tcp", addr)
-	if err != nil {
-		return 0, errors.WithStack(err)
-	}
-	defer l.Close()
-	return l.Addr().(*net.TCPAddr).Port, nil
-}
 
 type instance struct {
 	Pid  int `json:"pid"`

--- a/internal/services/ports.go
+++ b/internal/services/ports.go
@@ -7,7 +7,7 @@ import (
 )
 
 var disallowedPorts = map[int]string{
-	// Anything < 1024
+	// Anything <= 1024
 	1433: "MS-SQL (Microsoft SQL Server database management system)",
 	1434: "MS-SQL (Microsoft SQL Server database management system)",
 	1521: "Oracle SQL",

--- a/internal/services/ports.go
+++ b/internal/services/ports.go
@@ -1,0 +1,65 @@
+package services
+
+import (
+	"net"
+
+	"github.com/pkg/errors"
+)
+
+var disallowedPorts = map[int]string{
+	// Anything < 1024
+	1433: "MS-SQL (Microsoft SQL Server database management system)",
+	1434: "MS-SQL (Microsoft SQL Server database management system)",
+	1521: "Oracle SQL",
+	1701: "L2TP (Layer 2 Tunneling Protocol)",
+	1723: "PPTP (Point-to-Point Tunneling Protocol)",
+	2049: "NFS (Network File System)",
+	3000: "Node.js (Server-side JavaScript environment)",
+	3001: "Node.js (Server-side JavaScript environment)",
+	3306: "MySQL (Database system)",
+	3389: "RDP (Remote Desktop Protocol)",
+	5060: "SIP (Session Initiation Protocol)",
+	5145: "RSH (Remote Shell)",
+	5353: "mDNS (Multicast DNS)",
+	5432: "PostgreSQL (Database system)",
+	5900: "VNC (Virtual Network Computing)",
+	6379: "Redis (Database system)",
+	8000: "HTTP Alternate (http_alt)",
+	8080: "HTTP Alternate (http_alt)",
+	8082: "PHP FPM",
+	8443: "HTTPS Alternate (https_alt)",
+	9443: "Redis Enterprise (Database system)",
+}
+
+func getAvailablePort() (int, error) {
+	get := func() (int, error) {
+		addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+		if err != nil {
+			return 0, errors.WithStack(err)
+		}
+
+		l, err := net.ListenTCP("tcp", addr)
+		if err != nil {
+			return 0, errors.WithStack(err)
+		}
+		defer l.Close()
+		return l.Addr().(*net.TCPAddr).Port, nil
+	}
+
+	for range 1000 {
+		port, err := get()
+		if err != nil {
+			return 0, errors.WithStack(err)
+		}
+
+		if isAllowed(port) {
+			return port, nil
+		}
+	}
+
+	return 0, errors.New("no available port")
+}
+
+func isAllowed(port int) bool {
+	return port > 1024 && disallowedPorts[port] == ""
+}


### PR DESCRIPTION
## Summary

This helps fix the lapp and lepp stack test issues. It also provides a more reliable way to provide an unused port that does not have race condition issues or the limit of 10 ports.

## How was it tested?
devbox services start
