### PR TITLE
fix(direnv): set DEVBOX_SHELL_ENABLED when entering env via shellenv --init-hook

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -379,6 +379,18 @@ func (d *Devbox) EnvExports(ctx context.Context, opts devopt.EnvExportsOpts) (st
 		return "", err
 	}
 
+	// When we also run the init hooks we are fully entering the Devbox
+	// environment (this is what the direnv integration does via
+	// `devbox shellenv --init-hook`), so mark the shell as Devbox-enabled.
+	// This mirrors Shell() and RunScript(), and matches the documented
+	// behavior that DEVBOX_SHELL_ENABLED is set whenever the environment is
+	// loaded. We intentionally gate this on RunHooks so that the global
+	// integration (`devbox global shellenv`, which does not run init hooks)
+	// does not set it in every shell and break shell-inception detection.
+	if opts.RunHooks {
+		envs[envir.DevboxShellEnabled] = "1"
+	}
+
 	// Use the appropriate export format based on shell type
 	var envStr string
 	if opts.ShellFormat == devopt.ShellFormatNushell {

--- a/testscripts/shell/shellenv_init_hook.test.txt
+++ b/testscripts/shell/shellenv_init_hook.test.txt
@@ -1,0 +1,13 @@
+exec devbox init
+
+# When run with --init-hook (as the direnv integration does via
+# `devbox shellenv --init-hook`), we are fully entering the Devbox
+# environment, so DEVBOX_SHELL_ENABLED must be exported. See issue #2746.
+exec devbox shellenv --init-hook
+stdout 'export DEVBOX_SHELL_ENABLED="1";'
+
+# Plain shellenv (used by the global integration `devbox global shellenv`,
+# which runs in every shell) must NOT set DEVBOX_SHELL_ENABLED, otherwise
+# shell-inception detection would break in every shell.
+exec devbox shellenv
+! stdout 'DEVBOX_SHELL_ENABLED'


### PR DESCRIPTION
## Summary

Fixes #2746.

When using `direnv` to load a Devbox environment, `$DEVBOX_SHELL_ENABLED` was never set, even though the [documentation](https://www.jetify.com/docs/devbox/env-variables) states it is *"automatically set to 1 when you start a shell, run a script, or start services."*

The direnv integration loads the environment by evaluating `devbox shellenv --init-hook` (see `internal/devbox/generate/tmpl/envrcContent.tmpl`). That code path runs through `Devbox.EnvExports`, which — unlike `Shell()` and `RunScript()` — never set `DEVBOX_SHELL_ENABLED`. So `echo $DEVBOX_SHELL_ENABLED` printed nothing in a direnv-activated shell.

## Fix

Set `DEVBOX_SHELL_ENABLED=1` in `EnvExports` when init hooks are run, mirroring what `Shell()` and `RunScript()` already do.

The assignment is **gated on `RunHooks`** on purpose:

- The **direnv** integration uses `devbox shellenv --init-hook` (`RunHooks = true`) → now sets the variable. ✅
- The **global** integration `devbox global shellenv` runs in *every* shell and does **not** pass `--init-hook` (`RunHooks = false`) → still does **not** set the variable, so shell-inception detection (which relies on `DEVBOX_SHELL_ENABLED`) keeps working in every shell. ✅
- Plain `devbox shellenv` is likewise unaffected.

## How was it tested?

- `go build ./...` and `go vet ./internal/devbox/` pass.
- Added a regression testscript `testscripts/shell/shellenv_init_hook.test.txt` asserting that:
  - `devbox shellenv --init-hook` exports `DEVBOX_SHELL_ENABLED="1"`, and
  - plain `devbox shellenv` does **not** export it.

> Note: the nix-backed testscripts could not be executed in the authoring environment (no `nix` available), but the change is small and the new test documents the expected behavior for CI.

cc @miklschmidt (issue reporter)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UEgs7Lm5hvL8A1TAzsXx9j)_