### PR TITLE
Fix indentation in default devbox config

### DIFF
--- a/internal/devconfig/config.go
+++ b/internal/devconfig/config.go
@@ -46,25 +46,26 @@ type Config struct {
 
 const defaultInitHook = "echo 'Welcome to devbox!' > /dev/null"
 
-func DefaultConfig() *Config {
-	cfg, err := loadBytes([]byte(fmt.Sprintf(`{
-		"$schema": "https://raw.githubusercontent.com/jetify-com/devbox/%s/.schema/devbox.schema.json",
-		"packages": [],
-		"shell": {
-			"init_hook": [
-				"%s"
-			],
-			"scripts": {
-				"test": [
-					"echo \"Error: no test specified\" && exit 1"
-				]
-			}
+const defaultConfig = `{
+	"$schema": "https://raw.githubusercontent.com/jetify-com/devbox/%s/.schema/devbox.schema.json",
+	"packages": [],
+	"shell": {
+		"init_hook": [
+			"%s"
+		],
+		"scripts": {
+			"test": [
+				"echo \"Error: no test specified\" && exit 1"
+			]
 		}
 	}
-	`,
-		lo.Ternary(build.IsDev, "main", build.Version),
-		defaultInitHook,
-	)))
+}
+`
+
+func DefaultConfig() *Config {
+	schemaVersion := lo.Ternary(build.IsDev, "main", build.Version)
+
+	cfg, err := loadBytes([]byte(fmt.Sprintf(defaultConfig, schemaVersion, defaultInitHook)))
 	if err != nil {
 		panic("default devbox.json is invalid: " + err.Error())
 	}


### PR DESCRIPTION
## Summary

`DefaultConfig()` defines the default configuration using a raw string literal directly in the function body. Because raw string literals in Go preserve all whitespace, the resulting JSON ends up with extra leading spaces on almost every line.

This fix extracts the template into a package-level `const`, so the string starts at column zero and the resulting JSON is well-formed.

`devbox.json` before the change:

```
{␊
····"$schema":·"https://raw.githubusercontent.com/jetify-com/devbox/main/.schema/devbox.schema.json",␊
····"packages":·[],␊
····"shell":·{␊
······"init_hook":·[␊
········"echo·'Welcome·to·devbox!'·>·/dev/null"␊
······],␊
······"scripts":·{␊
········"test":·[␊
··········"echo·\"Error:·no·test·specified\"·&&·exit·1"␊
········]␊
······}␊
····}␊
··}␊
··
```

`devbox.json` after the change:

```
{␊
··"$schema":·"https://raw.githubusercontent.com/jetify-com/devbox/main/.schema/devbox.schema.json",␊
··"packages":·[],␊
··"shell":·{␊
····"init_hook":·[␊
······"echo·'Welcome·to·devbox!'·>·/dev/null"␊
····],␊
····"scripts":·{␊
······"test":·[␊
········"echo·\"Error:·no·test·specified\"·&&·exit·1"␊
······]␊
····}␊
··}␊
}␊
```

## How was it tested?

Ran `devbox init` locally and inspected the generated `devbox.json` before and after the change.

## Community Contribution License

All community contributions in this pull request are licensed to the project maintainers under the terms of the [Apache 2 License].

By creating this pull request, I represent that I have the right to license the contributions to the project maintainers under the Apache 2 License as stated in the [Community Contribution License].

[apache 2 license]: https://www.apache.org/licenses/LICENSE-2.0
[community contribution license]: https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license
