### PR TITLE
fix(nginx plugin): Put mime.types where nginx.conf expects it (#2908)

### DIFF
--- a/plugins/nginx.json
+++ b/plugins/nginx.json
@@ -1,6 +1,6 @@
 {
   "name": "nginx",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "nginx can be configured with env variables\n\nTo customize:\n* Use $NGINX_CONFDIR to change the configuration directory\n* Use $NGINX_TMPDIR to change the tmp directory. Use $NGINX_USER to change the user\n* Use $NGINX_WEB_PORT to change the port NGINX runs on. \n Note: This plugin uses envsubst when running `devbox services` to generate the nginx.conf file from the nginx.template file. To customize the nginx.conf file, edit the nginx.template file.\n",
   "packages": ["gettext@latest", "gawk@latest"],
   "env": {
@@ -14,7 +14,7 @@
   },
   "create_files": {
     "{{ .Virtenv }}/temp": "",
-    "{{ .Virtenv }}/mime.types": "nginx/mime.types",
+    "{{ .DevboxDir }}/mime.types": "nginx/mime.types",
     "{{ .Virtenv }}/process-compose.yaml": "nginx/process-compose.yaml",
     "{{ .DevboxDir }}/nginx.template": "nginx/nginx.template",
     "{{ .DevboxDir }}/nginx.conf": "nginx/nginx.conf",


### PR DESCRIPTION
## Summary

nginx starts with `-p $NGINX_PATH_PREFIX`, where -p means "set the prefix path". However this only affects the runtime path (for directives `root`, `error_log`, `access_log` etc). Relative configuration directives, like `include mime.types;`, are still resolved relative to `nginx.conf`. Therefore `mime.types` must go in `{{ .DevboxDir }}`, not `{{ .Virtenv }}`.

Fixes #2908

## How was it tested?

```
rm -rf /tmp/testnginx && \
mkdir /tmp/testnginx && \
cd /tmp/testnginx && \
devbox init && \
devbox add nginx
ls  devbox.d/nginx/mime.types    # file exists
devbox services up
```

nginx now comes up on port 8081, whereas previously it died with ` open() "/tmp/testnginx/devbox.d/nginx/mime.types" failed`.

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
