### PR TITLE
fix(shell): skip env vars with invalid names instead of breaking the shell

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -394,9 +394,9 @@ func (d *Devbox) EnvExports(ctx context.Context, opts devopt.EnvExportsOpts) (st
 	// Use the appropriate export format based on shell type
 	var envStr string
 	if opts.ShellFormat == devopt.ShellFormatNushell {
-		envStr = exportifyNushell(envs)
+		envStr = exportifyNushell(d.stderr, envs)
 	} else {
-		envStr = exportify(envs)
+		envStr = exportify(d.stderr, envs)
 	}
 
 	if opts.RunHooks {

--- a/internal/devbox/envvars.go
+++ b/internal/devbox/envvars.go
@@ -5,6 +5,7 @@ package devbox
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 	"slices"
@@ -32,7 +33,7 @@ func isValidEnvName(name string) bool {
 // cause is a "//" comment key in a devbox.json env block, which devbox would
 // otherwise emit as `export //=...` and break the entire shell with a cryptic
 // error.
-func warnInvalidEnvNames(names []string) {
+func warnInvalidEnvNames(w io.Writer, names []string) {
 	if len(names) == 0 {
 		return
 	}
@@ -41,9 +42,9 @@ func warnInvalidEnvNames(names []string) {
 		quoted[i] = fmt.Sprintf("%q", name)
 	}
 	ux.Fwarningf(
-		os.Stderr,
+		w,
 		"Skipping %d environment variable(s) with invalid names: %s.\n"+
-			"Environment variable names must match [a-zA-Z_][a-zA-Z0-9_]*. "+
+			"Environment variable names must match ^[a-zA-Z_][a-zA-Z0-9_]*$. "+
 			"If these are \"//\" comments in your devbox.json env block, remove or rename them.\n",
 		len(names),
 		strings.Join(quoted, ", "),
@@ -55,7 +56,7 @@ func warnInvalidEnvNames(names []string) {
 // value escaped. This means that the shell will always interpret values as
 // literal strings; no variable expansion or command substitution will take
 // place.
-func exportify(vars map[string]string) string {
+func exportify(w io.Writer, vars map[string]string) string {
 	keys := make([]string, len(vars))
 	i := 0
 	for k := range vars {
@@ -100,13 +101,13 @@ func exportify(vars map[string]string) string {
 			strb.WriteString("\";\n")
 		}
 	}
-	warnInvalidEnvNames(invalidNames)
+	warnInvalidEnvNames(w, invalidNames)
 	return strings.TrimSpace(strb.String())
 }
 
 // exportifyNushell formats vars as nushell environment variable assignments.
 // Each line is of the form `$env.KEY = "value"` with special characters escaped.
-func exportifyNushell(vars map[string]string) string {
+func exportifyNushell(w io.Writer, vars map[string]string) string {
 	// Nushell protected environment variables that cannot be set manually
 	// See: https://www.nushell.sh/book/environment.html#automatic-environment-variables
 	protectedVars := map[string]bool{
@@ -159,7 +160,7 @@ func exportifyNushell(vars map[string]string) string {
 		}
 		strb.WriteString("\"\n")
 	}
-	warnInvalidEnvNames(invalidNames)
+	warnInvalidEnvNames(w, invalidNames)
 	return strings.TrimSpace(strb.String())
 }
 

--- a/internal/devbox/envvars.go
+++ b/internal/devbox/envvars.go
@@ -4,15 +4,51 @@
 package devbox
 
 import (
+	"fmt"
 	"os"
+	"regexp"
 	"slices"
 	"strings"
 
 	"go.jetify.com/devbox/internal/devbox/envpath"
 	"go.jetify.com/devbox/internal/envir"
+	"go.jetify.com/devbox/internal/ux"
 )
 
 const devboxSetPrefix = "__DEVBOX_SET_"
+
+// envNameRegexp matches a valid POSIX shell environment variable name: it must
+// start with a letter or underscore and contain only letters, digits, and
+// underscores. Names that don't match (e.g. a "//" comment key in devbox.json's
+// env block) can't be exported without producing invalid shell syntax.
+var envNameRegexp = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+func isValidEnvName(name string) bool {
+	return envNameRegexp.MatchString(name)
+}
+
+// warnInvalidEnvNames prints a single warning naming any environment variables
+// that were skipped because they aren't valid shell identifiers. The most common
+// cause is a "//" comment key in a devbox.json env block, which devbox would
+// otherwise emit as `export //=...` and break the entire shell with a cryptic
+// error.
+func warnInvalidEnvNames(names []string) {
+	if len(names) == 0 {
+		return
+	}
+	quoted := make([]string, len(names))
+	for i, name := range names {
+		quoted[i] = fmt.Sprintf("%q", name)
+	}
+	ux.Fwarningf(
+		os.Stderr,
+		"Skipping %d environment variable(s) with invalid names: %s.\n"+
+			"Environment variable names must match [a-zA-Z_][a-zA-Z0-9_]*. "+
+			"If these are \"//\" comments in your devbox.json env block, remove or rename them.\n",
+		len(names),
+		strings.Join(quoted, ", "),
+	)
+}
 
 // exportify formats vars as a line-separated string of shell export statements.
 // Each line is of the form `export key="value";` with any special characters in
@@ -28,6 +64,7 @@ func exportify(vars map[string]string) string {
 	}
 	slices.Sort(keys) // for reproducibility
 
+	var invalidNames []string
 	strb := strings.Builder{}
 	for _, key := range keys {
 		if strings.HasPrefix(key, "BASH_FUNC_") && strings.HasSuffix(key, "%%") {
@@ -41,7 +78,13 @@ func exportify(vars map[string]string) string {
 			strb.WriteString(funcName)
 			strb.WriteString("\n")
 		} else {
-			// Regular variable
+			// Regular variable. Skip names that aren't valid shell
+			// identifiers; exporting them would produce invalid syntax that
+			// breaks the whole shell (e.g. `export //=...`).
+			if !isValidEnvName(key) {
+				invalidNames = append(invalidNames, key)
+				continue
+			}
 			strb.WriteString("export ")
 			strb.WriteString(key)
 			strb.WriteString(`="`)
@@ -57,6 +100,7 @@ func exportify(vars map[string]string) string {
 			strb.WriteString("\";\n")
 		}
 	}
+	warnInvalidEnvNames(invalidNames)
 	return strings.TrimSpace(strb.String())
 }
 
@@ -82,6 +126,7 @@ func exportifyNushell(vars map[string]string) string {
 	}
 	slices.Sort(keys) // for reproducibility
 
+	var invalidNames []string
 	strb := strings.Builder{}
 	for _, key := range keys {
 		// Skip bash functions for nushell
@@ -91,6 +136,12 @@ func exportifyNushell(vars map[string]string) string {
 
 		// Skip nushell protected environment variables
 		if protectedVars[key] {
+			continue
+		}
+
+		// Skip names that aren't valid environment variable identifiers.
+		if !isValidEnvName(key) {
+			invalidNames = append(invalidNames, key)
 			continue
 		}
 
@@ -108,6 +159,7 @@ func exportifyNushell(vars map[string]string) string {
 		}
 		strb.WriteString("\"\n")
 	}
+	warnInvalidEnvNames(invalidNames)
 	return strings.TrimSpace(strb.String())
 }
 

--- a/internal/devbox/envvars_test.go
+++ b/internal/devbox/envvars_test.go
@@ -4,6 +4,7 @@
 package devbox
 
 import (
+	"io"
 	"strings"
 	"testing"
 )
@@ -28,7 +29,7 @@ func TestIsValidEnvName(t *testing.T) {
 // shell identifiers (e.g. a "//" comment key in devbox.json) are dropped instead
 // of producing invalid shell that breaks the whole shell.
 func TestExportifySkipsInvalidNames(t *testing.T) {
-	got := exportify(map[string]string{
+	got := exportify(io.Discard, map[string]string{
 		"GOOD":     "value",
 		"//":       "comment-as-json-hack",
 		"//ccache": "another comment",
@@ -39,7 +40,7 @@ func TestExportifySkipsInvalidNames(t *testing.T) {
 	if !strings.Contains(got, `export GOOD="value";`) {
 		t.Errorf("expected valid var to be exported, got:\n%s", got)
 	}
-	for _, bad := range []string{"//", "bad.name", "1leading"} {
+	for _, bad := range []string{"//", "//ccache", "bad.name", "1leading"} {
 		if strings.Contains(got, bad) {
 			t.Errorf("expected invalid name %q to be skipped, got:\n%s", bad, got)
 		}
@@ -47,7 +48,7 @@ func TestExportifySkipsInvalidNames(t *testing.T) {
 }
 
 func TestExportifyNushellSkipsInvalidNames(t *testing.T) {
-	got := exportifyNushell(map[string]string{
+	got := exportifyNushell(io.Discard, map[string]string{
 		"GOOD": "value",
 		"//":   "comment",
 	})

--- a/internal/devbox/envvars_test.go
+++ b/internal/devbox/envvars_test.go
@@ -1,0 +1,61 @@
+// Copyright 2024 Jetify Inc. and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package devbox
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsValidEnvName(t *testing.T) {
+	valid := []string{"FOO", "_foo", "foo_BAR_123", "a", "_"}
+	for _, name := range valid {
+		if !isValidEnvName(name) {
+			t.Errorf("isValidEnvName(%q) = false, want true", name)
+		}
+	}
+
+	invalid := []string{"//", "//ccache", "bad.name", "1leading", "with space", "with-dash", ""}
+	for _, name := range invalid {
+		if isValidEnvName(name) {
+			t.Errorf("isValidEnvName(%q) = true, want false", name)
+		}
+	}
+}
+
+// TestExportifySkipsInvalidNames ensures that env vars whose names aren't valid
+// shell identifiers (e.g. a "//" comment key in devbox.json) are dropped instead
+// of producing invalid shell that breaks the whole shell.
+func TestExportifySkipsInvalidNames(t *testing.T) {
+	got := exportify(map[string]string{
+		"GOOD":     "value",
+		"//":       "comment-as-json-hack",
+		"//ccache": "another comment",
+		"bad.name": "dotted",
+		"1leading": "starts with digit",
+	})
+
+	if !strings.Contains(got, `export GOOD="value";`) {
+		t.Errorf("expected valid var to be exported, got:\n%s", got)
+	}
+	for _, bad := range []string{"//", "bad.name", "1leading"} {
+		if strings.Contains(got, bad) {
+			t.Errorf("expected invalid name %q to be skipped, got:\n%s", bad, got)
+		}
+	}
+}
+
+func TestExportifyNushellSkipsInvalidNames(t *testing.T) {
+	got := exportifyNushell(map[string]string{
+		"GOOD": "value",
+		"//":   "comment",
+	})
+
+	if !strings.Contains(got, `$env.GOOD = "value"`) {
+		t.Errorf("expected valid var to be exported, got:\n%s", got)
+	}
+	if strings.Contains(got, "//") {
+		t.Errorf("expected invalid name to be skipped, got:\n%s", got)
+	}
+}

--- a/internal/devbox/shell.go
+++ b/internal/devbox/shell.go
@@ -338,7 +338,7 @@ func (s *DevboxShell) writeDevboxShellrc() (path string, err error) {
 		HooksFilePath:      shellgen.ScriptPath(s.projectDir, shellgen.HooksFilename),
 		ShellStartTime:     telemetry.FormatShellStart(s.shellStartTime),
 		HistoryFile:        strings.TrimSpace(s.historyFile),
-		ExportEnv:          exportify(s.env),
+		ExportEnv:          exportify(s.devbox.stderr, s.env),
 		ShellName:          string(s.name),
 		ShellAliases:       s.aliasLines(),
 		RefreshAliasName:   s.devbox.refreshAliasName(),


### PR DESCRIPTION
## Summary

A `"//"` comment key in a `devbox.json` `env` block was exported verbatim as `export //=...`, which zsh rejects with the cryptic `not valid in this context: //`, breaking the entire `devbox shell`. `exportify` and `exportifyNushell` now skip env vars whose names aren't valid shell identifiers (`^[a-zA-Z_][a-zA-Z0-9_]*$`) and emit a single clear warning naming the offending keys, instead of generating invalid shell.

## How was it tested?

Added unit tests for `isValidEnvName` and for both export formats skipping invalid names; the full `internal/devbox` suite, `go vet`, and `go build ./...` pass. Reproduced the original failure (`export //=x` → `not valid in this context: //`) and confirmed the generated shellenv now passes `zsh -n` with only valid vars exported and the warning shown on stderr.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).