### PR TITLE
[docs] FAQ: add --experimental to nix store gc

### DIFF
--- a/docs/app/docs/faq.md
+++ b/docs/app/docs/faq.md
@@ -15,7 +15,7 @@ Devbox and Nix install your packages in the read-only Nix store, usually located
 
 ## How do I clean up unused packages from the Nix Store?
 
-You can use `devbox run -- nix store gc` to automatically clean up packages that are no longer needed for your projects.
+You can use `devbox run -- nix store gc --extra-experimental-features nix-command` to automatically clean up packages that are no longer needed for your projects.
 
 ## Does Devbox require Docker or Containers to work?
 


### PR DESCRIPTION
## Summary

Fixes #1938

This is more nix beginner friendly

## How was it tested?

will run the command locally (but takes time, so over lunch break)
`devbox run -- nix store gc --extra-experimental-features nix-command`




