### PR TITLE
[nix-outputs] Fix flake installable with custom outouts

### DIFF
--- a/internal/devpkg/outputs.go
+++ b/internal/devpkg/outputs.go
@@ -1,14 +1,20 @@
 package devpkg
 
+import "strings"
+
 // outputs are the nix package outputs
 type outputs struct {
 	selectedNames []string
 	defaultNames  []string
 }
 
-// initOutputs creates a new outputs struct.
-func initOutputs(selectedNames []string) *outputs {
-	return &outputs{selectedNames: selectedNames}
+// initOutputs initializes output for package. Outputs can be specified as part
+// of devbox.json or as part of flake reference.
+func (p *Package) initOutputs(selectedNames []string) {
+	if len(selectedNames) == 0 && p.installable.Outputs != "" {
+		selectedNames = strings.Split(p.installable.Outputs, ",")
+	}
+	p.outputs = outputs{selectedNames: selectedNames}
 }
 
 func (out *outputs) GetNames(pkg *Package) ([]string, error) {

--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -697,5 +697,10 @@ func (p *Package) GetOutputNames() ([]string, error) {
 	if p.IsRunX() {
 		return []string{}, nil
 	}
+
+	if p.installable.Outputs != "" {
+		return strings.Split(p.installable.Outputs, ","), nil
+	}
+
 	return p.outputs.GetNames(p)
 }

--- a/internal/devpkg/package.go
+++ b/internal/devpkg/package.go
@@ -76,7 +76,7 @@ type Package struct {
 	Raw string
 
 	// Outputs is a list of outputs to build from the package's derivation.
-	outputs *outputs
+	outputs outputs
 
 	// PatchGlibc applies a function to the package's derivation that
 	// patches any ELF binaries to use the latest version of nixpkgs#glibc.
@@ -106,7 +106,7 @@ func PackagesFromConfig(config *devconfig.Config, l lock.Locker) []*Package {
 		pkg := newPackage(cfgPkg.VersionedName(), cfgPkg.IsEnabledOnPlatform(), l)
 		pkg.DisablePlugin = cfgPkg.DisablePlugin
 		pkg.PatchGlibc = cfgPkg.PatchGlibc && nix.SystemIsLinux()
-		pkg.outputs = initOutputs(cfgPkg.Outputs)
+		pkg.initOutputs(cfgPkg.Outputs)
 		pkg.AllowInsecure = cfgPkg.AllowInsecure
 		result = append(result, pkg)
 	}
@@ -121,7 +121,7 @@ func PackageFromStringWithOptions(raw string, locker lock.Locker, opts devopt.Ad
 	pkg := PackageFromStringWithDefaults(raw, locker)
 	pkg.DisablePlugin = opts.DisablePlugin
 	pkg.PatchGlibc = opts.PatchGlibc
-	pkg.outputs = initOutputs(opts.Outputs)
+	pkg.initOutputs(opts.Outputs)
 	pkg.AllowInsecure = opts.AllowInsecure
 	return pkg
 }
@@ -131,7 +131,6 @@ func newPackage(raw string, isInstallable bool, locker lock.Locker) *Package {
 		Raw:           raw,
 		lockfile:      locker,
 		isInstallable: isInstallable,
-		outputs:       initOutputs([]string{}),
 	}
 
 	// The raw string is either a Devbox package ("name" or "name@version")
@@ -691,15 +690,11 @@ func (p *Package) DocsURL() string {
 	return ""
 }
 
-// GetOutputNames returns the names of the nix package outputs.
-// It may be empty if the package is not in the lockfile.
+// GetOutputNames returns the names of the nix package outputs. Outputs can be
+// specified in devbox.json package fields or as part of the flake reference.
 func (p *Package) GetOutputNames() ([]string, error) {
 	if p.IsRunX() {
 		return []string{}, nil
-	}
-
-	if p.installable.Outputs != "" {
-		return strings.Split(p.installable.Outputs, ","), nil
 	}
 
 	return p.outputs.GetNames(p)


### PR DESCRIPTION
## Summary

Fixes https://github.com/jetpack-io/devbox/issues/1852

Ensure we initialize outputs using flake if package is a flake.

Made outputs non-pointer so we don't have to worry about initialization. 

## How was it tested?

Installed `github:nixos/nixpkgs#curl^out,dev` and verified that flake and profile contain both outputs.