### PR TITLE
[devbox] GHA tests: add GITHUB_TOKEN to nix config to fix 403 errors

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -48,7 +48,9 @@ env:
   HOMEBREW_NO_EMOJI: 1
   HOMEBREW_NO_ENV_HINTS: 1
   HOMEBREW_NO_INSTALL_CLEANUP: 1
-
+  NIX_CONFIG: |
+    access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+    
 jobs:
   build-devbox:
     strategy:


### PR DESCRIPTION

The CICD test on `main` failed with

https://github.com/jetify-com/devbox/actions/runs/18188142079/job/51777031350 `"unable to download 'https://api.github.com/repos/NixOS/nixpkgs/commits/nixpkgs-unstable': HTTP error 403`

Adding GITHUB_TOKEN to the nix-config, as done also in `cache-upload.yml` should help