### PR TITLE
[process-compose] Remove old process compose using store path

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -782,7 +782,7 @@ func (d *Devbox) StartProcessManager(
 		oldProcessComposePkg := "github:F1bonacc1/process-compose/" + pcVersion + "#defaultPackage." + nix.System()
 		newProcessComposePkg := "github:F1bonacc1/process-compose/" + processComposeTargetVersion
 		// Find the old process Compose package
-		if err := d.removeDevboxUtilityPackage(oldProcessComposePkg); err != nil {
+		if err := d.removeDevboxUtilityPackage(ctx, oldProcessComposePkg); err != nil {
 			return err
 		}
 

--- a/internal/nix/profiles.go
+++ b/internal/nix/profiles.go
@@ -75,13 +75,15 @@ func ProfileInstall(ctx context.Context, args *ProfileInstallArgs) error {
 	return cmd.Run()
 }
 
-func ProfileRemove(profilePath string, indexes ...string) error {
+// ProfileRemove removes packages from a profile.
+// WARNING, don't use indexes, they are not supported by nix 2.20+
+func ProfileRemove(profilePath string, packageNames ...string) error {
 	cmd := command(
 		append([]string{
 			"profile", "remove",
 			"--profile", profilePath,
 			"--impure", // for NIXPKGS_ALLOW_UNFREE
-		}, indexes...)...,
+		}, packageNames...)...,
 	)
 	cmd.Env = allowUnfreeEnv(allowInsecureEnv(os.Environ()))
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/jetpack-io/devbox/issues/1901

Alternative: https://github.com/jetpack-io/devbox/pull/1902

nix 2.20 removed index support. Use store paths instead.

## How was it tested?
