### PR TITLE
[services] Bump process-compose version and fix extra stderr output

### DIFF
--- a/examples/servers/nginx/devbox.d/nginx/nginx.conf
+++ b/examples/servers/nginx/devbox.d/nginx/nginx.conf
@@ -1,8 +1,8 @@
 events {}
 http{
 server {
-         listen       8081;
-         listen       [::]:8081;
+         listen       8080;
+         listen       [::]:8080;
          server_name  localhost;
          root         ../../../devbox.d/web;
 

--- a/examples/servers/nginx/devbox.lock
+++ b/examples/servers/nginx/devbox.lock
@@ -185,6 +185,10 @@
         }
       }
     },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2026-04-27T06:11:55Z",
+      "resolved": "github:NixOS/nixpkgs/6368eda62c9775c38ef7f714b2555a741c20c72d?lastModified=1777270315&narHash=sha256-yKB4G6cKsQsWN7M6rZGk6gkJPDNPIzT05y4qzRyCDlI%3D"
+    },
     "nginx@latest": {
       "last_modified": "2024-02-10T18:15:24Z",
       "plugin_version": "0.0.4",

--- a/internal/devbox/util.go
+++ b/internal/devbox/util.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"github.com/pkg/errors"
 
@@ -16,7 +17,7 @@ import (
 	"go.jetify.com/devbox/internal/xdg"
 )
 
-const processComposeVersion = "1.87.0"
+const processComposeVersion = "1.110.0"
 
 var utilProjectConfigPath string
 
@@ -38,8 +39,23 @@ func initDevboxUtilityProject(ctx context.Context, stderr io.Writer) error {
 	utilities := []string{
 		"process-compose@" + processComposeVersion,
 	}
-	if err = box.Add(ctx, utilities, devopt.AddOpts{}); err != nil {
-		return err
+
+	// Skip Add for utilities whose exact versioned name is already in the
+	// config; calling Add anyway would print noisy "Package already in
+	// devbox.json" messages on every services interaction. A version mismatch
+	// (e.g. after bumping processComposeVersion) will fall through to Add,
+	// which replaces the existing package by canonical name.
+	existing := box.AllPackageNamesIncludingRemovedTriggerPackages()
+	toAdd := []string{}
+	for _, u := range utilities {
+		if !slices.Contains(existing, u) {
+			toAdd = append(toAdd, u)
+		}
+	}
+	if len(toAdd) > 0 {
+		if err = box.Add(ctx, toAdd, devopt.AddOpts{}); err != nil {
+			return err
+		}
 	}
 
 	return box.Install(ctx)


### PR DESCRIPTION
## Summary

- Bumps `processComposeVersion` from 1.87.0 to 1.110.0.
- Skips `Add` for utilities whose exact versioned name is already in the utility devbox config. Calling `Add` anyway printed noisy `Package "process-compose@..." already in devbox.json` output on every services interaction. A version mismatch (e.g. after bumping `processComposeVersion`) still falls through to `Add`, which replaces the existing package by canonical name.

nginx.conf and devbox.lock have minor automated changes.

## Test plan

- [x] `devbox services up` / `devbox services ls` no longer prints the "already in devbox.json" line.
- [x] Bumping `processComposeVersion` triggers a clean replace path (no stale 1.87.0 left behind).
- [x] Fresh install (no existing utility config) still adds process-compose correctly.