### PR TITLE
[nix-cache] Add cache copy command

### DIFF
--- a/internal/boxcli/cache.go
+++ b/internal/boxcli/cache.go
@@ -23,9 +23,8 @@ func cacheCmd() *cobra.Command {
 	}
 
 	copyCommand := &cobra.Command{
-		Use:   "copy <url>",
-		Short: "Copy nix store paths to the cache",
-		Long:  "Copies all nix packages in current project to url.",
+		Use:   "copy <uri>",
+		Short: "Copies all nix packages in current project to the cache at <uri>",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			box, err := devbox.Open(&devopt.Opts{

--- a/internal/boxcli/cache.go
+++ b/internal/boxcli/cache.go
@@ -1,0 +1,48 @@
+// Copyright 2024 Jetpack Technologies Inc and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package boxcli
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"go.jetpack.io/devbox/internal/devbox"
+	"go.jetpack.io/devbox/internal/devbox/devopt"
+)
+
+type cacheFlags struct {
+	pathFlag
+}
+
+func cacheCmd() *cobra.Command {
+	flags := cacheFlags{}
+	cacheCommand := &cobra.Command{
+		Use:               "cache",
+		Short:             "Collection of commands to interact with nix cache",
+		PersistentPreRunE: ensureNixInstalled,
+	}
+
+	copyCommand := &cobra.Command{
+		Use:   "copy <url>",
+		Short: "Copy nix store paths to the cache",
+		Long:  "Copies all nix packages in current project to url.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			box, err := devbox.Open(&devopt.Opts{
+				Dir:    flags.path,
+				Stderr: cmd.ErrOrStderr(),
+			})
+			if err != nil {
+				return errors.WithStack(err)
+			}
+			return box.CacheCopy(cmd.Context(), args[0])
+		},
+	}
+
+	flags.pathFlag.register(copyCommand)
+
+	cacheCommand.AddCommand(copyCommand)
+	cacheCommand.Hidden = true
+
+	return cacheCommand
+}

--- a/internal/boxcli/config.go
+++ b/internal/boxcli/config.go
@@ -9,28 +9,37 @@ import (
 
 // to be composed into xyzCmdFlags structs
 type configFlags struct {
-	path        string
+	pathFlag
 	environment string
 }
 
 func (flags *configFlags) register(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(
-		&flags.path, "config", "c", "", "path to directory containing a devbox.json config file",
-	)
+	flags.pathFlag.register(cmd)
 	cmd.Flags().StringVar(
 		&flags.environment, "environment", "dev", "environment to use, when supported (e.g.secrets support dev, prod, preview.)",
 	)
 }
 
 func (flags *configFlags) registerPersistent(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVarP(
-		&flags.path, "config", "c", "", "path to directory containing a devbox.json config file",
-	)
+	flags.pathFlag.registerPersistent(cmd)
 	cmd.PersistentFlags().StringVar(
 		&flags.environment, "environment", "dev", "environment to use, when supported (e.g. secrets support dev, prod, preview.)",
 	)
 }
 
-func (flags *configFlags) Environment() string {
-	return flags.environment
+// pathFlag is a flag for specifying the path to a devbox.json file
+type pathFlag struct {
+	path string
+}
+
+func (flags *pathFlag) register(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(
+		&flags.path, "config", "c", "", "path to directory containing a devbox.json config file",
+	)
+}
+
+func (flags *pathFlag) registerPersistent(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVarP(
+		&flags.path, "config", "c", "", "path to directory containing a devbox.json config file",
+	)
 }

--- a/internal/boxcli/pull.go
+++ b/internal/boxcli/pull.go
@@ -105,7 +105,7 @@ func pullCmdFunc(cmd *cobra.Command, url string, flags *pullCmdFlags) error {
 
 	return installCmdFunc(
 		cmd,
-		runCmdFlags{config: configFlags{path: flags.config.path}},
+		runCmdFlags{config: configFlags{pathFlag: pathFlag{path: flags.config.path}}},
 	)
 }
 

--- a/internal/boxcli/root.go
+++ b/internal/boxcli/root.go
@@ -60,6 +60,7 @@ func RootCmd() *cobra.Command {
 	if featureflag.Auth.Enabled() {
 		command.AddCommand(authCmd())
 	}
+	command.AddCommand(cacheCmd())
 	command.AddCommand(createCmd())
 	command.AddCommand(secretsCmd())
 	command.AddCommand(generateCmd())

--- a/internal/devbox/cache.go
+++ b/internal/devbox/cache.go
@@ -1,0 +1,16 @@
+package devbox
+
+import (
+	"context"
+
+	"go.jetpack.io/devbox/internal/nix"
+)
+
+func (d *Devbox) CacheCopy(ctx context.Context, cacheURL string) error {
+	profilePath, err := d.profilePath()
+	if err != nil {
+		return err
+	}
+
+	return nix.CopyInstallableToCache(ctx, d.stderr, cacheURL, profilePath)
+}

--- a/internal/devbox/cache.go
+++ b/internal/devbox/cache.go
@@ -6,11 +6,11 @@ import (
 	"go.jetpack.io/devbox/internal/nix"
 )
 
-func (d *Devbox) CacheCopy(ctx context.Context, cacheURL string) error {
+func (d *Devbox) CacheCopy(ctx context.Context, cacheURI string) error {
 	profilePath, err := d.profilePath()
 	if err != nil {
 		return err
 	}
 
-	return nix.CopyInstallableToCache(ctx, d.stderr, cacheURL, profilePath)
+	return nix.CopyInstallableToCache(ctx, d.stderr, cacheURI, profilePath)
 }

--- a/internal/nix/cache.go
+++ b/internal/nix/cache.go
@@ -1,0 +1,35 @@
+package nix
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+)
+
+func CopyInstallableToCache(
+	ctx context.Context,
+	out io.Writer,
+	// Note: installable is a string instead of a flake.Installable
+	// because flake.Installable does not support store paths yet. It converts
+	// paths into "path" flakes which is not what we want for /nix/store paths.
+	// TODO: Add support for store paths in flake.Installable
+	to, installable string,
+) error {
+	fmt.Fprintf(out, "Copying %s to %s\n", installable, to)
+	cmd := commandContext(
+		ctx,
+		"copy", "--to", to,
+		// --refresh checks the cache to ensure it is up to date. Otherwise if
+		// anything has was copied previously from this machine and then purged
+		// it may not be copied again. It's fairly fast, but not instant.
+		"--refresh",
+		installable,
+	)
+
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = out
+	cmd.Stderr = out
+
+	return cmd.Run()
+}


### PR DESCRIPTION
## Summary

Note: this may not be the final UX for this command. I'm just getting it in hidden so we can build the cache feature end-to-end and will refine details later.

Adds `devbox cache copy <url>` command. It copies the current devbox nix profile to the url. `<url>` can be anything supported by https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-copy

There are two future plans for this command:

* `url` will be optional when logged in. It will be determined by API in those cases. We may want to move url to be a flag in that case (possibly the `--to` flag to mimic `nix copy`). 
* This command will support specifying the package you wish to copy. Packages can be nix installable, but also devbox packages (i.e. package@version). We could even support runx in the future.

I used `copy` to mimic `nix` command name, but I slightly prefer `upload`. That and the above changes would make this command look like:

`devbox cache upload [--to <url>] [package]`

or as simple as 

`devbox cache upload`

to upload current profile when logged in.

## How was it tested?

`devbox cache copy "s3://mike-test-nix-cache?region=us-west-2"`
