### PR TITLE
Fix broken gitignore in venv shell hook

### DIFF
--- a/plugins/python/venvShellHook.sh
+++ b/plugins/python/venvShellHook.sh
@@ -12,7 +12,7 @@ is_devbox_venv() {
 
 create_venv() {
     python -m venv "$VENV_DIR" --clear
-    echo "*\n.*" >> "$VENV_DIR/.gitignore"
+    echo -e "*\n.*" >> "$VENV_DIR/.gitignore"
 }
 
 # Check that Python version supports venv


### PR DESCRIPTION
## Summary

The gitignore file contained an escaped newline, which prevented the files from actually being ignored

Old `.venv/.gitignore`:
```
*\n.*
```

New `.venv/.gitignore`
```
*
.*
```

## How was it tested?

Manually running `echo -e '*\n.*'` on my machine and verifying that it looks correct.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
