### PR TITLE
[gen-dockerfile] Make /code directory creation idempotent

### DIFF
--- a/internal/devbox/generate/tmpl/devcontainerDockerfile.tmpl
+++ b/internal/devbox/generate/tmpl/devcontainerDockerfile.tmpl
@@ -6,7 +6,7 @@
 WORKDIR /code
 {{- if not .RootUser }}
 USER root:root
-RUN mkdir /code && chown ${DEVBOX_USER}:${DEVBOX_USER} /code
+RUN mkdir -p /code && chown ${DEVBOX_USER}:${DEVBOX_USER} /code
 USER ${DEVBOX_USER}:${DEVBOX_USER}
 COPY --chown=${DEVBOX_USER}:${DEVBOX_USER} devbox.json devbox.json
 COPY --chown=${DEVBOX_USER}:${DEVBOX_USER} devbox.lock devbox.lock


### PR DESCRIPTION
## Summary

Resolves:
- https://github.com/jetpack-io/devbox/issues/1953
- https://github.com/jetpack-io/devbox/issues/1930

## How was it tested?

* Note: I don't recommend applying the patch below used to test this PR. Building an actual Dockerfile is way more of an integration test and I feel it is out of scope.

```diff
diff --git a/testscripts/generate/dockerfile.test.txt b/testscripts/generate/dockerfile.test.txt
index d63680b3..ec561564 100644
--- a/testscripts/generate/dockerfile.test.txt
+++ b/testscripts/generate/dockerfile.test.txt
@@ -1,3 +1,5 @@
 exec devbox init
 exec devbox generate dockerfile
 exists Dockerfile
+exec devbox add docker
+exec devbox run -- docker build .
```

Followed by:

```shell
$ go test ./testscripts -run TestScripts/dockerfile
```

which results in a successfully built dockerfile. 