### PR TITLE
ci: replace unmaintained github-tag-action with plain git tag/push

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -59,9 +59,10 @@ jobs:
         # This tag is semver and works with semver.Compare
         run: echo "EDGE_TAG=0.0.0-edge.$(date +%Y-%m-%d)" >> $GITHUB_ENV
       - name: Set edge tag
+        # Force so a same-day rerun (the edge tag already exists) is idempotent.
         run: |
-          git tag "$EDGE_TAG"
-          git push origin "$EDGE_TAG"
+          git tag -f "$EDGE_TAG"
+          git push -f origin "refs/tags/$EDGE_TAG"
       - name: Set up go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -57,12 +57,9 @@ jobs:
         # This tag is semver and works with semver.Compare
         run: echo "EDGE_TAG=0.0.0-edge.$(date +%Y-%m-%d)" >> $GITHUB_ENV
       - name: Set edge tag
-        id: tag_version
-        uses: mathieudutour/github-tag-action@v6.1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          custom_tag: ${{ env.EDGE_TAG }}
-          tag_prefix: ""
+        run: |
+          git tag "$EDGE_TAG"
+          git push origin "$EDGE_TAG"
       - name: Set up go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
## Summary

The edge release job only used `mathieudutour/github-tag-action` to create and push a pre-computed tag (`EDGE_TAG`), not its semver auto-bump feature. That action is unmaintained (last release Mar 2024) and runs on the soon-to-be-deprecated Node 20, so this replaces it with two plain `git` commands that do exactly what was being used. The existing `contents: write` permission and default `GITHUB_TOKEN` from checkout cover pushing the tag, and the step's outputs weren't referenced elsewhere.

## How was it tested?

Static review of the workflow — the change is a no-op on behavior, swapping the action for the equivalent `git tag`/`git push` it was performing. The full edge release path runs on the weekly schedule / manual dispatch.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).