### PR TITLE
Fix for #2041 for fish

### DIFF
--- a/internal/devbox/shellrc_fish.tmpl
+++ b/internal/devbox/shellrc_fish.tmpl
@@ -43,7 +43,8 @@ set fish_history devbox
 if not set -q devbox_no_prompt
     functions -c fish_prompt __devbox_fish_prompt_orig
     function fish_prompt
-        echo "(devbox)" (__devbox_fish_prompt_orig)
+        printf "(devbox) "
+        __devbox_fish_prompt_orig
     end
 end
 


### PR DESCRIPTION
## Summary

Fix for the fish part of #2041.
Piping the prompt through echo breaks things like newlines. Just use printf instead.

## How was it tested?

Manually changing the prompt on my machine and seeing that it resolves the issue.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
