### PR TITLE
Fix broken link for 'Installing Devbox'

### DIFF
--- a/examples/cloud_development/maelstrom/README.md
+++ b/examples/cloud_development/maelstrom/README.md
@@ -7,7 +7,7 @@ You should also check out the [Fly.io Distributed Systems Challenge](https://fly
 
 ## Prerequisites
 
-If you don't already have [Devbox](https://www.jetify.com/devbox/docs/installing_devbox/), you can install it by running the following command:
+If you don't already have [Devbox](https://www.jetify.com/docs/devbox/installing-devbox/index), you can install it by running the following command:
 
 ```bash
 curl -s https://get.jetify.com/install.sh | bash

--- a/examples/stacks/django/README.md
+++ b/examples/stacks/django/README.md
@@ -5,7 +5,7 @@
 
 ## How to Use
 
-1. Install [Devbox](https://www.jetify.com/devbox/docs/installing_devbox/)
+1. Install [Devbox](https://www.jetify.com/docs/devbox/installing-devbox/index)
 1. Run `devbox shell` to install your packages and run the init_hook. This will activate your virtual environment and install Django.
 1. Initialize PostgreSQL with `devbox run initdb`.
 1. Start the Postgres service by running `devbox services up postgresql`. You can start it in the background using `devbox services up -b postgresql`.
@@ -16,7 +16,7 @@
 
 ### Setting up the Project
 
-1. Install [Devbox](https://www.jetify.com/devbox/docs/installing_devbox/).
+1. Install [Devbox](https://www.jetify.com/docs/devbox/installing-devbox/index).
 1. Run `devbox create --template django` to create a new Devbox project in your directory.
 1. Install Python and PostgreSQL with `devbox install`. This will also install the Devbox plugins for pip (which sets up your .venv directory) and PostgreSQL.
 1. Copy the requirements.txt and `todo_project` directory into the root folder of your project

--- a/examples/stacks/jekyll/README.md
+++ b/examples/stacks/jekyll/README.md
@@ -7,7 +7,7 @@ Inspired by [This Example](https://litchipi.github.io/nix/2023/01/12/build-jekyl
 
 ## How to Use
 
-1. Install [Devbox](https://www.jetify.com/devbox/docs/installing_devbox/)
+1. Install [Devbox](https://www.jetify.com/docs/devbox/installing-devbox/index)
 1. Create a new project with:
 
     ```bash

--- a/examples/stacks/laravel/README.md
+++ b/examples/stacks/laravel/README.md
@@ -7,7 +7,7 @@ This example shows how to build a simple Laravel application backed by MariaDB a
 
 ## How to Run
 
-1. Install [Devbox](https://www.jetify.com/devbox/docs/installing_devbox/)
+1. Install [Devbox](https://www.jetify.com/docs/devbox/installing-devbox/index)
 
 1. Create a new Laravel App by running `devbox create --template laravel`. This will create a new Laravel project in your current directory.
 

--- a/examples/stacks/spring/README.md
+++ b/examples/stacks/spring/README.md
@@ -4,7 +4,7 @@ This example combines Java, Spring Boot, and MySQL to expose a simple REST API. 
 
 ## How to Run
 
-1. Install [Devbox](https://www.jetify.com/devbox/docs/installing_devbox/)
+1. Install [Devbox](https://www.jetify.com/docs/devbox/installing-devbox/index)
 
 1. Prepare the database by running `devbox run setup_db`. This will create the user and database that Spring expects in `stacks/spring/src/main/resources/application.properties`
 1. You can now start the Spring Boot service by running `devbox run bootRun`. This will start your MySQL service and run the application


### PR DESCRIPTION
## Summary
`Install Devbox` in multiple README files points to https://www.jetify.com/docs/devbox/installing_devbox which throws a 404 error.
This PR fix the broken links and updates with the new ones.

## How was it tested?
Looking and following the links that were broken

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
