### PR TITLE
release lock on global process-compose before attaching

### DIFF
--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -311,8 +311,8 @@ func AttachToProcessManager(ctx context.Context, w io.Writer, projectDir string,
 		return err
 	}
 
-	defer configFile.Close()
 	config := readGlobalProcessComposeJSON(configFile)
+	configFile.Close() // release the lock as this command is long running
 
 	project, ok := config.Instances[projectDir]
 	if !ok {


### PR DESCRIPTION
## Summary
After running `devbox services attach` all other `devbox services ...` commands hang until the attached UI is exited. This is because there's a lock put on the global process-compose file while it's being read and it's not released until the program exits.

You can see in `devbox services up` the lockfile is released, looks like it was just missed in attach.

https://github.com/jetify-com/devbox/blob/dd069a42b8cae746d93e2cd7ad5665b722a1973f/internal/services/manager.go#L188-L189



## How was it tested? (repro steps, hangs without this PR, works as expected with it)

In one terminal, in a devbox repo with process(es)
```sh
devbox services up -b
devbox services attach
```
In another terminal, in the same dir or any other devbox repo>
```sh
devbox services ls # or any services ... sub command
# will hang until <ctrl-c> in above terminal
```

## Other note

The `lock()` function has a timeout and error handling, why doesn't it work?

https://github.com/jetify-com/devbox/blob/dd069a42b8cae746d93e2cd7ad5665b722a1973f/internal/services/manager.go#L374-L394

The line that hangs is 391, when we're trying to close the file after the timeout, the file can't be closed because another process has it open and/or locked. I did investigate adding a timeout `file.Close()` but could not get it to work reliably for myself.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
