### PR TITLE
Bump lastTag version to 0.17.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
 
-        lastTag = "0.17.1";
+        lastTag = "0.17.2";
 
         revision = if (self ? shortRev) then "${self.shortRev}" else "${self.dirtyShortRev or "dirty"}";
 


### PR DESCRIPTION
## Summary
- Bump `lastTag` in `flake.nix` from 0.17.1 to 0.17.2
- Update `flake.lock` (nixpkgs 2026-04-14 → 2026-04-18)

## Test plan
- [x] `nix build .` succeeds
- [x] `./result/bin/devbox version` reports `0.17.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)