### PR TITLE
[outputs lockfile] make backwards compatible

### DIFF
--- a/internal/lock/lockfile.go
+++ b/internal/lock/lockfile.go
@@ -106,10 +106,8 @@ func (f *File) Save() error {
 	// such as `devbox update` or `devbox add` or `devbox remove`.
 	for pkgName, pkg := range f.Packages {
 		for sys, sysInfo := range pkg.Systems {
-			if !isDirty && sysInfo.StorePath != "" {
+			if !isDirty && sysInfo.outputIsFromStorePath {
 				f.Packages[pkgName].Systems[sys].Outputs = nil
-			} else {
-				f.Packages[pkgName].Systems[sys].StorePath = ""
 			}
 		}
 	}

--- a/internal/lock/lockfile.go
+++ b/internal/lock/lockfile.go
@@ -96,17 +96,31 @@ func (f *File) Resolve(pkg string) (*Package, error) {
 	return f.Packages[pkg], nil
 }
 
+// TODO:
+// Consider a design change to have the File struct match disk to make this system
+// easier to reason about, and have isDirty() compare the in-memory struct to the
+// on-disk struct.
+//
+// Proposal:
+// 1. Have an OutputsRaw field and a method called Outputs() to access it.
+// Outputs() will check if OutputsRaw is zero-value and fills it in from StorePath.
+// 2. Then, in Save(), we can check if OutputsRaw is zero and fill it in prior to writing
+// to disk.
 func (f *File) Save() error {
 	isDirty, err := f.isDirty()
 	if err != nil {
 		return err
 	}
+	if !isDirty {
+		return nil
+	}
+
 	// In SystemInfo, preserve legacy StorePath field and clear out modern Outputs before writing
 	// Reason: We want to update `devbox.lock` file only upon a user action
 	// such as `devbox update` or `devbox add` or `devbox remove`.
 	for pkgName, pkg := range f.Packages {
 		for sys, sysInfo := range pkg.Systems {
-			if !isDirty && sysInfo.outputIsFromStorePath {
+			if sysInfo.outputIsFromStorePath {
 				f.Packages[pkgName].Systems[sys].Outputs = nil
 			}
 		}


### PR DESCRIPTION
## Summary

This PR enables a `devbox.lock` updated by a user with the latest Devbox that has written Outputs to continue working for their teammate using a legacy Devbox.

Note two differences:
1. The legacyDevbox teammate will not benefit from output store-paths
2. If the legacyDevbox teammate modifies the lockfile in any way, then the Outputs will be lost. Presumably, this is not a huge problem since I anticipate most users rely on source control to track their `devbox.lock` in their devbox projects (except for maybe the Devbox global, but then those are less likely to be shared).

## How was it tested?

1. Added `devbox add curl` and `devbox add prometheus --outputs cli,out` using compiled devbox. This updated `devbox.lock` file.
2. `rm -rf .devbox`
3. `/usr/local/bin/devbox shell` using released Devbox. Observe that (1) it works (2) modifies `devbox.lock` file and drops `Outputs`.
