### PR TITLE
[devbox] add apple-sdk-15 to fix mac compile

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -5,8 +5,8 @@
     "fd":  "latest",
     "git": "latest",
     "go":  "latest",
-    "apple-sdk_15": {
-      "name":      "sdk_15",
+    "apple-sdk_12": {
+      "name":      "sdk_12",
       "version":   "latest",
       "platforms": ["aarch64-darwin", "x86_64-darwin"]
     }

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,31 +1,31 @@
 {
   "lockfile_version": "1",
   "packages": {
-    "apple-sdk_15@latest": {
+    "apple-sdk_12@latest": {
       "last_modified": "2025-09-18T16:33:27Z",
-      "resolved": "github:NixOS/nixpkgs/f4b140d5b253f5e2a1ff4e5506edbf8267724bde#apple-sdk_15",
+      "resolved": "github:NixOS/nixpkgs/f4b140d5b253f5e2a1ff4e5506edbf8267724bde#apple-sdk_12",
       "source": "devbox-search",
-      "version": "15.2",
+      "version": "12.3",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/3w6k7waxdw7bv0l6ip0azfaskm5ibk4p-apple-sdk-15.2",
+              "path": "/nix/store/ywb67nwhda4n7lww0dyw394hd7gqw1sr-apple-sdk-12.3",
               "default": true
             }
           ],
-          "store_path": "/nix/store/3w6k7waxdw7bv0l6ip0azfaskm5ibk4p-apple-sdk-15.2"
+          "store_path": "/nix/store/ywb67nwhda4n7lww0dyw394hd7gqw1sr-apple-sdk-12.3"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/jd692x02r6by0hckzqhjgjccj615dsn9-apple-sdk-15.2",
+              "path": "/nix/store/4fpxjs3ivdxdvys66hh24jpyczi5cwig-apple-sdk-12.3",
               "default": true
             }
           ],
-          "store_path": "/nix/store/jd692x02r6by0hckzqhjgjccj615dsn9-apple-sdk-15.2"
+          "store_path": "/nix/store/4fpxjs3ivdxdvys66hh24jpyczi5cwig-apple-sdk-12.3"
         }
       }
     },


### PR DESCRIPTION
## Summary

Getting this error:
```
% devbox run build
Info: Running script "build" on /Users/savil/code/jetify/devbox
go: downloading github.com/Masterminds/semver v1.5.0
go: downloading github.com/hashicorp/go-immutable-radix v1.3.1
# github.com/golangci/golangci-lint/cmd/golangci-lint
/Users/savil/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.darwin-arm64/pkg/tool/darwin_arm64/link: running clang failed: exit status 1
/nix/store/yr2068d9m3nsc3g5gbjgj1n3fbr9rb89-clang-wrapper-19.1.7/bin/clang -arch arm64 -Wl,-headerpad,1144 -Wl,-flat_namespace -Wl,-bind_at_load -o $WORK/b001/exe/a.out -Qunused-arguments /var/folders/9d/5l7cbnw53999fk9bynzcvhl40000gn/T/go-link-3646555948/go.o /var/folders/9d/5l7cbnw53999fk9bynzcvhl40000gn/T/go-link-3646555948/000000.o /var/folders/9d/5l7cbnw53999fk9bynzcvhl40000gn/T/go-link-3646555948/000001.o /var/folders/9d/5l7cbnw53999fk9bynzcvhl40000gn/T/go-link-3646555948/000002.o /var/folders/9d/5l7cbnw53999fk9bynzcvhl40000gn/T/go-link-3646555948/000003.o /var/folders/9d/5l7cbnw53999fk9bynzcvhl40000gn/T/go-link-3646555948/000004.o /var/folders/9d/5l7cbnw53999fk9bynzcvhl40000gn/T/go-link-3646555948/000005.o /var/folders/9d/5l7cbnw53999fk9bynzcvhl40000gn/T/go-link-3646555948/000006.o /var/folders/9d/5l7cbnw53999fk9bynzcvhl40000gn/T/go-link-3646555948/000007.o /var/folders/9d/5l7cbnw53999fk9bynzcvhl40000gn/T/go-link-3646555948/000008.o /var/folders/9d/5l7cbnw53999fk9bynzcvhl40000gn/T/go-link-3646555948/000009.o /var/folders/9d/5l7cbnw53999fk9bynzcvhl40000gn/T/go-link-3646555948/000010.o /var/folders/9d/5l7cbnw53999fk9bynzcvhl40000gn/T/go-link-3646555948/000011.o /var/folders/9d/5l7cbnw53999fk9bynzcvhl40000gn/T/go-link-3646555948/000012.o /var/folders/9d/5l7cbnw53999fk9bynzcvhl40000gn/T/go-link-3646555948/000013.o /var/folders/9d/5l7cbnw53999fk9bynzcvhl40000gn/T/go-link-3646555948/000014.o -lresolv -O2 -g -O2 -g -framework CoreFoundation -framework CoreFoundation -framework Security -O2 -g
Undefined symbols for architecture arm64:
  "_SecTrustCopyCertificateChain", referenced from:
      _crypto/x509/internal/macos.x509_SecTrustCopyCertificateChain_trampoline.abi0 in go.o
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

related issues:
- https://github.com/NixOS/nixpkgs/issues/433688


## How was it tested?


## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
