### PR TITLE
Support DEVBOX_CONFIG env var for the --config flag

### DIFF
--- a/internal/boxcli/config.go
+++ b/internal/boxcli/config.go
@@ -4,7 +4,11 @@
 package boxcli
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
+
+	"go.jetify.com/devbox/internal/envir"
 )
 
 // to be composed into xyzCmdFlags structs
@@ -34,12 +38,14 @@ type pathFlag struct {
 
 func (flags *pathFlag) register(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(
-		&flags.path, "config", "c", "", "path to directory containing a devbox.json config file",
+		&flags.path, "config", "c", os.Getenv(envir.DevboxConfig),
+		"path to directory containing a devbox.json config file. Defaults to the DEVBOX_CONFIG environment variable, when set.",
 	)
 }
 
 func (flags *pathFlag) registerPersistent(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVarP(
-		&flags.path, "config", "c", "", "path to directory containing a devbox.json config file",
+		&flags.path, "config", "c", os.Getenv(envir.DevboxConfig),
+		"path to directory containing a devbox.json config file. Defaults to the DEVBOX_CONFIG environment variable, when set.",
 	)
 }

--- a/internal/boxcli/config_test.go
+++ b/internal/boxcli/config_test.go
@@ -44,14 +44,14 @@ func TestPathFlagEnvVar(t *testing.T) {
 	}
 
 	for _, persistent := range []bool{false, true} {
-		for _, tt := range tests {
-			name := tt.name
+		for _, testCase := range tests {
+			name := testCase.name
 			if persistent {
 				name += " (persistent)"
 			}
 			t.Run(name, func(t *testing.T) {
-				if tt.envVal != "" {
-					t.Setenv(envir.DevboxConfig, tt.envVal)
+				if testCase.envVal != "" {
+					t.Setenv(envir.DevboxConfig, testCase.envVal)
 				} else {
 					// Ensure the env var is unset for this subtest.
 					t.Setenv(envir.DevboxConfig, "")
@@ -65,13 +65,13 @@ func TestPathFlagEnvVar(t *testing.T) {
 					flags.register(cmd)
 				}
 
-				cmd.SetArgs(tt.args)
+				cmd.SetArgs(testCase.args)
 				if err := cmd.Execute(); err != nil {
 					t.Fatalf("cmd.Execute() error = %v", err)
 				}
 
-				if flags.path != tt.want {
-					t.Errorf("flags.path = %q, want %q", flags.path, tt.want)
+				if flags.path != testCase.want {
+					t.Errorf("flags.path = %q, want %q", flags.path, testCase.want)
 				}
 			})
 		}

--- a/internal/boxcli/config_test.go
+++ b/internal/boxcli/config_test.go
@@ -1,0 +1,79 @@
+// Copyright 2024 Jetify Inc. and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package boxcli
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"go.jetify.com/devbox/internal/envir"
+)
+
+// TestPathFlagEnvVar verifies that the --config flag falls back to the
+// DEVBOX_CONFIG environment variable when the flag is not provided, and that
+// an explicitly passed --config flag takes precedence over the env var.
+func TestPathFlagEnvVar(t *testing.T) {
+	tests := []struct {
+		name   string
+		envVal string // empty means unset
+		args   []string
+		want   string
+	}{
+		{
+			name: "unset env and no flag yields empty path",
+			want: "",
+		},
+		{
+			name:   "env var sets path when flag is absent",
+			envVal: "/from/env",
+			want:   "/from/env",
+		},
+		{
+			name:   "explicit flag overrides env var",
+			envVal: "/from/env",
+			args:   []string{"--config", "/from/flag"},
+			want:   "/from/flag",
+		},
+		{
+			name: "explicit flag without env var",
+			args: []string{"--config", "/from/flag"},
+			want: "/from/flag",
+		},
+	}
+
+	for _, persistent := range []bool{false, true} {
+		for _, tt := range tests {
+			name := tt.name
+			if persistent {
+				name += " (persistent)"
+			}
+			t.Run(name, func(t *testing.T) {
+				if tt.envVal != "" {
+					t.Setenv(envir.DevboxConfig, tt.envVal)
+				} else {
+					// Ensure the env var is unset for this subtest.
+					t.Setenv(envir.DevboxConfig, "")
+				}
+
+				flags := &configFlags{}
+				cmd := &cobra.Command{Use: "test", RunE: func(*cobra.Command, []string) error { return nil }}
+				if persistent {
+					flags.registerPersistent(cmd)
+				} else {
+					flags.register(cmd)
+				}
+
+				cmd.SetArgs(tt.args)
+				if err := cmd.Execute(); err != nil {
+					t.Fatalf("cmd.Execute() error = %v", err)
+				}
+
+				if flags.path != tt.want {
+					t.Errorf("flags.path = %q, want %q", flags.path, tt.want)
+				}
+			})
+		}
+	}
+}

--- a/internal/boxcli/run.go
+++ b/internal/boxcli/run.go
@@ -90,7 +90,11 @@ func listScripts(cmd *cobra.Command, flags runCmdFlags) []string {
 	// * Flags need to be parsed again
 	// * cmd.Flag("config") contains the correct value, but flags.config.path is empty
 	// Give my low confidence, I'm making this a very narrow code path.
-	if path == "" && slices.Contains(os.Args, "__complete") {
+	//
+	// We always re-parse during completion (rather than only when path is
+	// empty) so that an explicit --config still takes precedence over the
+	// DEVBOX_CONFIG default baked into flags.config.path.
+	if slices.Contains(os.Args, "__complete") {
 		_ = cmd.ParseFlags(os.Args)
 		if flag := cmd.Flag("config"); flag != nil && flag.Value != nil {
 			path = flag.Value.String()

--- a/internal/envir/env.go
+++ b/internal/envir/env.go
@@ -5,6 +5,7 @@ package envir
 
 const (
 	DevboxCache   = "DEVBOX_CACHE"
+	DevboxConfig  = "DEVBOX_CONFIG"
 	DevboxGateway = "DEVBOX_GATEWAY"
 	// DevboxLatestVersion is the latest version available of the devbox CLI binary.
 	// NOTE: it should NOT start with v (like 0.4.8)


### PR DESCRIPTION
## Summary

Closes #245.

This lets the `--config` flag (the path to the directory containing a project's `devbox.json`) be set via a `DEVBOX_CONFIG` environment variable. This is handy for setting the config path once in a Dockerfile or CI environment instead of passing `--config` on every invocation:

```Dockerfile
ENV DEVBOX_CONFIG=/path/to/.devcontainer
```

### Behavior

- When `--config` is **not** passed, devbox falls back to `DEVBOX_CONFIG` (if set).
- When `--config` **is** passed explicitly, it takes precedence over the env var.
- When neither is set, behavior is unchanged (recursive search of the current directory and its parents).

This is implemented by using `os.Getenv(DEVBOX_CONFIG)` as the default value of the cobra flag, which gives the desired precedence for free and applies uniformly to every command that registers the config flag.

### Notes

The original issue also mentioned a `--cache` flag. That flag no longer exists in its 2022 form (the `.devbox` directory now lives at the project root, and `DEVBOX_CACHE` is used for the cloud cache), so this PR scopes the change to the `--config`/`DEVBOX_CONFIG` part, which is the still-relevant request.

## Test plan

- Added `TestPathFlagEnvVar` covering the unset / env-only / flag-overrides-env / flag-only cases for both the regular and persistent flag registration paths.
- `go test ./internal/boxcli/` passes.
- `go vet` and `gofmt` clean.
- Manually confirmed via `devbox help add` that the flag's default reflects `DEVBOX_CONFIG`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jyfadx4T6V6BJSfwnwyvqc)_