### PR TITLE
fix(nginx plugin): include mime.types so static files get correct Content-Type

### DIFF
--- a/examples/servers/nginx/devbox.d/nginx/nginx.conf
+++ b/examples/servers/nginx/devbox.d/nginx/nginx.conf
@@ -1,5 +1,6 @@
 events {}
 http{
+include mime.types;
 server {
          listen       8080;
          listen       [::]:8080;

--- a/examples/servers/nginx/devbox.d/nginx/nginx.template
+++ b/examples/servers/nginx/devbox.d/nginx/nginx.template
@@ -1,5 +1,6 @@
 events {}
 http{
+include mime.types;
 server {
          listen       $NGINX_WEB_PORT;
          listen       [::]:$NGINX_WEB_PORT;

--- a/plugins/nginx.json
+++ b/plugins/nginx.json
@@ -1,6 +1,6 @@
 {
   "name": "nginx",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "nginx can be configured with env variables\n\nTo customize:\n* Use $NGINX_CONFDIR to change the configuration directory\n* Use $NGINX_TMPDIR to change the tmp directory. Use $NGINX_USER to change the user\n* Use $NGINX_WEB_PORT to change the port NGINX runs on. \n Note: This plugin uses envsubst when running `devbox services` to generate the nginx.conf file from the nginx.template file. To customize the nginx.conf file, edit the nginx.template file.\n",
   "packages": ["gettext@latest", "gawk@latest"],
   "env": {
@@ -14,6 +14,7 @@
   },
   "create_files": {
     "{{ .Virtenv }}/temp": "",
+    "{{ .Virtenv }}/mime.types": "nginx/mime.types",
     "{{ .Virtenv }}/process-compose.yaml": "nginx/process-compose.yaml",
     "{{ .DevboxDir }}/nginx.template": "nginx/nginx.template",
     "{{ .DevboxDir }}/nginx.conf": "nginx/nginx.conf",

--- a/plugins/nginx/mime.types
+++ b/plugins/nginx/mime.types
@@ -1,0 +1,98 @@
+types {
+    text/html                                        html htm shtml;
+    text/css                                         css;
+    text/xml                                         xml;
+    image/gif                                        gif;
+    image/jpeg                                       jpeg jpg;
+    application/javascript                           js;
+    application/atom+xml                             atom;
+    application/rss+xml                              rss;
+
+    text/mathml                                      mml;
+    text/plain                                       txt;
+    text/vnd.sun.j2me.app-descriptor                 jad;
+    text/vnd.wap.wml                                 wml;
+    text/x-component                                 htc;
+
+    image/avif                                       avif;
+    image/png                                        png;
+    image/svg+xml                                    svg svgz;
+    image/tiff                                       tif tiff;
+    image/vnd.wap.wbmp                               wbmp;
+    image/webp                                       webp;
+    image/x-icon                                     ico;
+    image/x-jng                                      jng;
+    image/x-ms-bmp                                   bmp;
+
+    font/woff                                        woff;
+    font/woff2                                       woff2;
+
+    application/java-archive                         jar war ear;
+    application/json                                 json;
+    application/mac-binhex40                         hqx;
+    application/msword                               doc;
+    application/pdf                                  pdf;
+    application/postscript                           ps eps ai;
+    application/rtf                                  rtf;
+    application/vnd.apple.mpegurl                    m3u8;
+    application/vnd.google-earth.kml+xml             kml;
+    application/vnd.google-earth.kmz                 kmz;
+    application/vnd.ms-excel                         xls;
+    application/vnd.ms-fontobject                    eot;
+    application/vnd.ms-powerpoint                    ppt;
+    application/vnd.oasis.opendocument.graphics      odg;
+    application/vnd.oasis.opendocument.presentation  odp;
+    application/vnd.oasis.opendocument.spreadsheet   ods;
+    application/vnd.oasis.opendocument.text          odt;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation
+                                                     pptx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+                                                     xlsx;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+                                                     docx;
+    application/vnd.wap.wmlc                          wmlc;
+    application/wasm                                  wasm;
+    application/x-7z-compressed                       7z;
+    application/x-cocoa                               cco;
+    application/x-java-archive-diff                   jardiff;
+    application/x-java-jnlp-file                       jnlp;
+    application/x-makeself                            run;
+    application/x-perl                                pl pm;
+    application/x-pilot                               prc pdb;
+    application/x-rar-compressed                       rar;
+    application/x-redhat-package-manager              rpm;
+    application/x-sea                                 sea;
+    application/x-shockwave-flash                      swf;
+    application/x-stuffit                             sit;
+    application/x-tcl                                 tcl tk;
+    application/x-x509-ca-cert                        der pem crt;
+    application/x-xpinstall                           xpi;
+    application/xhtml+xml                             xhtml;
+    application/xspf+xml                              xspf;
+    application/zip                                   zip;
+
+    application/octet-stream                          bin exe dll;
+    application/octet-stream                          deb;
+    application/octet-stream                          dmg;
+    application/octet-stream                          iso img;
+    application/octet-stream                          msi msp msm;
+
+    audio/midi                                        mid midi kar;
+    audio/mpeg                                        mp3;
+    audio/ogg                                         ogg;
+    audio/x-m4a                                       m4a;
+    audio/x-realaudio                                 ra;
+
+    video/3gpp                                        3gpp 3gp;
+    video/mp2t                                        ts;
+    video/mp4                                         mp4;
+    video/mpeg                                        mpeg mpg;
+    video/quicktime                                   mov;
+    video/webm                                        webm;
+    video/x-flv                                       flv;
+    video/x-m4v                                       m4v;
+    video/x-mng                                       mng;
+    video/x-ms-asf                                    asx asf;
+    video/x-ms-wmv                                    wmv;
+    video/x-msvideo                                   avi;
+}

--- a/plugins/nginx/nginx.conf
+++ b/plugins/nginx/nginx.conf
@@ -3,6 +3,7 @@
 
 events {}
 http{
+include mime.types;
 server {
          listen       8081;
          listen       [::]:8081;

--- a/plugins/nginx/nginx.template
+++ b/plugins/nginx/nginx.template
@@ -3,6 +3,7 @@
 
 events {}
 http{
+include mime.types;
 server {
          listen       $NGINX_WEB_PORT;
          listen       [::]:$NGINX_WEB_PORT;


### PR DESCRIPTION
## Summary

Fixes #2693.

The `nginx` plugin generated an `nginx.conf` that did **not** include a `mime.types` map. As a result, nginx fell back to its default type and served every static file (CSS, JS, images, fonts, …) with `Content-Type: text/plain`, so browsers wouldn't apply stylesheets or run scripts.

### What changed

- Added a standard `mime.types` file to the plugin (`plugins/nginx/mime.types`).
- The plugin now creates it in the virtenv via `create_files` (`{{ .Virtenv }}/mime.types`).
- Added `include mime.types;` to the generated `http { … }` block in both `nginx.template` and `nginx.conf`.
- Bumped the plugin version `0.0.4` → `0.0.5`.
- Updated the checked-in `examples/servers/nginx` config to stay consistent.

### Why the virtenv (and a relative include)

The plugin launches nginx with `nginx -p $NGINX_PATH_PREFIX …`, where `NGINX_PATH_PREFIX` is the plugin's virtenv. nginx resolves relative paths against that prefix — which is exactly how the existing `error_log error.log`, `access_log access.log`, and `temp/*` paths already work. Placing `mime.types` in the virtenv and using a plain `include mime.types;` keeps the fix consistent with that convention and requires no new env var. The virtenv copy is also regenerated on every run, so it stays in sync with the plugin.

> Note: The `drupal` example stack already ships its own `mime.conf`, so it was left untouched. This change targets the default nginx plugin output described in the issue.

### How to verify

```sh
devbox add nginx
echo 'body{color:red}' > devbox.d/web/my.css
devbox services up
curl -I http://localhost:8081/my.css   # now: Content-Type: text/css
```

### Testing

- `go build ./...` passes.
- Plugin unit tests pass except for two pre-existing `TestGitPluginFileContentCache*` tests that fail only because they make local git commits (commit signing is unavailable in this CI sandbox) — unrelated to this change.

cc @ThomasLohner (issue reporter) — thanks for the clear repro!

---
_Generated by [Claude Code](https://claude.ai/code/session_017wjDHdnhNV5q26AK5aAkPh)_