### PR TITLE
[cicd] Run mac tests on cron only

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -26,10 +26,6 @@ permissions:
 jobs:
   tests:
     uses: ./.github/workflows/cli-tests.yaml
-    with:
-      # This will run the basic testscript unit tests on MacOS.
-      # NOTE: cli-tests will NEVER run project-tests on MacOS.
-      run-mac-tests: true
 
   report-test-failures:
     runs-on: ubuntu-latest

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -25,6 +25,8 @@ on:
       example-debug:
         type: boolean
         description: Run example tests with DEVBOX_DEBUG=1 to increase verbosity
+  schedule:
+    - cron: '30 8 * * *' # Run nightly at 8:30 UTC
 
 permissions:
   contents: read
@@ -116,12 +118,9 @@ jobs:
         # 2. latest nix version (note, 2.20.1 introduced a new profile change)
         nix-version: ["2.12.0", "2.19.2", "2.20.1"]
         exclude:
-          # Dont run mac tests on not-main unless explicitly requested.
-          - is-main: "not-main"
-            os: "${{ inputs.run-mac-tests && 'dummy' || 'macos-latest' }}"
-          # Only runs project tests on macos if explicitly requested
-          - run-project-tests: "project-tests-only"
-            os: "${{ inputs.run-mac-tests && 'dummy' || 'macos-latest' }}"
+          # Only runs tests on macos if explicitly requested, or on a schedule
+          - os: "${{ (inputs.run-mac-tests || github.event.schedule != '') && 'dummy' || 'macos-latest' }}"
+            
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60


### PR DESCRIPTION
## Summary

* Don't run mac tests on release
* Don't run mac tests on main
* Only run mac tests on request or nightly

## How was it tested?

CICD