### PR TITLE
Revert "[path with spaces] run scripts for projects with paths in spaces (#1924)"

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -282,7 +282,7 @@ func (d *Devbox) RunScript(ctx context.Context, cmdName string, cmdArgs []string
 		env["DEVBOX_RUN_CMD"] = strings.Join(append([]string{cmdName}, cmdArgs...), " ")
 	}
 
-	return nix.RunScript(d.projectDir, cmdWithArgs, env)
+	return nix.RunScript(d.projectDir, strings.Join(cmdWithArgs, " "), env)
 }
 
 // Install ensures that all the packages in the config are installed

--- a/internal/devbox/shellrc.tmpl
+++ b/internal/devbox/shellrc.tmpl
@@ -56,7 +56,7 @@ working_dir="$(pwd)"
 cd "{{ .ProjectDir }}" || exit
 
 # Source the hooks file, which contains the project's init hooks and plugin hooks.
-. "{{ .HooksFilePath }}"
+. {{ .HooksFilePath }}
 
 cd "$working_dir" || exit
 

--- a/internal/devbox/shellrc_fish.tmpl
+++ b/internal/devbox/shellrc_fish.tmpl
@@ -59,7 +59,7 @@ set workingDir (pwd)
 cd "{{ .ProjectDir }}" || exit
 
 # Source the hooks file, which contains the project's init hooks and plugin hooks.
-source "{{ .HooksFilePath }}"
+source {{ .HooksFilePath }}
 
 cd "$workingDir" || exit
 

--- a/internal/devbox/testdata/shellrc/basic/shellrc.golden
+++ b/internal/devbox/testdata/shellrc/basic/shellrc.golden
@@ -21,7 +21,7 @@ working_dir="$(pwd)"
 cd "/path/to/projectDir" || exit
 
 # Source the hooks file, which contains the project's init hooks and plugin hooks.
-. "/path/to/projectDir/.devbox/gen/scripts/.hooks.sh"
+. /path/to/projectDir/.devbox/gen/scripts/.hooks.sh
 
 cd "$working_dir" || exit
 

--- a/internal/devbox/testdata/shellrc/noshellrc/shellrc.golden
+++ b/internal/devbox/testdata/shellrc/noshellrc/shellrc.golden
@@ -15,7 +15,7 @@ working_dir="$(pwd)"
 cd "/path/to/projectDir" || exit
 
 # Source the hooks file, which contains the project's init hooks and plugin hooks.
-. "/path/to/projectDir/.devbox/gen/scripts/.hooks.sh"
+. /path/to/projectDir/.devbox/gen/scripts/.hooks.sh
 
 cd "$working_dir" || exit
 

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -19,7 +19,6 @@ import (
 	"go.jetpack.io/devbox/internal/boxcli/featureflag"
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/redact"
-	"go.jetpack.io/devbox/nix/flake"
 
 	"go.jetpack.io/devbox/internal/debug"
 )
@@ -70,19 +69,15 @@ func (*Nix) PrintDevEnv(ctx context.Context, args *PrintDevEnvArgs) (*PrintDevEn
 		return nil, errors.WithStack(err)
 	}
 
-	flakeRef, err := flake.ParseRef("path:" + flakeDirResolved)
-	if err != nil {
-		return nil, err
-	}
-
 	if len(data) == 0 {
 		cmd := exec.CommandContext(
 			ctx,
-			"nix", "print-dev-env", flakeRef.String(),
+			"nix", "print-dev-env",
+			"path:"+flakeDirResolved,
 		)
 		cmd.Args = append(cmd.Args, ExperimentalFlags()...)
 		cmd.Args = append(cmd.Args, "--json")
-		debug.Log("Running print-dev-env cmd: %s\n\n\n", cmd)
+		debug.Log("Running print-dev-env cmd: %s\n", cmd)
 		data, err = cmd.Output()
 		if insecure, insecureErr := IsExitErrorInsecurePackage(err, "" /*pkgName*/, "" /*installable*/); insecure {
 			return nil, insecureErr

--- a/internal/nix/run.go
+++ b/internal/nix/run.go
@@ -8,15 +8,14 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	"go.jetpack.io/devbox/internal/boxcli/usererr"
 	"go.jetpack.io/devbox/internal/cmdutil"
 	"go.jetpack.io/devbox/internal/debug"
 )
 
-func RunScript(projectDir string, cmdWithArgs []string, env map[string]string) error {
-	if len(cmdWithArgs) == 0 {
+func RunScript(projectDir, cmdWithArgs string, env map[string]string) error {
+	if cmdWithArgs == "" {
 		return errors.New("attempted to run an empty command or script")
 	}
 
@@ -25,13 +24,9 @@ func RunScript(projectDir string, cmdWithArgs []string, env map[string]string) e
 		envPairs = append(envPairs, fmt.Sprintf("%s=%s", k, v))
 	}
 
-	// Wrap in quotations since the command's path may contain spaces.
-	cmdWithArgs[0] = "\"" + cmdWithArgs[0] + "\""
-	cmdWithArgsStr := strings.Join(cmdWithArgs, " ")
-
 	// Try to find sh in the PATH, if not, default to a well known absolute path.
 	shPath := cmdutil.GetPathOrDefault("sh", "/bin/sh")
-	cmd := exec.Command(shPath, "-c", cmdWithArgsStr)
+	cmd := exec.Command(shPath, "-c", cmdWithArgs)
 	cmd.Env = envPairs
 	cmd.Dir = projectDir
 	cmd.Stdin = os.Stdin

--- a/internal/shellgen/tmpl/init-hook-wrapper.tmpl
+++ b/internal/shellgen/tmpl/init-hook-wrapper.tmpl
@@ -5,5 +5,5 @@ Code here should be fish and POSIX compatible. That's why we use export to
 remove the value
 */ -}}
 export {{ .InitHookHash }}=true
-. "{{ .RawHooksFile }}"
+. {{ .RawHooksFile }}
 export {{ .InitHookHash }}=""

--- a/internal/shellgen/tmpl/script-wrapper.tmpl
+++ b/internal/shellgen/tmpl/script-wrapper.tmpl
@@ -9,7 +9,7 @@
 
 if [ -z "${{ .InitHookHash }}" ]; then
     {{/* init hooks will export InitHookHash ensuring no recursive sourcing*/ -}}
-    . "{{ .InitHookPath }}"
+    . {{ .InitHookPath }}
 fi
 
 {{ .Body }}


### PR DESCRIPTION
## Summary

Will rework these and do better testing.

Revert "[path with spaces] run scripts for projects with paths in spaces (#1924)"

This reverts commit 8171595a5ec8d2000f349e82c77a97534af6567e.

Revert "Support Project Directory having spaces (#1920)"

This reverts commit 41294c291098634b040e12012d84446f90385796.


## How was it tested?
