### PR TITLE
[plugins] Fix rm for packages with __remove_trigger_package

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -1035,9 +1035,8 @@ func (d *Devbox) PackageNames() []string {
 
 // AllPackages returns the packages that are defined in devbox.json and
 // recursively added by plugins.
-// * NOTE1: This will not return packages removed by their plugin with the
+// NOTE: This will not return packages removed by their plugin with the
 // __remove_trigger_package field.
-// * NOTE2: the return type is different from devconfig.Packages
 func (d *Devbox) AllPackages() []*devpkg.Package {
 	return devpkg.PackagesFromConfig(d.cfg.Packages(), d.lockfile)
 }

--- a/internal/devbox/docgen/docgen.go
+++ b/internal/devbox/docgen/docgen.go
@@ -56,7 +56,8 @@ func GenerateReadme(
 		"Scripts":     devbox.Config().Scripts(),
 		"EnvVars":     devbox.Config().Env(),
 		"InitHook":    devbox.Config().InitHook(),
-		"Packages":    devbox.ConfigPackages(),
+		"Packages":    devbox.TopLevelPackages(),
+		// TODO add includes
 	})
 }
 

--- a/internal/devbox/packages.go
+++ b/internal/devbox/packages.go
@@ -294,7 +294,7 @@ func (d *Devbox) updateLockfile(recomputeState bool) error {
 	d.lockfile.Tidy()
 
 	// Update lockfile with new packages that are not to be installed
-	for _, pkg := range d.ConfigPackages() {
+	for _, pkg := range d.AllPackages() {
 		if err := pkg.EnsureUninstallableIsInLockfile(); err != nil {
 			return err
 		}

--- a/internal/devbox/update.go
+++ b/internal/devbox/update.go
@@ -81,7 +81,7 @@ func (d *Devbox) inputsToUpdate(
 	opts devopt.UpdateOpts,
 ) ([]*devpkg.Package, error) {
 	if len(opts.Pkgs) == 0 {
-		return d.ConfigPackages(), nil
+		return d.AllPackages(), nil
 	}
 
 	var pkgsToUpdate []*devpkg.Package

--- a/testscripts/rm/add-rm.test.txt
+++ b/testscripts/rm/add-rm.test.txt
@@ -1,12 +1,12 @@
 exec devbox init
 
-exec devbox add hello vim cowsay
+exec devbox add hello vim cowsay php
 json.superset devbox.json all.json
 
-exec devbox rm vim hello
+exec devbox rm vim hello php
 json.superset devbox.json cowsay.json
 
-exec devbox add vim hello vim hello vim hello vim hello cowsay
+exec devbox add vim hello vim hello vim hello vim hello cowsay php php
 json.superset devbox.json all.json
 
 exec devbox rm vim hello cowsay cowsay
@@ -14,7 +14,7 @@ json.superset devbox.json empty.json
 
 -- all.json --
 {
-  "packages": ["hello@latest", "vim@latest", "cowsay@latest"]
+  "packages": ["hello@latest", "vim@latest", "cowsay@latest", "php@latest"]
 }
 
 -- cowsay.json --

--- a/testscripts/rm/add-rm.test.txt
+++ b/testscripts/rm/add-rm.test.txt
@@ -9,7 +9,7 @@ json.superset devbox.json cowsay.json
 exec devbox add vim hello vim hello vim hello vim hello cowsay php php
 json.superset devbox.json all.json
 
-exec devbox rm vim hello cowsay cowsay
+exec devbox rm vim hello cowsay cowsay php
 json.superset devbox.json empty.json
 
 -- all.json --


### PR DESCRIPTION
## Summary

Fixes issue where user could not remove package that is replaced by a flake in plugin (uses `__remove_trigger_package`)

Fixes https://github.com/jetpack-io/devbox/issues/1936

We need two different functions for packages:

* `AllPackages` which is used for instalation and lock file. Includes packages added/removed by plugins.
* `TopLevelPackages` is only what is in root devbox.json

## How was it tested?

* Tested manually
* Added php to rm unit test