### PR TITLE
fix(shell): quote shellrc source guard so ZDOTDIR with spaces works

### DIFF
--- a/internal/devbox/shell_test.go
+++ b/internal/devbox/shell_test.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -485,5 +486,64 @@ func TestWriteDevboxShellrcWithZDOTDIR(t *testing.T) {
 	// Check that it sources the custom .zshrc
 	if !strings.Contains(contentStr, customZshrcPath) {
 		t.Error("Expected shellrc to source the custom .zshrc file")
+	}
+}
+
+// TestWriteDevboxShellrcZDOTDIRWithSpaces guards against a regression where the
+// `[ -f <path> ]` guard around sourcing the user's shellrc was unquoted. When
+// ZDOTDIR contains spaces (e.g. ".../Application Support/..."), the unquoted
+// path expands to multiple words and `[` fails with "too many arguments", so
+// the user's real shellrc never gets sourced.
+func TestWriteDevboxShellrcZDOTDIRWithSpaces(t *testing.T) {
+	// A ZDOTDIR with a space, like the one some terminal integrations inject.
+	zdotdir := filepath.Join(t.TempDir(), "Application Support", "zsh")
+	if err := os.MkdirAll(zdotdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("ZDOTDIR", zdotdir)
+
+	zshrcPath := filepath.Join(zdotdir, ".zshrc")
+	if err := os.WriteFile(zshrcPath, []byte("# user zshrc"), 0o644); err != nil {
+		t.Fatalf("Failed to create test .zshrc: %v", err)
+	}
+
+	shell := initShellBinaryFields("/usr/bin/zsh")
+	shell.devbox = &Devbox{projectDir: "/test/project"}
+	shell.projectDir = "/test/project"
+
+	shellrcPath, err := shell.writeDevboxShellrc()
+	if err != nil {
+		t.Fatalf("Failed to write devbox shellrc: %v", err)
+	}
+	content, err := os.ReadFile(shellrcPath)
+	if err != nil {
+		t.Fatalf("Failed to read generated shellrc: %v", err)
+	}
+	contentStr := string(content)
+
+	// The guard must quote the path so the space doesn't split into words.
+	wantGuard := `if [ -f "` + zshrcPath + `" ]; then`
+	if !strings.Contains(contentStr, wantGuard) {
+		t.Errorf("expected quoted guard %q in generated shellrc:\n%s", wantGuard, contentStr)
+	}
+
+	// Run the actual generated guard line through /bin/sh to prove it doesn't
+	// error with "too many arguments" on a space-containing path.
+	var guardLine string
+	for _, line := range strings.Split(contentStr, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "if [ -f ") {
+			guardLine = strings.TrimSpace(line) + " echo sourced; fi"
+			break
+		}
+	}
+	if guardLine == "" {
+		t.Fatalf("could not find guard line in generated shellrc:\n%s", contentStr)
+	}
+	out, err := exec.Command("/bin/sh", "-c", guardLine).CombinedOutput()
+	if err != nil {
+		t.Fatalf("guard line failed to execute (%v): %s\nline: %s", err, out, guardLine)
+	}
+	if strings.TrimSpace(string(out)) != "sourced" {
+		t.Errorf("guard line did not take the true branch; output: %q\nline: %s", out, guardLine)
 	}
 }

--- a/internal/devbox/shellrc.tmpl
+++ b/internal/devbox/shellrc.tmpl
@@ -20,14 +20,14 @@ content readable.
 
 {{- if .OriginalInitPath -}}
 {{- if eq .ShellName "zsh" -}}
-if [ -f {{ .OriginalInitPath }} ]; then
+if [ -f "{{ .OriginalInitPath }}" ]; then
   local DEVBOX_ZDOTDIR="$ZDOTDIR"
   export ZDOTDIR="{{dirPath .OriginalInitPath}}"
   . "{{ .OriginalInitPath }}"
   export ZDOTDIR="$DEVBOX_ZDOTDIR"
 fi
 {{ else -}}
-if [ -f {{ .OriginalInitPath }} ]; then
+if [ -f "{{ .OriginalInitPath }}" ]; then
   . "{{ .OriginalInitPath }}"
 fi
 {{ end -}}

--- a/internal/devbox/testdata/shellrc/basic/shellrc.golden
+++ b/internal/devbox/testdata/shellrc/basic/shellrc.golden
@@ -1,4 +1,4 @@
-if [ -f testdata/shellrc/basic/shellrc ]; then
+if [ -f "testdata/shellrc/basic/shellrc" ]; then
   . "testdata/shellrc/basic/shellrc"
 fi
 # Begin Devbox Post-init Hook

--- a/internal/devbox/testdata/shellrc/zsh_zdotdir/shellrc.golden
+++ b/internal/devbox/testdata/shellrc/zsh_zdotdir/shellrc.golden
@@ -1,4 +1,4 @@
-if [ -f testdata/shellrc/zsh_zdotdir/shellrc ]; then
+if [ -f "testdata/shellrc/zsh_zdotdir/shellrc" ]; then
   local DEVBOX_ZDOTDIR="$ZDOTDIR"
   export ZDOTDIR="testdata/shellrc/zsh_zdotdir"
   . "testdata/shellrc/zsh_zdotdir/shellrc"


### PR DESCRIPTION
## Summary

The `[ -f <path> ]` guard that devbox generates around sourcing the user's original shellrc was unquoted in both the zsh and bash branches of `shellrc.tmpl`. When `ZDOTDIR` (and therefore the baked-in path) contains a space — e.g. a terminal integration that sets `.../Application Support/...` — the path split into multiple words, `[` failed with `too many arguments`, the whole `if` block was skipped, and the user's real shellrc (prompt, aliases, oh-my-zsh, etc.) never got sourced. This quotes the path in both branches and updates the affected golden files.

## How was it tested?

`devbox run -- go test ./internal/devbox/` passes, including a new regression test `TestWriteDevboxShellrcZDOTDIRWithSpaces` that builds a shellrc from a `ZDOTDIR` containing `Application Support`, asserts the guard is quoted, and runs the generated guard line through `/bin/sh` to confirm it no longer errors with "too many arguments".

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

🤖 Generated with [Claude Code](https://claude.com/claude-code)