### PR TITLE
[nix-cache] Add ability to use nix cache with env var

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -86,3 +86,6 @@ linters-settings:
   wrapcheck:
     ignorePackageGlobs:
       - go.jetpack.io/devbox/*
+  misspell:
+    ignore-words:
+      - substituters

--- a/internal/devbox/bincache/bincache.go
+++ b/internal/devbox/bincache/bincache.go
@@ -2,8 +2,8 @@ package bincache
 
 import "os"
 
-// ExtraSubstituter returns the URL of the extra substituter to use.
-// a substituter is a bin cache url that nix can use to fetch pre-built
+// ExtraSubstituter returns the URI of the extra substituter to use.
+// a substituter is a bin cache URI that nix can use to fetch pre-built
 // binaries from.
 func ExtraSubstituter() (string, error) {
 	if err := ensureTrustedUser(); err != nil {
@@ -11,10 +11,10 @@ func ExtraSubstituter() (string, error) {
 	}
 
 	// TODO: if user is logged in (or if we have token we can refresh)
-	// then we try to fetch the bincache URL from the API.
+	// then we try to fetch the bincache URI from the API.
 
-	// DEVBOX_NIX_BINCACHE_URL seems like a friendlier name than "substituter"
-	return os.Getenv("DEVBOX_NIX_BINCACHE_URL"), nil
+	// DEVBOX_NIX_BINCACHE_URI seems like a friendlier name than "substituter"
+	return os.Getenv("DEVBOX_NIX_BINCACHE_URI"), nil
 }
 
 func ensureTrustedUser() error {

--- a/internal/devbox/bincache/bincache.go
+++ b/internal/devbox/bincache/bincache.go
@@ -1,0 +1,25 @@
+package bincache
+
+import "os"
+
+// ExtraSubstituter returns the URL of the extra substituter to use.
+// a substituter is a bin cache url that nix can use to fetch pre-built
+// binaries from.
+func ExtraSubstituter() (string, error) {
+	if err := ensureTrustedUser(); err != nil {
+		return "", err
+	}
+
+	// TODO: if user is logged in (or if we have token we can refresh)
+	// then we try to fetch the bincache URL from the API.
+
+	// DEVBOX_NIX_BINCACHE_URL seems like a friendlier name than "substituter"
+	return os.Getenv("DEVBOX_NIX_BINCACHE_URL"), nil
+}
+
+func ensureTrustedUser() error {
+	// TODO: we need to ensure that the user can actually use the extra
+	// substituter. If the user did a root install, then we need to add
+	// the extra substituter to the nix.conf file and restart the daemon.
+	return nil
+}

--- a/internal/devbox/packages.go
+++ b/internal/devbox/packages.go
@@ -17,6 +17,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
+	"go.jetpack.io/devbox/internal/devbox/bincache"
 	"go.jetpack.io/devbox/internal/devbox/devopt"
 	"go.jetpack.io/devbox/internal/devconfig"
 	"go.jetpack.io/devbox/internal/devpkg"
@@ -445,11 +446,17 @@ func (d *Devbox) installNixPackagesToStore(ctx context.Context, mode installMode
 			flags = append(flags, "--refresh")
 		}
 
+		extraSubstituter, err := bincache.ExtraSubstituter()
+		if err != nil {
+			return err
+		}
+
 		for _, installable := range installables {
 			args := &nix.BuildArgs{
-				AllowInsecure: pkg.HasAllowInsecure(),
-				Flags:         flags,
-				Writer:        d.stderr,
+				AllowInsecure:    pkg.HasAllowInsecure(),
+				Flags:            flags,
+				Writer:           d.stderr,
+				ExtraSubstituter: extraSubstituter,
 			}
 			err = nix.Build(ctx, args, installable)
 			if err != nil {

--- a/internal/nix/build.go
+++ b/internal/nix/build.go
@@ -12,9 +12,10 @@ import (
 )
 
 type BuildArgs struct {
-	AllowInsecure bool
-	Flags         []string
-	Writer        io.Writer
+	AllowInsecure    bool
+	ExtraSubstituter string
+	Flags            []string
+	Writer           io.Writer
 }
 
 func Build(ctx context.Context, args *BuildArgs, installables ...string) error {
@@ -22,6 +23,11 @@ func Build(ctx context.Context, args *BuildArgs, installables ...string) error {
 	cmd := commandContext(ctx, "build", "--impure")
 	cmd.Args = append(cmd.Args, args.Flags...)
 	cmd.Args = append(cmd.Args, installables...)
+	// Adding extra substituters only here to be conservative, but this could also
+	// be added to ExperimentalFlags() in the future.
+	if args.ExtraSubstituter != "" {
+		cmd.Args = append(cmd.Args, "--extra-substituters", args.ExtraSubstituter)
+	}
 	cmd.Env = allowUnfreeEnv(os.Environ())
 	if args.AllowInsecure {
 		debug.Log("Setting Allow-insecure env-var\n")


### PR DESCRIPTION
## Summary

Sets up boilerplate to use nix cache and allows use via environment variable.

TODOs: (in follow ups)

- [ ] Setup user permissions automatically to make user trusted in multi-user setups
- [ ] Hook up to API to fetch cache url and credentials

## How was it tested?

`DEVBOX_NIX_BINCACHE_URI="s3://mike-test-nix-cache?region=us-west-2" devbox add hello`
