### PR TITLE
chore: improve devbox maintenance path

### DIFF
--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -174,6 +174,9 @@ func IsExitErrorInsecurePackage(err error, pkgNameOrEmpty, installableOrEmpty st
 		if strings.Contains(string(exitErr.Stderr), "is marked as insecure") {
 			packageRegex := regexp.MustCompile(`Package ([^ ]+)`)
 			packageMatch := packageRegex.FindStringSubmatch(string(exitErr.Stderr))
+			if len(packageMatch) < 2 {
+				return false, nil
+			}
 
 			knownVulnerabilities := []string{}
 			if installableOrEmpty != "" {

--- a/internal/nix/nix_test.go
+++ b/internal/nix/nix_test.go
@@ -1,6 +1,7 @@
 package nix
 
 import (
+	"os/exec"
 	"testing"
 )
 
@@ -66,5 +67,24 @@ func TestParseInsecurePackagesFromExitError(t *testing.T) {
 	}
 	if packages[0] != "python-2.7.18.7" {
 		t.Errorf("Expected package 'python-2.7.18.7', got %s", packages[0])
+	}
+}
+
+func TestIsExitErrorInsecurePackageMissingPackageName(t *testing.T) {
+	// Simulate an exit error whose stderr contains "is marked as insecure"
+	// but lacks the expected "Package <name>" prefix. This defends against
+	// a panic when the regex match is empty in CI/build environments.
+	cmd := exec.Command("sh", "-c", `echo "error: something is marked as insecure, refusing to evaluate." >&2; exit 1`)
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected a command error")
+	}
+
+	insecure, errOut := IsExitErrorInsecurePackage(err, "", "")
+	if insecure {
+		t.Error("expected insecure=false when package name is missing")
+	}
+	if errOut != nil {
+		t.Errorf("expected nil error, got %v", errOut)
 	}
 }


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in nix/nix_test.go, internal/nix/nix.go related to CI, Docker, Kubernetes, build tooling, release automation; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.