### PR TITLE
Guard cli-post-release on cli-release success for the same tag

### DIFF
--- a/.github/workflows/cli-post-release.yml
+++ b/.github/workflows/cli-post-release.yml
@@ -11,9 +11,28 @@ permissions:
   id-token: write # Needed for aws-actions/configure-aws-credentials@v1
 
 jobs:
+  # Make sure the cli-release workflow that built this tag actually succeeded
+  # before we promote it to stable. The `released` event can fire even when
+  # cli-release failed partway (or a release was published by other means), so
+  # guard against finalizing a broken release.
+  check-release:
+    runs-on: ubuntu-latest
+    steps:
+      # The `released` event can fire before the cli-release run has finished,
+      # so wait for it to complete. The action exits with failure if the waited
+      # workflow failed, which blocks the publish job below.
+      - name: Wait for cli-release to succeed for this tag
+        uses: int128/wait-for-workflows-action@v1.76.0
+        with:
+          sha: ${{ github.sha }}
+          # cli-release is triggered by the tag push, not the release event.
+          filter-workflow-events: push
+          filter-workflow-names: cli-release
+
   publish:
     runs-on: ubuntu-latest
     environment: release
+    needs: check-release
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/cli-post-release.yml
+++ b/.github/workflows/cli-post-release.yml
@@ -16,6 +16,9 @@ jobs:
   # cli-release failed partway (or a release was published by other means), so
   # guard against finalizing a broken release.
   check-release:
+    permissions:
+      actions: read
+      contents: read
     runs-on: ubuntu-latest
     steps:
       # The `released` event can fire before the cli-release run has finished,


### PR DESCRIPTION
## What

`cli-post-release` runs on the GitHub `release: [released]` event and promotes the tag to `stable` in S3. That event can fire even when `cli-release` failed partway (or a release was published by other means), which would promote a broken build.

This adds a `check-release` gate job (which `publish` now `needs:`) that waits for the `cli-release` workflow run for the **same commit** to finish and **fails if it did not succeed**, using [`int128/wait-for-workflows-action`](https://github.com/int128/wait-for-workflows-action).

## Notes

- `sha: ${{ github.sha }}` — on the `release` event this is the tag's commit, matching the SHA `cli-release` ran on.
- `filter-workflow-events: push` — overrides the action's default (current event = `release`); `cli-release` is triggered by the **tag push**.
- `filter-workflow-names: cli-release` — waits only on that workflow.

The common case (tests fail → `release` job skipped → no release published) already never fires the event; this guard covers the partial-failure / externally-published edge cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)