### PR TITLE
fix(examples/jekyll): declare csv/base64/logger gems for Ruby 3.4

### DIFF
--- a/examples/stacks/jekyll/myblog/Gemfile
+++ b/examples/stacks/jekyll/myblog/Gemfile
@@ -41,3 +41,11 @@ gem "kramdown-parser-gfm"
 gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
 
 gem "webrick", "~> 1.8"
+
+# Ruby 3.4 moved these from default gems to bundled gems, so they must be
+# declared explicitly or a `require` fails with a LoadError (e.g. jekyll 3.9
+# does `require "csv"` on startup). Needed because `bundler@latest` runs
+# jekyll under Ruby 3.4+.
+gem "csv"
+gem "base64"
+gem "logger"

--- a/examples/stacks/jekyll/myblog/Gemfile.lock
+++ b/examples/stacks/jekyll/myblog/Gemfile.lock
@@ -3,8 +3,10 @@ GEM
   specs:
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.3.0)
     colorator (1.1.0)
     concurrent-ruby (1.3.4)
+    csv (3.3.5)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -45,6 +47,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
     mercenary (0.3.6)
     minima (2.5.2)
       jekyll (>= 3.5, < 5.0)
@@ -81,10 +84,13 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  base64
+  csv
   http_parser.rb (~> 0.6.0)
   jekyll (~> 3.9.2)
   jekyll-feed (~> 0.6)
   kramdown-parser-gfm
+  logger
   minima (~> 2.0)
   tzinfo (~> 1.2)
   tzinfo-data


### PR DESCRIPTION
Split out from `mikeland73/fix-flaky-cicd-tests` (5/5).

Ruby 3.4 moved `csv`, `base64`, and `logger` from default gems to bundled gems, so they must be declared explicitly or jekyll fails on startup with a `LoadError` (e.g. jekyll 3.9 does `require "csv"`). Needed because `bundler@latest` runs jekyll under Ruby 3.4+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)