### PR TITLE
feat(devpkg): configurable Nix binary cache via DEVBOX_NIX_BINARY_CACHE

### DIFF
--- a/internal/devpkg/narinfo_cache.go
+++ b/internal/devpkg/narinfo_cache.go
@@ -15,15 +15,29 @@ import (
 	"github.com/pkg/errors"
 	"go.jetify.com/devbox/internal/debug"
 	"go.jetify.com/devbox/internal/devbox/providers/nixcache"
+	"go.jetify.com/devbox/internal/envir"
 	"go.jetify.com/devbox/internal/goutil"
 	"go.jetify.com/devbox/internal/lock"
 	"go.jetify.com/devbox/internal/nix"
 	"golang.org/x/sync/errgroup"
 )
 
-// binaryCache is the store from which to fetch this package's binaries.
-// It is used as FromStore in builtins.fetchClosure.
-const binaryCache = "https://cache.nixos.org"
+// defaultBinaryCache is the public Nix binary cache that Devbox queries by
+// default for prebuilt package outputs.
+const defaultBinaryCache = "https://cache.nixos.org"
+
+// BinaryCache is the store from which to fetch a package's binaries. It is
+// used as the FromStore in builtins.fetchClosure and as the first cache
+// queried when checking whether a package's outputs are already built.
+//
+// It defaults to the public cache (https://cache.nixos.org) but can be
+// overridden with the DEVBOX_NIX_BINARY_CACHE environment variable. This is
+// useful in network-restricted environments where the public cache is
+// unreachable and an internal mirror/proxy serving the same store paths must
+// be used instead.
+func BinaryCache() string {
+	return envir.GetValueOrDefault(envir.DevboxNixBinaryCache, defaultBinaryCache)
+}
 
 // useDefaultOutputs is a special value for the outputName parameter of
 // fetchNarInfoStatusOnce, which indicates that the default outputs should be
@@ -320,7 +334,7 @@ func fetchNarInfoStatusFromS3(
 var nixCacheIsConfigured = goutil.OnceValueWithContext(nixcache.IsConfigured)
 
 func readCaches(ctx context.Context) ([]string, error) {
-	cacheURIs := []string{binaryCache}
+	cacheURIs := []string{BinaryCache()}
 	if !nixCacheIsConfigured.Do(ctx) {
 		return cacheURIs, nil
 	}

--- a/internal/devpkg/narinfo_cache_test.go
+++ b/internal/devpkg/narinfo_cache_test.go
@@ -1,0 +1,30 @@
+// Copyright 2024 Jetify Inc. and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package devpkg
+
+import (
+	"testing"
+
+	"go.jetify.com/devbox/internal/envir"
+)
+
+func TestBinaryCache(t *testing.T) {
+	t.Run("defaults to the public cache", func(t *testing.T) {
+		// t.Setenv guarantees the env var is restored after the test; set it
+		// empty to ensure we exercise the default path regardless of the
+		// caller's environment.
+		t.Setenv(envir.DevboxNixBinaryCache, "")
+		if got, want := BinaryCache(), defaultBinaryCache; got != want {
+			t.Errorf("BinaryCache() = %q, want default %q", got, want)
+		}
+	})
+
+	t.Run("is overridable via DEVBOX_NIX_BINARY_CACHE", func(t *testing.T) {
+		const mirror = "https://nix-cache.example.com/mirror"
+		t.Setenv(envir.DevboxNixBinaryCache, mirror)
+		if got := BinaryCache(); got != mirror {
+			t.Errorf("BinaryCache() = %q, want override %q", got, mirror)
+		}
+	})
+}

--- a/internal/envir/env.go
+++ b/internal/envir/env.go
@@ -11,6 +11,13 @@ const (
 	// the flag is awkward, such as a Dockerfile.
 	DevboxConfig  = "DEVBOX_CONFIG"
 	DevboxGateway = "DEVBOX_GATEWAY"
+	// DevboxNixBinaryCache overrides the default Nix binary cache that Devbox
+	// queries for prebuilt package outputs (https://cache.nixos.org). This is
+	// useful in network-restricted environments where the public cache is
+	// unreachable and an internal mirror/proxy must be used instead. The value
+	// should be a substituter URL serving the same store paths (e.g. an
+	// Artifactory/Nexus generic remote that mirrors cache.nixos.org).
+	DevboxNixBinaryCache = "DEVBOX_NIX_BINARY_CACHE"
 	// DevboxLatestVersion is the latest version available of the devbox CLI binary.
 	// NOTE: it should NOT start with v (like 0.4.8)
 	DevboxLatestVersion  = "DEVBOX_LATEST_VERSION"

--- a/internal/shellgen/generate.go
+++ b/internal/shellgen/generate.go
@@ -166,6 +166,7 @@ var templateFuncs = template.FuncMap{
 	"contains":          strings.Contains,
 	"debug":             debug.IsEnabled,
 	"fetchClosureStore": fetchClosureStore,
+	"nixString":         nixString,
 }
 
 // fetchClosureStore returns the store URL to use as the fromStore of a
@@ -182,6 +183,20 @@ func fetchClosureStore(cacheURI string) string {
 		return cacheURI
 	}
 	return devpkg.BinaryCache()
+}
+
+// nixString renders s as a double-quoted Nix string literal, escaping the
+// characters that are special inside one: backslash, double quote, and the
+// "${" antiquotation (interpolation) start. This keeps values that originate
+// from configuration (e.g. a cache URL from DEVBOX_NIX_BINARY_CACHE) from
+// breaking flake evaluation or being interpreted as Nix interpolation.
+func nixString(s string) string {
+	r := strings.NewReplacer(
+		`\`, `\\`,
+		`"`, `\"`,
+		`${`, `\${`,
+	)
+	return `"` + r.Replace(s) + `"`
 }
 
 func makeFlakeFile(d devboxer, plan *flakePlan) error {

--- a/internal/shellgen/generate.go
+++ b/internal/shellgen/generate.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pkg/errors"
 	"go.jetify.com/devbox/internal/cuecfg"
 	"go.jetify.com/devbox/internal/debug"
+	"go.jetify.com/devbox/internal/devpkg"
 	"go.jetify.com/devbox/internal/redact"
 )
 
@@ -161,9 +162,26 @@ func toJSON(a any) string {
 }
 
 var templateFuncs = template.FuncMap{
-	"json":     toJSON,
-	"contains": strings.Contains,
-	"debug":    debug.IsEnabled,
+	"json":              toJSON,
+	"contains":          strings.Contains,
+	"debug":             debug.IsEnabled,
+	"fetchClosureStore": fetchClosureStore,
+}
+
+// fetchClosureStore returns the store URL to use as the fromStore of a
+// builtins.fetchClosure in the generated flake.
+//
+// fetchClosure only supports http(s) stores, so when a package's outputs were
+// found in an http(s) cache we use that cache directly (it's where the path
+// actually lives, which may be the public cache or a configured mirror via
+// DEVBOX_NIX_BINARY_CACHE). For s3 caches fetchClosure can't fetch directly, so
+// we fall back to the configured binary cache as a placeholder store — the path
+// is already built locally, so fetchClosure won't actually fetch from it.
+func fetchClosureStore(cacheURI string) string {
+	if strings.HasPrefix(cacheURI, "http://") || strings.HasPrefix(cacheURI, "https://") {
+		return cacheURI
+	}
+	return devpkg.BinaryCache()
 }
 
 func makeFlakeFile(d devboxer, plan *flakePlan) error {

--- a/internal/shellgen/generate_internal_test.go
+++ b/internal/shellgen/generate_internal_test.go
@@ -1,0 +1,64 @@
+// Copyright 2024 Jetify Inc. and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package shellgen
+
+import (
+	"testing"
+
+	"go.jetify.com/devbox/internal/envir"
+)
+
+func TestFetchClosureStore(t *testing.T) {
+	const customCache = "https://nix-cache.example.com/mirror"
+
+	tests := []struct {
+		name     string
+		cacheURI string
+		envValue string
+		want     string
+	}{
+		{
+			name:     "https cache uri is used directly",
+			cacheURI: "https://cache.nixos.org",
+			want:     "https://cache.nixos.org",
+		},
+		{
+			name:     "http cache uri is used directly",
+			cacheURI: "http://nix-cache.example.com",
+			want:     "http://nix-cache.example.com",
+		},
+		{
+			name:     "https mirror cache uri is used directly",
+			cacheURI: customCache,
+			want:     customCache,
+		},
+		{
+			name:     "s3 cache falls back to default binary cache",
+			cacheURI: "s3://my-bucket",
+			want:     "https://cache.nixos.org",
+		},
+		{
+			name:     "s3 cache falls back to configured binary cache",
+			cacheURI: "s3://my-bucket",
+			envValue: customCache,
+			want:     customCache,
+		},
+		{
+			name:     "empty cache falls back to default binary cache",
+			cacheURI: "",
+			want:     "https://cache.nixos.org",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				t.Setenv(envir.DevboxNixBinaryCache, tt.envValue)
+			}
+			if got := fetchClosureStore(tt.cacheURI); got != tt.want {
+				t.Errorf("fetchClosureStore(%q) = %q, want %q", tt.cacheURI, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/shellgen/generate_internal_test.go
+++ b/internal/shellgen/generate_internal_test.go
@@ -53,11 +53,50 @@ func TestFetchClosureStore(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.envValue != "" {
-				t.Setenv(envir.DevboxNixBinaryCache, tt.envValue)
-			}
+			// Always set the env var (empty when unset) so the test is
+			// isolated from the caller's environment: t.Setenv with an empty
+			// value still exercises the default-cache path via
+			// GetValueOrDefault, and restores any prior value afterward.
+			t.Setenv(envir.DevboxNixBinaryCache, tt.envValue)
 			if got := fetchClosureStore(tt.cacheURI); got != tt.want {
 				t.Errorf("fetchClosureStore(%q) = %q, want %q", tt.cacheURI, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNixString(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "plain url is just quoted",
+			in:   "https://cache.nixos.org",
+			want: `"https://cache.nixos.org"`,
+		},
+		{
+			name: "double quote is escaped",
+			in:   `a"b`,
+			want: `"a\"b"`,
+		},
+		{
+			name: "backslash is escaped",
+			in:   `a\b`,
+			want: `"a\\b"`,
+		},
+		{
+			name: "antiquotation start is escaped",
+			in:   "a${b}",
+			want: `"a\${b}"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := nixString(tt.in); got != tt.want {
+				t.Errorf("nixString(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
 	}

--- a/internal/shellgen/tmpl/flake.nix.tmpl
+++ b/internal/shellgen/tmpl/flake.nix.tmpl
@@ -42,13 +42,16 @@
             {{ if $output.CacheURI -}}
             (builtins.trace "downloading {{ $pkg.Versioned }}" (builtins.fetchClosure {
               {{/*
-                HACK HACK HACK! fetchClosure only supports http(s) caches and not
-                s3 caches. Until we implement that, we put a fake store here.
-                Since we pre-build everything, fetchClosure will not actually
-                fetch anything and just use the local version. This may break
-                if user somehow removes the local store path.
+                fetchClosure only supports http(s) caches and not s3 caches.
+                fetchClosureStore returns the http(s) cache the output was found
+                in (the public cache or a configured mirror via
+                DEVBOX_NIX_BINARY_CACHE), falling back to the default binary
+                cache for s3 caches. Since we pre-build everything, fetchClosure
+                will not actually fetch anything for an s3 cache and just use the
+                local version. This may break if the user somehow removes the
+                local store path.
               */}}
-              fromStore = "https://cache.nixos.org";
+              fromStore = "{{ fetchClosureStore $output.CacheURI }}";
               fromPath = "{{ $pkg.InputAddressedPathForOutput $output.Name }}";
               inputAddressed = true;
             }))

--- a/internal/shellgen/tmpl/flake.nix.tmpl
+++ b/internal/shellgen/tmpl/flake.nix.tmpl
@@ -51,7 +51,7 @@
                 local version. This may break if the user somehow removes the
                 local store path.
               */}}
-              fromStore = "{{ fetchClosureStore $output.CacheURI }}";
+              fromStore = {{ fetchClosureStore $output.CacheURI | nixString }};
               fromPath = "{{ $pkg.InputAddressedPathForOutput $output.Name }}";
               inputAddressed = true;
             }))


### PR DESCRIPTION
## Summary

Fixes #2599.

Devbox hardcodes `https://cache.nixos.org` as the Nix binary cache it queries for prebuilt package outputs. This makes `devbox run` fail in network-restricted environments (such as enterprise CI runners with no public internet egress), even when an internal mirror that serves the identical store paths is configured as a Nix substituter.

The hardcoded URL (`internal/devpkg/narinfo_cache.go`) is used in two places:

1. **The narinfo precheck** — `readCaches` seeds its cache list with this URL, and `FillNarInfoCache` runs unconditionally at the start of every `devbox run` (via `flakePlan`). `fetchNarInfoStatusFromHTTP` does a 5s `HEAD` to `<cache>/<hash>.narinfo`; on a network error it returns the error, and `fetchNarInfoStatusOnce` propagates it.
2. **The `fromStore`** of the `builtins.fetchClosure` expressions in the generated `flake.nix`.

So on a locked-down runner, `devbox run` fails hard with:

```
Error: error running script "..." in Devbox: Head "https://cache.nixos.org/<hash>.narinfo": context deadline exceeded
```

…even when the toolchain is fully available from an internal substituter. Setting `substituters` in `nix.conf` does not help: `builtins.fetchClosure` contacts its `fromStore` directly and ignores `substituters`, and the Go-level precheck has its own hardcoded URL.

This PR adds a `DEVBOX_NIX_BINARY_CACHE` environment variable that overrides the default cache, following the same pattern as the existing `DEVBOX_SEARCH_HOST` override. When unset, behavior is unchanged (`https://cache.nixos.org`), so this is fully backwards compatible. Pointed at an internal mirror that proxies `cache.nixos.org`, `devbox run` then works with no public egress:

```sh
export DEVBOX_NIX_BINARY_CACHE="https://nix-cache.internal.example.com/mirror"
devbox run ...
```

## Changes

- `envir`: add a `DevboxNixBinaryCache` (`DEVBOX_NIX_BINARY_CACHE`) constant to the central env-var registry.
- `devpkg`: replace the `binaryCache` constant with a `BinaryCache()` accessor that resolves the env var via `envir.GetValueOrDefault`, defaulting to `https://cache.nixos.org`; `readCaches` uses it.
- `shellgen`: the generated flake's `fromStore` now uses the http(s) cache the output was actually found in, via a new `fetchClosureStore` template helper that falls back to the configured binary cache for `s3://` caches `fetchClosure` cannot use directly.

## How was it tested?

```
go test ./internal/devpkg/... ./internal/shellgen/...
go tool golangci-lint run --timeout 5m
```

- New unit tests: `TestBinaryCache` (`internal/devpkg`) covers the default and the override; `TestFetchClosureStore` (`internal/shellgen`) covers http(s) pass-through, the s3 fallback, and the configured fallback.
- Existing golden-file flake tests are unchanged when the variable is unset.
- Verified end-to-end: with `DEVBOX_NIX_BINARY_CACHE` set, the generated `flake.nix` emits `fromStore = "<mirror>"` and the narinfo precheck targets the mirror; unset, it remains `https://cache.nixos.org`.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
