### PR TITLE
Support Project Directory having spaces

### DIFF
--- a/internal/devbox/shellrc.tmpl
+++ b/internal/devbox/shellrc.tmpl
@@ -56,7 +56,7 @@ working_dir="$(pwd)"
 cd "{{ .ProjectDir }}" || exit
 
 # Source the hooks file, which contains the project's init hooks and plugin hooks.
-. {{ .HooksFilePath }}
+. "{{ .HooksFilePath }}"
 
 cd "$working_dir" || exit
 

--- a/internal/devbox/shellrc_fish.tmpl
+++ b/internal/devbox/shellrc_fish.tmpl
@@ -59,7 +59,7 @@ set workingDir (pwd)
 cd "{{ .ProjectDir }}" || exit
 
 # Source the hooks file, which contains the project's init hooks and plugin hooks.
-source {{ .HooksFilePath }}
+source "{{ .HooksFilePath }}"
 
 cd "$workingDir" || exit
 

--- a/internal/devbox/testdata/shellrc/basic/shellrc.golden
+++ b/internal/devbox/testdata/shellrc/basic/shellrc.golden
@@ -21,7 +21,7 @@ working_dir="$(pwd)"
 cd "/path/to/projectDir" || exit
 
 # Source the hooks file, which contains the project's init hooks and plugin hooks.
-. /path/to/projectDir/.devbox/gen/scripts/.hooks.sh
+. "/path/to/projectDir/.devbox/gen/scripts/.hooks.sh"
 
 cd "$working_dir" || exit
 

--- a/internal/devbox/testdata/shellrc/noshellrc/shellrc.golden
+++ b/internal/devbox/testdata/shellrc/noshellrc/shellrc.golden
@@ -15,7 +15,7 @@ working_dir="$(pwd)"
 cd "/path/to/projectDir" || exit
 
 # Source the hooks file, which contains the project's init hooks and plugin hooks.
-. /path/to/projectDir/.devbox/gen/scripts/.hooks.sh
+. "/path/to/projectDir/.devbox/gen/scripts/.hooks.sh"
 
 cd "$working_dir" || exit
 

--- a/internal/shellgen/tmpl/init-hook-wrapper.tmpl
+++ b/internal/shellgen/tmpl/init-hook-wrapper.tmpl
@@ -5,5 +5,5 @@ Code here should be fish and POSIX compatible. That's why we use export to
 remove the value
 */ -}}
 export {{ .InitHookHash }}=true
-. {{ .RawHooksFile }}
+. "{{ .RawHooksFile }}"
 export {{ .InitHookHash }}=""

--- a/internal/shellgen/tmpl/script-wrapper.tmpl
+++ b/internal/shellgen/tmpl/script-wrapper.tmpl
@@ -9,7 +9,7 @@
 
 if [ -z "${{ .InitHookHash }}" ]; then
     {{/* init hooks will export InitHookHash ensuring no recursive sourcing*/ -}}
-    . {{ .InitHookPath }}
+    . "{{ .InitHookPath }}"
 fi
 
 {{ .Body }}


### PR DESCRIPTION
## Summary
In aid of #1914

Added some basic support for spaces. I think this requires more extensive testing around:
1. plugins
2. flake packages

I should try to have the examples tests run in cicd with a space in their path.


## How was it tested?

```
mkdir -p `/Users/<omitted>/code/jetpack/devbox-projects/path with space`
devbox init
devbox shell
devbox add hello
devbox add cowsay
```

could run:
```
cowsay hello
```

set `export FISH=$(which fish)` and repeat the above steps


