### PR TITLE
Add services pcport command

### DIFF
--- a/internal/boxcli/services.go
+++ b/internal/boxcli/services.go
@@ -124,6 +124,15 @@ func servicesCmd(persistentPreRunE ...cobraFunc) *cobra.Command {
 		},
 	}
 
+	pcportCommand := &cobra.Command{
+		Use:   "pcport",
+		Short: "Display the port that process-compose is running on",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return showProcessComposePort(cmd, flags)
+		},
+	}
+
 	flags.envFlag.register(servicesCommand)
 	flags.config.registerPersistent(servicesCommand)
 	servicesCommand.PersistentFlags().BoolVar(
@@ -141,6 +150,7 @@ func servicesCmd(persistentPreRunE ...cobraFunc) *cobra.Command {
 	servicesCommand.AddCommand(restartCommand)
 	servicesCommand.AddCommand(startCommand)
 	servicesCommand.AddCommand(stopCommand)
+	servicesCommand.AddCommand(pcportCommand)
 	return servicesCommand
 }
 
@@ -273,4 +283,17 @@ func startProcessManager(
 			ProcessComposePort: flags.pcport,
 		},
 	)
+}
+
+func showProcessComposePort(cmd *cobra.Command, flags servicesCmdFlags) error {
+	box, err := devbox.Open(&devopt.Opts{
+		Dir:         flags.config.path,
+		Environment: flags.config.environment,
+		Stderr:      cmd.ErrOrStderr(),
+	})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return box.ShowProcessComposePort(cmd.Context(), cmd.OutOrStdout())
 }

--- a/internal/devbox/services.go
+++ b/internal/devbox/services.go
@@ -3,6 +3,7 @@ package devbox
 import (
 	"context"
 	"fmt"
+	"io"
 	"strconv"
 	"text/tabwriter"
 
@@ -271,4 +272,14 @@ func (d *Devbox) StartProcessManager(
 func (d *Devbox) runDevboxServicesScript(ctx context.Context, cmdArgs []string) error {
 	cmdArgs = append([]string{"services"}, cmdArgs...)
 	return d.RunScript(ctx, devopt.EnvOptions{}, "devbox", cmdArgs)
+}
+
+func (d *Devbox) ShowProcessComposePort(ctx context.Context, writer io.Writer) error {
+	port, err := services.GetProcessManagerPort(d.projectDir)
+	if err != nil {
+		return err // Error already contains user-friendly message from services layer
+	}
+
+	fmt.Fprintf(writer, "%d\n", port)
+	return nil
 }


### PR DESCRIPTION
Closes https://github.com/jetify-com/devbox/issues/2783

## Summary

This command returns the port that process-compose is running on. That makes it more feasible to use the process-compose api in scripting.

For example:
```
pcport=$(devbox services pcport)
curl http://localhost:$pcport/process/good-server | jq ".status, .is_ready"
```

## How was it tested?

With process-compose running:
```
$ dist/devbox services pcport
53173

$ echo $?
0
```

With process-compose stopped:
```
$ dist/devbox services pcport

Error: process-compose is not running or it's config is missing. To start it, run `devbox services up`
source: failed to find projectDir /Users/elliott.hilaire/github.com/elliotthilaire-ca/devbox in config.Instances

$ echo $?
1
```

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

## AI disclosure

Claude code assisted in creating this PR.