### PR TITLE
ci: upgrade GitHub Actions off the deprecated Node.js 20 runtime

### DIFF
--- a/.github/workflows/cache-upload.yml
+++ b/.github/workflows/cache-upload.yml
@@ -34,12 +34,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Build devbox from scratch because released devbox has a bug that prevents 
       # DEVBOX_API_TOKEN use
       # we can remove this after 0.10.6 is out.
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: ./go.mod
       - name: Build devbox

--- a/.github/workflows/cli-post-release.yml
+++ b/.github/workflows/cli-post-release.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: read
-  id-token: write # Needed for aws-actions/configure-aws-credentials@v1
+  id-token: write # Needed for aws-actions/configure-aws-credentials@v6
 
 jobs:
   # Make sure the cli-release workflow that built this tag actually succeeded
@@ -38,7 +38,7 @@ jobs:
     needs: check-release
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}
           aws-region: us-west-2

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -21,7 +21,7 @@ on:
 permissions:
   contents: write
   pull-requests: read
-  id-token: write # Needed for aws-actions/configure-aws-credentials@v1
+  id-token: write # Needed for aws-actions/configure-aws-credentials@v6
 
 jobs:
   tests:
@@ -34,14 +34,16 @@ jobs:
     steps:
       - name: Notify jetpack.io slack of release status (only if tests fail)
         id: slack
-        uses: slackapi/slack-github-action@v1.25.0
+        uses: slackapi/slack-github-action@v3.0.3
         with:
+          # v2+ moved the webhook URL from the SLACK_WEBHOOK_URL env var to the
+          # `webhook` input and made `webhook-type` required.
+          webhook: ${{ secrets.SLACK_CLI_RELEASE_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "status": "test ${{ needs.tests.result }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CLI_RELEASE_WEBHOOK_URL }}
 
   edge:
     runs-on: ubuntu-latest
@@ -50,7 +52,7 @@ jobs:
     if: ${{ inputs.create_edge_release || github.event.schedule }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Needed by goreleaser to browse history.
       - name: Determine edge tag
@@ -58,17 +60,17 @@ jobs:
         run: echo "EDGE_TAG=0.0.0-edge.$(date +%Y-%m-%d)" >> $GITHUB_ENV
       - name: Set edge tag
         id: tag_version
-        uses: mathieudutour/github-tag-action@v6.1
+        uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ env.EDGE_TAG }}
           tag_prefix: ""
       - name: Set up go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ./go.mod
       - name: Build snapshot with goreleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: latest
@@ -88,7 +90,7 @@ jobs:
           version:  ${{ env.EDGE_TAG }}
           version_prefix: "devbox@"
       - name: Publish snapshot release to GitHub
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           prerelease: true
           body: "${{ env.EDGE_TAG }} edge release"
@@ -98,7 +100,7 @@ jobs:
             dist/checksums.txt
             dist/*.tar.gz
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}
           aws-region: us-west-2
@@ -116,11 +118,11 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Needed by goreleaser to browse history.
       - name: Set up go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ./go.mod
       - name: Create Sentry release
@@ -134,7 +136,7 @@ jobs:
           version: ${{ github.ref }}
           version_prefix: "devbox@"
       - name: Release with goreleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: latest
@@ -148,11 +150,13 @@ jobs:
       - name: Notify jetpack.io slack of release status
         id: slack
         if: always()
-        uses: slackapi/slack-github-action@v1.25.0
+        uses: slackapi/slack-github-action@v3.0.3
         with:
+          # v2+ moved the webhook URL from the SLACK_WEBHOOK_URL env var to the
+          # `webhook` input and made `webhook-type` required.
+          webhook: ${{ secrets.SLACK_CLI_RELEASE_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "status": "release ${{ job.status }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CLI_RELEASE_WEBHOOK_URL }}

--- a/.github/workflows/cli-tests.yaml
+++ b/.github/workflows/cli-tests.yaml
@@ -58,14 +58,14 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
         with:
           go-version-file: ./go.mod
       - name: Build devbox
         run: go build -o dist/devbox ./cmd/devbox
       - name: Upload devbox artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: devbox-${{ runner.os }}-${{ runner.arch }}
           path: ./dist/devbox
@@ -76,7 +76,7 @@ jobs:
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: crate-ci/typos@v1.16.26
 
   flake-test:
@@ -84,7 +84,7 @@ jobs:
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install devbox
         uses: jetify-com/devbox-install-action@jl/migrate-installer
         with:
@@ -104,7 +104,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@jl/migrate-installer
@@ -112,7 +112,7 @@ jobs:
           enable-cache: true
 
       - name: Mount golang cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/golangci-lint
@@ -160,9 +160,9 @@ jobs:
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Mount golang cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/go-build
@@ -240,9 +240,9 @@ jobs:
         use-detsys: [true, false]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Download devbox
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: devbox-${{ runner.os }}-${{ runner.arch }}
       - name: Add devbox to path
@@ -289,9 +289,9 @@ jobs:
         nix-version: [2.18.0, 2.19.2, 2.24.7, 2.30.2]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Download devbox
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: devbox-${{ runner.os }}-${{ runner.arch }}
       - name: Add devbox to path

--- a/.github/workflows/debug.yaml
+++ b/.github/workflows/debug.yaml
@@ -36,8 +36,8 @@ jobs:
               --show-error \
               --silent \
             | jq .
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
         with:
           go-version-file: ./go.mod
       - run: |

--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             jetpackio/devbox
@@ -32,7 +32,7 @@ jobs:
             latest=false
       - name: Docker meta root
         id: metaroot
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             jetpackio/devbox-root-user
@@ -41,14 +41,14 @@ jobs:
           flavor: |
             latest=false
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Build and push default
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ./internal/devbox/generate/tmpl/
           file: ./internal/devbox/generate/tmpl/DevboxImageDockerfile
@@ -58,7 +58,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
       - name: Build and push root user
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ./internal/devbox/generate/tmpl/
           file: ./internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser
@@ -69,7 +69,7 @@ jobs:
           tags: ${{ steps.metaroot.outputs.tags }}
       - name: Docker meta latest
         id: metalatest
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             jetpackio/devbox
@@ -78,7 +78,7 @@ jobs:
           flavor: |
             latest=true
       - name: Build and push latest
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ./internal/devbox/generate/tmpl/
           file: ./internal/devbox/generate/tmpl/DevboxImageDockerfile
@@ -87,7 +87,7 @@ jobs:
           tags: ${{ steps.metalatest.outputs.tags }}
       - name: Docker meta root latest
         id: metarootlatest
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             jetpackio/devbox-root-user
@@ -96,7 +96,7 @@ jobs:
           flavor: |
             latest=true
       - name: Build and push root user latest
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ./internal/devbox/generate/tmpl/
           file: ./internal/devbox/generate/tmpl/DevboxImageDockerfileRootUser

--- a/.github/workflows/random-reviewer-assignment.yml
+++ b/.github/workflows/random-reviewer-assignment.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Randomly assign reviewer from team
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         with:
           script: |
             const TRIAGE_USERNAME = 'Lagoja';

--- a/.github/workflows/stale-issue-cleanup.yml
+++ b/.github/workflows/stale-issue-cleanup.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v7
+      - uses: actions/stale@v10
         with:
           stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove the `stale` label or add a comment, otherwise this issue will be closed in 5 days.'
           stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove the `stale` label or add a comment, otherwise this PR will be closed in 5 days.'

--- a/.github/workflows/vscode-ext-release.yaml
+++ b/.github/workflows/vscode-ext-release.yaml
@@ -11,9 +11,9 @@ jobs:
     environment: release
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Setup NodeJS 24
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: 24
       - name: Install dependencies


### PR DESCRIPTION
## Summary

GitHub is [deprecating the Node.js 20 Actions runtime](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), so every action targeting node12/16/20 now emits a deprecation warning; this bumps all of them across the 9 workflow files to their latest release (node24) — `checkout` v7, `setup-go` v6, `setup-node` v6, `cache` v5, `upload-artifact` v7, `download-artifact` v8, `github-script` v9, `stale` v10, `configure-aws-credentials` v6, `goreleaser-action` v7, `action-gh-release` v3, the `docker/*` actions, and `github-tag-action` v6.2. The only breaking change requiring code edits was `slackapi/slack-github-action` v1→v3, which moved the webhook URL from the `SLACK_WEBHOOK_URL` env var to a `webhook` input and made `webhook-type: incoming-webhook` required (migrated both Slack steps in `cli-release.yml`). All other major bumps were verified input-compatible for how this repo uses them. Composite actions (getsentry, typos, nix-installer) and already-node24 actions (action-tmate, wait-for-workflows) were left alone since they don't emit the warning, and the branch-pinned `devbox-install-action` was left as-is. Note: `mathieudutour/github-tag-action`'s latest release still targets node20 upstream, so it will keep warning until they ship a node24 build.

## How was it tested?

Validated all 9 workflow files parse as valid YAML and confirmed every target version's `action.yml` declares `runs.using: node24` by reading each at its pinned tag. No runtime behavior was changed beyond the action versions and the Slack input migration.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).