### PR TITLE
internal/shellgen: add trace messages to flake

### DIFF
--- a/internal/shellgen/tmpl/flake_remove_nixpkgs.nix.tmpl
+++ b/internal/shellgen/tmpl/flake_remove_nixpkgs.nix.tmpl
@@ -40,11 +40,11 @@
             {{- range $_, $pkg := .Packages }}
             {{- range $_, $outputName := $pkg.GetOutputNames }}
             {{ if and ($pkg.IsOutputInBinaryCache $outputName) (not $pkg.PatchGlibc) -}}
-            (builtins.fetchClosure {
+            (builtins.trace "downloading {{ $pkg.Versioned }}" (builtins.fetchClosure {
               fromStore = "{{ $.BinaryCache }}";
               fromPath = "{{ $pkg.InputAddressedPathForOutput $outputName }}";
               inputAddressed = true;
-            })
+            }))
             {{- end }}
             {{- end }}
             {{- end }}
@@ -54,13 +54,13 @@
               name = "{{.Name}}";
               paths = [
                 {{- range .Paths }}
-                {{.}}
+                (builtins.trace "evaluating {{.}}" {{.}})
                 {{- end }}
               ];
             })
             {{- end }}
             {{- range .BuildInputs }}
-            {{.}}
+            (builtins.trace "evaluating {{.}}" {{.}})
             {{- end }}
             {{- end }}
           ];


### PR DESCRIPTION
Add a few traces to the flake that print the package being downloaded or evaluated. The user should never see these, but it makes debugging the flake easier.