### PR TITLE
[easy][UX] use ux.Finfo for printing ensuring packages are installed

### DIFF
--- a/internal/devbox/packages.go
+++ b/internal/devbox/packages.go
@@ -256,7 +256,7 @@ func (d *Devbox) ensureStateIsUpToDate(ctx context.Context, mode installMode) er
 		if upToDate {
 			return nil
 		}
-		fmt.Fprintln(d.stderr, "Ensuring packages are installed.")
+		ux.Finfo(d.stderr, "Ensuring packages are installed.")
 	}
 
 	if mode == install || mode == update || mode == ensure {


### PR DESCRIPTION
## Summary

## How was it tested?

Did `devbox shell` after a minor change and saw it print with `Info:`
