### PR TITLE
Add a comment about where PHP error_log() output goes. #2680

### DIFF
--- a/examples/development/php/latest/devbox.d/php/php-fpm.conf
+++ b/examples/development/php/latest/devbox.d/php/php-fpm.conf
@@ -1,5 +1,6 @@
 [global]
 pid = ${PHPFPM_PID_FILE}
+; Note: this is PHP-FPM's error log, not PHP's (see below)
 error_log = ${PHPFPM_ERROR_LOG_FILE}
 daemonize = yes
 
@@ -15,3 +16,9 @@ pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
 chdir = /
+
+; Note: PHP's error_log() output is typically found in your webserver error log, not in PHP-FPM's. By default error_log() writes to stderr (unless 'error_log' is set in php.log), and then on to the FastCGI client (the webserver), which logs it. If you want error_log() logged at the PHP-FPM layer, set a file here:
+;
+; php_admin_value[error_log] = ...
+; php_admin_flag[log_errors] = on
+

--- a/examples/flakes/php/devbox.d/php/php-fpm.conf
+++ b/examples/flakes/php/devbox.d/php/php-fpm.conf
@@ -1,5 +1,6 @@
 [global]
 pid = ${PHPFPM_PID_FILE}
+; Note: this is PHP-FPM's error log, not PHP's (see below)
 error_log = ${PHPFPM_ERROR_LOG_FILE}
 daemonize = yes
 
@@ -15,3 +16,9 @@ pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
 chdir = /
+
+; Note: PHP's error_log() output is typically found in your webserver error log, not in PHP-FPM's. By default error_log() writes to stderr (unless 'error_log' is set in php.log), and then on to the FastCGI client (the webserver), which logs it. If you want error_log() logged at the PHP-FPM layer, set a file here:
+;
+; php_admin_value[error_log] = ...
+; php_admin_flag[log_errors] = on
+

--- a/examples/plugins/builtin/devbox.d/php84/php-fpm.conf
+++ b/examples/plugins/builtin/devbox.d/php84/php-fpm.conf
@@ -15,3 +15,9 @@ pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
 chdir = /
+
+; Note: PHP's error_log() output is typically found in your webserver error log, not in PHP-FPM's. By default error_log() writes to stderr (unless 'error_log' is set in php.log), and then on to the FastCGI client (the webserver), which logs it. If you want error_log() logged at the PHP-FPM layer, set a file here:
+;
+; php_admin_value[error_log] = ...
+; php_admin_flag[log_errors] = on
+

--- a/examples/stacks/drupal/devbox.d/php/php-fpm.conf
+++ b/examples/stacks/drupal/devbox.d/php/php-fpm.conf
@@ -1,5 +1,6 @@
 [global]
 pid = ${PHPFPM_PID_FILE}
+; Note: this is PHP-FPM's error log, not PHP's (see below)
 error_log = ${PHPFPM_ERROR_LOG_FILE}
 daemonize = yes
 
@@ -15,3 +16,9 @@ pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
 chdir = /
+
+; Note: PHP's error_log() output is typically found in your webserver error log, not in PHP-FPM's. By default error_log() writes to stderr (unless 'error_log' is set in php.log), and then on to the FastCGI client (the webserver), which logs it. If you want error_log() logged at the PHP-FPM layer, set a file here:
+;
+; php_admin_value[error_log] = ...
+; php_admin_flag[log_errors] = on
+

--- a/examples/stacks/lapp-stack/devbox.d/php/php-fpm.conf
+++ b/examples/stacks/lapp-stack/devbox.d/php/php-fpm.conf
@@ -1,5 +1,6 @@
 [global]
 pid = ${PHPFPM_PID_FILE}
+; Note: this is PHP-FPM's error log, not PHP's (see below)
 error_log = ${PHPFPM_ERROR_LOG_FILE}
 daemonize = yes
 
@@ -15,3 +16,9 @@ pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
 chdir = /
+
+; Note: PHP's error_log() output is typically found in your webserver error log, not in PHP-FPM's. By default error_log() writes to stderr (unless 'error_log' is set in php.log), and then on to the FastCGI client (the webserver), which logs it. If you want error_log() logged at the PHP-FPM layer, set a file here:
+;
+; php_admin_value[error_log] = ...
+; php_admin_flag[log_errors] = on
+

--- a/examples/stacks/laravel/devbox.d/php/php-fpm.conf
+++ b/examples/stacks/laravel/devbox.d/php/php-fpm.conf
@@ -1,5 +1,6 @@
 [global]
 pid = ${PHPFPM_PID_FILE}
+; Note: this is PHP-FPM's error log, not PHP's (see below)
 error_log = ${PHPFPM_ERROR_LOG_FILE}
 
 [www]
@@ -14,3 +15,9 @@ pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
 chdir = /
+
+; Note: PHP's error_log() output is typically found in your webserver error log, not in PHP-FPM's. By default error_log() writes to stderr (unless 'error_log' is set in php.log), and then on to the FastCGI client (the webserver), which logs it. If you want error_log() logged at the PHP-FPM layer, set a file here:
+;
+; php_admin_value[error_log] = ...
+; php_admin_flag[log_errors] = on
+

--- a/examples/stacks/lepp-stack/devbox.d/php/php-fpm.conf
+++ b/examples/stacks/lepp-stack/devbox.d/php/php-fpm.conf
@@ -1,5 +1,6 @@
 [global]
 pid = ${PHPFPM_PID_FILE}
+; Note: this is PHP-FPM's error log, not PHP's (see below)
 error_log = ${PHPFPM_ERROR_LOG_FILE}
 daemonize = yes
 
@@ -15,3 +16,9 @@ pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
 chdir = /
+
+; Note: PHP's error_log() output is typically found in your webserver error log, not in PHP-FPM's. By default error_log() writes to stderr (unless 'error_log' is set in php.log), and then on to the FastCGI client (the webserver), which logs it. If you want error_log() logged at the PHP-FPM layer, set a file here:
+;
+; php_admin_value[error_log] = ...
+; php_admin_flag[log_errors] = on
+

--- a/plugins/php/php-fpm.conf
+++ b/plugins/php/php-fpm.conf
@@ -1,5 +1,6 @@
 [global]
 pid = ${PHPFPM_PID_FILE}
+; Note: this is PHP-FPM's error log, not PHP's (see below)
 error_log = ${PHPFPM_ERROR_LOG_FILE}
 daemonize = yes
 
@@ -15,3 +16,9 @@ pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
 chdir = /
+
+; Note: PHP's error_log() output is typically found in your webserver error log, not in PHP-FPM's. By default error_log() writes to stderr (unless 'error_log' is set in php.log), and then on to the FastCGI client (the webserver), which logs it. If you want error_log() logged at the PHP-FPM layer, set a file here:
+;
+; php_admin_value[error_log] = ...
+; php_admin_flag[log_errors] = on
+


### PR DESCRIPTION
## Summary

Per #2680, this adds a comment to the php plugin's `devbox.d/php/php-fpm.conf` explaining where to find `error_log()` output for PHP scripts running under PHP-FPM - because despite appearances, they do not go to the `error_log` file configured at the top:

```ini
[global]
pid = ${PHPFPM_PID_FILE}
error_log = ${PHPFPM_ERROR_LOG_FILE}
daemonize = yes
```

It is a verbose comment, and arguably it's not our job to be educating numpties, but it would have helped me. I'll leave the call of including this up to you!

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
