### PR TITLE
[flakes] Ensure flake outputs are always used

### DIFF
--- a/internal/devpkg/outputs.go
+++ b/internal/devpkg/outputs.go
@@ -1,20 +1,9 @@
 package devpkg
 
-import "strings"
-
 // outputs are the nix package outputs
 type outputs struct {
 	selectedNames []string
 	defaultNames  []string
-}
-
-// initOutputs initializes output for package. Outputs can be specified as part
-// of devbox.json or as part of flake reference.
-func (p *Package) initOutputs(selectedNames []string) {
-	if len(selectedNames) == 0 && p.installable.Outputs != "" {
-		selectedNames = strings.Split(p.installable.Outputs, ",")
-	}
-	p.outputs = outputs{selectedNames: selectedNames}
 }
 
 func (out *outputs) GetNames(pkg *Package) ([]string, error) {


### PR DESCRIPTION
## Summary

Ensure flake packages always parse outputs. (re-do of https://github.com/jetpack-io/devbox/pull/1864)

This approach is more general. It also supports (with some small changes) the use of devbox output flags with flakes (e.g. `devbox add github:nixos/nixpkgs#curl --outputs out,dev`)

## How was it tested?
