### PR TITLE
Support setting the --config flag via the DEVBOX_CONFIG env var

### DIFF
--- a/internal/boxcli/config.go
+++ b/internal/boxcli/config.go
@@ -4,7 +4,11 @@
 package boxcli
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
+
+	"go.jetify.com/devbox/internal/envir"
 )
 
 // to be composed into xyzCmdFlags structs
@@ -34,12 +38,15 @@ type pathFlag struct {
 
 func (flags *pathFlag) register(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(
-		&flags.path, "config", "c", "", "path to directory containing a devbox.json config file",
+		&flags.path, "config", "c", os.Getenv(envir.DevboxConfig), pathFlagUsage,
 	)
 }
 
 func (flags *pathFlag) registerPersistent(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVarP(
-		&flags.path, "config", "c", "", "path to directory containing a devbox.json config file",
+		&flags.path, "config", "c", os.Getenv(envir.DevboxConfig), pathFlagUsage,
 	)
 }
+
+const pathFlagUsage = "path to directory containing a devbox.json config file " +
+	"(defaults to the " + envir.DevboxConfig + " env var, if set)"

--- a/internal/boxcli/config_test.go
+++ b/internal/boxcli/config_test.go
@@ -1,0 +1,67 @@
+// Copyright 2024 Jetify Inc. and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package boxcli
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"go.jetify.com/devbox/internal/envir"
+)
+
+// TestConfigFlagDefaultsToEnv verifies that the --config flag defaults to the
+// DEVBOX_CONFIG environment variable when the flag is not passed, and that an
+// explicit flag value still takes precedence.
+func TestConfigFlagDefaultsToEnv(t *testing.T) {
+	tests := []struct {
+		name   string
+		envVal string // empty means unset
+		args   []string
+		want   string
+	}{
+		{
+			name: "unset env and no flag yields empty path",
+			want: "",
+		},
+		{
+			name:   "env var sets the default config path",
+			envVal: "/path/from/env",
+			want:   "/path/from/env",
+		},
+		{
+			name:   "explicit flag overrides env var",
+			envVal: "/path/from/env",
+			args:   []string{"--config", "/path/from/flag"},
+			want:   "/path/from/flag",
+		},
+		{
+			name: "explicit flag without env var",
+			args: []string{"-c", "/path/from/flag"},
+			want: "/path/from/flag",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.envVal != "" {
+				t.Setenv(envir.DevboxConfig, testCase.envVal)
+			} else {
+				t.Setenv(envir.DevboxConfig, "")
+			}
+
+			flags := &pathFlag{}
+			cmd := &cobra.Command{Use: "test", RunE: func(*cobra.Command, []string) error { return nil }}
+			flags.register(cmd)
+			cmd.SetArgs(testCase.args)
+			if err := cmd.Execute(); err != nil {
+				t.Fatal(err)
+			}
+
+			if flags.path != testCase.want {
+				t.Errorf("flags.path = %q, want %q", flags.path, testCase.want)
+			}
+		})
+	}
+}

--- a/internal/envir/env.go
+++ b/internal/envir/env.go
@@ -4,7 +4,12 @@
 package envir
 
 const (
-	DevboxCache   = "DEVBOX_CACHE"
+	DevboxCache = "DEVBOX_CACHE"
+	// DevboxConfig sets the default value for the --config flag, i.e. the path
+	// to the directory (or devbox.json file) of the devbox project to use. This
+	// is convenient for setting the config path in environments where passing
+	// the flag is awkward, such as a Dockerfile.
+	DevboxConfig  = "DEVBOX_CONFIG"
 	DevboxGateway = "DEVBOX_GATEWAY"
 	// DevboxLatestVersion is the latest version available of the devbox CLI binary.
 	// NOTE: it should NOT start with v (like 0.4.8)


### PR DESCRIPTION
## Summary

Fixes #245.

The `--config` flag lets users point devbox at a `devbox.json` that lives in a non-default location. Until now there was no way to set it from the environment, which is awkward in contexts where passing the flag to every invocation is repetitive — the motivating example in the issue is a Dockerfile:

```dockerfile
ENV DEVBOX_CONFIG=.devcontainer
RUN devbox install   # picks up DEVBOX_CONFIG automatically
```

This PR defaults the `--config` flag to the `DEVBOX_CONFIG` environment variable when the flag isn't passed explicitly. An explicitly passed `--config`/`-c` flag still takes precedence over the env var.

## Changes

- Add a `DevboxConfig` (`DEVBOX_CONFIG`) constant in `internal/envir`.
- Use `os.Getenv(DEVBOX_CONFIG)` as the default value for the `--config` flag in both `register` and `registerPersistent`, and mention the env var in the flag usage text.
- Add `TestConfigFlagDefaultsToEnv` covering: unset env, env-as-default, and explicit-flag-overrides-env.

## Notes / scope

Issue #245 also mentions a `--cache` flag. devbox no longer exposes a `--cache` flag for the `.devbox` directory location (`DEVBOX_CACHE` today is used for a different purpose — the nixpkgs cache base URL), so this PR scopes the change to the `--config` flag, which is the part that's actionable against the current CLI. Happy to follow up if a configurable `.devbox` path is still desired (tracked separately in #244).

## Testing

```
go test ./internal/boxcli/ -run TestConfigFlagDefaultsToEnv
go vet ./internal/boxcli/ ./internal/envir/
```

https://claude.ai/code/session_01UQSFvFRfQ4Ku4F4LXbKjFn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQSFvFRfQ4Ku4F4LXbKjFn)_