### PR TITLE
Fix nodejs plugin corepack setup failing in "type": "module" projects

### DIFF
--- a/plugins/nodejs.json
+++ b/plugins/nodejs.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/main/.schema/devbox-plugin.schema.json",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "name": "nodejs",
     "readme": "Devbox automatically configures Corepack for Nodejs when DEVBOX_COREPACK_ENABLED=1. You can install Yarn or Pnpm by adding them to your `package.json` file using `packageManager`\nCorepack binaries will be installed in your local `.devbox` directory\n\nWhen Corepack is enabled, Devbox also activates the package manager pinned in your `package.json` `packageManager` field automatically. Set DEVBOX_DISABLE_NODEJS_PACKAGE_MANAGER_AUTODETECT=1 to disable this behavior.",
     "env": {
@@ -9,11 +9,11 @@
     },
     "shell": {
         "init_hook": [
-            "node \"{{ .Virtenv }}/bin/setup-corepack.js\""
+            "node \"{{ .Virtenv }}/bin/setup-corepack.cjs\""
         ]
     },
     "create_files": {
       "{{ .Virtenv }}/corepack-bin": "",
-      "{{ .Virtenv }}/bin/setup-corepack.js": "nodejs/setup-corepack.js"
+      "{{ .Virtenv }}/bin/setup-corepack.cjs": "nodejs/setup-corepack.cjs"
     }
 }

--- a/plugins/nodejs/setup-corepack.cjs
+++ b/plugins/nodejs/setup-corepack.cjs
@@ -1,5 +1,9 @@
 // Configures Corepack for the Devbox shell. This is the nodejs plugin's
-// init_hook, invoked as: node setup-corepack.js
+// init_hook, invoked as: node setup-corepack.cjs
+//
+// The .cjs extension forces CommonJS regardless of the project's package.json,
+// which may declare "type": "module" (otherwise the require() calls below fail
+// with "require is not defined in ES module scope"). See issue #2856.
 //
 // It is a no-op unless DEVBOX_COREPACK_ENABLED is set, in which case it:
 //   1. Enables Corepack, installing its package-manager shims into the

--- a/testscripts/plugin/nodejs_corepack_autodetect.test.txt
+++ b/testscripts/plugin/nodejs_corepack_autodetect.test.txt
@@ -23,8 +23,21 @@ cp package-no-pkgmgr.json package.json
 exec devbox run -- node -e 'console.log("case2-ok")'
 stdout 'case2-ok'
 
+# Case 3: package.json declares "type": "module" (issue #2856).
+# The setup-corepack script must still load (it uses a .cjs extension so it is
+# always treated as CommonJS) and shell init must still succeed.
+cp package-esm.json package.json
+exec devbox run -- node -e 'console.log("case3-ok")'
+stdout 'case3-ok'
+
 -- package-no-pkgmgr.json --
 {
   "name": "nodejs-corepack-autodetect",
   "version": "1.0.0"
+}
+-- package-esm.json --
+{
+  "name": "nodejs-corepack-autodetect",
+  "version": "1.0.0",
+  "type": "module"
 }


### PR DESCRIPTION
## Summary

Fixes #2856.

The `nodejs` plugin runs a Corepack setup script as its `init_hook`. The script uses CommonJS `require()`, but it was named `setup-corepack.js`. When a project's root `package.json` declares `"type": "module"`, Node treats every `.js` file in that package — including this one — as an ES module, so the script crashes with:

```
ReferenceError: require is not defined in ES module scope, you can use import instead
```

This breaks `devbox shell` entirely for any Node project using ES modules, which is increasingly common.

## Fix

Rename the script to `setup-corepack.cjs`. The `.cjs` extension forces Node to always interpret it as CommonJS, regardless of the surrounding `package.json` `type` field. The plugin's `init_hook` and `create_files` references are updated accordingly, and the plugin version is bumped `0.0.3` → `0.0.4`.

## Testing

- Added a third case to `testscripts/plugin/nodejs_corepack_autodetect.test.txt` that copies a `package.json` declaring `"type": "module"` and verifies shell init still succeeds.
- Verified at the Node level that a `.js` file with `require()` fails under `"type": "module"` while the equivalent `.cjs` file loads correctly.

## Notes

cc @AdaptivChris (issue reporter) — thanks for the clear reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015e5foES7T8gDQRHK3hJSdH

---
_Generated by [Claude Code](https://claude.ai/code/session_015e5foES7T8gDQRHK3hJSdH)_