### PR TITLE
Reuse existing draft release in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,6 +45,12 @@ release:
   # exists, so a manually-written description is preserved.
   mode: keep-existing
   replace_existing_draft: false
+  # GitHub's "get release by tag" API doesn't return drafts, so this is required
+  # for goreleaser to actually find and attach assets to the existing draft.
+  use_existing_draft: true
+  # Allow re-runs on the same tag to overwrite already-uploaded assets instead of
+  # failing with a 422 conflict.
+  replace_existing_artifacts: true
   github:
     owner: jetify-com
     name: devbox

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,6 +40,11 @@ checksum:
 release:
   prerelease: auto
   draft: true
+  # Reuse an existing draft release for this tag instead of creating a new one.
+  # `keep-existing` leaves the release (and its description) as is if one already
+  # exists, so a manually-written description is preserved.
+  mode: keep-existing
+  replace_existing_draft: false
   github:
     owner: jetify-com
     name: devbox


### PR DESCRIPTION
## What

Configure goreleaser to reuse an existing draft release on tag push instead of creating a new one.

On tag push, the `release` job in `.github/workflows/cli-release.yml` runs `goreleaser release --clean`. With only `draft: true` set, goreleaser would generate a fresh release body, which can clobber or duplicate a draft release that already exists for the tag.

## Change

In `.goreleaser.yaml`'s `release:` block:

- `mode: keep-existing` — reuse an existing release for the tag and leave its description as-is (just attach the built artifacts). Creates one if none exists.
- `replace_existing_draft: false` — explicitly avoid deleting-and-recreating an existing draft, preserving a hand-written description.

## Note

GitHub's "get release by tag" API doesn't return drafts, so reuse depends on goreleaser's draft-aware lookup. Worth confirming on the next tag push that artifacts attach to the existing draft rather than spawning a second one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)