### PR TITLE
Ignore PROFILEREAD envvar that is read-only in SUSE/openSUSE

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -1065,6 +1065,10 @@ var ignoreCurrentEnvVar = map[string]bool{
 
 	// The "_" variable is read-only, so we ignore it to avoid attempting to write it later.
 	"_": true,
+
+	// PROFILEREAD is read-only in SUSE/openSUSE to prevent duplicate processing
+	// of system and user environment variables.
+	"PROFILEREAD": true,
 }
 
 // ignoreDevEnvVar contains environment variables that Devbox should remove from


### PR DESCRIPTION
## Summary
Ignore `PROFILEREAD` envvar in `devbox shellenv` and `devbox global shellenv` since it is read-only in SUSE/openSUSE.

Current devbox does not ignore `PROFILEREAD`, so performing `eval $(devbox global shellenv)` causes following  error and `refresh-global` is not available.
```sh
(eval):55: read-only variable: PROFILEREAD
```
This change fixes the error in SUSE/openSUSE.
I understand this change is only for specific distributions, but required for supporting them.

## How was it tested?
Run `devbox run devbox global shellenv` and verified `export PROFILEREAD="true";` is not printed in openSUSE as below.

```sh
~/r/g/g/devbox  feat/ignore-profileread-envvar 🐹  v1.26.2
❯ cat /etc/os-release
NAME="openSUSE Tumbleweed-Slowroll"
# VERSION="20260504"
ID="opensuse-slowroll"
ID_LIKE="opensuse-tumbleweed opensuse suse"
VERSION_ID="20260504"
PRETTY_NAME="openSUSE Tumbleweed-Slowroll"
ANSI_COLOR="0;32"
# CPE 2.3 format, boo#1217921
CPE_NAME="cpe:2.3:o:opensuse:slowroll:20260504:*:*:*:*:*:*:*"
#CPE 2.2 format
#CPE_NAME="cpe:/o:opensuse:slowroll:20260504"
BUG_REPORT_URL="https://bugzilla.opensuse.org"
SUPPORT_URL="https://bugs.opensuse.org"
HOME_URL="https://www.opensuse.org"
DOCUMENTATION_URL="https://en.opensuse.org/openSUSE:Slowroll"
LOGO="distributor-logo-Slowroll"

~/r/g/g/devbox  feat/ignore-profileread-envvar 🐹  v1.26.2
❯ printenv PROFILEREAD
true

~/r/g/g/devbox  feat/ignore-profileread-envvar 🐹  v1.26.2
❯ devbox run devbox global shellenv
Info: Running script "devbox" on /home/tharada/repo/github.com/gasuketsu/devbox
Warning: Your devbox environment may be out of date. Run `refresh-global` or `eval "$(devbox global shellenv --preserve-path-stack -r)" && hash -r` to update it.
export AR="ar";
export AS="as";
export BUN_INSTALL_BIN="/home/tharada/.local/bin";
export CC="gcc";
export CGO_ENABLED="0";
export CONFIG_SHELL="/nix/store/v8sa6r6q037ihghxfbwzjj4p59v2x0pv-bash-5.3p9/bin/bash";
export CPU="x86_64";
export CSHEDIT="emacs";
export CXX="g++";
export DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/1000/bus";
export DEBUGINFOD_URLS="https://debuginfod.opensuse.org/ ";
export DEVBOX_CONFIG_DIR="/home/tharada/.local/share/devbox/global/default/devbox.d";
export DEVBOX_DEFAULT_PYPROJECT_DIR="/home/tharada/.local/share/devbox/global/default";
export DEVBOX_INIT_PATH="/home/tharada/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/lib/wsl/lib:/home/tharada/.local/bin:/usr/local/bin:/usr/bin:/bin";
export DEVBOX_NIX_ENV_PATH_1dcdaf953120a95c1ff874038aa1773cd0c943cbba4da48acd062aed949da402="/home/tharada/repo/github.com/gasuketsu/devbox/dist/tools:/home/tharada/repo/github.com/gasuketsu/devbox/.devbox/nix/profile/default/bin:/nix/store/sj3f6y3j8m1831l0gqm1bsk1f46jzkfd-patchelf-0.15.2/bin:/nix/store/hb2bs5fg5wkm04x565737qd5nh2hy5nk-gcc-wrapper-15.2.0/bin:/nix/store/lvwga6ivl1d4lnw0zis9ajs0rqx9gp4i-gcc-15.2.0/bin:/nix/store/9hm3jdm6kk4m4ppwjcxz4s1dsdvd6fin-glibc-2.42-51-bin/bin:/nix/store/74sind1d6vf2bfwd7yklg8chsvzqxmmq-coreutils-9.10/bin:/nix/store/x7ikkplbrv5dlihy1bqq32gp6lilkval-binutils-wrapper-2.44/bin:/nix/store/rfp8lhk4dl9syfn64rwb3h3c73426p08-binutils-2.44/bin:/nix/store/c89zz4vh8v9dbs8169wk8ahwxvrdxgm5-findutils-4.10.0/bin:/nix/store/355mp4ns4042sb5p51rx3ys4mlliiwc5-diffutils-3.12/bin:/nix/store/jpsqy47rdl0j0dvyyzb4kw8gqajw8nx0-gnused-4.9/bin:/nix/store/h6hdbgkfh59np7bi7h8qa76pq27ixz8r-gnugrep-3.12/bin:/nix/store/gg169kyil5vhsg5aqcpagyhs8fwl0r5r-gawk-5.3.2/bin:/nix/store/kvmqv1jqv4792rsihf7yjc5kwk3d8z6x-gnutar-1.35/bin:/nix/store/pnxiz967z73a45f4x7c1icldjaaqmlcp-gzip-1.14/bin:/nix/store/by6npbc13ly5a1zgsqghv7wv5bklyiny-bzip2-1.0.8-bin/bin:/nix/store/1fvcxyhg3i5fvw0j4l8wmyml10dnvm7q-gnumake-4.4.1/bin:/nix/store/v8sa6r6q037ihghxfbwzjj4p59v2x0pv-bash-5.3p9/bin:/nix/store/ca84rbhb0bhwdcci7q51dad20nkbn9xc-patch-2.8/bin:/nix/store/g6mlwdvpg92rchq352ll7jbi0pz7h43r-xz-5.8.2-bin/bin:/nix/store/kjg8z2k0zvsczaij78803g7imlfm1vfb-file-5.45/bin:/home/tharada/repo/github.com/gasuketsu/devbox/dist:/home/tharada/repo/github.com/gasuketsu/devbox/.devbox/virtenv/runx/bin";
export DEVBOX_NIX_ENV_PATH_a545b47339823787f5c6fd2ec3f91a12fb163aa1cb925dbfdbd579f40a92120d="/home/tharada/.local/share/devbox/global/default/.devbox/nix/profile/default/bin:/home/tharada/repo/github.com/gasuketsu/devbox/dist/tools:/home/tharada/repo/github.com/gasuketsu/devbox/.devbox/nix/profile/default/bin:/nix/store/sj3f6y3j8m1831l0gqm1bsk1f46jzkfd-patchelf-0.15.2/bin:/nix/store/hb2bs5fg5wkm04x565737qd5nh2hy5nk-gcc-wrapper-15.2.0/bin:/nix/store/lvwga6ivl1d4lnw0zis9ajs0rqx9gp4i-gcc-15.2.0/bin:/nix/store/9hm3jdm6kk4m4ppwjcxz4s1dsdvd6fin-glibc-2.42-51-bin/bin:/nix/store/74sind1d6vf2bfwd7yklg8chsvzqxmmq-coreutils-9.10/bin:/nix/store/x7ikkplbrv5dlihy1bqq32gp6lilkval-binutils-wrapper-2.44/bin:/nix/store/rfp8lhk4dl9syfn64rwb3h3c73426p08-binutils-2.44/bin:/nix/store/c89zz4vh8v9dbs8169wk8ahwxvrdxgm5-findutils-4.10.0/bin:/nix/store/355mp4ns4042sb5p51rx3ys4mlliiwc5-diffutils-3.12/bin:/nix/store/jpsqy47rdl0j0dvyyzb4kw8gqajw8nx0-gnused-4.9/bin:/nix/store/h6hdbgkfh59np7bi7h8qa76pq27ixz8r-gnugrep-3.12/bin:/nix/store/gg169kyil5vhsg5aqcpagyhs8fwl0r5r-gawk-5.3.2/bin:/nix/store/kvmqv1jqv4792rsihf7yjc5kwk3d8z6x-gnutar-1.35/bin:/nix/store/pnxiz967z73a45f4x7c1icldjaaqmlcp-gzip-1.14/bin:/nix/store/by6npbc13ly5a1zgsqghv7wv5bklyiny-bzip2-1.0.8-bin/bin:/nix/store/1fvcxyhg3i5fvw0j4l8wmyml10dnvm7q-gnumake-4.4.1/bin:/nix/store/v8sa6r6q037ihghxfbwzjj4p59v2x0pv-bash-5.3p9/bin:/nix/store/ca84rbhb0bhwdcci7q51dad20nkbn9xc-patch-2.8/bin:/nix/store/g6mlwdvpg92rchq352ll7jbi0pz7h43r-xz-5.8.2-bin/bin:/nix/store/kjg8z2k0zvsczaij78803g7imlfm1vfb-file-5.45/bin:/home/tharada/repo/github.com/gasuketsu/devbox/dist:/home/tharada/repo/github.com/gasuketsu/devbox/.devbox/virtenv/runx/bin:/home/tharada/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/lib/wsl/lib:/home/tharada/.local/bin:/home/tharada/.local/share/devbox/global/default/.devbox/virtenv/runx/bin";
export DEVBOX_PACKAGES_DIR="/home/tharada/.local/share/devbox/global/default/.devbox/nix/profile/default";
export DEVBOX_PATH_STACK="DEVBOX_NIX_ENV_PATH_a545b47339823787f5c6fd2ec3f91a12fb163aa1cb925dbfdbd579f40a92120d:DEVBOX_NIX_ENV_PATH_1dcdaf953120a95c1ff874038aa1773cd0c943cbba4da48acd062aed949da402:DEVBOX_INIT_PATH";
export DEVBOX_PROJECT_ROOT="/home/tharada/.local/share/devbox/global/default";
export DEVBOX_RUN_CMD="devbox \"global\" \"shellenv\"";
export DEVBOX_SHELL_ENABLED="1";
export DEVBOX_SYSTEM_BASH="/usr/bin/bash";
export DEVBOX_SYSTEM_SED="/usr/bin/sed";
export DEVBOX_WD="/home/tharada/repo/github.com/gasuketsu/devbox";
export DISPLAY=":0";
export EDITOR="nvim";
export FZF_DEFAULT_OPTS_FILE="/home/tharada/.config/fzf/config";
export GALLIUM_DRIVER="d3d12";
export GOENV="off";
export GPG_TTY="/dev/pts/2";
export G_BROKEN_FILENAMES="1";
export G_FILENAME_ENCODING="@locale,UTF-8,ISO-8859-15,CP1252";
export HISTSIZE="1000";
export HOME="/home/tharada";
export HOST="qube";
export HOSTNAME="qube";
export HOSTTYPE="x86_64";
export HOST_PATH="/nix/store/836lndidk1144z81npf27c7dcgmczid3-fd-10.4.2/bin:/nix/store/7yvcckar1lzhqnr0xx2n19nsdjd4qa4d-git-2.53.0/bin:/nix/store/ckcq2mj8zk0drhaaacy6mp9d924hnr4m-go-1.26.1/bin:/nix/store/74sind1d6vf2bfwd7yklg8chsvzqxmmq-coreutils-9.10/bin:/nix/store/c89zz4vh8v9dbs8169wk8ahwxvrdxgm5-findutils-4.10.0/bin:/nix/store/355mp4ns4042sb5p51rx3ys4mlliiwc5-diffutils-3.12/bin:/nix/store/jpsqy47rdl0j0dvyyzb4kw8gqajw8nx0-gnused-4.9/bin:/nix/store/h6hdbgkfh59np7bi7h8qa76pq27ixz8r-gnugrep-3.12/bin:/nix/store/gg169kyil5vhsg5aqcpagyhs8fwl0r5r-gawk-5.3.2/bin:/nix/store/kvmqv1jqv4792rsihf7yjc5kwk3d8z6x-gnutar-1.35/bin:/nix/store/pnxiz967z73a45f4x7c1icldjaaqmlcp-gzip-1.14/bin:/nix/store/by6npbc13ly5a1zgsqghv7wv5bklyiny-bzip2-1.0.8-bin/bin:/nix/store/1fvcxyhg3i5fvw0j4l8wmyml10dnvm7q-gnumake-4.4.1/bin:/nix/store/v8sa6r6q037ihghxfbwzjj4p59v2x0pv-bash-5.3p9/bin:/nix/store/ca84rbhb0bhwdcci7q51dad20nkbn9xc-patch-2.8/bin:/nix/store/g6mlwdvpg92rchq352ll7jbi0pz7h43r-xz-5.8.2-bin/bin:/nix/store/kjg8z2k0zvsczaij78803g7imlfm1vfb-file-5.45/bin";
export IN_NIX_SHELL="impure";
export LANG="en_US.UTF-8";
export LAUNCHER_PATH="/usr/local/bin/devbox";
export LAUNCHER_VERSION="0.2.2";
export LD="ld";
export LESS="-M -I -R";
export LESSCLOSE="lessclose.sh %s %s";
export LESSKEY="/usr/etc/lesskey.bin";
export LESSOPEN="lessopen.sh %s";
export LESS_ADVANCED_PREPROCESSOR="no";
export LIBVA_DRIVER_NAME="d3d12";
export LOGNAME="tharada";
export LS_OPTIONS="-N --color=tty -T 0";
export MACHTYPE="x86_64";
export MAIL="/var/mail/tharada";
export MANPATH="/usr/local/man:/usr/share/man";
export MANPATHISSET="yes";
export MINICOM="-c on";
export MORE="-sl";
export NAME="qube";
export NIX_BINTOOLS="/nix/store/x7ikkplbrv5dlihy1bqq32gp6lilkval-binutils-wrapper-2.44";
export NIX_BINTOOLS_WRAPPER_TARGET_HOST_x86_64_unknown_linux_gnu="1";
export NIX_BUILD_CORES="6";
export NIX_CC="/nix/store/hb2bs5fg5wkm04x565737qd5nh2hy5nk-gcc-wrapper-15.2.0";
export NIX_CC_WRAPPER_TARGET_HOST_x86_64_unknown_linux_gnu="1";
export NIX_CFLAGS_COMPILE=" -frandom-seed=z9ff4q0qw8";
export NIX_ENFORCE_NO_NATIVE="1";
export NIX_HARDENING_ENABLE="bindnow format fortify fortify3 libcxxhardeningfast pic relro stackclashprotection stackprotector strictflexarrays1 strictoverflow zerocallusedregs";
export NIX_LDFLAGS="-rpath /nix/store/z9ff4q0qw8cmchhppfgxz1mdr1l2i3mm-nix-shell-env/lib ";
export NIX_PROFILES="/nix/var/nix/profiles/default /home/tharada/.nix-profile";
export NIX_SSL_CERT_FILE="/etc/ssl/ca-bundle.pem";
export NIX_STORE="/nix/store";
export NM="nm";
export OBJCOPY="objcopy";
export OBJDUMP="objdump";
export OSTYPE="linux-gnu";
export PAGER="less";
export PATH="/home/tharada/.local/share/devbox/global/default/.devbox/nix/profile/default/bin:/home/tharada/repo/github.com/gasuketsu/devbox/dist/tools:/home/tharada/repo/github.com/gasuketsu/devbox/.devbox/nix/profile/default/bin:/nix/store/sj3f6y3j8m1831l0gqm1bsk1f46jzkfd-patchelf-0.15.2/bin:/nix/store/hb2bs5fg5wkm04x565737qd5nh2hy5nk-gcc-wrapper-15.2.0/bin:/nix/store/lvwga6ivl1d4lnw0zis9ajs0rqx9gp4i-gcc-15.2.0/bin:/nix/store/9hm3jdm6kk4m4ppwjcxz4s1dsdvd6fin-glibc-2.42-51-bin/bin:/nix/store/74sind1d6vf2bfwd7yklg8chsvzqxmmq-coreutils-9.10/bin:/nix/store/x7ikkplbrv5dlihy1bqq32gp6lilkval-binutils-wrapper-2.44/bin:/nix/store/rfp8lhk4dl9syfn64rwb3h3c73426p08-binutils-2.44/bin:/nix/store/c89zz4vh8v9dbs8169wk8ahwxvrdxgm5-findutils-4.10.0/bin:/nix/store/355mp4ns4042sb5p51rx3ys4mlliiwc5-diffutils-3.12/bin:/nix/store/jpsqy47rdl0j0dvyyzb4kw8gqajw8nx0-gnused-4.9/bin:/nix/store/h6hdbgkfh59np7bi7h8qa76pq27ixz8r-gnugrep-3.12/bin:/nix/store/gg169kyil5vhsg5aqcpagyhs8fwl0r5r-gawk-5.3.2/bin:/nix/store/kvmqv1jqv4792rsihf7yjc5kwk3d8z6x-gnutar-1.35/bin:/nix/store/pnxiz967z73a45f4x7c1icldjaaqmlcp-gzip-1.14/bin:/nix/store/by6npbc13ly5a1zgsqghv7wv5bklyiny-bzip2-1.0.8-bin/bin:/nix/store/1fvcxyhg3i5fvw0j4l8wmyml10dnvm7q-gnumake-4.4.1/bin:/nix/store/v8sa6r6q037ihghxfbwzjj4p59v2x0pv-bash-5.3p9/bin:/nix/store/ca84rbhb0bhwdcci7q51dad20nkbn9xc-patch-2.8/bin:/nix/store/g6mlwdvpg92rchq352ll7jbi0pz7h43r-xz-5.8.2-bin/bin:/nix/store/kjg8z2k0zvsczaij78803g7imlfm1vfb-file-5.45/bin:/home/tharada/repo/github.com/gasuketsu/devbox/dist:/home/tharada/repo/github.com/gasuketsu/devbox/.devbox/virtenv/runx/bin:/home/tharada/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/lib/wsl/lib:/home/tharada/.local/bin:/home/tharada/.local/share/devbox/global/default/.devbox/virtenv/runx/bin";
export PIPENV_VENV_IN_PROJECT="1";
export POETRY_VIRTUALENVS_CREATE="true";
export POETRY_VIRTUALENVS_IN_PROJECT="true";
export POETRY_VIRTUALENVS_PATH="/home/tharada/.local/share/devbox/global/default/.devbox/virtenv/poetry/.virtualenvs";
export PULSE_SERVER="unix:/mnt/wslg/PulseServer";
export PYTHONSTARTUP="/etc/pythonstart";
export RANLIB="ranlib";
export READELF="readelf";
export SIZE="size";
export SOURCE_DATE_EPOCH="315532800";
export STARSHIP_SESSION_KEY="1543426316465216";
export STARSHIP_SHELL="zsh";
export STRINGS="strings";
export STRIP="strip";
export TERM="xterm-256color";
export USER="tharada";
export VENDOR="suse";
export WAYLAND_DISPLAY="wayland-0";
export WINDOWMANAGER="xterm";
export WSL2_GUI_APPS_ENABLED="1";
export WSLENV="WT_SESSION:WT_PROFILE_ID:";
export WSL_DISTRO_NAME="slowroll";
export WSL_INTEROP="/run/WSL/16542_interop";
export WT_PROFILE_ID="{c6c74430-5a91-5b17-9d1f-f3abc60d339a}";
export WT_SESSION="c8286b86-fbee-443e-9e1d-cf1642eda2f5";
export XDG_CONFIG_DIRS="/etc/xdg:/usr/local/etc/xdg:/usr/etc/xdg";
export XDG_DATA_DIRS="/nix/store/sj3f6y3j8m1831l0gqm1bsk1f46jzkfd-patchelf-0.15.2/share:/usr/local/share:/usr/share:/home/tharada/.nix-profile/share:/nix/var/nix/profiles/default/share";
export XDG_RUNTIME_DIR="/run/user/1000";
export XKEYSYMDB="/usr/X11R6/lib/X11/XKeysymDB";
export XNLSPATH="/usr/X11R6/lib/X11/nls";
export ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="fg=#54546d";
export __DEVBOX_SHELLENV_HASH_1dcdaf953120a95c1ff874038aa1773cd0c943cbba4da48acd062aed949da402="6c9af3015aa4dde2d6d161747335c4ea6b30029f8a656d15ef67cdb47d6dc3b0";
export __DEVBOX_SHELLENV_HASH_a545b47339823787f5c6fd2ec3f91a12fb163aa1cb925dbfdbd579f40a92120d="65c23e75ed354f7b69229839d9eed371d7e776ff24b13dae8da1c7f74e0d08d8";
export __DEVBOX_VERSION_CHECK="1";
export __ETC_PROFILE_NIX_SOURCED="1";
export __structuredAttrs="";
export buildInputs="/nix/store/836lndidk1144z81npf27c7dcgmczid3-fd-10.4.2 /nix/store/7yvcckar1lzhqnr0xx2n19nsdjd4qa4d-git-2.53.0 /nix/store/ckcq2mj8zk0drhaaacy6mp9d924hnr4m-go-1.26.1";
export buildPhase="{ echo \"------------------------------------------------------------\";\
  echo \" WARNING: the existence of this path is not guaranteed.\";\
  echo \" It is an internal implementation detail for pkgs.mkShell.\";\
  echo \"------------------------------------------------------------\";\
  echo;\
  # Record all build inputs as runtime dependencies\
  export;\
} >> \"\$out\"\
";
export builder="/nix/store/v8sa6r6q037ihghxfbwzjj4p59v2x0pv-bash-5.3p9/bin/bash";
export cmakeFlags="";
export configureFlags="";
export depsBuildBuild="";
export depsBuildBuildPropagated="";
export depsBuildTarget="";
export depsBuildTargetPropagated="";
export depsHostHost="";
export depsHostHostPropagated="";
export depsTargetTarget="";
export depsTargetTargetPropagated="";
export doCheck="";
export doInstallCheck="";
export dontAddDisableDepTrack="1";
export mesonFlags="";
export name="nix-shell-env";
export nativeBuildInputs="";
export out="/nix/store/z9ff4q0qw8cmchhppfgxz1mdr1l2i3mm-nix-shell-env";
export outputs="out";
export patches="";
export phases="buildPhase";
export preferLocalBuild="1";
export propagatedBuildInputs="";
export propagatedNativeBuildInputs="";
export shell="/nix/store/v8sa6r6q037ihghxfbwzjj4p59v2x0pv-bash-5.3p9/bin/bash";
export shellHook="";
export stdenv="/nix/store/gvq9hvvnmkvrk27mba0jjjppj068z55x-stdenv-linux";
export strictDeps="";
export system="x86_64-linux";
if ! type refresh-global >/dev/null 2>&1; then
        export DEVBOX_REFRESH_ALIAS_a545b47339823787f5c6fd2ec3f91a12fb163aa1cb925dbfdbd579f40a92120d='eval "$(devbox global shellenv --preserve-path-stack -r)" && hash -r'
        alias refresh-global='eval "$(devbox global shellenv --preserve-path-stack -r)" && hash -r'
fi
hash -r
```

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
