### PR TITLE
fix(generate): use fully-qualified docker.io image in generated Dockerfiles

### DIFF
--- a/internal/devbox/generate/tmpl/dev.Dockerfile.tmpl
+++ b/internal/devbox/generate/tmpl/dev.Dockerfile.tmpl
@@ -1,5 +1,5 @@
-{{- if .RootUser }}FROM jetpackio/devbox-root-user:latest
-{{- else }}FROM jetpackio/devbox:latest
+{{- if .RootUser }}FROM docker.io/jetpackio/devbox-root-user:latest
+{{- else }}FROM docker.io/jetpackio/devbox:latest
 {{- end}}
 
 # Installing your devbox project

--- a/internal/devbox/generate/tmpl/prod.Dockerfile.tmpl
+++ b/internal/devbox/generate/tmpl/prod.Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM jetpackio/devbox:latest
+FROM docker.io/jetpackio/devbox:latest
 
 WORKDIR /code
 USER root:root


### PR DESCRIPTION
## Summary

Fixes #2520.

The Dockerfiles produced by `devbox generate dockerfile` and `devbox generate devcontainer` referenced the base image with an **unqualified** name:

```dockerfile
FROM jetpackio/devbox:latest
# and, for --root-user:
FROM jetpackio/devbox-root-user:latest
```

Docker itself implicitly expands unqualified names to Docker Hub (`docker.io/`), but other OCI runtimes do **not**. Podman, Buildah, and containerd/nerdctl either fail to resolve an unqualified reference or prompt the user to pick a registry (depending on `registries.conf`). As the issue requests, the generated Dockerfile should use the fully-qualified image path so it builds consistently regardless of runtime.

## Changes

Qualify the base image with the explicit `docker.io/` registry in both generated-Dockerfile templates:

| File | Before | After |
| --- | --- | --- |
| `internal/devbox/generate/tmpl/dev.Dockerfile.tmpl` | `jetpackio/devbox:latest` / `jetpackio/devbox-root-user:latest` | `docker.io/jetpackio/devbox:latest` / `docker.io/jetpackio/devbox-root-user:latest` |
| `internal/devbox/generate/tmpl/prod.Dockerfile.tmpl` | `jetpackio/devbox:latest` | `docker.io/jetpackio/devbox:latest` |

The namespace is unchanged — these images are published to Docker Hub under `jetpackio/devbox` and `jetpackio/devbox-root-user` (see `.github/workflows/docker-image-release.yml`), so `docker.io/` is the correct prefix.

## How was it tested?

- `go build ./internal/devbox/generate/` — clean.
- Rendered both templates (dev and prod, with `RootUser` true/false) and confirmed every `FROM` line now uses the `docker.io/` prefix.
- The existing generate testscripts (`testscripts/generate/dockerfile.test.txt`, `devcontainer.test.txt`) only assert that the files are produced, so behavior is unaffected.

cc @codegod100 (issue reporter)

---
_Generated by [Claude Code](https://claude.ai/code/session_019LZQTYeJHCGVZEUmc3kgvE)_