### PR TITLE
Fix #1783: Support non-root install in pure mode

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -1262,12 +1262,11 @@ func (d *Devbox) parseEnvAndExcludeSpecialCases(currentEnv []string) (map[string
 		// Finding nix executables in path and passing it through
 		// As well as adding devbox itself to PATH
 		// Both are needed for devbox commands inside pure shell to work
-		includedInPath, err := findNixInPATH(env)
+		nixPath, err := findNixInPATH()
 		if err != nil {
 			return nil, err
 		}
-		includedInPath = append(includedInPath, dotdevboxBinPath(d))
-		env["PATH"] = envpath.JoinPathLists(includedInPath...)
+		env["PATH"] = envpath.JoinPathLists(nixPath, dotdevboxBinPath(d))
 	}
 	return env, nil
 }

--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -1262,10 +1262,11 @@ func (d *Devbox) parseEnvAndExcludeSpecialCases(currentEnv []string) (map[string
 		// Finding nix executables in path and passing it through
 		// As well as adding devbox itself to PATH
 		// Both are needed for devbox commands inside pure shell to work
-		nixPath, err := findNixInPATH()
+		nixPath, err := exec.LookPath("nix")
 		if err != nil {
-			return nil, err
+			return nil, errors.New("could not find any nix executable in PATH. Make sure Nix is installed and in PATH, then try again")
 		}
+		nixPath = filepath.Dir(nixPath)
 		env["PATH"] = envpath.JoinPathLists(nixPath, dotdevboxBinPath(d))
 	}
 	return env, nil

--- a/internal/devbox/pure_shell.go
+++ b/internal/devbox/pure_shell.go
@@ -6,36 +6,10 @@ package devbox
 import (
 	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"github.com/pkg/errors"
-	"go.jetpack.io/devbox/internal/debug"
 )
-
-// findNixInPATH looks for locations in PATH which nix might exist and
-// it returns the path that contains nix.
-func findNixInPATH() (string, error) {
-	path, err := exec.LookPath("nix")
-	if err != nil {
-		if errors.Is(err, exec.ErrDot) {
-			err = nil
-			workingDirectory, err := os.Getwd()
-			if err != nil {
-				return "", errors.New("could not find any nix executable in PATH. Make sure Nix is installed and in PATH, then try again")
-			}
-			path = workingDirectory
-		}
-		if err != nil {
-			return "", errors.New("could not find any nix executable in PATH. Make sure Nix is installed and in PATH, then try again")
-		}
-	} else {
-		path = filepath.Dir(path)
-	}
-
-	debug.Log("found nix in PATH: %s", path)
-	return path, nil
-}
 
 // Creates a symlink for devbox in .devbox/bin
 // so that devbox can be available inside a pure shell

--- a/internal/devbox/pure_shell.go
+++ b/internal/devbox/pure_shell.go
@@ -4,12 +4,13 @@
 package devbox
 
 import (
-	"github.com/pkg/errors"
-	"go.jetpack.io/devbox/internal/debug"
 	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"github.com/pkg/errors"
+	"go.jetpack.io/devbox/internal/debug"
 )
 
 // findNixInPATH looks for locations in PATH which nix might exist and

--- a/internal/devbox/pure_shell.go
+++ b/internal/devbox/pure_shell.go
@@ -4,42 +4,36 @@
 package devbox
 
 import (
-	"fmt"
-	"io/fs"
-	"os"
-	"path/filepath"
-	"strings"
-
 	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/internal/debug"
-	"go.jetpack.io/devbox/internal/xdg"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
 )
 
 // findNixInPATH looks for locations in PATH which nix might exist and
-// it returns a slice containing all paths that might contain nix.
-// For single-user, and multi-user installation there are default locations
-// unless XDG_* env variables are set. So we look for nix in 3 locations
-// to see if any of those exist in path.
-func findNixInPATH(env map[string]string) ([]string, error) {
-	defaultSingleUserNixBin := fmt.Sprintf("%s/.nix-profile/bin", env["HOME"])
-	defaultMultiUserNixBin := "/nix/var/nix/profiles/default/bin"
-	xdgNixBin := xdg.StateSubpath("/nix/profile/bin")
-	pathElements := strings.Split(env["PATH"], ":")
-	debug.Log("path elements: %v", pathElements)
-	nixBinsInPath := []string{}
-	for _, el := range pathElements {
-		if el == xdgNixBin ||
-			el == defaultSingleUserNixBin ||
-			el == defaultMultiUserNixBin {
-			nixBinsInPath = append(nixBinsInPath, el)
+// it returns the path that contains nix.
+func findNixInPATH() (string, error) {
+	path, err := exec.LookPath("nix")
+	if err != nil {
+		if errors.Is(err, exec.ErrDot) {
+			err = nil
+			workingDirectory, err := os.Getwd()
+			if err != nil {
+				return "", errors.New("could not find any nix executable in PATH. Make sure Nix is installed and in PATH, then try again")
+			}
+			path = workingDirectory
 		}
+		if err != nil {
+			return "", errors.New("could not find any nix executable in PATH. Make sure Nix is installed and in PATH, then try again")
+		}
+	} else {
+		path = filepath.Dir(path)
 	}
 
-	if len(nixBinsInPath) == 0 {
-		// did not find nix executable in PATH, return error
-		return nil, errors.New("could not find any nix executable in PATH. Make sure Nix is installed and in PATH, then try again")
-	}
-	return nixBinsInPath, nil
+	debug.Log("found nix in PATH: %s", path)
+	return path, nil
 }
 
 // Creates a symlink for devbox in .devbox/bin


### PR DESCRIPTION
## Summary
Fix #1783: Support non-root install in pure mode

## How was it tested?
Ran `devbox shell` and `devbox shell --pure` and they both work now with my non-root install of nix on MacOS.