### PR TITLE
[plugins] support reading (and discarding) comments plugin.json files

### DIFF
--- a/examples/plugins/local/my-plugin/plugin.json
+++ b/examples/plugins/local/my-plugin/plugin.json
@@ -6,13 +6,18 @@
     "MY_FOO_VAR": "BAR"
   },
   "create_files": {
+    /*
+this is a comment inside the create files
+    */
     "{{ .Virtenv }}/empty-dir": "",
     "{{ .Virtenv }}/some-file": "some-file.txt",
     "{{ .DevboxDir }}/some-file.txt": "some-file.txt",
     "{{ .Virtenv }}/process-compose.yaml": "process-compose.yaml"
   },
   "shell": {
+      // this is a comment before init-hooks
       "init_hook": [
+          "echo \"ran local plugin init hook\"",
           "export MY_INIT_HOOK_VAR=BAR"
       ]
   }

--- a/internal/plugin/github.go
+++ b/internal/plugin/github.go
@@ -43,7 +43,11 @@ func newGithubPlugin(ref flake.Ref) (*githubPlugin, error) {
 }
 
 func (p *githubPlugin) Fetch() ([]byte, error) {
-	return p.FileContent(pluginConfigName)
+	content, err := p.FileContent(pluginConfigName)
+	if err != nil {
+		return nil, err
+	}
+	return jsonPurifyPluginContent(content)
 }
 
 func (p *githubPlugin) CanonicalName() string {

--- a/internal/plugin/local.go
+++ b/internal/plugin/local.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/pkg/errors"
 	"go.jetpack.io/devbox/internal/cachehash"
 	"go.jetpack.io/devbox/nix/flake"
 )
@@ -26,7 +27,11 @@ func newLocalPlugin(ref flake.Ref, pluginDir string) (*LocalPlugin, error) {
 }
 
 func (l *LocalPlugin) Fetch() ([]byte, error) {
-	return os.ReadFile(addFilenameIfMissing(l.Path()))
+	content, err := os.ReadFile(addFilenameIfMissing(l.Path()))
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return jsonPurifyPluginContent(content)
 }
 
 func (l *LocalPlugin) CanonicalName() string {

--- a/plugins/python.json
+++ b/plugins/python.json
@@ -3,11 +3,15 @@
   "version": "0.0.3",
   "description": "Python in Devbox works best when used with a virtual environment (vent, virtualenv, etc.). Devbox will automatically create a virtual environment using `venv` for python3 projects, so you can install packages with pip as normal.\nTo activate the environment, run `. $VENV_DIR/bin/activate` or add it to the init_hook of your devbox.json\nTo change where your virtual environment is created, modify the $VENV_DIR environment variable in your init_hook",
   "env": {
+      /*
+        This is a block comment
+      */
       "VENV_DIR": "{{ .Virtenv }}/.venv"
   },
   "create_files": {
       "{{ .Virtenv }}/bin/venvShellHook.sh": "pip/venvShellHook.sh"
   },
+  // this is a line comment above shell
   "shell": {
       "init_hook": [
           "{{ .Virtenv }}/bin/venvShellHook.sh"


### PR DESCRIPTION
## Summary

Fixes #1911

This PR cleans the json-file-content of comments before processing it as "json content" i.e. we discard the comments prior to invoking existing logic for ingesting the `plugin.json` file.

This PR relies on Devbox not programmatically modifying the `plugin.json`. For now, users hand edit the `plugin.json` files. This is different from `devbox.json` which we do programmatically modify due to `devbox add`, `devbox rm` and similar commands, and so need to keep track of the json-with-comments' AST.

## How was it tested?

To test, I added comments to the following:
1. local plugin example
2. a builtin plugin (python)

I did NOT test remote Github plugin. But I tried to modify its code path. Did i get it right?

