### PR TITLE
fix(examples): drop unused cowboy dep from elixir example

### DIFF
--- a/examples/development/elixir/elixir_hello/mix.exs
+++ b/examples/development/elixir/elixir_hello/mix.exs
@@ -22,7 +22,6 @@ defmodule ElixirHello.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:cowboy, "~> 2.9"}
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
     ]

--- a/examples/development/elixir/elixir_hello/mix.lock
+++ b/examples/development/elixir/elixir_hello/mix.lock
@@ -1,5 +1,0 @@
-%{
-  "cowboy": {:hex, :cowboy, "2.9.0", "865dd8b6607e14cf03282e10e934023a1bd8be6f6bacf921a7e2a96d800cd452", [:make, :rebar3], [{:cowlib, "2.11.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "1.8.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm", "2c729f934b4e1aa149aff882f57c6372c15399a20d54f65c8d67bef583021bde"},
-  "cowlib": {:hex, :cowlib, "2.11.0", "0b9ff9c346629256c42ebe1eeb769a83c6cb771a6ee5960bd110ab0b9b872063", [:make, :rebar3], [], "hexpm", "2b3e9da0b21c4565751a6d4901c20d1b4cc25cbb7fd50d91d2ab6dd287bc86a9"},
-  "ranch": {:hex, :ranch, "1.8.0", "8c7a100a139fd57f17327b6413e4167ac559fbc04ca7448e9be9057311597a1d", [:make, :rebar3], [], "hexpm", "49fbcfd3682fab1f5d109351b61257676da1a2fdbe295904176d5e521a2ddfe5"},
-}


### PR DESCRIPTION
## Summary

The `elixir_hello` example's `run_test` (`mix run`) was failing in CI with a TLS `key_usage_mismatch` alert when Mix tried to install Hex from `builds.hex.pm` — a strict certificate check in the pinned Erlang/OTP 27.2. Mix only reached out to the network because the example declared a hex dependency on `cowboy`, which is entirely unused (`lib/elixir_hello.ex` just prints "Hello World!"). This PR removes the dead `cowboy` dependency (and the now-empty `mix.lock`), making the example fully offline so the test no longer touches the network.

## How was it tested?

Reproduced the original CI failure locally, then confirmed `devbox run run_test` now compiles and prints `Hello World!` from a clean `_build`/`deps` with no network access.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).