### PR TITLE
Use portable shebang in .envrc template for NixOS compatibility

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Automatically sets up your devbox environment whenever you cd into this
 # directory via our direnv integration:

--- a/internal/devbox/generate/tmpl/envrc.tmpl
+++ b/internal/devbox/generate/tmpl/envrc.tmpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Automatically sets up your devbox environment whenever you cd into this
 # directory via our direnv integration:


### PR DESCRIPTION
## Summary

NixOS does not have /bin/bash, so generated .envrc doesn't work. This changes /bin/bash to portable /usr/bin/env bash.

## How was it tested?

Ran `go build -o ./devbox-test ./cmd/devbox && ./devbox-test generate direnv && direnv reload && cat .envrc`

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
