### PR TITLE
[error message UX] Bring back nicer error messages for insecure and platform-incompatible packages

### DIFF
--- a/internal/nix/build.go
+++ b/internal/nix/build.go
@@ -2,13 +2,13 @@ package nix
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
 
 	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/internal/debug"
+	"go.jetpack.io/devbox/internal/redact"
 )
 
 type BuildArgs struct {
@@ -39,7 +39,11 @@ func Build(ctx context.Context, args *BuildArgs, installables ...string) error {
 	if err := cmd.Run(); err != nil {
 		if exitErr := (&exec.ExitError{}); errors.As(err, &exitErr) {
 			debug.Log("Nix build exit code: %d, output: %s\n", exitErr.ExitCode(), exitErr.Stderr)
-			return fmt.Errorf("nix build exit code: %d, output: %s, err: %w", exitErr.ExitCode(), exitErr.Stderr, err)
+			return redact.Errorf("nix build exit code: %d, output: %s, err: %w",
+				redact.Safe(exitErr.ExitCode()),
+				exitErr.Stderr,
+				err,
+			)
 		}
 		return err
 	}

--- a/internal/nix/store.go
+++ b/internal/nix/store.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"go.jetpack.io/devbox/internal/debug"
+	"go.jetpack.io/devbox/internal/redact"
 	"golang.org/x/exp/maps"
 )
 
@@ -36,8 +37,14 @@ func StorePathsFromInstallable(ctx context.Context, installable string, allowIns
 	resultBytes, err := cmd.Output()
 	if err != nil {
 		if exitErr := (&exec.ExitError{}); errors.As(err, &exitErr) {
-			return nil, fmt.Errorf("nix path-info exit code: %d, output: %s, err: %w", exitErr.ExitCode(), exitErr.Stderr, err)
+			return nil, redact.Errorf(
+				"nix path-info exit code: %d, output: %s, err: %w",
+				redact.Safe(exitErr.ExitCode()),
+				exitErr.Stderr,
+				err,
+			)
 		}
+
 		return nil, err
 	}
 	return parseStorePathFromInstallableOutput(installable, resultBytes)


### PR DESCRIPTION
## Summary

Amidst the recent changes to improving installing packages, we lost the nicer error messages for two scenarios:
1. Packages that are incompatible for the current system, but installable on other systems (`glibcLocales` is incompatible on darwin, but installable on linux)
2. Insecure packages

Also, improved both kinds of error messages:
1.  added support for incompatible-packages for a different kind of error message I saw with `sublime4` package.
2. Added the package name (when available) to the suggested command in `devbox add <pkg> --allow-insecure=<package>` so users can copy paste it directly.

## How was it tested?

Incompatible packages:
```
devbox add glibcLocales
```

Added support for a new kind of error message:
```
devbox add sublime4
```

Insecure packages:
```
devbox add python@2.7
```
