### PR TITLE
[small] Upgraded node version since it was incompatible with vsce

### DIFF
--- a/.github/workflows/vscode-ext-release.yaml
+++ b/.github/workflows/vscode-ext-release.yaml
@@ -11,11 +11,11 @@ jobs:
     environment: release
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup NodeJS 18
-        uses: actions/setup-node@v4
+        uses: actions/checkout@v5
+      - name: Setup NodeJS 24
+        uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 24
       - name: Install dependencies
         run: |
           npm install -g yarn


### PR DESCRIPTION
## Summary
upgraded github action node version for vscode extension release (requires node versions higher than 18) 
see https://github.com/jetify-com/devbox/actions/runs/18883516801/job/53892792809 for failed publish action.

## How was it tested?
not tested
## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
