### PR TITLE
[vscode extension] extension version and readme update to 0.1.8

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "devbox" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.1.8]
+
+- Added support "Reopen in Devbox" feature for Windows with WSL
+  - Credit: [Adrian Grucza](https://github.com/apgrucza)
+
 ## [0.1.7]
 
 - Removed Open In Desktop feature since devbox.sh web app is deprecated.

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -20,6 +20,8 @@ If the opened workspace in VSCode has a devbox.json file, from command palette, 
 NOTE: Requires devbox CLI v0.5.5 and above
   installed and in PATH. This feature is in beta. Please report any bugs/issues in [Github](https://github.com/jetify-com/devbox) or our [Discord](https://discord.gg/jetify).
 
+NOTE2: This feature works with Linux, MacOS, and Windows with WSL (project files should reside in WSL and devbox CLI needs to be installed and in PATH in WSL)
+
 ### Run devbox commands from command palette
 
 `cmd/ctrl + shift + p` opens vscode's command palette. Typing devbox filters all available commands devbox extension can run. Those commands are:

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "devbox",
   "displayName": "devbox by Jetify",
   "description": "devbox integration for VSCode",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "icon": "assets/icon.png",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
version update to 0.1.8
updated README
updated CHANGELOG
updated version number in package.json

## How was it tested?
N/A

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
