### PR TITLE
Allow package versions in devbox.json to reference a file (#2931)

### DIFF
--- a/internal/devconfig/configfile/packages.go
+++ b/internal/devconfig/configfile/packages.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -14,6 +16,12 @@ import (
 	"go.jetify.com/devbox/internal/nix"
 	"go.jetify.com/devbox/internal/searcher"
 	"go.jetify.com/devbox/internal/ux"
+)
+
+var versionPattern = regexp.MustCompile(
+	`\d+\.\d+\.\d+` + // MAJOR.MINOR.PATCH
+		`(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?` + // optional pre-release
+		`(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?`, // optional build metadata
 )
 
 type PackagesMutator struct {
@@ -345,6 +353,9 @@ func (p *Package) UnmarshalJSON(data []byte) error {
 		*p = Package(*alias)
 	}
 
+	// If the version is a file path, read and clean the version from it.
+	p.Version = resolveVersionFromFile(p.Version)
+
 	if p.Patch == "" {
 		if p.PatchGlibc {
 			// Force patching if the user has an old config with the deprecated
@@ -380,4 +391,31 @@ func packagesFromLegacyList(packages []string) []Package {
 		packagesList = append(packagesList, NewVersionOnlyPackage(name, version))
 	}
 	return packagesList
+}
+
+// resolveVersionFromFile checks if version is a path to an existing file.
+// If so, it reads the file and extracts a version string (e.g. "1.2.3").
+// Otherwise it returns the version unchanged.
+func resolveVersionFromFile(version string) string {
+	if version == "" {
+		return version
+	}
+
+	info, err := os.Stat(version)
+	if err != nil || info.IsDir() {
+		return version
+	}
+
+	data, err := os.ReadFile(version)
+	if err != nil {
+		return version
+	}
+
+	cleaned := strings.TrimSpace(string(data))
+	match := versionPattern.FindString(cleaned)
+	if match == "" {
+		return version
+	}
+
+	return match
 }

--- a/internal/devconfig/configfile/packages_test.go
+++ b/internal/devconfig/configfile/packages_test.go
@@ -1,6 +1,9 @@
 package configfile
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -10,6 +13,12 @@ import (
 
 // TestJsonifyConfigPackages tests the jsonMarshal and jsonUnmarshal of the Config.Packages field
 func TestJsonifyConfigPackages(t *testing.T) {
+	fileVersionContent := "1.20\n"
+	tmpFileVersion := filepath.Join(t.TempDir(), "version")
+	if err := os.WriteFile(tmpFileVersion, []byte(fileVersionContent), 0o644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+
 	testCases := []struct {
 		name       string
 		jsonConfig string
@@ -46,7 +55,16 @@ func TestJsonifyConfigPackages(t *testing.T) {
 				},
 			},
 		},
-
+		{
+			name:       "map-with-file-value",
+			jsonConfig: fmt.Sprintf(`{"packages":{"python":"latest","go":"%s"}}`, tmpFileVersion),
+			expected: PackagesMutator{
+				collection: []Package{
+					NewVersionOnlyPackage("python", "latest"),
+					NewVersionOnlyPackage("go", "1.20"),
+				},
+			},
+		},
 		{
 			name:       "map-with-struct-value",
 			jsonConfig: `{"packages":{"python":{"version":"latest"}}}`,
@@ -231,6 +249,110 @@ func diffPackages(t *testing.T, got, want PackagesMutator) string {
 	t.Helper()
 
 	return cmp.Diff(want, got, cmpopts.IgnoreUnexported(PackagesMutator{}, Package{}))
+}
+
+func TestVersionFromFile(t *testing.T) {
+	testCases := []struct {
+		name            string
+		fileContent     string
+		expectedVersion string
+	}{
+		{
+			name:            "semver",
+			fileContent:     "1.2.3",
+			expectedVersion: "1.2.3",
+		},
+		{
+			name:            "semver-with-newline",
+			fileContent:     "1.2.3\n",
+			expectedVersion: "1.2.3",
+		},
+		{
+			name:            "semver-with-whitespace",
+			fileContent:     "  1.2.3  \n",
+			expectedVersion: "1.2.3",
+		},
+		{
+			name:            "v-prefix",
+			fileContent:     "v1.2.3\n",
+			expectedVersion: "1.2.3",
+		},
+		{
+			name:            "semver-pre-release",
+			fileContent:     "1.0.0-alpha\n",
+			expectedVersion: "1.0.0-alpha",
+		},
+		{
+			name:            "semver-pre-release-dotted",
+			fileContent:     "1.0.0-alpha.1\n",
+			expectedVersion: "1.0.0-alpha.1",
+		},
+		{
+			name:            "semver-pre-release-numeric",
+			fileContent:     "1.0.0-0.3.7\n",
+			expectedVersion: "1.0.0-0.3.7",
+		},
+		{
+			name:            "semver-build-metadata",
+			fileContent:     "1.0.0+build.123\n",
+			expectedVersion: "1.0.0+build.123",
+		},
+		{
+			name:            "semver-pre-release-and-build",
+			fileContent:     "1.0.0-beta.1+build.456\n",
+			expectedVersion: "1.0.0-beta.1+build.456",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run("string-value-"+testCase.name, func(t *testing.T) {
+			tmpFile := filepath.Join(t.TempDir(), "version")
+			if err := os.WriteFile(tmpFile, []byte(testCase.fileContent), 0o644); err != nil {
+				t.Fatalf("failed to write temp file: %v", err)
+			}
+
+			version := resolveVersionFromFile(tmpFile)
+
+			if version != testCase.expectedVersion {
+				t.Errorf("version: expected %q, got %q", testCase.expectedVersion, version)
+			}
+		})
+	}
+}
+
+func TestInvalidVersionFromFile(t *testing.T) {
+	t.Run("no-file", func(t *testing.T) {
+		tmpFile := "nonexistent"
+		version := resolveVersionFromFile(tmpFile)
+
+		if tmpFile != version {
+			t.Errorf("version: expected %q, got %q", tmpFile, version)
+		}
+	})
+
+	t.Run("no-version-in-file", func(t *testing.T) {
+		fileContent := "hello world\n"
+		tmpFile := filepath.Join(t.TempDir(), "version")
+		if err := os.WriteFile(tmpFile, []byte(fileContent), 0o644); err != nil {
+			t.Fatalf("failed to write temp file: %v", err)
+		}
+
+		version := resolveVersionFromFile(tmpFile)
+
+		if tmpFile != version {
+			t.Errorf("version: expected %q, got %q", tmpFile, version)
+		}
+	})
+
+	t.Run("directory-not-treated-as-file", func(t *testing.T) {
+		dir := t.TempDir()
+
+		version := resolveVersionFromFile(dir)
+
+		if dir != version {
+			t.Errorf("version: expected %q, got %q", dir, version)
+		}
+	})
 }
 
 func TestParseVersionedName(t *testing.T) {


### PR DESCRIPTION
## Related issues

Fixes https://github.com/jetify-com/devbox/issues/2931

## Summary

Allow package versions in `devbox.json` to reference a file containing the version string (e.g., `.go-version`, `.node-version`). Teams commonly store versions in files to share them across CI, Docker builds, and local development — this ensures devbox environments stay in sync with production without manual duplication.

## How was it tested?

1. Create a dummy directory

```console
mkdir dummy
```

2. Create the following files 

#### dummy/devbox.json
```json
{
  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.17.1/.schema/devbox.schema.json",
  "packages": {
    "go": ".go-version"
  },
  "shell": {
    "init_hook": ["echo 'Welcome to devbox!' > /dev/null"],
    "scripts": {
      "test": ["echo \"Error: no test specified\" && exit 1"]
    }
  }
}
```

#### dummy/.go-version

```
1.24.0
```

3. Run the following command from the root of the project

```console
devbox run build && cd dummy && ../dist/devbox shell
```

The expected result should that devbox download the go version `1.24.0` when shell is enabled.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
