### PR TITLE
fix(mariadb plugin): Fix warning by using 'mariadb-install-db' instead of 'mysql_install_db'. #2910

### DIFF
--- a/plugins/mariadb/process-compose.yaml
+++ b/plugins/mariadb/process-compose.yaml
@@ -2,7 +2,7 @@ version: "0.5"
 
 processes:
   mariadb:
-    command: "echo 'Starting mysqld... check mariadb_logs for details'; mariadbd --log-error=$MYSQL_HOME/mysql.log"
+    command: "echo 'Starting mariadbd... check mariadb_logs for details'; mariadbd --log-error=$MYSQL_HOME/mysql.log"
     is_daemon: false
     shutdown:
       command: "mariadb-admin -u root shutdown"

--- a/plugins/mariadb/setup_db.sh
+++ b/plugins/mariadb/setup_db.sh
@@ -2,7 +2,7 @@
 
 if [ ! -d "$MYSQL_DATADIR" ]; then
 # Install the Database
-    mysql_install_db --auth-root-authentication-method=normal \
+    mariadb-install-db --auth-root-authentication-method=normal \
         --datadir=$MYSQL_DATADIR --basedir=$MYSQL_BASEDIR \
         --pid-file=$MYSQL_PID_FILE
 fi


### PR DESCRIPTION
## Summary

Change setup_db.sh (run via init hook) to user the proper MariaDB executable name 'mariadb-install-db', rather than its compatibility symlink 'mysql_install_db'. This prevents users seeing the note:

```
.../.devbox/nix/profile/default/bin/mysql_install_db: Deprecated program name. It will be removed in a future release, use 'mariadb-install-db' instead 
```

Fixes #2910

## How was it tested?

```
mkdir /tmp/mariadbtest
cd /tmp/mariadbtest
devbox init
devbox add mariadb
devbox services up
```
No longer prints the deprecation warning:
```sh
jturner@jturner-desktop:/tmp/mariadbtest$ devbox services up
Info: Ensuring packages are installed.
✓ Computed the Devbox environment.
Installing MariaDB/MySQL system tables in '/tmp/mariadbtest/.devbox/virtenv/mariadb/data' ...
OK
...
```

## Community Contribution License

All community contributions in this pull request are licensed to the project
maintainers under the terms of the
[Apache 2 License](https://www.apache.org/licenses/LICENSE-2.0).

By creating this pull request, I represent that I have the right to license the
contributions to the project maintainers under the Apache 2 License as stated in
the
[Community Contribution License](https://github.com/jetify-com/opensource/blob/main/CONTRIBUTING.md#community-contribution-license).
