### PR TITLE
Update plugins/builtin example to use php83 to avoid flaky tests

### DIFF
--- a/examples/plugins/builtin/devbox.json
+++ b/examples/plugins/builtin/devbox.json
@@ -11,7 +11,7 @@
     }
   },
   "include": [
-    // Installs the php plugin using php82 as trigger package
-    "plugin:php82"
+    // Installs the php plugin using php83 as trigger package
+    "plugin:php83"
   ]
 }


### PR DESCRIPTION
## Problem

The cli-tests on main failed on Oct 24 due to a flaky test in the php-dom extension for PHP 8.2.29:

```
building '/nix/store/4m46w082habdfswbjagviz3b43g86c8z-php-dom-8.2.29.drv'...
error: builder for '/nix/store/4m46w082habdfswbjagviz3b43g86c8z-php-dom-8.2.29.drv' failed with exit code 2;

FAILED TEST SUMMARY
GH-10234 (Setting DOMAttr::textContent results in an empty attribute value.) [tests/gh10234.phpt]
```

## Analysis

**Evidence of PHP version difference between runs:**

### Oct 23 run - ✅ SUCCESS
- **Run**: [18735766466](https://github.com/jetify-com/devbox/actions/runs/18735766466)
- **Job**: [test (is-main, ubuntu-latest, project-tests-only, 2.12.0)](https://github.com/jetify-com/devbox/actions/runs/18735766466/job/53442022209)
- **PHP Version**: 8.3.3
- **Log excerpt**:
  ```
  copying path '/nix/store/2c7asm2fwnlziayhmyhywldsym5mwpg9-php-dom-8.3.3' from 'https://cache.nixos.org'...
  ```

### Oct 24 run - ❌ FAILURE
- **Run**: [18774433913](https://github.com/jetify-com/devbox/actions/runs/18774433913)  
- **Job**: [test (is-main, ubuntu-latest, project-tests-only, 2.12.0)](https://github.com/jetify-com/devbox/actions/runs/18774433913/job/53565816996)
- **PHP Version**: 8.2.29
- **Log excerpt**:
  ```
  building '/nix/store/4m46w082habdfswbjagviz3b43g86c8z-php-dom-8.2.29.drv'...
  error: builder for '/nix/store/4m46w082habdfswbjagviz3b43g86c8z-php-dom-8.2.29.drv' failed with exit code 2;
  
  FAILED TEST SUMMARY
  GH-10234 (Setting DOMAttr::textContent results in an empty attribute value.) [tests/gh10234.phpt]
  ```

The issue is specific to PHP 8.2.29 in nixpkgs-unstable.

## Solution

Update the `examples/plugins/builtin` example from `php82` to `php83`.

This is a conservative approach because:
- ✅ PHP 8.3.3 already proven to work (Oct 23 success)
- ✅ Maintains upstream testing (doesn't skip tests)
- ✅ Minimal change (one line)
- ✅ Avoids the problematic PHP 8.2.29 version

## Changes

- `examples/plugins/builtin/devbox.json`: Change from `plugin:php82` to `plugin:php83`

## Alternative Considered

Initially considered adding `doCheck = false` to the PHP plugin flake, but updating the PHP version is cleaner and more conservative since PHP 8.3 is already known to work.

## Testing

This PR will trigger cli-tests. The `examples/plugins/builtin` test should pass with PHP 8.3.