### PR TITLE
Add builtin plugin for nodejs + Corepack support

### DIFF
--- a/plugins/builtins.go
+++ b/plugins/builtins.go
@@ -30,6 +30,7 @@ var builtInMap = map[*regexp.Regexp]string{
 	regexp.MustCompile(`^(ghc|haskell\.compiler\.(.*))$`):              "haskell",
 	regexp.MustCompile(`^mariadb(-embedded)?_?[0-9]*$`):                "mariadb",
 	regexp.MustCompile(`^mysql?[0-9]*$`):                               "mysql",
+	regexp.MustCompile(`^nodejs(-slim)?_?[0-9]*$`):                     "nodejs",
 	regexp.MustCompile(`^php[0-9]*$`):                                  "php",
 	regexp.MustCompile(`^python3[0-9]*Packages.pip$`):                  "pip",
 	regexp.MustCompile(`^(\w*\.)?poetry$`):                             "poetry",

--- a/plugins/nodejs.json
+++ b/plugins/nodejs.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://raw.githubusercontent.com/jetpack-io/devbox/main/.schema/devbox-plugin.schema.json",
+    "version": "0.0.1",
+    "name": "nodejs",
+    "readme": "Devbox automatically configures Corepack for Nodejs. You can install Yarn or Pnpm by adding them to your `package.json` file using `packageManager`\nCorepack binaries will be installed in your local `.devbox` directory",
+    "env" : {
+        "PATH": "{{ .Virtenv }}/corepack-bin/:$PATH"
+    },
+    "shell": {
+        "init_hook": [
+            "mkdir -p {{ .Virtenv }}/corepack-bin",
+            "corepack enable --install-directory \"{{ .Virtenv }}/corepack-bin/\""
+        ]
+    }
+}


### PR DESCRIPTION
## Summary

Builtin version of the plugin built by @jasononeil to fix #1577. This plugin configures Corepack to work with Devbox, so developers can install pnpm + nodejs via corepack.

This will require updates to documentation and examples for Nodejs as well. 

## How was it tested?

* Create an empty Devbox project, and add `nodejs@latest`. 
* You should see the readme from the plugin, describing how to use Corepack
* Create a `package.json`, and add ` "packageManager": "pnpm@8.15.3"` or "packageManager": "yarn@1.22.21"`
* Run `pnpm -v` or `yarn -v` and confirm the version matches what's in your package.json