### PR TITLE
fix(mariadb,mysql plugin): ignore /etc/mysql config files, for better isolation (#2904)

### DIFF
--- a/plugins/mariadb/flake.nix
+++ b/plugins/mariadb/flake.nix
@@ -14,28 +14,37 @@
         nativeBuildInputs = [ nixpkgs.legacyPackages.{{.System}}.makeWrapper];
         postBuild = ''
 
-          wrapProgram $out/bin/mysqld \
-            --add-flags '--basedir=$out --datadir=''$MYSQL_DATADIR --pid-file=''$MYSQL_PID_FILE --socket=''$MYSQL_UNIX_PORT';
-
           wrapProgram $out/bin/mariadbd \
-            --add-flags '--basedir=$out --datadir=''$MYSQL_DATADIR --pid-file=''$MYSQL_PID_FILE --socket=''$MYSQL_UNIX_PORT';
-
-          wrapProgram $out/bin/mysqld_safe \
-            --add-flags '--basedir=$out --datadir=''$MYSQL_DATADIR --pid-file=''$MYSQL_PID_FILE --socket=''$MYSQL_UNIX_PORT';
+            --add-flags '--defaults-file=''$MYSQL_CONF --basedir=$out --datadir=''$MYSQL_DATADIR --pid-file=''$MYSQL_PID_FILE --socket=''$MYSQL_UNIX_PORT';
 
           if [ -f $out/bin/mariadbd-safe ]; then
             wrapProgram $out/bin/mariadbd-safe \
-              --add-flags '--basedir=$out --datadir=''$MYSQL_DATADIR --pid-file=''$MYSQL_PID_FILE --socket=''$MYSQL_UNIX_PORT';
+              --add-flags '--defaults-file=''$MYSQL_CONF --basedir=$out --datadir=''$MYSQL_DATADIR --pid-file=''$MYSQL_PID_FILE --socket=''$MYSQL_UNIX_PORT';
           fi
 
-          wrapProgram "$out/bin/mysql_install_db" \
-            --add-flags '--basedir=$out --datadir=''$MYSQL_DATADIR --pid-file=''$MYSQL_PID_FILE --basedir=''$MYSQL_BASEDIR';
+          # my_print_defaults needs --defaults-file too, otherwise it
+          # falls back to /etc/mysql. mariadb-install-db calls it via
+          # $print_defaults, not via mariadbd's wrapper.
+          wrapProgram $out/bin/my_print_defaults \
+            --add-flags '--defaults-file=''$MYSQL_CONF';
 
           if [ -f $out/bin/mariadb-install-db ]; then
             # Note: no --defaults-file= as mariadb-install-db wraps mariadbd which already has it
             wrapProgram "$out/bin/mariadb-install-db" \
               --add-flags '--basedir=$out --datadir=''$MYSQL_DATADIR --pid-file=''$MYSQL_PID_FILE --basedir=''$MYSQL_BASEDIR';
           fi
+
+          wrapProgram $out/bin/mariadb-admin \
+            --add-flags '--defaults-file=''$MYSQL_CONF --socket=''$MYSQL_UNIX_PORT';
+
+          wrapProgram $out/bin/mariadb \
+            --add-flags '--defaults-file=''$MYSQL_CONF --socket=''$MYSQL_UNIX_PORT';
+
+          wrapProgram $out/bin/mariadb-dump \
+            --add-flags '--defaults-file=''$MYSQL_CONF --socket=''$MYSQL_UNIX_PORT';
+
+          # Don't wrap 'mysql' or any mysql binaries, as they are correctly left as symlinks
+
         '';
       };
     in{

--- a/plugins/mariadb/flake.nix
+++ b/plugins/mariadb/flake.nix
@@ -23,16 +23,17 @@
           wrapProgram $out/bin/mysqld_safe \
             --add-flags '--basedir=$out --datadir=''$MYSQL_DATADIR --pid-file=''$MYSQL_PID_FILE --socket=''$MYSQL_UNIX_PORT';
 
-          if [-f $out/bin/mariadbd-safe]; then
-            wrapProgram $out/bin/mariadbd_safe \
+          if [ -f $out/bin/mariadbd-safe ]; then
+            wrapProgram $out/bin/mariadbd-safe \
               --add-flags '--basedir=$out --datadir=''$MYSQL_DATADIR --pid-file=''$MYSQL_PID_FILE --socket=''$MYSQL_UNIX_PORT';
           fi
 
           wrapProgram "$out/bin/mysql_install_db" \
             --add-flags '--basedir=$out --datadir=''$MYSQL_DATADIR --pid-file=''$MYSQL_PID_FILE --basedir=''$MYSQL_BASEDIR';
 
-          if [-f $out/bin/mariadb-install-db]; then
-            wrapProgram "$out/bin/mariadb_install_db" \
+          if [ -f $out/bin/mariadb-install-db ]; then
+            # Note: no --defaults-file= as mariadb-install-db wraps mariadbd which already has it
+            wrapProgram "$out/bin/mariadb-install-db" \
               --add-flags '--basedir=$out --datadir=''$MYSQL_DATADIR --pid-file=''$MYSQL_PID_FILE --basedir=''$MYSQL_BASEDIR';
           fi
         '';

--- a/plugins/mariadb/my.cnf
+++ b/plugins/mariadb/my.cnf
@@ -1,6 +1,17 @@
-# MySQL configuration file
+# MySQL configuration file for Devbox MariaDB
+#
+# This file is read via --defaults-file, which means ONLY this config file
+# is read (system configs in /etc/ are skipped).
+#
+# Runtime paths (datadir, socket, pid-file, basedir) are set by the wrapper
+# script via environment variables and cannot be overridden here:
+#
+#   MYSQL_DATADIR  = --datadir   (default: .devbox/virtenv/mariadb/data)
+#   MYSQL_UNIX_PORT = --socket   (default: .devbox/virtenv/mariadb/run/mysql.sock)
+#   MYSQL_PID_FILE = --pid-file  (default: .devbox/virtenv/mariadb/run/mysql.pid)
 
 [mariadbd]
-# Change this port if 3306 is already used
-#port = 3306
-log_error=mysql.log
+
+# The TCP/IP port the server listens on.
+# Change this if 3306 is already in use.
+# port = 3306

--- a/plugins/mysql/flake.nix
+++ b/plugins/mysql/flake.nix
@@ -15,10 +15,19 @@
         postBuild = ''
 
           wrapProgram $out/bin/mysqld \
-            --add-flags '--basedir=''$MYSQL_BASEDIR --datadir=''$MYSQL_DATADIR --pid-file=''$MYSQL_PID_FILE --socket=''$MYSQL_UNIX_PORT';
+            --add-flags '--defaults-file=''$MYSQL_CONF --basedir=''$MYSQL_BASEDIR --datadir=''$MYSQL_DATADIR --pid-file=''$MYSQL_PID_FILE --socket=''$MYSQL_UNIX_PORT';
 
           wrapProgram $out/bin/mysqld_safe \
-            --add-flags '--basedir=''$MYSQL_BASEDIR --datadir=''$MYSQL_DATADIR --pid-file=''$MYSQL_PID_FILE --socket=''$MYSQL_UNIX_PORT';
+            --add-flags '--defaults-file=''$MYSQL_CONF --basedir=''$MYSQL_BASEDIR --datadir=''$MYSQL_DATADIR --pid-file=''$MYSQL_PID_FILE --socket=''$MYSQL_UNIX_PORT';
+
+          wrapProgram $out/bin/mysqladmin \
+            --add-flags '--defaults-file=''$MYSQL_CONF --socket=''$MYSQL_UNIX_PORT';
+
+          wrapProgram $out/bin/mysql \
+            --add-flags '--defaults-file=''$MYSQL_CONF --socket=''$MYSQL_UNIX_PORT';
+
+          wrapProgram $out/bin/mysqldump \
+            --add-flags '--defaults-file=''$MYSQL_CONF --socket=''$MYSQL_UNIX_PORT';
         '';
       };
     in{

--- a/plugins/mysql/my.cnf
+++ b/plugins/mysql/my.cnf
@@ -1,6 +1,19 @@
-# MySQL configuration file
+# MySQL configuration file for Devbox MySQL
+#
+# This file is read via --defaults-file, which means ONLY this config file
+# is read (system configs in /etc/ are skipped).
+#
+# Runtime paths (datadir, socket, pid-file, basedir) are set by the wrapper
+# script via environment variables and cannot be overridden here:
+#
+#   MYSQL_DATADIR  = --datadir   (default: .devbox/virtenv/mysql/data)
+#   MYSQL_UNIX_PORT = --socket   (default: .devbox/virtenv/mysql/run/mysql.sock)
+#   MYSQL_PID_FILE = --pid-file  (default: .devbox/virtenv/mysql/run/mysql.pid)
 
-# [mysqld]
+[mysqld]
+# Uncomment to disable binary logging.
 # skip-log-bin
-# Change this port if 3306 is already used
+#
+# The TCP/IP port the server listens on.
+# Change this if 3306 is already in use.
 #port = 3306


### PR DESCRIPTION
## Summary

Fixes #2904.

By default, mariadbd reads /etc/mysql/mariadb.cnf, and if the system has another version of MariaDB installed, those config files can cause the Devbox mariadbd to fail (e.g. requesting loading plugins not available).

Devbox services ought to be isolated from their environment. This commit causes devbox mariadbd (and mysqld) to only read from $MYSQL_CONF (typically devbox.d/mariadb/my.cnf).

Additionally, wrap the client/admin binaries (mariadb, mariadb-admin, mariadb-dump, mysqldump, mysql, mysqladmin) with --defaults-file and --socket so they also ignore /etc/mysql and connect to the correct socket.

## How was it tested?

### Mariadb

Optionally, create a deliberately broken config option in the default `mariadb.cnf` as a canary:
```sh
echo -e "[server]\nunknown_param_to_break_mariadbd_devbox_testing=true" | sudo tee -a /etc/mysql/mariadb.cnf
```
Then run:
```sh
mkdir /tmp/mariadbtest
cd /tmp/mariadbtest
devbox init
devbox add mariadb
devbox run mariadbd --verbose --help | grep ^port   # prints 3306
echo "port = 13306" >> devbox.d/mariadb/my.cnf  # Set a nonstandard port
devbox run mariadbd --verbose --help | grep ^port   # prints 13306, showing my.cnf is used
devbox services up -b
devbox run mariadb -e "show variables where variable_name in ('datadir', 'port', 'log_error', 'socket');"
devbox run mariadb -e "status;"
```
For me the latter prints:
```
jturner@jturner-desktop:/tmp/mariadbtest$ devbox run mariadb -e "show variables where variable_name in ('datadir', 'port', 'log_error', 'socket');"
Info: Running script "mariadb" on /tmp/mariadbtest
+---------------+---------------------------------------------------------+
| Variable_name | Value                                                   |
+---------------+---------------------------------------------------------+
| datadir       | /tmp/mariadbtest/.devbox/virtenv/mariadb/data/          |
| log_error     | /tmp/mariadbtest/.devbox/virtenv/mariadb/run/mysql.log  |
| port          | 13306                                                   |
| socket        | /tmp/mariadbtest/.devbox/virtenv/mariadb/run/mysql.sock |
+---------------+---------------------------------------------------------+

jturner@jturner-desktop:/tmp/mariadbtest$ devbox run mariadb -e "status;"
Info: Running script "mariadb" on /tmp/mariadbtest
--------------
/tmp/mariadbtest/.devbox/nix/profile/default/bin/mariadb from 11.8.8-MariaDB, client 15.2 for Linux (x86_64) using readline 5.1

Connection id:          4
Current database:
Current user:           jturner@localhost
SSL:                    Cipher in use is TLS_AES_256_GCM_SHA384, cert is OK
Current pager:          stdout
Using outfile:          ''
Using delimiter:        ;
Server:                 MariaDB
Server version:         11.8.8-MariaDB MariaDB Server
Protocol version:       10
Connection:             Localhost via UNIX socket
Server characterset:    utf8mb4
Db     characterset:    utf8mb4
Client characterset:    utf8mb4
Conn.  characterset:    utf8mb4
UNIX socket:            /tmp/mariadbtest/.devbox/virtenv/mariadb/run/mysql.sock
Uptime:                 1 min 0 sec

Threads: 1  Questions: 9  Slow queries: 0  Opens: 17  Open tables: 10  Queries per second avg: 0.150
--------------
```

### mysql80

```sh
mkdir /tmp/mysqltest
cd /tmp/mysqltest
devbox init
devbox add mysql80
devbox run mysqld --verbose --help | grep ^port    # prints 3306
echo "port = 23306" >> devbox.d/mysql80/my.cnf  # Set a nonstandard port
devbox run mysqld --verbose --help | grep ^port   # prints 23306, showing my.cnf is used
devbox services up -b
devbox run mysql -uroot -e "show variables where variable_name in ('datadir', 'port', 'log_error', 'socket');"
devbox run mysqladmin -uroot  create mydb     # Show mysqladmin wrapper works
devbox run mysql -uroot mydb -e "select database();"  # prints 'mydb'
devbox run mysqldump -uroot mydb    # prints sql
```
For me the latter commands show:

```sh
jturner@jturner-desktop:/tmp/mysqltest$ devbox run mysql -uroot -e "show variables where variable_name in ('datadir', 'port', 'log_error', 'so
cket');"
Info: Running script "mysql" on /tmp/mysqltest
+---------------+-------------------------------------------------------+
| Variable_name | Value                                                 |
+---------------+-------------------------------------------------------+
| datadir       | /tmp/mysqltest/.devbox/virtenv/mysql80/data/          |
| log_error     | /tmp/mysqltest/.devbox/virtenv/mysql80/run/mysql.log  |
| port          | 23306                                                 |
| socket        | /tmp/mysqltest/.devbox/virtenv/mysql80/run/mysql.sock |
+---------------+-------------------------------------------------------+

jturner@jturner-desktop:/tmp/mysqltest$ devbox run mysqladmin -uroot  create mydb              
Info: Running script "mysqladmin" on /tmp/mysqltest                    
jturner@jturner-desktop:/tmp/mysqltest$ devbox run mysql -uroot mydb -e "select database();"
Info: Running script "mysql" on /tmp/mysqltest
+------------+
| database() |
+------------+
| mydb       |
+------------+
```

This change (#2904) finishes the job begun by #2524. Also obsoletes (fixes in a nicer way) #2522.


## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
