### PR TITLE
[Outputs] Update generated flake to handle store paths for each output

### DIFF
--- a/internal/devbox/update_test.go
+++ b/internal/devbox/update_test.go
@@ -63,7 +63,7 @@ func TestUpdateNewCurrentSysInfoIsAdded(t *testing.T) {
 
 	require.Contains(t, lockfile.Packages, raw)
 	require.Contains(t, lockfile.Packages[raw].Systems, sys)
-	require.Equal(t, "store_path1", lockfile.Packages[raw].Systems[sys].DefaultStorePath())
+	require.Equal(t, "store_path1", lockfile.Packages[raw].Systems[sys].Outputs[0].Path)
 }
 
 func TestUpdateNewSysInfoIsAdded(t *testing.T) {
@@ -123,7 +123,7 @@ func TestUpdateNewSysInfoIsAdded(t *testing.T) {
 	require.Contains(t, lockfile.Packages, raw)
 	require.Contains(t, lockfile.Packages[raw].Systems, sys1)
 	require.Contains(t, lockfile.Packages[raw].Systems, sys2)
-	require.Equal(t, "store_path2", lockfile.Packages[raw].Systems[sys2].DefaultStorePath())
+	require.Equal(t, "store_path2", lockfile.Packages[raw].Systems[sys2].Outputs[0].Path)
 }
 
 func TestUpdateOtherSysInfoIsReplaced(t *testing.T) {
@@ -191,8 +191,8 @@ func TestUpdateOtherSysInfoIsReplaced(t *testing.T) {
 	require.Contains(t, lockfile.Packages, raw)
 	require.Contains(t, lockfile.Packages[raw].Systems, sys1)
 	require.Contains(t, lockfile.Packages[raw].Systems, sys2)
-	require.Equal(t, "store_path1", lockfile.Packages[raw].Systems[sys1].DefaultStorePath())
-	require.Equal(t, "store_path2", lockfile.Packages[raw].Systems[sys2].DefaultStorePath())
+	require.Equal(t, "store_path1", lockfile.Packages[raw].Systems[sys1].Outputs[0].Path)
+	require.Equal(t, "store_path2", lockfile.Packages[raw].Systems[sys2].Outputs[0].Path)
 }
 
 func currentSystem(_t *testing.T) string {

--- a/internal/devpkg/narinfo_cache.go
+++ b/internal/devpkg/narinfo_cache.go
@@ -2,8 +2,10 @@ package devpkg
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
@@ -19,24 +21,28 @@ import (
 // It is used as FromStore in builtins.fetchClosure.
 const BinaryCache = "https://cache.nixos.org"
 
-// IsInBinaryCache returns true if the package is in the binary cache.
-// ALERT: Callers in a perf-sensitive code path should call FillNarInfoCache
-// before calling this function.
-func (p *Package) IsInBinaryCache() (bool, error) {
-	// Patched glibc packages are not in the binary cache.
-	if p.PatchGlibc {
-		return false, nil
-	}
-	// Packages with non-default outputs are not to be taken from the binary cache.
-	if len(p.Outputs) > 0 {
-		return false, nil
-	}
+func (p *Package) IsOutputInBinaryCache(outputName string) (bool, error) {
+	fmt.Fprintf(os.Stderr, "IsOutputInBinaryCache with outputName %s\n", outputName)
 	if eligible, err := p.isEligibleForBinaryCache(); err != nil {
 		return false, err
 	} else if !eligible {
 		return false, nil
 	}
-	return p.fetchNarInfoStatusOnce()
+
+	return p.fetchNarInfoStatusOnce(outputName)
+}
+
+// IsInBinaryCache returns true if the package is in the binary cache.
+// ALERT: Callers in a perf-sensitive code path should call FillNarInfoCache
+// before calling this function.
+func (p *Package) IsInBinaryCache() (bool, error) {
+	if eligible, err := p.isEligibleForBinaryCache(); err != nil {
+		return false, err
+	} else if !eligible {
+		return false, nil
+	}
+
+	return p.fetchNarInfoStatusOnce(UseDefaultOutput)
 }
 
 // FillNarInfoCache checks the remote binary cache for the narinfo of each
@@ -72,10 +78,18 @@ func FillNarInfoCache(ctx context.Context, packages ...*Package) error {
 	group, _ := errgroup.WithContext(ctx)
 	for _, p := range eligiblePackages {
 		pkg := p // copy the loop variable since its used in a closure below
-		group.Go(func() error {
-			_, err := pkg.fetchNarInfoStatusOnce()
+		names, err := pkg.GetOutputNames()
+		if err != nil {
 			return err
-		})
+		}
+
+		for _, o := range names {
+			output := o
+			group.Go(func() error {
+				_, err := pkg.fetchNarInfoStatusOnce(output)
+				return err
+			})
+		}
 	}
 	return group.Wait()
 }
@@ -87,12 +101,13 @@ var narInfoStatusFnCache = sync.Map{}
 
 // fetchNarInfoStatusOnce is like fetchNarInfoStatus, but will only ever run
 // once and cache the result.
-func (p *Package) fetchNarInfoStatusOnce() (bool, error) {
+func (p *Package) fetchNarInfoStatusOnce(output string) (bool, error) {
 	type inCacheFunc func() (bool, error)
 	f, ok := narInfoStatusFnCache.Load(p.Raw)
 	if !ok {
-		f = inCacheFunc(sync.OnceValues(p.fetchNarInfoStatus))
-		f, _ = narInfoStatusFnCache.LoadOrStore(p.Raw, f)
+		key := fmt.Sprintf("%s^%s", p.Raw, output)
+		f = inCacheFunc(sync.OnceValues(func() (bool, error) { return p.fetchNarInfoStatus(output) }))
+		f, _ = narInfoStatusFnCache.LoadOrStore(key, f)
 	}
 	return f.(inCacheFunc)()
 }
@@ -101,7 +116,7 @@ func (p *Package) fetchNarInfoStatusOnce() (bool, error) {
 // true if cache exists, false otherwise.
 // NOTE: This function always performs an HTTP request and should not be called
 // more than once per package.
-func (p *Package) fetchNarInfoStatus() (bool, error) {
+func (p *Package) fetchNarInfoStatus(outputName string) (bool, error) {
 	sysInfo, err := p.sysInfoIfExists()
 	if err != nil {
 		return false, err
@@ -112,28 +127,53 @@ func (p *Package) fetchNarInfoStatus() (bool, error) {
 		)
 	}
 
-	pathParts := nix.NewStorePathParts(sysInfo.DefaultStorePath())
-	reqURL := BinaryCache + "/" + pathParts.Hash + ".narinfo"
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, reqURL, nil)
-	if err != nil {
-		return false, err
+	var outputs []lock.Output
+	if outputName == UseDefaultOutput {
+		outputs = sysInfo.DefaultOutputs()
+	} else {
+		out, err := sysInfo.Output(outputName)
+		if err != nil {
+			return false, err
+		}
+		outputs = []lock.Output{out}
 	}
-	res, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return false, err
-	}
-	// read the body fully, and close it to ensure the connection is reused.
-	_, _ = io.Copy(io.Discard, res.Body)
-	defer res.Body.Close()
 
-	return res.StatusCode == 200, nil
+	outputInCache := map[string]bool{} // key = output name, value = in cache
+	for _, output := range outputs {
+		pathParts := nix.NewStorePathParts(output.Path)
+		reqURL := BinaryCache + "/" + pathParts.Hash + ".narinfo"
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, http.MethodHead, reqURL, nil)
+		if err != nil {
+			return false, err
+		}
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return false, err
+		}
+		// read the body fully, and close it to ensure the connection is reused.
+		_, _ = io.Copy(io.Discard, res.Body)
+		outputInCache[output.Name] = res.StatusCode == 200
+		res.Body.Close()
+	}
+
+	// If any output is not in the cache, then the package is deemed to be not in the cache.
+	for _, inCache := range outputInCache {
+		if !inCache {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 // isEligibleForBinaryCache returns true if we have additional metadata about
 // the package to query it from the binary cache.
 func (p *Package) isEligibleForBinaryCache() (bool, error) {
+	// Patched glibc packages are not in the binary cache.
+	if p.PatchGlibc {
+		return false, nil
+	}
 	sysInfo, err := p.sysInfoIfExists()
 	if err != nil {
 		return false, err

--- a/internal/devpkg/outputs.go
+++ b/internal/devpkg/outputs.go
@@ -1,0 +1,47 @@
+package devpkg
+
+// outputs are the nix package outputs
+type outputs struct {
+	selectedNames []string
+	defaultNames  []string
+}
+
+// initOutputs creates a new outputs struct.
+func initOutputs(selectedNames []string) *outputs {
+	return &outputs{selectedNames: selectedNames}
+}
+
+func (out *outputs) GetNames(pkg *Package) ([]string, error) {
+	if len(out.selectedNames) > 0 {
+		return out.selectedNames, nil
+	}
+
+	// else, get the default outputs from the lockfile
+	// if we haven't already
+	if out.defaultNames == nil {
+		if err := out.initDefaultNames(pkg); err != nil {
+			return []string{}, err
+		}
+	}
+	return out.defaultNames, nil
+}
+
+// initDefaultNames initializes the defaultNames field of the Outputs object.
+// We run this lazily (rather than eagerly in initOutputs) because it depends on the Package,
+// and initOutputs is called from the Package constructor, so cannot depend on Package.
+func (out *outputs) initDefaultNames(pkg *Package) error {
+	sysInfo, err := pkg.sysInfoIfExists()
+	if err != nil {
+		return err
+	}
+
+	out.defaultNames = []string{}
+	if sysInfo == nil {
+		return nil
+	}
+
+	for _, output := range sysInfo.DefaultOutputs() {
+		out.defaultNames = append(out.defaultNames, output.Name)
+	}
+	return nil
+}

--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -61,10 +62,6 @@ type Package struct {
 	// For flake packages (non-devbox packages), resolve is a no-op.
 	resolve func() error
 
-	// storePath is set by resolve if the package exists in the Nix binary
-	// cache.
-	storePath string
-
 	// Raw is the devbox package name from the devbox.json config.
 	// Raw has a few forms:
 	// 1. Devbox Packages
@@ -81,6 +78,9 @@ type Package struct {
 
 	// Outputs is a list of outputs to build from the package's derivation.
 	// If empty, the default output is used.
+	//
+	// Note the distinction: these are user-selected outputs, whereas the lockfile has outputs
+	// whose store-paths are available outputs with store-paths.
 	Outputs []string
 
 	// PatchGlibc applies a function to the package's derivation that
@@ -122,7 +122,7 @@ func PackagesFromConfig(config *devconfig.Config, l lock.Locker) []*Package {
 		pkg := newPackage(cfgPkg.VersionedName(), cfgPkg.IsEnabledOnPlatform(), l)
 		pkg.DisablePlugin = cfgPkg.DisablePlugin
 		pkg.PatchGlibc = cfgPkg.PatchGlibc && nix.SystemIsLinux()
-		pkg.Outputs = cfgPkg.Outputs
+		pkg.Outputs = initOutputsField(cfgPkg.Outputs)
 		pkg.AllowInsecure = cfgPkg.AllowInsecure
 		result = append(result, pkg)
 	}
@@ -137,7 +137,7 @@ func PackageFromStringWithOptions(raw string, locker lock.Locker, opts devopt.Ad
 	pkg := PackageFromStringWithDefaults(raw, locker)
 	pkg.DisablePlugin = opts.DisablePlugin
 	pkg.PatchGlibc = opts.PatchGlibc
-	pkg.Outputs = opts.Outputs
+	pkg.Outputs = initOutputsField(opts.Outputs)
 	pkg.AllowInsecure = opts.AllowInsecure
 	return pkg
 }
@@ -147,6 +147,7 @@ func newPackage(raw string, isInstallable bool, locker lock.Locker) *Package {
 		Raw:           raw,
 		lockfile:      locker,
 		isInstallable: isInstallable,
+		Outputs:       initOutputsField([]string{}),
 	}
 
 	// The raw string is either a Devbox package ("name" or "name@version")
@@ -165,6 +166,20 @@ func newPackage(raw string, isInstallable bool, locker lock.Locker) *Package {
 	pkg.resolve = sync.OnceValue(func() error { return nil })
 	pkg.setInstallable(parsed, locker.ProjectDir())
 	return pkg
+}
+
+// UseDefaultOutput is a special signifier to use the default outputs of a package.
+// It is used to indicate that the user hasn't explicitly specified the outputs they want.
+const UseDefaultOutput = "__useDefaultOutput__"
+
+// initOutputsField initializes the outputs field of a package. It is meant to be used in the
+// Package struct constructor functions
+func initOutputsField(selectedOutputs []string) []string {
+	outputs := []string{UseDefaultOutput}
+	if len(selectedOutputs) > 0 {
+		outputs = selectedOutputs
+	}
+	return outputs
 }
 
 // isAmbiguous returns true if a package string could be a Devbox package or
@@ -206,13 +221,15 @@ func resolve(pkg *Package) error {
 	if err != nil {
 		return err
 	}
-	if inCache, err := pkg.IsInBinaryCache(); err == nil && inCache {
-		pkg.storePath = resolved.Systems[nix.System()].DefaultStorePath()
-	}
 	parsed, err := flake.ParseInstallable(resolved.Resolved)
 	if err != nil {
 		return err
 	}
+
+	// TODO savil. Check with Greg about setting the user-specified outputs
+	// somehow here.
+	// NOTE: The below code fails with the php testscript.
+
 	pkg.setInstallable(parsed, pkg.lockfile.ProjectDir())
 	return nil
 }
@@ -278,23 +295,54 @@ func (p *Package) IsInstallable() bool {
 // Installable for this package. Installable is a nix concept defined here:
 // https://nixos.org/manual/nix/stable/command-ref/new-cli/nix.html#installables
 func (p *Package) Installable() (string, error) {
-	inCache, err := p.IsInBinaryCache()
+	outputs, err := p.GetOutputNames()
+	if err != nil {
+		return "", err
+	}
+	fmt.Fprintf(os.Stderr, "Package.Installable: outputs for package %s: %v\n", p.Raw, outputs)
+	installables := []string{}
+	for _, output := range outputs {
+		i, err := p.InstallableForOutput(output)
+		if err != nil {
+			return "", err
+		}
+		installables = append(installables, i)
+	}
+	if len(installables) == 0 {
+		// This means that the package is not in the binary cache
+		// OR it is a flake (??)
+		installable, err := p.urlForInstall()
+		if err != nil {
+			return "", err
+		}
+		return installable, nil
+	}
+	// TODO savil: return all installables
+	return installables[0], nil
+}
+
+func (p *Package) InstallableForOutput(output string) (string, error) {
+	inCache, err := p.IsOutputInBinaryCache(output)
 	if err != nil {
 		return "", err
 	}
 
 	if inCache {
-		installable, err := p.InputAddressedPath()
+		fmt.Fprintf(os.Stderr, "InstallableForOutput: Package %s output %s is in the binary cache\n", p.Raw, output)
+		installable, err := p.InputAddressedPathForOutput(output)
 		if err != nil {
 			return "", err
 		}
 		return installable, nil
 	}
 
+	// TODO savil: make work for output
 	installable, err := p.urlForInstall()
 	if err != nil {
 		return "", err
 	}
+	fmt.Fprintf(os.Stderr, "InstallableForOutput: Package %s output %s is NOT in the binary cache\n", p.Raw, output)
+	fmt.Fprintf(os.Stderr, "InstallableForOutput: Package %s output %s installable: %s \n", p.Raw, output, installable)
 	return installable, nil
 }
 
@@ -576,7 +624,32 @@ func (p *Package) InputAddressedPath() (string, error) {
 	}
 
 	sysInfo := entry.Systems[nix.System()]
-	return sysInfo.DefaultStorePath(), nil
+	outputs := sysInfo.DefaultOutputs()
+
+	// TODO return an array of outputs
+	return p.InputAddressedPathForOutput(outputs[0].Name)
+}
+
+func (p *Package) InputAddressedPathForOutput(output string) (string, error) {
+	if inCache, err := p.IsInBinaryCache(); err != nil {
+		return "", err
+	} else if !inCache {
+		return "",
+			errors.Errorf("Package %q cannot be fetched from binary cache store", p.Raw)
+	}
+
+	entry, err := p.lockfile.Resolve(p.Raw)
+	if err != nil {
+		return "", err
+	}
+
+	sysInfo := entry.Systems[nix.System()]
+	for _, out := range sysInfo.Outputs {
+		if out.Name == output {
+			return out.Path, nil
+		}
+	}
+	return "", errors.Errorf("Output %q not found for package %q", output, p.Raw)
 }
 
 func (p *Package) HasAllowInsecure() bool {
@@ -645,4 +718,36 @@ func (p *Package) DocsURL() string {
 		return fmt.Sprintf("https://www.nixhub.io/packages/%s", p.CanonicalName())
 	}
 	return ""
+}
+
+// GetOutputNames returns the names of the nix package outputs.
+// It may be empty if the package is not in the lockfile.
+func (p *Package) GetOutputNames() ([]string, error) {
+	if p.IsRunX() {
+		return []string{}, nil
+	}
+
+	// if p.Outputs has user specified outputs:
+	if len(p.Outputs) > 1 || p.Outputs[0] != UseDefaultOutput {
+		fmt.Fprintf(os.Stderr, "Returning user specified outputs: %v\n", p.Outputs)
+		return p.Outputs, nil
+	}
+	// else, get the default outputs from the lockfile
+
+	sysInfo, err := p.sysInfoIfExists()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error getting sysInfo: %v\n", err)
+		return []string{}, err
+	} else if sysInfo == nil {
+		fmt.Fprintf(os.Stderr, "No sysInfo found for pkg %s\n", p.Raw)
+		// TODO should this be "out" or empty?
+		return []string{}, nil
+	}
+
+	names := []string{}
+	for _, output := range sysInfo.DefaultOutputs() {
+		names = append(names, output.Name)
+	}
+	fmt.Fprintf(os.Stderr, "for package %s returning default outputs : %v\n", p.Raw, names)
+	return names, nil
 }

--- a/internal/lock/package.go
+++ b/internal/lock/package.go
@@ -70,23 +70,6 @@ func (i *SystemInfo) String() string {
 	return fmt.Sprintf("%+v", *i)
 }
 
-// TODO savil. There are multiple possible default store paths.
-// Remove. Only used in update_test.go
-func (i *SystemInfo) DefaultStorePath() string {
-	if i == nil || len(i.Outputs) == 0 {
-		return ""
-	}
-
-	for _, output := range i.Outputs {
-		if output.Default {
-			return output.Path
-		}
-	}
-
-	// TODO: should this be "out" output always, instead of first one?
-	return i.Outputs[0].Path
-}
-
 func (i *SystemInfo) Output(name string) (Output, error) {
 	if i == nil {
 		return Output{}, nil

--- a/internal/lock/package.go
+++ b/internal/lock/package.go
@@ -70,6 +70,8 @@ func (i *SystemInfo) String() string {
 	return fmt.Sprintf("%+v", *i)
 }
 
+// TODO savil. There are multiple possible default store paths.
+// Remove. Only used in update_test.go
 func (i *SystemInfo) DefaultStorePath() string {
 	if i == nil || len(i.Outputs) == 0 {
 		return ""
@@ -81,7 +83,45 @@ func (i *SystemInfo) DefaultStorePath() string {
 		}
 	}
 
+	// TODO: should this be "out" output always, instead of first one?
 	return i.Outputs[0].Path
+}
+
+func (i *SystemInfo) Output(name string) (Output, error) {
+	if i == nil {
+		return Output{}, nil
+	}
+
+	for _, output := range i.Outputs {
+		if output.Name == name {
+			return output, nil
+		}
+	}
+
+	return Output{}, fmt.Errorf("Output %s not found", name)
+}
+
+func (i *SystemInfo) DefaultOutputs() []Output {
+	if i == nil {
+		return nil
+	}
+
+	if len(i.Outputs) == 0 {
+		return nil
+	}
+
+	res := []Output{}
+	for _, output := range i.Outputs {
+		if output.Default {
+			res = append(res, output)
+		}
+	}
+	if len(res) > 0 {
+		return res
+	}
+
+	// If no default outputs, return the first one
+	return []Output{i.Outputs[0]}
 }
 
 func (i *SystemInfo) Equals(other *SystemInfo) bool {

--- a/internal/shellgen/flake_input.go
+++ b/internal/shellgen/flake_input.go
@@ -62,7 +62,16 @@ type SymlinkJoin struct {
 func (f *flakeInput) BuildInputsForSymlinkJoin() ([]*SymlinkJoin, error) {
 	joins := []*SymlinkJoin{}
 	for _, pkg := range f.Packages {
-		// skip packages that are already in the binary cache
+
+		// Skip packages that don't need a symlink join.
+		if needs, err := needsSymlinkJoin(pkg); err != nil {
+			return nil, err
+		} else if !needs {
+			continue
+		}
+
+		// Skip packages that are already in the binary cache. These will be directly
+		// included in the buildInputs using `builtins.fetchClosure` of their store paths.
 		inCache, err := pkg.IsInBinaryCache()
 		if err != nil {
 			return nil, err
@@ -102,10 +111,15 @@ func (f *flakeInput) BuildInputsForSymlinkJoin() ([]*SymlinkJoin, error) {
 func (f *flakeInput) BuildInputs() ([]string, error) {
 	var err error
 
-	// Filter packages that have multiple outputs. Those are handled by SymlinkJoin.
-	packages := lo.Filter(f.Packages, func(pkg *devpkg.Package, _ int) bool {
-		return len(pkg.Outputs) == 1
-	})
+	// Skip packages that will be handled in BuildInputsForSymlinkJoin
+	packages := []*devpkg.Package{}
+	for _, pkg := range f.Packages {
+		if needs, err := needsSymlinkJoin(pkg); err != nil {
+			return nil, err
+		} else if !needs {
+			packages = append(packages, pkg)
+		}
+	}
 
 	attributePaths := lo.Map(packages, func(pkg *devpkg.Package, _ int) string {
 		attributePath, attributePathErr := pkg.FullPackageAttributePath()
@@ -209,4 +223,15 @@ func (k *keyedSlice) getOrAppend(key string) *flakeInput {
 	k.slice = append(k.slice, flakeInput{})
 	k.lookup[key] = len(k.slice) - 1
 	return &k.slice[len(k.slice)-1]
+}
+
+// needsSymlinkJoin is used to filter packages with multiple outputs.
+// Multiple outputs -> SymlinkJoin.
+// Single or no output -> directly use in buildInputs
+func needsSymlinkJoin(pkg *devpkg.Package) (bool, error) {
+	outputNames, err := pkg.GetOutputNames()
+	if err != nil {
+		return false, err
+	}
+	return len(outputNames) > 1, nil
 }

--- a/internal/shellgen/tmpl/flake_remove_nixpkgs.nix.tmpl
+++ b/internal/shellgen/tmpl/flake_remove_nixpkgs.nix.tmpl
@@ -37,13 +37,15 @@
       {
         devShells.{{ .System }}.default = pkgs.mkShell {
           buildInputs = [
-            {{- range .Packages }}
-            {{ if and .IsInBinaryCache (not .PatchGlibc) -}}
+            {{- range $_, $pkg := .Packages }}
+            {{- range $_, $outputName := $pkg.GetOutputNames }}
+            {{ if and ($pkg.IsOutputInBinaryCache $outputName) (not $pkg.PatchGlibc) -}}
             (builtins.fetchClosure {
               fromStore = "{{ $.BinaryCache }}";
-              fromPath = "{{ .InputAddressedPath }}";
+              fromPath = "{{ $pkg.InputAddressedPathForOutput $outputName }}";
               inputAddressed = true;
             })
+            {{- end }}
             {{- end }}
             {{- end }}
             {{- range $_, $flakeInput := .FlakeInputs }}


### PR DESCRIPTION
## Summary

Goal:
This PR ensures we add store-paths for package outputs in the generated flake. This means users can skip the nixpkgs download saving 30-60 seconds, for packages with non-default outputs.

Along the way, it also improves how we handle multiple default outputs of packages. Well, the follow up PR #1842 achieves that.

Implementation:
- Needed to add an `outputs` struct in `devpkg`. It was needed to abstract the handling of user-selected outputs versus default outputs.
- The logic in `devpkg/narinfo_cache.go` to determine if the store-path is cached needed updating to be output-specific. 
- Needed to add output-specific versions of `package.Installable()` and `package.InputAddressedPath`

For ease of reviewing, I suggest toggling "Hide Whitespace":
<img width="460" alt="Screenshot 2024-02-26 at 12 23 59 PM" src="https://github.com/jetpack-io/devbox/assets/676452/8afccdb1-41a7-4837-8650-7a105d72410c">

## How was it tested?

`devbox add prometheus --outputs cli,out`

The testscripts have some flakes that are added, which continue to work.
