### PR TITLE
Fix update installing all packages instead of target

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -68,6 +68,10 @@ type Devbox struct {
 
 	// This is needed because of the --quiet flag.
 	stderr io.Writer
+
+	// packagesBeingUpdated tracks which packages are being updated so that
+	// installNixPackagesToStore only refreshes those, not all packages.
+	packagesBeingUpdated []*devpkg.Package
 }
 
 var legacyPackagesWarningHasBeenShown = false

--- a/internal/devbox/packages.go
+++ b/internal/devbox/packages.go
@@ -637,7 +637,7 @@ func (d *Devbox) packagesToInstallInStore(ctx context.Context, mode installMode)
 	packagesToInstall := []*devpkg.Package{}
 	storePathsForPackage := map[*devpkg.Package][]string{}
 	for _, pkg := range packages {
-		if mode == update {
+		if mode == update && d.isBeingUpdated(pkg) {
 			packagesToInstall = append(packagesToInstall, pkg)
 			continue
 		}
@@ -664,6 +664,15 @@ func (d *Devbox) packagesToInstallInStore(ctx context.Context, mode installMode)
 	}
 
 	return lo.Uniq(packagesToInstall), nil
+}
+
+func (d *Devbox) isBeingUpdated(pkg *devpkg.Package) bool {
+	for _, u := range d.packagesBeingUpdated {
+		if u.Raw == pkg.Raw {
+			return true
+		}
+	}
+	return false
 }
 
 // moveAllowInsecureFromLockfile will modernize a Devbox project by moving the allow_insecure: boolean

--- a/internal/devbox/update.go
+++ b/internal/devbox/update.go
@@ -80,6 +80,8 @@ func (d *Devbox) Update(ctx context.Context, opts devopt.UpdateOpts) error {
 		}
 	}
 
+	d.packagesBeingUpdated = inputs
+
 	mode := update
 	if opts.NoInstall {
 		mode = noInstall

--- a/internal/devbox/update_test.go
+++ b/internal/devbox/update_test.go
@@ -191,6 +191,43 @@ func TestUpdateOtherSysInfoIsReplaced(t *testing.T) {
 	require.Equal(t, "store_path2", lockfile.Packages[raw].Systems[sys2].Outputs[0].Path)
 }
 
+func TestUpdateOnlyTargetedPackagesAreSelected(t *testing.T) {
+	d := devboxForTesting(t)
+
+	pkgA := devpkg.PackageFromStringWithDefaults("hello@1.2.3", nil)
+	pkgB := devpkg.PackageFromStringWithDefaults("curl@latest", nil)
+	pkgC := devpkg.PackageFromStringWithDefaults("git@latest", nil)
+
+	// Simulate updating only pkgB.
+	d.packagesBeingUpdated = []*devpkg.Package{pkgB}
+
+	require.False(t, d.isBeingUpdated(pkgA), "pkgA should not be marked as being updated")
+	require.True(t, d.isBeingUpdated(pkgB), "pkgB should be marked as being updated")
+	require.False(t, d.isBeingUpdated(pkgC), "pkgC should not be marked as being updated")
+}
+
+func TestUpdateAllPackagesSelectedWhenNoneTargeted(t *testing.T) {
+	d := devboxForTesting(t)
+
+	pkgA := devpkg.PackageFromStringWithDefaults("hello@1.2.3", nil)
+	pkgB := devpkg.PackageFromStringWithDefaults("curl@latest", nil)
+
+	// Simulate `devbox update` with no args: all packages are in the update list.
+	d.packagesBeingUpdated = []*devpkg.Package{pkgA, pkgB}
+
+	require.True(t, d.isBeingUpdated(pkgA))
+	require.True(t, d.isBeingUpdated(pkgB))
+}
+
+func TestUpdateEmptyUpdateListSelectsNothing(t *testing.T) {
+	d := devboxForTesting(t)
+
+	pkg := devpkg.PackageFromStringWithDefaults("hello@1.2.3", nil)
+
+	// packagesBeingUpdated is nil (default) — no package should be force-refreshed.
+	require.False(t, d.isBeingUpdated(pkg))
+}
+
 func currentSystem(*testing.T) string {
 	sys := nix.System() // NOTE: we could mock this too, if it helps.
 	return sys

--- a/internal/devbox/update_test.go
+++ b/internal/devbox/update_test.go
@@ -192,40 +192,40 @@ func TestUpdateOtherSysInfoIsReplaced(t *testing.T) {
 }
 
 func TestUpdateOnlyTargetedPackagesAreSelected(t *testing.T) {
-	d := devboxForTesting(t)
+	devbox := devboxForTesting(t)
 
 	pkgA := devpkg.PackageFromStringWithDefaults("hello@1.2.3", nil)
 	pkgB := devpkg.PackageFromStringWithDefaults("curl@latest", nil)
 	pkgC := devpkg.PackageFromStringWithDefaults("git@latest", nil)
 
 	// Simulate updating only pkgB.
-	d.packagesBeingUpdated = []*devpkg.Package{pkgB}
+	devbox.packagesBeingUpdated = []*devpkg.Package{pkgB}
 
-	require.False(t, d.isBeingUpdated(pkgA), "pkgA should not be marked as being updated")
-	require.True(t, d.isBeingUpdated(pkgB), "pkgB should be marked as being updated")
-	require.False(t, d.isBeingUpdated(pkgC), "pkgC should not be marked as being updated")
+	require.False(t, devbox.isBeingUpdated(pkgA), "pkgA should not be marked as being updated")
+	require.True(t, devbox.isBeingUpdated(pkgB), "pkgB should be marked as being updated")
+	require.False(t, devbox.isBeingUpdated(pkgC), "pkgC should not be marked as being updated")
 }
 
 func TestUpdateAllPackagesSelectedWhenNoneTargeted(t *testing.T) {
-	d := devboxForTesting(t)
+	devbox := devboxForTesting(t)
 
 	pkgA := devpkg.PackageFromStringWithDefaults("hello@1.2.3", nil)
 	pkgB := devpkg.PackageFromStringWithDefaults("curl@latest", nil)
 
 	// Simulate `devbox update` with no args: all packages are in the update list.
-	d.packagesBeingUpdated = []*devpkg.Package{pkgA, pkgB}
+	devbox.packagesBeingUpdated = []*devpkg.Package{pkgA, pkgB}
 
-	require.True(t, d.isBeingUpdated(pkgA))
-	require.True(t, d.isBeingUpdated(pkgB))
+	require.True(t, devbox.isBeingUpdated(pkgA))
+	require.True(t, devbox.isBeingUpdated(pkgB))
 }
 
 func TestUpdateEmptyUpdateListSelectsNothing(t *testing.T) {
-	d := devboxForTesting(t)
+	devbox := devboxForTesting(t)
 
-	pkg := devpkg.PackageFromStringWithDefaults("hello@1.2.3", nil)
+	helloPkg := devpkg.PackageFromStringWithDefaults("hello@1.2.3", nil)
 
 	// packagesBeingUpdated is nil (default) — no package should be force-refreshed.
-	require.False(t, d.isBeingUpdated(pkg))
+	require.False(t, devbox.isBeingUpdated(helloPkg))
 }
 
 func currentSystem(*testing.T) string {


### PR DESCRIPTION
## Summary
- Fixes `devbox update <pkg>` causing all packages to be re-installed instead of just the specified one
- Tracks which packages are being updated via a new field on the `Devbox` struct
- `packagesToInstallInStore()` now only force-installs the targeted packages; others go through the normal store-path check

Fixes #2653

## Test plan
- [x] Run `devbox update <single-pkg>` with multiple packages in devbox.json — only the target should be installed
- [x] Run `devbox update` (no args) — all packages should still be updated
