### PR TITLE
[gen-readme] For generated readme scripts, replace absolute paths

### DIFF
--- a/internal/devbox/docgen/docgen.go
+++ b/internal/devbox/docgen/docgen.go
@@ -53,10 +53,11 @@ func GenerateReadme(
 	return tmpl.Execute(f, map[string]any{
 		"Name":        devbox.Config().Root.Name,
 		"Description": devbox.Config().Root.Description,
-		"Scripts":     devbox.Config().Scripts(),
-		"EnvVars":     devbox.Config().Env(),
-		"InitHook":    devbox.Config().InitHook(),
-		"Packages":    devbox.TopLevelPackages(),
+		"Scripts": devbox.Config().Scripts().
+			WithRelativePaths(devbox.ProjectDir()),
+		"EnvVars":  devbox.Config().Env(),
+		"InitHook": devbox.Config().InitHook(),
+		"Packages": devbox.TopLevelPackages(),
 		// TODO add includes
 	})
 }

--- a/internal/devconfig/configfile/scripts.go
+++ b/internal/devconfig/configfile/scripts.go
@@ -1,6 +1,10 @@
 package configfile
 
-import "go.jetpack.io/devbox/internal/devbox/shellcmd"
+import (
+	"strings"
+
+	"go.jetpack.io/devbox/internal/devbox/shellcmd"
+)
 
 type script struct {
 	shellcmd.Commands
@@ -25,5 +29,23 @@ func (c *ConfigFile) Scripts() Scripts {
 		}
 	}
 
+	return result
+}
+
+func (s Scripts) WithRelativePaths(projectDir string) Scripts {
+	result := make(Scripts, len(s))
+	for name, s := range s {
+		commandsWithRelativePaths := shellcmd.Commands{}
+		for _, c := range s.Commands.Cmds {
+			commandsWithRelativePaths.Cmds = append(
+				commandsWithRelativePaths.Cmds,
+				strings.ReplaceAll(c, projectDir, "."),
+			)
+		}
+		result[name] = &script{
+			Commands: commandsWithRelativePaths,
+			Comments: s.Comments,
+		}
+	}
 	return result
 }


### PR DESCRIPTION
## Summary

Plugins v2 allow scripts that may have `Virtenv` or `DevboxDir` in them.  This causes the commands to show up as absolute paths in the readme. This fixes that issue.

An alternative is to read the raw scripts from the plugin (including the un-templatized string). This may be a better solution long term, but is more work and would require specially plugin parsing only for the readme generation so I punted on that approach for now.

## How was it tested?

Tested with new go monorepo plugin https://github.com/jetpack-io/devbox-plugins/pull/7