### PR TITLE
[easy] devbox docs: direnv, remove warning about 0.5.0 breaking change

### DIFF
--- a/docs/app/docs/ide_configuration/direnv.md
+++ b/docs/app/docs/ide_configuration/direnv.md
@@ -7,14 +7,6 @@ title: direnv
 ___
 [direnv](https://direnv.net) is an open source environment management tool that allows setting unique environment variables per directory in your file system. This guide covers how to configure direnv to seamlessly work with a devbox project.
 
-:::note
-Devbox 0.5.0 makes changes to how the environment is sourced in order to ensure better compatibility with the user's host shell. This may raise some errors if you generated your `.envrc` file with an older version of devbox.
-
-If you see any errors when activating your `.envrc` file, you will need to run `devbox generate direnv --force`, and then re-run `devbox shell` to apply the latest changes. Be sure to back up your old `.envrc` file before running this command.
-
-Direnv only supports modifying environment variables, so your `init_hook` functionality will be restricted. In particular, aliases, functions, and command completions will not work. If you use these, stick with the manual `devbox shell`.
-:::
-
 ### Prerequisites
 * Install direnv and hook it to your shell. Follow [this guide](https://direnv.net/#basic-installation) if you haven't done it.
 


### PR DESCRIPTION
## Summary

I think we can remove this from the top of the page. Its been a loooong time now.

## How was it tested?
