### PR TITLE
[Plugins] Do not overwrite existing user-config files of plugins

### DIFF
--- a/internal/devbox/packages.go
+++ b/internal/devbox/packages.go
@@ -257,7 +257,7 @@ func (d *Devbox) ensureStateIsUpToDate(ctx context.Context, mode installMode) er
 		if upToDate {
 			return nil
 		}
-		ux.Finfo(d.stderr, "Ensuring packages are installed.")
+		ux.Finfo(d.stderr, "Ensuring packages are installed.\n")
 	}
 
 	if mode == install || mode == update || mode == ensure {


### PR DESCRIPTION
## Summary

Fixes #1909

Makes two changes:
1. The users control `devbox.d` directory files once the plugin has generated it for them. Devbox should never be overwriting them. Added code to check for this.
2. For the code that checks if filepath contains `.devbox` or `devbox.d`, I now try to make that stricter by checking if filepath contains `/.devbox/` or `/devbox.d/`. As pointed out in the issue, the jetpack-mongodb plugin is generating user-configs at `devbox.d/jetpack-io.devbox-plugins.mongodb` which also contains `.devbox` string. This will pass checks for `strings.Contains(filepath, ".devbox")` even though that is not the intention of that particular check.

cc @mikeland73 

## How was it tested?

Repro'd the scenario of the issue.
Added the files via `git init && git commit -a`
Ran `rm -rf .devbox` and `devbox install`
Ran `git status` and confirmed that no `devbox.d` files were modified
