### PR TITLE
[path with spaces] run scripts for projects with paths in spaces

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -282,7 +282,7 @@ func (d *Devbox) RunScript(ctx context.Context, cmdName string, cmdArgs []string
 		env["DEVBOX_RUN_CMD"] = strings.Join(append([]string{cmdName}, cmdArgs...), " ")
 	}
 
-	return nix.RunScript(d.projectDir, strings.Join(cmdWithArgs, " "), env)
+	return nix.RunScript(d.projectDir, cmdWithArgs, env)
 }
 
 // Install ensures that all the packages in the config are installed

--- a/internal/nix/run.go
+++ b/internal/nix/run.go
@@ -8,14 +8,15 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/cmdutil"
 	"go.jetpack.io/devbox/internal/debug"
 )
 
-func RunScript(projectDir, cmdWithArgs string, env map[string]string) error {
-	if cmdWithArgs == "" {
+func RunScript(projectDir string, cmdWithArgs []string, env map[string]string) error {
+	if len(cmdWithArgs) == 0 {
 		return errors.New("attempted to run an empty command or script")
 	}
 
@@ -24,9 +25,13 @@ func RunScript(projectDir, cmdWithArgs string, env map[string]string) error {
 		envPairs = append(envPairs, fmt.Sprintf("%s=%s", k, v))
 	}
 
+	// Wrap in quotations since the command's path may contain spaces.
+	cmdWithArgs[0] = "\"" + cmdWithArgs[0] + "\""
+	cmdWithArgsStr := strings.Join(cmdWithArgs, " ")
+
 	// Try to find sh in the PATH, if not, default to a well known absolute path.
 	shPath := cmdutil.GetPathOrDefault("sh", "/bin/sh")
-	cmd := exec.Command(shPath, "-c", cmdWithArgs)
+	cmd := exec.Command(shPath, "-c", cmdWithArgsStr)
 	cmd.Env = envPairs
 	cmd.Dir = projectDir
 	cmd.Stdin = os.Stdin


### PR DESCRIPTION
## Summary

Related to #1914

Ran into this scenario during further testing

## How was it tested?

move the plugins examples:
`mv devbox/examples "devbox/examples with plugins"`

`cd examples/plugins with spaces/v2-github`
`devbox run run_test` -> this would previously fail
