### PR TITLE
[Outputs] make pkg.Installable and pkg.InputAddressedPaths return array

### DIFF
--- a/internal/nix/nixprofile/item.go
+++ b/internal/nix/nixprofile/item.go
@@ -62,14 +62,17 @@ func (i *NixProfileListItem) Matches(pkg *devpkg.Package, locker lock.Locker) bo
 	if i.addedByStorePath() {
 		// If an Item was added via store path, the best we can do when comparing to a Package is to check
 		// if its store path matches that of the Package. Note that the item should only have 1 store path.
-		path, err := pkg.InputAddressedPath()
+		paths, err := pkg.InputAddressedPaths()
 		if err != nil {
 			// pkg couldn't have been added by store path if we can't get the store path for it, so return
 			// false. There are some edge cases (e.g. cache is down, index changed, etc., but it's OK to
 			// err on the side of false).
 			return false
 		}
-		return len(i.nixStorePaths) == 1 && i.nixStorePaths[0] == path
+		for _, path := range paths {
+			return len(i.nixStorePaths) == 1 && i.nixStorePaths[0] == path
+		}
+		return false
 	}
 
 	return pkg.Equals(devpkg.PackageFromStringWithDefaults(i.unlockedReference, locker))

--- a/internal/shellgen/flake_plan.go
+++ b/internal/shellgen/flake_plan.go
@@ -137,16 +137,20 @@ func (g *glibcPatchFlake) addPackageOutput(pkg *devpkg.Package) error {
 	return nil
 }
 
+// TODO: this only handles the first store path, but we should handle all of them
 func (g *glibcPatchFlake) fetchClosureExpr(pkg *devpkg.Package) (string, error) {
-	storePath, err := pkg.InputAddressedPath()
+	storePaths, err := pkg.InputAddressedPaths()
 	if err != nil {
 		return "", err
+	}
+	if len(storePaths) == 0 {
+		return "", fmt.Errorf("no store path for package %s", pkg.Raw)
 	}
 	return fmt.Sprintf(`builtins.fetchClosure {
   fromStore = "%s";
   fromPath = "%s";
   inputAddressed = true;
-}`, devpkg.BinaryCache, storePath), nil
+}`, devpkg.BinaryCache, storePaths[0]), nil
 }
 
 func (g *glibcPatchFlake) writeTo(dir string) error {


### PR DESCRIPTION
## Summary

This is a follow up to #1837.

It enables packages with multiple default outputs to work properly. 

## How was it tested?

`devbox add curl && devbox install`. Then inspect `.devbox/gen/flake/flake.nix` to see both `-bin` and `-man` outputs are included:
```
  1 {
  2    description = "A devbox shell";
  3
  4    inputs = {
  5      nixpkgs.url = "github:NixOS/nixpkgs/75a52265bda7fd25e06e3a67dee3f0354e73243c";
  6    };
  7
  8    outputs = {
  9      self,
 10      nixpkgs,
 11    }:
 12       let
 13         pkgs = nixpkgs.legacyPackages.x86_64-darwin;
 14       in
 15       {
 16         devShells.x86_64-darwin.default = pkgs.mkShell {
 17           buildInputs = [
 18             (builtins.fetchClosure {
 19               fromStore = "https://cache.nixos.org";
 20               fromPath = "/nix/store/fgkl3qk8p5hnd07b0dhzfky3ys5gxjmq-go-1.22.0";
 21               inputAddressed = true;
 22             })
 23             (builtins.fetchClosure {
 24               fromStore = "https://cache.nixos.org";
 25               fromPath = "/nix/store/i7fa8s6xczlalkmxy28amfyb6j3ymng4-curl-8.6.0-bin";
 26               inputAddressed = true;
 27             })
 28             (builtins.fetchClosure {
 29               fromStore = "https://cache.nixos.org";
 30               fromPath = "/nix/store/bwn4n0lxc3gaxcj8kqsq7yfcmxhbshz9-curl-8.6.0-man";
 31               inputAddressed = true;
 32             })
 33           ];
 34         };
 35       };
 36  }
```


