### PR TITLE
fix(env): preserve user-set NIX_SSL_CERT_FILE / SSL_CERT_FILE

### DIFF
--- a/internal/devbox/devbox.go
+++ b/internal/devbox/devbox.go
@@ -738,6 +738,15 @@ func (d *Devbox) computeEnv(
 		for k, v := range nixEnv {
 			env[k] = v
 		}
+
+		// The Nix dev-env sets the SSL certificate-bundle variables to a Nix
+		// store path whenever a package pulls in nss-cacert (e.g. httpie,
+		// python). That clobbers a value the user deliberately set in their own
+		// environment — most importantly a corporate MITM/proxy CA bundle —
+		// breaking outbound TLS for the rest of the project. Restore the user's
+		// own value so custom CA bundles keep working, mirroring how `nix shell`
+		// leaves these untouched. See jetify-com/devbox#2604.
+		preserveUserSSLCertFiles(env, originalEnv)
 	}
 	slog.Debug("nix environment PATH", "path", env["PATH"])
 
@@ -1098,6 +1107,27 @@ var ignoreDevEnvVar = map[string]bool{
 	"TMPDIR":             true,
 	"TZ":                 true,
 	"UID":                true,
+}
+
+// sslCertFileEnvVars are the certificate-bundle environment variables that
+// Nix's build environment sets (via packages such as nss-cacert, pulled in by
+// httpie, python, etc.). They point at a Nix store CA bundle, which is the right
+// default when the user hasn't set one themselves but is wrong when they have:
+// a user who exports one of these — typically to a corporate MITM/proxy CA
+// bundle — needs that value preserved for outbound TLS to keep working.
+var sslCertFileEnvVars = []string{"NIX_SSL_CERT_FILE", "SSL_CERT_FILE"}
+
+// preserveUserSSLCertFiles restores the user's own certificate-bundle variables
+// (taken from userEnv, the ambient environment captured before the Nix dev-env
+// is layered on) into env, so that a value the user explicitly set wins over the
+// Nix store path injected by the dev-env. Variables the user did not set are
+// left as-is, keeping the Nix default. See jetify-com/devbox#2604.
+func preserveUserSSLCertFiles(env, userEnv map[string]string) {
+	for _, key := range sslCertFileEnvVars {
+		if val, ok := userEnv[key]; ok && val != "" {
+			env[key] = val
+		}
+	}
 }
 
 func (d *Devbox) ProjectDirHash() string {

--- a/internal/devbox/devbox_test.go
+++ b/internal/devbox/devbox_test.go
@@ -120,6 +120,68 @@ func TestComputeDevboxPathWhenRemoving(t *testing.T) {
 	assert.NotEqual(t, path, path2, "path should not be the same")
 }
 
+// testNixVars is a nix.Nixer mock whose PrintDevEnv returns a configurable set
+// of exported variables. Used to exercise how computeEnv layers the Nix
+// dev-env on top of the ambient environment.
+type testNixVars struct {
+	vars map[string]string
+}
+
+func (n *testNixVars) PrintDevEnv(ctx context.Context, args *nix.PrintDevEnvArgs) (*nix.PrintDevEnvOut, error) {
+	variables := map[string]nix.Variable{}
+	for k, v := range n.vars {
+		variables[k] = nix.Variable{Type: "exported", Value: v}
+	}
+	return &nix.PrintDevEnvOut{Variables: variables}, nil
+}
+
+func TestPreserveUserSSLCertFiles(t *testing.T) {
+	const userBundle = "/Library/Application Support/Netskope/STAgent/data/nscacert_combined.pem"
+	const nixBundle = "/nix/store/abc-nss-cacert-3.108/etc/ssl/certs/ca-bundle.crt"
+
+	t.Run("restores user value when set", func(t *testing.T) {
+		env := map[string]string{"NIX_SSL_CERT_FILE": nixBundle, "SSL_CERT_FILE": nixBundle}
+		userEnv := map[string]string{"NIX_SSL_CERT_FILE": userBundle, "SSL_CERT_FILE": userBundle}
+		preserveUserSSLCertFiles(env, userEnv)
+		assert.Equal(t, userBundle, env["NIX_SSL_CERT_FILE"])
+		assert.Equal(t, userBundle, env["SSL_CERT_FILE"])
+	})
+
+	t.Run("keeps nix value when user did not set one", func(t *testing.T) {
+		env := map[string]string{"NIX_SSL_CERT_FILE": nixBundle}
+		preserveUserSSLCertFiles(env, map[string]string{})
+		assert.Equal(t, nixBundle, env["NIX_SSL_CERT_FILE"])
+	})
+
+	t.Run("ignores empty user value", func(t *testing.T) {
+		env := map[string]string{"NIX_SSL_CERT_FILE": nixBundle}
+		preserveUserSSLCertFiles(env, map[string]string{"NIX_SSL_CERT_FILE": ""})
+		assert.Equal(t, nixBundle, env["NIX_SSL_CERT_FILE"])
+	})
+}
+
+// TestComputeEnvPreservesUserSSLCertFile is a regression test for
+// jetify-com/devbox#2604: adding a package that pulls in nss-cacert (e.g.
+// httpie) must not clobber a NIX_SSL_CERT_FILE the user set in their own
+// environment (e.g. a corporate MITM CA bundle).
+func TestComputeEnvPreservesUserSSLCertFile(t *testing.T) {
+	const userBundle = "/Library/Application Support/Netskope/STAgent/data/nscacert_combined.pem"
+	const nixBundle = "/nix/store/abc-nss-cacert-3.108/etc/ssl/certs/ca-bundle.crt"
+
+	d := devboxForTesting(t)
+	d.nix = &testNixVars{vars: map[string]string{
+		"PATH":              "/tmp/my/path",
+		"NIX_SSL_CERT_FILE": nixBundle,
+	}}
+
+	t.Setenv("NIX_SSL_CERT_FILE", userBundle)
+
+	env, err := d.computeEnv(t.Context(), false /*use cache*/, devopt.EnvOptions{})
+	require.NoError(t, err, "computeEnv should not fail")
+	assert.Equal(t, userBundle, env["NIX_SSL_CERT_FILE"],
+		"the user's NIX_SSL_CERT_FILE should win over the nix dev-env value")
+}
+
 func devboxForTesting(t *testing.T) *Devbox {
 	path := t.TempDir()
 	_, err := devconfig.Init(path)


### PR DESCRIPTION
## Summary

Fixes #2604.

Adding a package that pulls in `nss-cacert` (for example `httpie`, or anything depending on `python`) silently changed `NIX_SSL_CERT_FILE` inside the Devbox environment:

```sh
❯ devbox run -- 'echo $NIX_SSL_CERT_FILE'
# /Library/Application Support/Netskope/STAgent/data/nscacert_combined.pem

❯ devbox add httpie
❯ devbox run -- 'echo $NIX_SSL_CERT_FILE'
# /nix/store/…-nss-cacert-3.108/etc/ssl/certs/ca-bundle.crt   ← clobbered
```

On machines behind a corporate MITM/proxy, users set `NIX_SSL_CERT_FILE` (and `SSL_CERT_FILE`) to a custom CA bundle so that TLS works. When Nix's build environment injected its own store CA bundle, that user value was overwritten and outbound TLS broke for the rest of the project (e.g. `bundle install` failing). Plain `nix shell nixpkgs#httpie` leaves the variable untouched, so the behavior was also inconsistent with Nix itself.

### Root cause

`computeEnv` (`internal/devbox/devbox.go`) layers the output of `nix print-dev-env` on top of the ambient environment, unconditionally overwriting duplicate keys:

```go
for k, v := range nixEnv {
    env[k] = v
}
```

When a package brings in `nss-cacert`, its setup hook sets `NIX_SSL_CERT_FILE`/`SSL_CERT_FILE` to a Nix store path, and that value wins over whatever the user had exported. Devbox already special-cases `SSL_CERT_FILE` for the `/no-cert-file.crt` sentinel, but nothing protected a real user-provided value, and `NIX_SSL_CERT_FILE` wasn't handled at all.

### Fix

After layering the Nix dev-env, restore the user's own certificate-bundle variables (captured in `originalEnv` before the merge) when they had explicitly set them:

- User set `NIX_SSL_CERT_FILE`/`SSL_CERT_FILE` → their value is kept (custom CA bundle keeps working).
- User did not set it → the Nix store value is used, so default behavior is unchanged.

This mirrors how `nix shell` leaves these variables untouched, and is scoped strictly to the two certificate-bundle variables so the rest of the env layering is unaffected.

cc @jay-aye-see-kay (issue reporter) — thanks for the detailed write-up and for narrowing it down to the env layering.

## How was it tested?

- `go test ./internal/devbox/ -run 'SSLCert|ComputeEnv'` — passes.
- Added `TestPreserveUserSSLCertFiles` (unit test for the restore helper) and `TestComputeEnvPreservesUserSSLCertFile` (end-to-end through `computeEnv` with a Nix mock that returns the store CA bundle). The latter fails before this change (returns the Nix store path) and passes after.
- `gofmt` and `go vet ./internal/devbox/` are clean.

> Note: the Nix-backed end-to-end testscripts could not be run in the authoring environment (no `nix` binary available), but the added tests exercise the exact env-layering logic that gates this behavior.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1aHkQxSgAg5xYXsm1pYRQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1aHkQxSgAg5xYXsm1pYRQ)_