### PR TITLE
Add pid, namespace, age, health, restarts to services ls

### DIFF
--- a/internal/devbox/services.go
+++ b/internal/devbox/services.go
@@ -123,9 +123,9 @@ func (d *Devbox) ListServices(ctx context.Context, runInCurrentShell bool) error
 		fmt.Fprintln(d.stderr, "Error listing services: ", err)
 	} else {
 		fmt.Fprintln(d.stderr, "Services running in process-compose:")
-		fmt.Fprintln(tw, "NAME\tSTATUS\tAGE\tHEALTH\tRESTARTS\tEXIT CODE")
+		fmt.Fprintln(tw, "PID\tNAME\tNAMESPACE\tSTATUS\tAGE\tHEALTH\tRESTARTS\tEXIT CODE")
 		for _, s := range pcSvcs {
-			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%d\n", s.Name, s.Status, s.Age, s.Health, s.Restarts, s.ExitCode)
+			fmt.Fprintf(tw, "%d\t%s\t%s\t%s\t%s\t%s\t%d\t%d\n", s.PID, s.Name, s.Namespace, s.Status, s.Age, s.Health, s.Restarts, s.ExitCode)
 		}
 		tw.Flush()
 	}

--- a/internal/services/client.go
+++ b/internal/services/client.go
@@ -18,12 +18,14 @@ import (
 type processStates = types.ProcessesState
 
 type Process struct {
-	Name     string
-	Status   string
-	Age      time.Duration
-	Health   string
-	Restarts int
-	ExitCode int
+	PID       int
+	Name      string
+	Namespace string
+	Status    string
+	Age       time.Duration
+	Health    string
+	Restarts  int
+	ExitCode  int
 }
 
 func StartServices(ctx context.Context, w io.Writer, serviceName, projectDir string) error {
@@ -95,12 +97,14 @@ func ListServices(ctx context.Context, projectDir string, w io.Writer) ([]Proces
 		}
 		for _, process := range processes.States {
 			results = append(results, Process{
-				Name:     process.Name,
-				Status:   process.Status,
-				Age:      process.Age.Round(time.Second),
-				Health:   process.Health,
-				Restarts: process.Restarts,
-				ExitCode: process.ExitCode,
+				PID:       process.Pid,
+				Name:      process.Name,
+				Namespace: process.Namespace,
+				Status:    process.Status,
+				Age:       process.Age.Round(time.Second),
+				Health:    process.Health,
+				Restarts:  process.Restarts,
+				ExitCode:  process.ExitCode,
 			})
 		}
 		return results, nil


### PR DESCRIPTION
## Summary

This PR adds additional output to the `devbox services ls` command to see specifically to see the status of the readiness checks.

Without the HEALTH information in the output it's impossible to tell if a service is still booting up or if it is fully up and running based on the readiness check.

Before:
```
NAME                   STATUS           EXIT CODE
failed-server          Completed        -1
good-server            Launching        0
starting-server        Launching        0
```

After:
```
Services running in process-compose:
PID          NAME                   NAMESPACE        STATUS           AGE        HEALTH           RESTARTS        EXIT CODE
19996        good-server            default          Launching        5s         Ready            0               0
19995        starting-server        default          Launching        5s         Not Ready        0               0
19997        failed-server          default          Completed        2s         -                0               -1
```

## Additional consideration

This PR brings the output of `devbox services ls` closer to that of `process-compose list -o wide`.

The output of `process-compose list -o wide` for comparison:
```
PID     NAME              NAMESPACE   STATUS      AGE   HEALTH      RESTARTS   EXITCODE
11518   failed-server     default     Completed   2s    -           0          -1
11520   good-server       default     Launching   3s    Ready       0          0
11519   starting-server   default     Launching   3s    Not Ready   0          0
```

(The only differences I see is the spacing between columns and no space in the title EXITCODE)

## How was it tested?

With a sample process-compose.yaml file and running:
```
devbox run build
dist/devbox shell
devbox services start
devbox services ls 
```

The sample process-compose.yaml file used for testing.
```
processes:
 
  good-server:
    command: python -m http.server 8081
    is_daemon: true
    readiness_probe:
      exec:
        command: curl -f http://localhost:8081
      initial_delay_seconds: 1
      period_seconds: 1

  starting-server:
    command: python -m http.server 8082
    is_daemon: true
    readiness_probe:
      exec:
        command: curl -f http://localhost:8082/wait
      initial_delay_seconds: 1
      period_seconds: 100

  failed-server:
    command: python -m http.server 8083
    is_daemon: true
    readiness_probe:
      exec:
        command: curl -f http://localhost:8083/not_there
      initial_delay_seconds: 1
      period_seconds: 1    
```

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
