### PR TITLE
[plugins] Added support for being able to specify PGPORT to postgres plugin

### DIFF
--- a/plugins/postgresql/process-compose.yaml
+++ b/plugins/postgresql/process-compose.yaml
@@ -2,7 +2,7 @@ version: "0.5"
 
 processes:
   postgresql:
-    command: "pg_ctl start -o \"-k '$PGHOST'\""
+    command: "pg_ctl start -o \"-k '$PGHOST' ${PGPORT:+-p '$PGPORT'}\""
     is_daemon: true
     shutdown: 
       command: "pg_ctl stop -m fast"
@@ -10,4 +10,4 @@ processes:
       restart: "always"
     readiness_probe:
       exec:
-        command: "pg_isready"
+        command: "pg_isready ${PGPORT:+-p '$PGPORT'}"


### PR DESCRIPTION
## Summary
Addresses #2773 

## How was it tested?
- prerequisite: add alias to compiled and built devbox binary (dx="path_to_devbox/dist/devbox")
- in 2 different directories named pg_test1 and pg_test2 run:
- - `dx init`
- - `dx add postgresql`
- - `dx run -- initdb`
- in pg_test2/devbox.json add `"env": { "PGPORT": "5433" }`
- - in both directories run `dx services up`
- - confirm both process composes run postgress on ports 5432 and 5433 without error

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
