### PR TITLE
Fix elixir plugin for new Darwin SDK pattern

### DIFF
--- a/plugins/elixir.json
+++ b/plugins/elixir.json
@@ -1,11 +1,6 @@
 {
   "name": "elixir",
-  "version": "0.0.1",
-  "packages": {
-    "darwin.apple_sdk.frameworks.CoreServices": {
-      "platforms": ["aarch64-darwin", "x86_64-darwin"]
-    }
-  },
+  "version": "0.0.2",
   "env": {
     "MIX_HOME": "{{ .Virtenv }}/mix",
     "HEX_HOME": "{{ .Virtenv }}/hex",


### PR DESCRIPTION
## Summary

Fixes the elixir plugin to work with the new Darwin SDK pattern in nixpkgs by removing the explicit `darwin.apple_sdk.frameworks.CoreServices` dependency.

## How was it tested?

Tested on **macOS (darwin-arm64)**:

1. **Built devbox locally**: `devbox run build`
2. **Added elixir package**: `devbox add elixir`
   - ✅ No `darwin.apple_sdk_11_0 has been removed` error
   - ✅ Successfully installed Elixir 1.18.1 with Erlang/OTP 27

<img width="736" height="37" alt="image" src="https://github.com/user-attachments/assets/5808dfab-b525-4816-a19c-69ba8070dfaa" />

3. **Verified elixir functionality**: `elixir --version` successfully showed version information

<img width="1506" height="272" alt="image" src="https://github.com/user-attachments/assets/37230f7f-1b2a-42c4-83da-c8db28b70984" />

4. **Tested the original issue** - compiling `file_system` package (used by Phoenix for Live Reload):
   - Created a Mix project with `file_system` dependency
   - ✅ Successfully compiled the native macOS FSEvents watcher
   - Log output: `Compiling file system watcher for Mac... Done.`

<img width="609" height="203" alt="image" src="https://github.com/user-attachments/assets/b13e60c5-1c38-417a-926c-fa4d358dc5b6" />

This confirms that the CoreServices framework is now automatically available through the new Darwin stdenv, and the explicit `darwin.apple_sdk.frameworks.CoreServices` package reference is no longer needed.

## Background

The elixir plugin currently includes `darwin.apple_sdk.frameworks.CoreServices` in its packages section (added in  https://github.com/jetify-com/devbox/pull/2462#issuecomment-2568462297 to fix `file_system` package compilation on macOS). However, this reference uses the old Darwin SDK pattern that has been removed from nixpkgs.

As documented in [NixOS/nixpkgs#354146](https://github.com/NixOS/nixpkgs/issues/354146), nixpkgs has migrated to a new Darwin SDK pattern where:
- The stdenv now provides a default SDK automatically
- Framework dependencies like CoreServices are bundled in the SDK
- Explicit framework references using the old `darwin.apple_sdk_11_0` pattern cause errors

## Changes

- Removed the `packages` section from `plugins/elixir.json`
- Bumped plugin version from `0.0.1` to `0.0.2`

The `file_system` package will continue to work on macOS because CoreServices is now automatically available through the new Darwin stdenv.

Fixes #2705
Fixes #2557