### PR TITLE
Hotfix/doc readme link

### DIFF
--- a/docs/app/docs/cli_reference/devbox_generate.md
+++ b/docs/app/docs/cli_reference/devbox_generate.md
@@ -20,7 +20,7 @@ devbox generate <devcontainer|dockerfile|direnv> [flags]
 * [devbox generate devcontainer](devbox_generate_devcontainer.md)	 - Generate Dockerfile and devcontainer.json files under .devcontainer/ directory
 * [devbox generate direnv](devbox_generate_direnv.md)  - Generate a .envrc file to use with direnv
 * [devbox generate dockerfile](devbox_generate_dockerfile.md)	 - Generate a Dockerfile that replicates devbox shell
-* [devbox generate readme](devbox_generate_dockerfile.md)	 -  Generate markdown readme file for your project
+* [devbox generate readme](devbox_generate_readme.md)	 -  Generate markdown readme file for your project
 
 ## SEE ALSO
 

--- a/docs/app/docs/cli_reference/devbox_generate_devcontainer.md
+++ b/docs/app/docs/cli_reference/devbox_generate_devcontainer.md
@@ -23,5 +23,4 @@ devbox generate devcontainer [flags]
 
 ### SEE ALSO
 
-* [devbox generate](devbox_generate.md)	 - 
-
+* [devbox generate](devbox_generate.md)	 - Generate supporting files for your project

--- a/docs/app/docs/cli_reference/devbox_generate_direnv.md
+++ b/docs/app/docs/cli_reference/devbox_generate_direnv.md
@@ -19,4 +19,4 @@ devbox generate direnv [flags]
 
 ## SEE ALSO
 
-* [devbox](devbox.md)	 - Instant, easy, predictable development environments
+* [devbox generate](devbox_generate.md)	 - Generate supporting files for your project

--- a/docs/app/docs/cli_reference/devbox_generate_dockerfile.md
+++ b/docs/app/docs/cli_reference/devbox_generate_dockerfile.md
@@ -24,5 +24,4 @@ devbox generate dockerfile [flags]
 
 ## SEE ALSO
 
-* [devbox generate](devbox_generate.md)	 - 
-
+* [devbox generate](devbox_generate.md)	 - Generate supporting files for your project

--- a/docs/app/docs/cli_reference/devbox_generate_readme.md
+++ b/docs/app/docs/cli_reference/devbox_generate_readme.md
@@ -18,5 +18,4 @@ devbox generate readme [filename] [flags]
 
 ## SEE ALSO
 
-* [devbox generate](devbox_generate.md)	 - 
-
+* [devbox generate](devbox_generate.md)	 - Generate supporting files for your project


### PR DESCRIPTION
## Summary

Fixed a few mislinks in cli documentation and standardized some of the "see also" notes for that section.

Original page with the bad link (specifically the link for "devbox generate readme"): https://www.jetpack.io/devbox/docs/cli_reference/devbox_generate/

## How was it tested?

Using the live-preview provided in the yarn script by following the directions in CONTRIBUTING.md