### PR TITLE
ci: remove dead nix-version matrix from cli-tests test job

### DIFF
--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -133,11 +133,14 @@ jobs:
         # the devbox.json tests. We can require the other tests to complete before
         # merging, while keeping the others as an additional non-required signal
         run-project-tests: ["project-tests-only", "project-tests-off"]
-        # Run tests on:
-        # 1. the oldest supported nix version (Nixpkgs requires >= 2.18 as of 2026)
-        # 2. nix 2.19.2: version before nix profile changes
-        # 3. latest nix version (note, 2.20.1 introduced a new profile change)
-        nix-version: ["2.18.0", "2.19.2", "2.30.2"]
+        # NOTE: this job used to run a `nix-version` matrix, but the
+        # devbox-install-action we now use to install Nix doesn't let us pin a
+        # specific Nix version. The matrix legs were therefore running identical
+        # duplicates (3x the jobs, 3x the flake surface, no extra coverage), so
+        # it was removed. Cross-version coverage is currently provided by the
+        # separate `test-nix-versions` job. Once the install action supports
+        # specifying a Nix version, re-add the matrix here and wire it into the
+        # "Install devbox" step.
         exclude:
           # Only runs tests on macos if explicitly requested, or on a schedule
           - os: "${{ (inputs.run-mac-tests || github.event.schedule != '') && 'dummy' || 'macos-latest' }}"


### PR DESCRIPTION
## Summary

The `test` job in `cli-tests.yaml` defined a 3-value `nix-version` matrix, but the value was never referenced in any step after [#1839](https://github.com/jetify-com/devbox/pull/1839) switched the job to installing Nix via `devbox-install-action` (which can't pin a Nix version) — so the three legs ran identical duplicates, tripling the slowest and flakiest job for zero extra coverage. This PR removes the matrix and leaves a comment explaining how to re-add it once the install action supports specifying a Nix version. Cross-version coverage is still provided by the separate `test-nix-versions` job, and this cuts the `test` job from 6 → 2 runs per PR.

> [!NOTE]
> The `test` job names lose their nix-version suffix (e.g. `test (not-main, ubuntu-latest, project-tests-off)`); branch protection required-checks may need updating to match.

## How was it tested?

CI on this PR; no test logic changed (only redundant matrix legs removed).

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).