### PR TITLE
Enforce explicit npm: prefix and improve error handling for missing packages

### DIFF
--- a/internal/devpkg/package_test.go
+++ b/internal/devpkg/package_test.go
@@ -211,3 +211,30 @@ func TestCanonicalName(t *testing.T) {
 		})
 	}
 }
+
+func TestScopedPackageTransformation(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"@angular/cli", "@angular/cli"}, // No longer transformed without npm: prefix
+		{"@angular/cli@1.0", "@angular/cli@1.0"},
+		{"@github/copilot", "@github/copilot"},
+		{"npm:@angular/cli", `nodePackages."@angular/cli"`},
+		{"npm:@angular/cli@1.0", `nodePackages."@angular/cli"@1.0`},
+		{"npm:lodash", `nodePackages."lodash"`},
+		{"npm:lodash@4.17.21", `nodePackages."lodash"@4.17.21`},
+		{"regular", "regular"},
+		{"@notscoped", "@notscoped"}, // no slash, so not transformed
+		{"go@1.20", "go@1.20"},       // not npm
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			pkg := PackageFromStringWithDefaults(tt.input, &lockfile{})
+			if pkg.Raw != tt.expected {
+				t.Errorf("Expected Raw %q, but got %q", tt.expected, pkg.Raw)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR enhances Devbox's npm package support by enforcing an explicit `npm:` prefix for npm packages, removing implicit transformation of scoped packages (e.g., `@angular/cli` no longer auto-transforms). It improves version parsing for npm-prefixed packages, refactors the parsing logic for better maintainability, and provides clearer error messages when npm packages are not found in Nixpkgs. Users now get actionable guidance, including a workaround to set npm's global prefix and install manually.

Partially fixes #2300

## Changes Made
- Enforced explicit `npm:` prefix in `parsePackageInput` and `newPackage`.
- Updated error handling in `initDefaultNames` for user-friendly npm package not-found messages.
- Refactored code to extract helper functions and consolidate logic.
- Updated tests to reflect new behavior.

## How was it tested?
- Built the local Devbox binary and tested installation of valid npm packages (e.g., `npm:lodash`).
- Attempted installation of non-existent npm packages (e.g., `npm:@github/copilot`) to verify improved error messages.
- Ran unit tests to ensure no regressions.
- Verified that bare scoped packages (e.g., `@angular/cli`) are no longer transformed.

## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers under the terms of the [Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the contributions to the project maintainers under the Apache 2 License as stated in the [Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).