### PR TITLE
Fix process-compose update on nix 2.20

### DIFF
--- a/internal/devbox/util.go
+++ b/internal/devbox/util.go
@@ -5,7 +5,6 @@ package devbox
 
 import (
 	"context"
-	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -65,9 +64,9 @@ func (d *Devbox) removeDevboxUtilityPackage(pkgName string) error {
 	}
 
 	for _, installable := range installables {
-		for i, profileItem := range profile {
+		for _, profileItem := range profile {
 			if profileItem.MatchesUnlockedReference(installable) {
-				err = nix.ProfileRemove(utilityProfilePath, fmt.Sprint(i))
+				err = nix.ProfileRemove(utilityProfilePath, profileItem.NameOrIndex())
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
## Summary
TSIA, fixes an issue with our process-compose update with Nix 2.20. (#1901 )

Nix 2.20 dropped support for uninstalling packages by index, while adding support for uninstalling by name. this fix uses NameOrIndex to get the right value to pass to `nix profile remove`

## How was it tested?
Verified on localhost with Nix 2.20. CI Tests should confirm that it's compatible with Nix 2.18. 