### PR TITLE
[plugins] Support private GitHub repositories

### DIFF
--- a/internal/plugin/github.go
+++ b/internal/plugin/github.go
@@ -2,9 +2,11 @@ package plugin
 
 import (
 	"cmp"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"strings"
 
@@ -56,12 +58,13 @@ func (p *githubPlugin) Hash() string {
 }
 
 func (p *githubPlugin) FileContent(subpath string) ([]byte, error) {
-	contentURL, err := p.url(subpath)
+	req, err := p.request(subpath)
 	if err != nil {
 		return nil, err
 	}
 
-	res, err := http.Get(contentURL)
+	client := &http.Client{}
+	res, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +74,7 @@ func (p *githubPlugin) FileContent(subpath string) ([]byte, error) {
 			"failed to get plugin %s @ %s (Status code %d). \nPlease make "+
 				"sure a plugin.json file exists in plugin directory.",
 			p.LockfileKey(),
-			contentURL,
+			req.URL.String(),
 			res.StatusCode,
 		)
 	}
@@ -89,6 +92,28 @@ func (p *githubPlugin) url(subpath string) (string, error) {
 		p.ref.Dir,
 		subpath,
 	)
+}
+
+func (p *githubPlugin) request(subpath string) (*http.Request, error) {
+	contentURL, err := p.url(subpath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, contentURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add github token to request if available
+	ghToken := os.Getenv("GITHUB_TOKEN")
+
+	if ghToken != "" {
+		authValue := fmt.Sprintf("token %s", ghToken)
+		req.Header.Add("Authorization", authValue)
+	}
+
+	return req, nil
 }
 
 func (p *githubPlugin) LockfileKey() string {

--- a/internal/plugin/github_test.go
+++ b/internal/plugin/github_test.go
@@ -102,3 +102,32 @@ func newGithubPluginForTest(include string) (*githubPlugin, error) {
 	)
 	return plugin, nil
 }
+
+func TestGithubPluginAuth(t *testing.T) {
+	githubPlugin := githubPlugin{
+		ref: flake.Ref{
+			Type:  "github",
+			Owner: "jetpack-io",
+			Repo:  "devbox-plugins",
+		},
+		name: "jetpack-io.devbox-plugins",
+	}
+
+	expectedURL := "https://raw.githubusercontent.com/jetpack-io/devbox-plugins/master/test"
+
+	t.Run("generate request for public Github repository", func(t *testing.T) {
+		actual, err := githubPlugin.request("test")
+		assert.NoError(t, err)
+		assert.Equal(t, expectedURL, actual.URL.String())
+		assert.Equal(t, "", actual.Header.Get("Authorization"))
+	})
+
+	t.Run("generate request for private Github repository", func(t *testing.T) {
+		t.Setenv("GITHUB_TOKEN", "gh_abcd")
+
+		actual, err := githubPlugin.request("test")
+		assert.NoError(t, err)
+		assert.Equal(t, expectedURL, actual.URL.String())
+		assert.Equal(t, "token gh_abcd", actual.Header.Get("Authorization"))
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #1918 

Plugins stored in a private GitHub repository fail to pull due to due to a lack of authentication. This PR will add an `Authorization: token <GITHUB_TOKEN>` header to the request if the `GITHUB_TOKEN` environment variable is set.

## How was it tested?

Added test cases for `http.Request` with and without environment variable.

Manually tested on my machine:
- Added a private GitHub repo to devbox.json `"include"`
- `devbox shell`: confirmed existing 404 error
- `GITHUB_TOKEN=xxx devbox shell`: shell environment boots correctly
